### PR TITLE
Centralize import attempt result finalization

### DIFF
--- a/lib/dispatch/core.py
+++ b/lib/dispatch/core.py
@@ -88,6 +88,7 @@ def dispatch_import_core(
     source_dirs: list[str] | None = None,
     candidate_import_job_id: int | None = None,
     attempt_spectral_audit: "SpectralDetail | None" = None,
+    attempt_result: ImportAttemptResult | None = None,
     candidate_download_log_id: int | None = None,
     prevalidated_candidate_result: CandidateEvidenceActionResult | None = None,
     quality_gate_fn: QualityGateFn = _check_quality_gate_core,
@@ -116,24 +117,12 @@ def dispatch_import_core(
     logger.info(f"{mode}: {label} "
                 f"(source=request, dist={dist_label})")
 
-    if attempt_spectral_audit is None and candidate_import_job_id is not None:
-        try:
-            job = db.get_import_job(candidate_import_job_id)
-            raw = (
-                job.preview_result.get("import_result")
-                if job is not None and job.preview_result is not None
-                else None
-            )
-            if isinstance(raw, dict):
-                attempt_spectral_audit = ImportResult.from_dict(raw).spectral
-        except Exception:
-            logger.warning(
-                "Unable to decode preview spectral audit for import job %s",
-                candidate_import_job_id,
-                exc_info=True,
-            )
-
-    attempt_result = ImportAttemptResult(attempt_spectral_audit)
+    if attempt_result is None:
+        attempt_result = ImportAttemptResult.from_import_job(
+            db,
+            candidate_import_job_id,
+            attempt_spectral_audit,
+        )
 
     outcome_success = False
     outcome_message = ""

--- a/lib/dispatch/core.py
+++ b/lib/dispatch/core.py
@@ -36,7 +36,7 @@ from lib.quality_evidence import (audit_v0_probe_from_metric,
 from lib.util import cleanup_disambiguation_orphans, trigger_meelo_clean
 
 from lib.dispatch.types import (DispatchOutcome, FORCE_MANUAL_SCENARIOS,
-                                ImportOneRun, QualityGateFn)
+                                ImportAttemptResult, ImportOneRun, QualityGateFn)
 from lib.dispatch.subprocess_runner import run_import_one
 from lib.dispatch.helpers import (_cleanup_staged_dir, _guard_failure_detail,
                                   _log_postflight_bad_extensions,
@@ -63,16 +63,6 @@ if TYPE_CHECKING:
     from lib.quality import SpectralDetail
 
 logger = logging.getLogger("cratedigger")
-
-
-def _attach_attempt_spectral_audit(
-    import_result: ImportResult,
-    audit: "SpectralDetail | None",
-) -> ImportResult:
-    """Attach display-only audit without touching policy-facing fields."""
-    if audit is not None:
-        import_result.spectral = audit
-    return import_result
 
 
 def dispatch_import_core(
@@ -142,6 +132,8 @@ def dispatch_import_core(
                 candidate_import_job_id,
                 exc_info=True,
             )
+
+    attempt_result = ImportAttemptResult(attempt_spectral_audit)
 
     outcome_success = False
     outcome_message = ""
@@ -325,7 +317,7 @@ def dispatch_import_core(
                         "import-time persisted evidence rejected candidate "
                         f"(decision={decision})"
                     )
-                    evidence_import_result = ImportResult(
+                    attempt_result.merge(ImportResult(
                         decision=decision,
                         new_measurement=evidence_gate.candidate.measurement,
                         existing_measurement=(
@@ -340,15 +332,12 @@ def dispatch_import_core(
                         comparison_basis=comparison_basis_from_decision(
                             evidence_decision
                         ),
-                        spectral=(attempt_spectral_audit
-                                  if attempt_spectral_audit is not None
-                                  else ImportResult().spectral),
-                    )
+                    ))
                     return _reject_import_from_evidence_decision(
                         db=db,
                         request_id=request_id,
                         dl_info=dl_info,
-                        import_result=evidence_import_result,
+                        attempt_result=attempt_result,
                         distance=distance,
                         decision=decision,
                         detail=detail,
@@ -424,12 +413,8 @@ def dispatch_import_core(
 
             ir = run.import_result
             if ir is not None:
-                ir = _attach_attempt_spectral_audit(
-                    ir, attempt_spectral_audit)
+                ir = attempt_result.merge(ir)
             if ir is None:
-                if attempt_spectral_audit is not None:
-                    dl_info.import_result = _attach_attempt_spectral_audit(
-                        ImportResult(), attempt_spectral_audit).to_json()
                 logger.error(
                     f"{mode} FAILED (no JSON, rc={run.returncode}): {label}")
                 for line in run.stdout.strip().split("\n"):
@@ -447,7 +432,8 @@ def dispatch_import_core(
                         error=f"rc={run.returncode}",
                         source_dirs=source_dirs,
                     ).to_json(),
-                    staged_path=path)
+                    staged_path=path,
+                    attempt_result=attempt_result)
                 outcome_message = f"No JSON result (rc={run.returncode})"
             else:
                 _populate_dl_info_from_import_result(dl_info, ir)
@@ -484,7 +470,8 @@ def dispatch_import_core(
                         imported_path=ir.postflight.imported_path,
                         clear_stale_v0_probe=(
                             decision != "preflight_existing"
-                        ))
+                        ),
+                        attempt_result=attempt_result)
                     try:
                         _refresh_current_evidence_after_import(
                             db,
@@ -589,13 +576,14 @@ def dispatch_import_core(
                     elif decision == "duplicate_remove_guard_failed":
                         fail_scenario = "duplicate_remove_guard_failed"
                         fail_detail = _guard_failure_detail(ir)
-                        _quarantine_duplicate_remove_guard_source(
-                            ir=ir,
-                            path=path,
-                            request_id=request_id,
-                            cfg=cfg,
+                        attempt_result.apply(
+                            lambda result: _quarantine_duplicate_remove_guard_source(
+                                ir=result,
+                                path=path,
+                                request_id=request_id,
+                                cfg=cfg,
+                            )
                         )
-                        dl_info.import_result = ir.to_json()
                         guard = ir.postflight.duplicate_remove_guard
                         if guard is not None:
                             logger.error(
@@ -703,7 +691,8 @@ def dispatch_import_core(
                                                error=fail_error,
                                                source_dirs=source_dirs,
                                            ).to_json()),
-                        staged_path=path)
+                        staged_path=path,
+                        attempt_result=attempt_result)
                     if narrowed_override is not None:
                         logger.info(
                             f"  Narrowed search_filetype_override '{current_override}'"
@@ -822,10 +811,6 @@ def dispatch_import_core(
                         trigger_meelo_clean(cfg)
         except sp.TimeoutExpired:
             logger.error(f"{mode} TIMEOUT: {label}")
-            if (attempt_spectral_audit is not None
-                    and dl_info.import_result is None):
-                dl_info.import_result = _attach_attempt_spectral_audit(
-                    ImportResult(), attempt_spectral_audit).to_json()
             _record_rejection_and_maybe_requeue(
                 db, request_id, dl_info,
                 detail="import_one.py timed out", error="timeout",
@@ -837,14 +822,11 @@ def dispatch_import_core(
                     error="timeout",
                     source_dirs=source_dirs,
                 ).to_json(),
-                staged_path=path)
+                staged_path=path,
+                attempt_result=attempt_result)
             outcome_message = "Import timed out"
         except Exception:
             logger.exception(f"{mode} ERROR: {label}")
-            if (attempt_spectral_audit is not None
-                    and dl_info.import_result is None):
-                dl_info.import_result = _attach_attempt_spectral_audit(
-                    ImportResult(), attempt_spectral_audit).to_json()
             _record_rejection_and_maybe_requeue(
                 db, request_id, dl_info,
                 detail="unhandled exception in auto-import", error="exception",
@@ -856,7 +838,8 @@ def dispatch_import_core(
                     error="exception",
                     source_dirs=source_dirs,
                 ).to_json(),
-                staged_path=path)
+                staged_path=path,
+                attempt_result=attempt_result)
             outcome_message = "Unhandled exception"
         finally:
             _remove_quality_evidence_action_file(quality_evidence_action_file)

--- a/lib/dispatch/entry_points.py
+++ b/lib/dispatch/entry_points.py
@@ -15,7 +15,8 @@ from typing import TYPE_CHECKING
 from lib.processing_paths import normalize_source_dirs
 from lib.import_evidence import ensure_candidate_evidence_for_action
 
-from lib.dispatch.types import DISPATCH_CODE_BAD_REQUEST, DispatchOutcome
+from lib.dispatch.types import (DISPATCH_CODE_BAD_REQUEST, DispatchOutcome,
+                                ImportAttemptResult)
 from lib.dispatch.manifest_guard import _guard_force_manual_audio_manifest
 from lib.dispatch.evidence_gate import (_download_info_from_candidate_evidence,
                                         _requeue_import_job_to_preview)
@@ -157,12 +158,14 @@ def _dispatch_import_from_db_locked(
     if not os.path.isdir(failed_path):
         return DispatchOutcome(success=False, message=f"Path not found: {failed_path}")
 
+    attempt_result = ImportAttemptResult.from_import_job(db, import_job_id)
     manifest_reject = _guard_force_manual_audio_manifest(
         db,
         request_id=request_id,
         failed_path=failed_path,
         download_log_id=download_log_id,
         source_username=source_username,
+        attempt_result=attempt_result,
     )
     if manifest_reject is not None:
         return manifest_reject
@@ -228,6 +231,7 @@ def _dispatch_import_from_db_locked(
         requeue_on_failure=False,
         source_dirs=source_dirs,
         candidate_import_job_id=import_job_id,
+        attempt_result=attempt_result,
         candidate_download_log_id=download_log_id,
         prevalidated_candidate_result=candidate_result,
         quality_gate_fn=resolved_quality_gate_fn,

--- a/lib/dispatch/helpers.py
+++ b/lib/dispatch/helpers.py
@@ -118,7 +118,6 @@ def _populate_dl_info_from_import_result(dl_info: DownloadInfo,
             existing_m.spectral_grade, existing_m.spectral_bitrate_kbps)
         if existing_m.min_bitrate_kbps is not None:
             dl_info.existing_min_bitrate = existing_m.min_bitrate_kbps
-    dl_info.import_result = ir.to_json()
     dl_info.v0_probe = ir.v0_probe
     dl_info.existing_v0_probe = ir.existing_v0_probe
     if ir.final_format:

--- a/lib/dispatch/manifest_guard.py
+++ b/lib/dispatch/manifest_guard.py
@@ -20,7 +20,7 @@ from lib.validation_envelope import decode_validation_envelope
 from lib.quality import ValidationResult
 
 from lib.dispatch.types import (DISPATCH_CODE_IMPORT_MANIFEST_REJECTED,
-                                DispatchOutcome)
+                                DispatchOutcome, ImportAttemptResult)
 from lib.dispatch.outcome_actions import _record_rejection_and_maybe_requeue
 
 if TYPE_CHECKING:
@@ -61,6 +61,7 @@ def _guard_reject(
     request_id: int,
     failed_path: str,
     source_username: str | None,
+    attempt_result: ImportAttemptResult,
     detail: str,
     scenario: str,
 ) -> DispatchOutcome:
@@ -112,6 +113,7 @@ def _guard_reject(
         requeue=True,
         outcome_label="rejected",
         staged_path=failed_path,
+        attempt_result=attempt_result,
     )
     return DispatchOutcome(
         success=False,
@@ -127,6 +129,7 @@ def _guard_force_manual_audio_manifest(
     failed_path: str,
     download_log_id: int | None,
     source_username: str | None,
+    attempt_result: ImportAttemptResult,
 ) -> DispatchOutcome | None:
     """Reconcile the staged source against its validated audio reference.
 
@@ -164,13 +167,13 @@ def _guard_force_manual_audio_manifest(
         return _guard_reject(
             db, request_id=request_id, failed_path=failed_path,
             source_username=source_username, detail=detail,
-            scenario="incomplete_fileset")
+            scenario="incomplete_fileset", attempt_result=attempt_result)
 
     def extra(detail: str, *, scenario: str = "untracked_audio") -> DispatchOutcome:
         return _guard_reject(
             db, request_id=request_id, failed_path=failed_path,
             source_username=source_username, detail=detail,
-            scenario=scenario)
+            scenario=scenario, attempt_result=attempt_result)
 
     # Empty source: the canonical empty_fileset early-exit in the evidence
     # pipeline self-heals this. Returning None lets the import flow reach it.

--- a/lib/dispatch/outcome_actions.py
+++ b/lib/dispatch/outcome_actions.py
@@ -24,7 +24,7 @@ from lib.quality import (DownloadInfo, ValidationResult, dispatch_action, extrac
                          is_comparable_lossless_source_probe)
 
 from lib.dispatch.types import (DISPATCH_CODE_QUALITY_PIPELINE_REJECTED,
-                                DispatchOutcome,
+                                DispatchOutcome, ImportAttemptResult,
                                 _PREIMPORT_FACT_REJECT_DECISIONS)
 from lib.dispatch.helpers import (_cleanup_staged_dir,
                                   _populate_dl_info_from_import_result,
@@ -42,7 +42,7 @@ def _reject_import_from_evidence_decision(
     db: "PipelineDB",
     request_id: int,
     dl_info: DownloadInfo,
-    import_result: ImportResult,
+    attempt_result: ImportAttemptResult,
     distance: float | None,
     decision: str,
     detail: str,
@@ -63,7 +63,8 @@ def _reject_import_from_evidence_decision(
     ``_route_preimport_decision_reject``). One decision function, one
     rejection helper, one denylist policy.
 
-    Threads ``import_result`` through ``_populate_dl_info_from_import_result``
+    Reads the owner's richest result through
+    ``_populate_dl_info_from_import_result``
     so the same top-level ``download_log`` columns the post-import reject
     path populates (``bitrate``, ``actual_filetype``, ``spectral_grade``,
     ``existing_min_bitrate``, ``v0_probe_*``, etc.) get filled here too.
@@ -82,6 +83,9 @@ def _reject_import_from_evidence_decision(
     because the operator already chose to act on this source).
     """
 
+    import_result = attempt_result.result
+    if import_result is None:
+        raise RuntimeError("persisted-evidence rejection requires an import result")
     _populate_dl_info_from_import_result(dl_info, import_result)
     action = dispatch_action(decision)
     # U11: force requeue on folder/audio-integrity rejects (formerly the
@@ -102,6 +106,7 @@ def _reject_import_from_evidence_decision(
         outcome_label="rejected",
         validation_result=rejection_validation,
         staged_path=staged_path,
+        attempt_result=attempt_result,
     )
     if action.denylist:
         usernames = extract_usernames(files or [])
@@ -152,6 +157,7 @@ def _do_mark_done(
     detail: str | None = None,
     imported_path: str | None = None,
     clear_stale_v0_probe: bool = True,
+    attempt_result: ImportAttemptResult | None = None,
 ) -> int | None:
     """Mark album as imported — standalone version of DatabaseSource.mark_done.
 
@@ -225,6 +231,8 @@ def _do_mark_done(
         scenario=scenario,
         detail=detail,
     ).to_json()
+    if attempt_result is not None:
+        attempt_result.finalize_into(dl_info)
     return db.log_download(
         request_id=request_id,
         soulseek_username=dl_info.username,
@@ -362,6 +370,7 @@ def _record_rejection_and_maybe_requeue(
     outcome_label: DownloadLogOutcome = "rejected",
     search_filetype_override: str | None = None,
     staged_path: str | None = None,
+    attempt_result: ImportAttemptResult | None = None,
 ) -> int:
     """Importer-side rejection entry point.
 
@@ -384,6 +393,8 @@ def _record_rejection_and_maybe_requeue(
     input for the audit row. ``PipelineDB.log_download`` derives its
     denormalized query columns from that envelope.
     """
+    if attempt_result is not None:
+        attempt_result.finalize_into(dl_info)
     log_download_kwargs: dict[str, Any] = {
         "soulseek_username": dl_info.username,
         "filetype": dl_info.filetype,

--- a/lib/dispatch/types.py
+++ b/lib/dispatch/types.py
@@ -8,10 +8,13 @@ remaining types are value-only definitions shared above every use site.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from typing import Callable, Protocol, Sequence, TYPE_CHECKING
 
 from lib.wrong_match_policy import PREIMPORT_FACT_REJECTION_SCENARIOS
+
+logger = logging.getLogger("cratedigger")
 
 if TYPE_CHECKING:
     from lib.config import CratediggerConfig
@@ -142,6 +145,34 @@ class ImportAttemptResult:
     @property
     def result(self) -> "ImportResult | None":
         return self._result
+
+    @classmethod
+    def from_import_job(
+        cls,
+        db: "PipelineDB",
+        import_job_id: int | None,
+        audit: "SpectralDetail | None" = None,
+    ) -> "ImportAttemptResult":
+        """Recover the preview audit once, before any terminal branch."""
+        if audit is not None or import_job_id is None:
+            return cls(audit)
+        try:
+            job = db.get_import_job(import_job_id)
+            raw = (
+                job.preview_result.get("import_result")
+                if job is not None and job.preview_result is not None
+                else None
+            )
+            if isinstance(raw, dict):
+                from lib.quality import ImportResult
+                audit = ImportResult.from_dict(raw).spectral
+        except Exception:
+            logger.warning(
+                "Unable to decode preview spectral audit for import job %s",
+                import_job_id,
+                exc_info=True,
+            )
+        return cls(audit)
 
     def merge(self, result: "ImportResult") -> "ImportResult":
         if self._audit is not None:

--- a/lib/dispatch/types.py
+++ b/lib/dispatch/types.py
@@ -2,12 +2,13 @@
 
 Extracted from ``lib/import_dispatch.py`` (issue #139). Holds the typed
 results and the taxonomy/scenario constants shared across the dispatch
-package. No behaviour; these types are defined above every use site.
+package. The import-attempt accumulator here owns result finalization; the
+remaining types are value-only definitions shared above every use site.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Callable, Protocol, Sequence, TYPE_CHECKING
 
 from lib.wrong_match_policy import PREIMPORT_FACT_REJECTION_SCENARIOS
@@ -17,7 +18,7 @@ if TYPE_CHECKING:
     from lib.import_evidence import CandidateEvidenceActionResult
     from lib.pipeline_db import DownloadLogOutcome, PipelineDB
     from lib.quality import (AlbumQualityEvidence, AudioQualityMeasurement,
-                             DownloadInfo, ImportResult)
+                             DownloadInfo, ImportResult, SpectralDetail)
 
 
 # U2: when the importer claim arrives without valid candidate evidence
@@ -120,6 +121,46 @@ class ImportOneRun:
     stdout: str
     stderr: str
     import_result: ImportResult | None
+
+
+@dataclass
+class ImportAttemptResult:
+    """Own the richest result persisted for one dispatch attempt.
+
+    The preview audit is display-only state. Harness results and later
+    postflight mutations flow through this owner; serialization happens only
+    when a terminal download-log writer calls :meth:`finalize_into`.
+    """
+
+    _audit: "SpectralDetail | None"
+    _result: "ImportResult | None" = field(init=False, default=None, repr=False)
+
+    @property
+    def audit(self) -> "SpectralDetail | None":
+        return self._audit
+
+    @property
+    def result(self) -> "ImportResult | None":
+        return self._result
+
+    def merge(self, result: "ImportResult") -> "ImportResult":
+        if self._audit is not None:
+            result.spectral = self._audit
+        self._result = result
+        return result
+
+    def apply(self, mutation: Callable[["ImportResult"], None]) -> None:
+        if self._result is None:
+            raise RuntimeError("cannot mutate an import attempt before a result exists")
+        mutation(self._result)
+
+    def finalize_into(self, dl_info: "DownloadInfo") -> None:
+        result = self._result
+        if result is None and self._audit is not None:
+            from lib.quality import ImportResult
+            result = ImportResult(spectral=self._audit)
+            self._result = result
+        dl_info.import_result = result.to_json() if result is not None else None
 
 
 @dataclass(frozen=True)

--- a/tests/test_dispatch_outcomes_generated.py
+++ b/tests/test_dispatch_outcomes_generated.py
@@ -55,7 +55,7 @@ from hypothesis import strategies as st
 
 from lib.config import CratediggerConfig
 from lib.dispatch import DispatchOutcome
-from lib.dispatch.types import _PREIMPORT_FACT_REJECT_DECISIONS
+from lib.dispatch.types import ImportAttemptResult, _PREIMPORT_FACT_REJECT_DECISIONS
 from lib.quality import (
     QUALITY_DECISION_IMPORT_STAGE_DECISIONS,
     QUALITY_DECISION_REJECT_STAGE_DECISIONS,
@@ -229,12 +229,14 @@ def _reject_via_evidence_decision(
         id=42, status="downloading", mb_release_id="test-mbid"))
     dl_info = DownloadInfo(filetype="mp3", username=source_username)
     ir = make_import_result(decision=decision, new_min_bitrate=new_min_bitrate)
+    attempt_result = ImportAttemptResult(None)
+    attempt_result.merge(ir)
     with patch_dispatch_externals():
         _reject_import_from_evidence_decision(
             db=db,  # type: ignore[arg-type]
             request_id=42,
             dl_info=dl_info,
-            import_result=ir,
+            attempt_result=attempt_result,
             distance=distance,
             decision=decision,
             detail=f"generated {decision}",
@@ -283,15 +285,18 @@ def _run_rejection_writer(
     if writer == "evidence_decision":
         from lib.dispatch import _reject_import_from_evidence_decision
 
+        attempt_result = ImportAttemptResult(None)
+        attempt_result.merge(make_import_result(
+            decision="downgrade",
+            new_min_bitrate=128,
+        ))
+
         with patch_dispatch_externals():
             _reject_import_from_evidence_decision(
                 db=db,  # type: ignore[arg-type]
                 request_id=42,
                 dl_info=DownloadInfo(username="generated-user"),
-                import_result=make_import_result(
-                    decision="downgrade",
-                    new_min_bitrate=128,
-                ),
+                attempt_result=attempt_result,
                 distance=distance,
                 decision="downgrade",
                 detail="generated reject",

--- a/tests/test_import_dispatch.py
+++ b/tests/test_import_dispatch.py
@@ -345,7 +345,11 @@ class TestRejectImportFromEvidenceDecision(unittest.TestCase):
 
     def test_evidence_rejection_populates_download_log_columns(self) -> None:
         from lib.dispatch import _reject_import_from_evidence_decision
-        from lib.quality import AudioQualityMeasurement, ImportResult
+        from lib.dispatch.types import ImportAttemptResult
+        from lib.quality import (
+            AudioQualityMeasurement, ImportResult, SpectralAnalysisDetail,
+            SpectralDetail,
+        )
 
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=42, status="downloading"))
@@ -368,13 +372,21 @@ class TestRejectImportFromEvidenceDecision(unittest.TestCase):
                 is_cbr=True,
             ),
         )
+        audit = SpectralDetail(
+            candidate=SpectralAnalysisDetail(
+                attempted=True, grade="suspect", bitrate_kbps=96),
+            existing=SpectralAnalysisDetail(
+                attempted=True, grade="genuine", bitrate_kbps=192),
+        )
+        attempt_result = ImportAttemptResult(audit)
+        attempt_result.merge(ir)
 
         with patch_dispatch_externals():
             _reject_import_from_evidence_decision(
                 db=db,  # type: ignore[arg-type]
                 request_id=42,
                 dl_info=dl_info,
-                import_result=ir,
+                attempt_result=attempt_result,
                 distance=0.1279,
                 decision="downgrade",
                 detail="import-time persisted evidence rejected candidate",
@@ -403,6 +415,8 @@ class TestRejectImportFromEvidenceDecision(unittest.TestCase):
         self.assertEqual(log.extra["existing_spectral_bitrate"], None)
         # The full ImportResult is still serialized into the JSONB.
         self.assertIsNotNone(log.import_result)
+        assert log.import_result is not None
+        self.assertEqual(ImportResult.from_json(log.import_result).spectral, audit)
 
 
 class TestRejectImportFromEvidenceDecisionForcedRequeue(unittest.TestCase):
@@ -421,6 +435,7 @@ class TestRejectImportFromEvidenceDecisionForcedRequeue(unittest.TestCase):
 
     def _reject(self, *, decision: str, requeue_on_failure: bool):
         from lib.dispatch import _reject_import_from_evidence_decision
+        from lib.dispatch.types import ImportAttemptResult
         from lib.quality import AudioQualityMeasurement, ImportResult
 
         db = FakePipelineDB()
@@ -439,12 +454,14 @@ class TestRejectImportFromEvidenceDecisionForcedRequeue(unittest.TestCase):
                 is_cbr=True,
             ),
         )
+        attempt_result = ImportAttemptResult(None)
+        attempt_result.merge(ir)
         with patch_dispatch_externals():
             _reject_import_from_evidence_decision(
                 db=db,  # type: ignore[arg-type]
                 request_id=42,
                 dl_info=dl_info,
-                import_result=ir,
+                attempt_result=attempt_result,
                 distance=0.0,
                 decision=decision,
                 detail=f"test {decision}",
@@ -810,6 +827,7 @@ class TestDispatchImport(unittest.TestCase):
 
     def test_duplicate_remove_guard_failure_denylists_and_quarantines(self):
         from lib.dispatch import dispatch_import_core
+        from lib.quality import SpectralAnalysisDetail, SpectralDetail
 
         staging_root = tempfile.mkdtemp()
         source = os.path.join(staging_root, "auto-import", "Artist", "Album")
@@ -838,11 +856,22 @@ class TestDispatchImport(unittest.TestCase):
                 ),
             ],
         )
-        ir = ImportResult(
-            exit_code=7,
+        ir = make_import_result(
             decision="duplicate_remove_guard_failed",
-            error=guard.message,
-            postflight=PostflightInfo(duplicate_remove_guard=guard),
+            new_min_bitrate=245,
+            prev_min_bitrate=128,
+            was_converted=True,
+            original_filetype="flac",
+            target_filetype="opus",
+        )
+        ir.exit_code = 7
+        ir.error = guard.message
+        ir.postflight.duplicate_remove_guard = guard
+        audit = SpectralDetail(
+            candidate=SpectralAnalysisDetail(
+                attempted=True, grade="suspect", bitrate_kbps=128),
+            existing=SpectralAnalysisDetail(
+                attempted=True, grade="genuine", bitrate_kbps=245),
         )
 
         db = FakePipelineDB()
@@ -868,6 +897,7 @@ class TestDispatchImport(unittest.TestCase):
                     files=[],
                     cfg=cfg,
                     requeue_on_failure=True,
+                    attempt_spectral_audit=audit,
                 )
         finally:
             shutil.rmtree(staging_root, ignore_errors=True)
@@ -882,6 +912,11 @@ class TestDispatchImport(unittest.TestCase):
         ext.cleanup.assert_not_called()
 
         persisted = ImportResult.from_json(db.download_logs[0].import_result)
+        self.assertEqual(persisted.spectral, audit)
+        self.assertEqual(persisted.decision, "duplicate_remove_guard_failed")
+        self.assertIsNotNone(persisted.new_measurement)
+        self.assertIsNotNone(persisted.existing_measurement)
+        self.assertTrue(persisted.conversion.was_converted)
         persisted_guard = persisted.postflight.duplicate_remove_guard
         assert persisted_guard is not None
         self.assertIsNotNone(persisted_guard.quarantine_path)

--- a/tests/test_import_manifest.py
+++ b/tests/test_import_manifest.py
@@ -103,6 +103,10 @@ class TestImportManifest(unittest.TestCase):
 
 class TestForceImportManifestGuard(unittest.TestCase):
     def test_force_import_rejects_audio_not_in_origin_manifest(self):
+        import msgspec
+        from lib.import_queue import IMPORT_JOB_FORCE, force_import_payload
+        from lib.quality import ImportResult, SpectralAnalysisDetail, SpectralDetail
+
         db = FakePipelineDB()
         db.seed_request(make_request_row(
             id=42,
@@ -122,13 +126,35 @@ class TestForceImportManifestGuard(unittest.TestCase):
                     "items": [{"path": os.path.join(root, "01 Perth.flac")}],
                 },
             )
+            job = db.enqueue_import_job(
+                IMPORT_JOB_FORCE,
+                request_id=42,
+                payload=force_import_payload(
+                    download_log_id=log_id,
+                    failed_path=root,
+                    source_username="alice",
+                ),
+            )
+            audit = SpectralDetail(
+                candidate=SpectralAnalysisDetail(
+                    attempted=True, grade="suspect", bitrate_kbps=96),
+                existing=SpectralAnalysisDetail(
+                    attempted=True, grade="genuine", bitrate_kbps=245),
+            )
+            preview_import_result = msgspec.to_builtins(
+                ImportResult(spectral=audit))
+            assert isinstance(preview_import_result, dict)
+            db.mark_import_job_preview_importable(
+                job.id,
+                preview_result={"import_result": preview_import_result},
+            )
 
             outcome = dispatch_import_from_db(
                 cast(Any, db),
                 request_id=42,
                 failed_path=root,
                 force=True,
-                import_job_id=99,
+                import_job_id=job.id,
                 download_log_id=log_id,
             )
 
@@ -143,6 +169,16 @@ class TestForceImportManifestGuard(unittest.TestCase):
         self.assertEqual(db.request(42)["status"], "wanted")
         outcomes = [(log.outcome, log.beets_scenario) for log in db.download_logs]
         self.assertIn(("rejected", "untracked_audio"), outcomes)
+        rejection = next(
+            log for log in db.download_logs
+            if log.outcome == "rejected" and log.beets_scenario == "untracked_audio"
+        )
+        self.assertIsNotNone(rejection.import_result)
+        assert rejection.import_result is not None
+        self.assertEqual(
+            ImportResult.from_json(rejection.import_result).spectral,
+            audit,
+        )
         # Operator's folder choice, not the peer's fault — never denylist.
         self.assertEqual(len(db.denylist), 0)
 

--- a/tests/test_import_result.py
+++ b/tests/test_import_result.py
@@ -1222,7 +1222,7 @@ class TestPopulateDlInfoFromImportResult(unittest.TestCase):
         assert dl.current_spectral is not None
         self.assertEqual(dl.current_spectral.bitrate_kbps, 128)
         self.assertTrue(dl.verified_lossless_override)
-        self.assertIsNotNone(dl.import_result)
+        self.assertIsNone(dl.import_result)
 
     def test_no_conversion(self) -> None:
         dl = DownloadInfo(filetype="mp3", bitrate=320000)
@@ -1236,6 +1236,94 @@ class TestPopulateDlInfoFromImportResult(unittest.TestCase):
         self.assertEqual(dl.slskd_filetype, "mp3")
         self.assertEqual(dl.actual_filetype, "mp3")
         self.assertEqual(dl.bitrate, 320000)
+
+
+class TestImportAttemptResult(unittest.TestCase):
+    """The dispatch-owned accumulator is the sole persistence owner."""
+
+    def test_merge_preserves_rich_result_and_exact_preview_audit(self):
+        from lib.dispatch.types import ImportAttemptResult
+        from lib.quality import (
+            QualityEvidenceActionProvenance,
+            QualityComparisonBasis,
+            SpectralAnalysisDetail,
+            SpectralDetail,
+        )
+        from tests.helpers import make_import_result
+
+        audit = SpectralDetail(
+            candidate=SpectralAnalysisDetail(
+                attempted=True, grade="suspect", bitrate_kbps=128),
+            existing=SpectralAnalysisDetail(
+                attempted=True, grade="genuine", bitrate_kbps=245),
+        )
+        harness_result = make_import_result(
+            decision="import",
+            new_min_bitrate=245,
+            prev_min_bitrate=128,
+            was_converted=True,
+            original_filetype="flac",
+            target_filetype="opus",
+            imported_path="/Beets/Artist/Album",
+            disambiguated=True,
+            final_format="opus 128",
+        )
+        harness_result.postflight.beets_id = 77
+        harness_result.postflight.track_count = 9
+        harness_result.comparison_basis = QualityComparisonBasis(
+            verdict="better", branch="rank", new_rank="mp3_v0",
+            existing_rank="mp3_v2", new_value_kbps=245,
+            existing_value_kbps=128,
+        )
+        harness_result.quality_evidence_provenance = QualityEvidenceActionProvenance(
+            candidate_status="ready",
+            current_status="ready",
+            snapshot_status="matched",
+        )
+        owner = ImportAttemptResult(audit)
+
+        merged = owner.merge(harness_result)
+
+        self.assertIs(merged, harness_result)
+        self.assertEqual(merged.spectral, audit)
+        self.assertEqual(merged.decision, "import")
+        self.assertIsNotNone(merged.new_measurement)
+        self.assertIsNotNone(merged.existing_measurement)
+        self.assertTrue(merged.conversion.was_converted)
+        self.assertEqual(merged.postflight.beets_id, 77)
+        self.assertIsNotNone(merged.comparison_basis)
+        self.assertEqual(
+            merged.quality_evidence_provenance.candidate_status, "ready")
+
+    def test_result_cannot_be_seeded_without_merge(self):
+        from lib.dispatch.types import ImportAttemptResult
+        from lib.quality import ImportResult
+
+        with self.assertRaises(TypeError):
+            ImportAttemptResult(None, ImportResult())  # type: ignore[call-arg]
+
+    def test_apply_mutation_is_included_only_when_owner_finalizes(self):
+        from lib.dispatch.types import ImportAttemptResult
+        from lib.quality import DownloadInfo, DuplicateRemoveGuardInfo, ImportResult
+
+        owner = ImportAttemptResult(None)
+        owner.merge(ImportResult(decision="duplicate_remove_guard_failed"))
+        owner.apply(lambda result: setattr(
+            result.postflight,
+            "duplicate_remove_guard",
+            DuplicateRemoveGuardInfo(quarantine_path="/failed/quarantine"),
+        ))
+        dl_info = DownloadInfo()
+
+        owner.finalize_into(dl_info)
+
+        assert dl_info.import_result is not None
+        persisted = ImportResult.from_json(dl_info.import_result)
+        assert persisted.postflight.duplicate_remove_guard is not None
+        self.assertEqual(
+            persisted.postflight.duplicate_remove_guard.quarantine_path,
+            "/failed/quarantine",
+        )
 
 
 class TestActiveDownloadState(unittest.TestCase):

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -1330,6 +1330,86 @@ class TestLosslessSourceLockedSlice(unittest.TestCase):
 class TestDispatchNoJsonResult(unittest.TestCase):
     """Integration slice: sp.run returns no sentinel -> record rejection."""
 
+    def test_success_preserves_full_import_result_and_exact_attempt_audit(self):
+        from lib.dispatch import dispatch_import_core
+        from lib.dispatch.types import ImportOneRun
+        from lib.quality import (
+            QualityEvidenceActionProvenance,
+            QualityComparisonBasis,
+            SpectralAnalysisDetail,
+            SpectralDetail,
+        )
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=42, status="downloading"))
+        cfg = CratediggerConfig(
+            beets_harness_path=_HARNESS, pipeline_db_enabled=True)
+        audit = SpectralDetail(
+            candidate=SpectralAnalysisDetail(
+                attempted=True, grade="suspect", bitrate_kbps=128),
+            existing=SpectralAnalysisDetail(
+                attempted=True, grade="genuine", bitrate_kbps=245),
+        )
+        result = make_import_result(
+            decision="import",
+            new_min_bitrate=245,
+            prev_min_bitrate=128,
+            was_converted=True,
+            original_filetype="flac",
+            target_filetype="opus",
+            imported_path="/Beets/Artist/Album",
+            disambiguated=True,
+            final_format="opus 128",
+        )
+        result.postflight.beets_id = 77
+        result.postflight.track_count = 9
+        result.comparison_basis = QualityComparisonBasis(
+            verdict="better", branch="rank", new_rank="mp3_v0",
+            existing_rank="mp3_v2", new_value_kbps=245,
+            existing_value_kbps=128,
+        )
+        result.quality_evidence_provenance = QualityEvidenceActionProvenance(
+            candidate_status="ready",
+            current_status="ready",
+            snapshot_status="matched",
+        )
+
+        def parsed_import(*args: Any, **kwargs: Any) -> ImportOneRun:
+            return ImportOneRun(
+                command=("import_one",), returncode=0,
+                stdout="", stderr="", import_result=result)
+
+        tmpdir = tempfile.mkdtemp()
+        try:
+            with patch_dispatch_externals():
+                dispatch_import_core(
+                    path=tmpdir,
+                    mb_release_id="mbid-123",
+                    request_id=42,
+                    label="Test Artist - Test Album",
+                    beets_harness_path=_HARNESS,
+                    db=db,  # type: ignore[arg-type]
+                    dl_info=DownloadInfo(username="user1"),
+                    cfg=cfg,
+                    attempt_spectral_audit=audit,
+                    run_import_fn=parsed_import,
+                    quality_gate_fn=lambda **kwargs: None,
+                )
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+        logged_raw = db.download_logs[0].import_result
+        assert logged_raw is not None
+        logged = ImportResult.from_json(logged_raw)
+        self.assertEqual(logged, result)
+        self.assertEqual(logged.spectral, audit)
+        self.assertEqual(logged.decision, "import")
+        self.assertIsNotNone(logged.new_measurement)
+        self.assertIsNotNone(logged.existing_measurement)
+        self.assertTrue(logged.conversion.was_converted)
+        self.assertEqual(logged.postflight.beets_id, 77)
+        self.assertIsNotNone(logged.comparison_basis)
+
     def test_no_json_marks_failed_and_requeues(self):
         """No __IMPORT_RESULT__ in stdout → scenario=no_json_result, requeue."""
         from lib.dispatch import dispatch_import_core
@@ -6474,6 +6554,8 @@ class TestU6ImporterPreimportDecideSlice(unittest.TestCase):
         """AE2: candidate evidence with audio_corrupt=True → preimport_decide
         rejects → request → wanted, download_log carries audio_corrupt scenario,
         beets (sp.run) is never invoked."""
+        import msgspec
+        from lib.quality import SpectralAnalysisDetail, SpectralDetail
         from lib.quality_evidence import snapshot_audio_files
 
         db = FakePipelineDB()
@@ -6517,6 +6599,18 @@ class TestU6ImporterPreimportDecideSlice(unittest.TestCase):
                     audio_corrupt=True,
                 ),
             )
+            audit = SpectralDetail(
+                candidate=SpectralAnalysisDetail(
+                    attempted=True, grade="suspect", bitrate_kbps=96),
+                existing=SpectralAnalysisDetail(
+                    attempted=True, grade="genuine", bitrate_kbps=128),
+            )
+            preview_result = msgspec.to_builtins(ImportResult(spectral=audit))
+            assert isinstance(preview_result, dict)
+            db.mark_import_job_preview_importable(
+                job.id,
+                preview_result={"import_result": preview_result},
+            )
             self._wire_current(db, 42, self._build_current_evidence(owner_id=42))
 
             result, ext = self._drive_dispatch(
@@ -6537,6 +6631,15 @@ class TestU6ImporterPreimportDecideSlice(unittest.TestCase):
         # download_log row records the rejection scenario.
         outcomes = [(log.outcome, log.beets_scenario) for log in db.download_logs]
         self.assertIn(("rejected", "audio_corrupt"), outcomes)
+        rejection = next(
+            log for log in db.download_logs
+            if log.outcome == "rejected" and log.beets_scenario == "audio_corrupt"
+        )
+        assert rejection.import_result is not None
+        self.assertEqual(
+            ImportResult.from_json(rejection.import_result).spectral,
+            audit,
+        )
 
     def test_nested_layout_evidence_routes_through_self_heal(self):
         """AE3: folder_layout='nested' → preimport_decide rejects → self-heal."""

--- a/tests/test_spectral_attempt_audit_generated.py
+++ b/tests/test_spectral_attempt_audit_generated.py
@@ -146,20 +146,52 @@ def _run_dispatch_finalization_world(
             raise RuntimeError("after result")
         noop_quality_gate()
 
-    with patch_dispatch_externals(), _silence_logs():
-        dispatch_import_core(
-            path="/tmp/cratedigger-generated-attempt",
-            mb_release_id="generated-mbid",
-            request_id=42,
-            label="Generated Artist - Generated Album",
-            beets_harness_path=cfg.beets_harness_path,
-            db=db,  # type: ignore[arg-type]
-            dl_info=DownloadInfo(username="generated-user", filetype="mp3"),
-            cfg=cfg,
-            attempt_spectral_audit=audit,
-            run_import_fn=run_import,
-            quality_gate_fn=quality_gate,
-        )
+    if mode == "manifest_rejection":
+        from lib.dispatch import dispatch_import_from_db
+        from lib.import_queue import IMPORT_JOB_MANUAL, manual_import_payload
+
+        db.set_tracks(42, [{"track_number": 1, "title": "One"}])
+        with tempfile.TemporaryDirectory() as source:
+            for filename in ("01.mp3", "bonus.mp3"):
+                with open(os.path.join(source, filename), "wb") as handle:
+                    handle.write(b"audio")
+            job = db.enqueue_import_job(
+                IMPORT_JOB_MANUAL,
+                request_id=42,
+                payload=manual_import_payload(failed_path=source),
+            )
+            preview_result: dict[str, Any] = {}
+            if audit is not None:
+                builtins = msgspec.to_builtins(ImportResult(spectral=audit))
+                assert isinstance(builtins, dict)
+                preview_result["import_result"] = builtins
+            db.mark_import_job_preview_importable(
+                job.id,
+                preview_result=preview_result,
+            )
+            with _silence_logs():
+                dispatch_import_from_db(
+                    db,  # type: ignore[arg-type]
+                    request_id=42,
+                    failed_path=source,
+                    import_job_id=job.id,
+                    source_username="generated-user",
+                )
+    else:
+        with patch_dispatch_externals(), _silence_logs():
+            dispatch_import_core(
+                path="/tmp/cratedigger-generated-attempt",
+                mb_release_id="generated-mbid",
+                request_id=42,
+                label="Generated Artist - Generated Album",
+                beets_harness_path=cfg.beets_harness_path,
+                db=db,  # type: ignore[arg-type]
+                dl_info=DownloadInfo(username="generated-user", filetype="mp3"),
+                cfg=cfg,
+                attempt_spectral_audit=audit,
+                run_import_fn=run_import,
+                quality_gate_fn=quality_gate,
+            )
 
     last_log = db.download_logs[-1]
     return {
@@ -199,6 +231,7 @@ class TestAttemptAuditGenerated(unittest.TestCase):
         mode=st.sampled_from((
             "success", "rejection", "no_json", "timeout",
             "pre_result_exception", "post_result_exception",
+            "manifest_rejection",
         )),
         new_bitrate=st.integers(min_value=64, max_value=400),
         existing_bitrate=st.integers(min_value=64, max_value=400),

--- a/tests/test_spectral_attempt_audit_generated.py
+++ b/tests/test_spectral_attempt_audit_generated.py
@@ -1,15 +1,31 @@
 """Generated invariant for independent two-sided spectral attempt audit."""
 
+from contextlib import contextmanager
+import logging
 import os
+import subprocess as sp
 import tempfile
 import unittest
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import patch
 
+import msgspec
+
 from hypothesis import given, strategies as st
 
+import tests._hypothesis_profiles  # noqa: F401  (loads active profile)
 from tests.fakes import FakeBeetsDB
+
+
+@contextmanager
+def _silence_logs():
+    previous_level = logging.root.manager.disable
+    logging.disable(logging.CRITICAL)
+    try:
+        yield
+    finally:
+        logging.disable(previous_level)
 
 
 def _both_sides_attempted(calls: list[str]) -> bool:
@@ -34,6 +50,126 @@ def _audit_only_policy_inputs_unchanged(
     return inputs == (None, None)
 
 
+def _persisted_attempt_has_exact_audit(
+    import_result_json: str | None,
+    expected_audit,
+) -> bool:
+    if import_result_json is None:
+        return False
+    from lib.quality import ImportResult
+    return ImportResult.from_json(import_result_json).spectral == expected_audit
+
+
+def _policy_payload(import_result_json: str | None) -> dict[str, Any]:
+    from lib.quality import ImportResult, SpectralDetail
+
+    result = (
+        ImportResult.from_json(import_result_json)
+        if import_result_json is not None
+        else ImportResult()
+    )
+    payload = msgspec.to_builtins(result)
+    assert isinstance(payload, dict)
+    payload["spectral"] = msgspec.to_builtins(SpectralDetail())
+    return payload
+
+
+def _run_dispatch_finalization_world(
+    *,
+    mode: str,
+    audit,
+    new_bitrate: int,
+    existing_bitrate: int,
+    converted: bool,
+) -> dict[str, Any]:
+    """Drive the real dispatch terminal writers with injected failure timing."""
+    from lib.config import CratediggerConfig
+    from lib.dispatch import dispatch_import_core
+    from lib.dispatch.types import ImportOneRun
+    from lib.quality import DownloadInfo, ImportResult, QualityComparisonBasis
+    from tests.fakes import FakePipelineDB
+    from tests.helpers import (
+        make_import_result,
+        make_request_row,
+        noop_quality_gate,
+        patch_dispatch_externals,
+    )
+
+    db = FakePipelineDB()
+    db.seed_request(make_request_row(
+        id=42,
+        status="downloading",
+        search_filetype_override="mp3",
+    ))
+    cfg = CratediggerConfig(
+        beets_harness_path="/nix/store/fake/harness/run_beets_harness.sh",
+        pipeline_db_enabled=True,
+    )
+
+    def rich_result() -> ImportResult:
+        result = make_import_result(
+            decision="downgrade" if mode == "rejection" else "import",
+            new_min_bitrate=new_bitrate,
+            prev_min_bitrate=existing_bitrate,
+            was_converted=converted,
+            original_filetype="flac" if converted else None,
+            target_filetype="opus" if converted else None,
+            imported_path="/Beets/Generated/Album",
+            disambiguated=True,
+            final_format="opus 128" if converted else "mp3 320",
+        )
+        result.postflight.beets_id = 77
+        result.postflight.track_count = 9
+        result.comparison_basis = QualityComparisonBasis(
+            verdict="better" if mode != "rejection" else "worse",
+            branch="rank",
+            new_rank="mp3_v0",
+            existing_rank="mp3_v2",
+            new_value_kbps=new_bitrate,
+            existing_value_kbps=existing_bitrate,
+        )
+        return result
+
+    def run_import(*args: Any, **kwargs: Any) -> ImportOneRun:
+        del args, kwargs
+        if mode == "timeout":
+            raise sp.TimeoutExpired("import_one", 300)
+        if mode == "pre_result_exception":
+            raise RuntimeError("before result")
+        if mode == "no_json":
+            return ImportOneRun(("import_one",), 1, "", "", None)
+        return ImportOneRun(("import_one",), 0, "", "", rich_result())
+
+    def quality_gate(**kwargs: Any) -> None:
+        del kwargs
+        if mode == "post_result_exception":
+            raise RuntimeError("after result")
+        noop_quality_gate()
+
+    with patch_dispatch_externals(), _silence_logs():
+        dispatch_import_core(
+            path="/tmp/cratedigger-generated-attempt",
+            mb_release_id="generated-mbid",
+            request_id=42,
+            label="Generated Artist - Generated Album",
+            beets_harness_path=cfg.beets_harness_path,
+            db=db,  # type: ignore[arg-type]
+            dl_info=DownloadInfo(username="generated-user", filetype="mp3"),
+            cfg=cfg,
+            attempt_spectral_audit=audit,
+            run_import_fn=run_import,
+            quality_gate_fn=quality_gate,
+        )
+
+    last_log = db.download_logs[-1]
+    return {
+        "import_result": last_log.import_result,
+        "outcomes": [row.outcome for row in db.download_logs],
+        "status": db.request(42)["status"],
+        "denylist": [(row.username, row.reason) for row in db.denylist],
+    }
+
+
 class TestAttemptAuditCheckerQualification(unittest.TestCase):
     def test_checker_rejects_short_circuiting_known_bad_trace(self):
         self.assertFalse(_both_sides_attempted(["candidate"]))
@@ -48,8 +184,70 @@ class TestAttemptAuditCheckerQualification(unittest.TestCase):
             _audit_only_policy_inputs_unchanged(("suspect", 96))
         )
 
+    def test_finalization_checker_rejects_skipped_terminal_finalization(self):
+        from lib.quality import ImportResult, SpectralAnalysisDetail, SpectralDetail
+
+        audit = SpectralDetail(candidate=SpectralAnalysisDetail(
+            attempted=True, grade="suspect", bitrate_kbps=96))
+        skipped_finalization = ImportResult(decision="import").to_json()
+        self.assertFalse(_persisted_attempt_has_exact_audit(
+            skipped_finalization, audit))
+
 
 class TestAttemptAuditGenerated(unittest.TestCase):
+    @given(
+        mode=st.sampled_from((
+            "success", "rejection", "no_json", "timeout",
+            "pre_result_exception", "post_result_exception",
+        )),
+        new_bitrate=st.integers(min_value=64, max_value=400),
+        existing_bitrate=st.integers(min_value=64, max_value=400),
+        converted=st.booleans(),
+        audit_grade=st.sampled_from(("genuine", "suspect", "likely_transcode")),
+        audit_bitrate=st.one_of(st.none(), st.integers(min_value=32, max_value=400)),
+    )
+    def test_real_dispatch_finalization_preserves_audit_without_policy_drift(
+        self,
+        mode: str,
+        new_bitrate: int,
+        existing_bitrate: int,
+        converted: bool,
+        audit_grade: str,
+        audit_bitrate: int | None,
+    ):
+        from lib.quality import SpectralAnalysisDetail, SpectralDetail
+
+        audit = SpectralDetail(
+            candidate=SpectralAnalysisDetail(
+                attempted=True, grade=audit_grade, bitrate_kbps=audit_bitrate),
+            existing=SpectralAnalysisDetail(
+                attempted=True, grade="genuine", bitrate_kbps=existing_bitrate),
+        )
+        audited = _run_dispatch_finalization_world(
+            mode=mode,
+            audit=audit,
+            new_bitrate=new_bitrate,
+            existing_bitrate=existing_bitrate,
+            converted=converted,
+        )
+        unaudited = _run_dispatch_finalization_world(
+            mode=mode,
+            audit=None,
+            new_bitrate=new_bitrate,
+            existing_bitrate=existing_bitrate,
+            converted=converted,
+        )
+
+        self.assertTrue(_persisted_attempt_has_exact_audit(
+            audited["import_result"], audit))
+        self.assertEqual(
+            _policy_payload(audited["import_result"]),
+            _policy_payload(unaudited["import_result"]),
+        )
+        self.assertEqual(audited["outcomes"], unaudited["outcomes"])
+        self.assertEqual(audited["status"], unaudited["status"])
+        self.assertEqual(audited["denylist"], unaudited["denylist"])
+
     @given(
         artist=st.text(
             alphabet=st.characters(whitelist_categories=("Ll", "Lu", "Nd")),
@@ -166,7 +364,7 @@ class TestAttemptAuditGenerated(unittest.TestCase):
         audit_grade: str, audit_floor: int | None,
         candidate_fails: bool, existing_fails: bool,
     ):
-        from lib.dispatch.core import _attach_attempt_spectral_audit
+        from lib.dispatch.types import ImportAttemptResult
         from lib.quality import (
             AudioQualityMeasurement, ImportResult, SpectralAnalysisDetail,
             SpectralDetail,
@@ -193,7 +391,7 @@ class TestAttemptAuditGenerated(unittest.TestCase):
                 error="existing failed" if existing_fails else None),
         )
         before = _policy_snapshot(result)
-        attached = _attach_attempt_spectral_audit(result, audit)
+        attached = ImportAttemptResult(audit).merge(result)
         self.assertTrue(_policy_snapshot_unchanged(before, attached))
         self.assertIs(attached.spectral, audit)
 


### PR DESCRIPTION
## Summary

- add a dispatch-owned `ImportAttemptResult` accumulator seeded from the preview spectral audit
- create that owner before the force/manual manifest guard and reuse the same owner through core dispatch, so entry-point terminal rejection cannot bypass finalization
- merge harness results and duplicate-guard postflight mutations through the owner
- serialize only at terminal download-log writers, including manifest rejection, persisted-evidence rejection, success, no-JSON, timeout, and exception paths
- preserve the existing JSON/UI contract and keep audit-only spectral details outside policy measurements and decisions

## Reviewer reproduction

The initial implementation missed force/manual manifest rejection because it terminates in `entry_points.py` before `dispatch_import_core()`. A real `dispatch_import_from_db()` pin reproduced an `untracked_audio` rejection whose preview audit was present but whose terminal `import_result` was `None`. The generated finalization property also failed and shrank to `mode='manifest_rejection'` before the correction. Both are green with the owner constructed before the guard.

## Verification

- deterministic pins cover success, persisted-evidence rejection, force/manual manifest rejection, no JSON, timeout, pre-result exception, post-result exception, and duplicate-remove-guard mutation
- generated property drives the real dispatch finalization path, including the real DB entry point for manifest rejection, and compares audited vs unaudited policy/state outcomes
- known-bad timeout-finalization mutant killed and shrunk to `mode=timeout`
- affected fuzz profile: 20,000 generated examples per property, 10 tests green in 631.313s on the final head
- `nix-shell --run "pyright"`: 0 errors
- full suite: 5,515 Python tests plus JS/dead-code/docs gates, green; exact-head artifact verified
- `nix flake check`: green
- pre-push sharded generated burst and flake gate: green

Refs #649
