### PR TITLE
Handle newline-free Forgejo token files

### DIFF
--- a/scripts/pin_nixosconfig.sh
+++ b/scripts/pin_nixosconfig.sh
@@ -178,7 +178,7 @@ forgejo_with_token() (
   unset GIT_CURL_VERBOSE
 
   [[ -r "$TOKEN_FILE" ]] || die "Forgejo token is not readable: $TOKEN_FILE"
-  IFS= read -r token < "$TOKEN_FILE"
+  token=$(<"$TOKEN_FILE")
   [[ -n "$token" ]] || die "Forgejo token is empty: $TOKEN_FILE"
   export GIT_CONFIG_COUNT=1
   export GIT_CONFIG_KEY_0='http.https://git.ablz.au.extraHeader'

--- a/tests/fakes/deploy_pin.py
+++ b/tests/fakes/deploy_pin.py
@@ -309,6 +309,7 @@ save()
 class FakeDeployPinCommands:
     """State-respecting fake git/nix/token environment for the Bash helper."""
 
+    TOKEN_BYTES = b"test-secret-token" + (b"x" * 23)
     BASE_REV = "1" * 40
     OLD_TARGET = "2" * 40
     TARGET_REV = "3" * 40
@@ -326,7 +327,7 @@ class FakeDeployPinCommands:
         (self.repo / ".git").mkdir()
         self.fake_bin.mkdir()
         self.tmp.mkdir()
-        self.token_file.write_text("test-secret-token\n", encoding="utf-8")
+        self.token_file.write_bytes(self.TOKEN_BYTES)
         for name in ("git", "nix", "hostname"):
             path = self.fake_bin / name
             path.write_text(_FAKE_COMMAND, encoding="utf-8")

--- a/tests/test_deploy_pin_script.py
+++ b/tests/test_deploy_pin_script.py
@@ -68,6 +68,29 @@ class TestDeployPinScript(unittest.TestCase):
             self.assertNotIn("test-secret-token", " ".join(call))
             self.assertNotIn("Authorization:", " ".join(call))
 
+    def test_no_newline_token_fixture_matches_production_and_succeeds(self) -> None:
+        token_bytes = self.fake.token_file.read_bytes()
+        self.assertEqual(token_bytes, self.fake.TOKEN_BYTES)
+        self.assertEqual(len(token_bytes), 40)
+        self.assertFalse(token_bytes.endswith(b"\n"))
+
+        proc = self.fake.run(SCRIPT)
+
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(self.fake.state["remote_rev"],
+                         self.fake.state["receipt_rev"])
+
+    def test_empty_token_is_rejected_before_authenticated_git(self) -> None:
+        self.fake.token_file.write_bytes(b"")
+
+        proc = self.fake.run(SCRIPT)
+        state = self.fake.state
+
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("Forgejo token is empty", proc.stderr)
+        self.assertFalse(any(event[0] in {"push", "ls-remote"}
+                             for event in state["events"]))
+
     def test_inherited_xtrace_never_prints_token(self) -> None:
         proc = self.fake.run(
             SCRIPT,


### PR DESCRIPTION
## Summary

- read the Forgejo token with Bash file command substitution so a valid final line without a trailing newline does not become a `set -e` failure
- keep the read after `set +x` and inside the existing short-lived token subshell, preserving xtrace/Trace2 secrecy and environment-only authorization-header lifetime
- make the process fake match production with an exact 40-byte nonempty token and no trailing newline
- pin successful no-newline recovery plus explicit empty-token rejection before authenticated Git operations

## Live evidence

- `/run/secrets/forgejo/nixbot-token` is 40 bytes with no trailing newline
- the prior helper created and preserved exact signed nixosconfig receipt `d41fa24888a84e670da18e1a367939d86b1fe5c1`
- recovery aborted at the EOF-sensitive `read` before Forgejo `ls-remote` or push; no wrong mutation occurred
- this PR does not manipulate that receipt or any nixosconfig ref

## Verification

- `shellcheck scripts/pin_nixosconfig.sh`
- focused deterministic + generated deploy-pin modules: 31/31 green
- push-profile and fuzz-profile deploy lifecycle modules: green
- full-repo `pyright`: 0 errors
- full clean-head suite: 5,556/5,556 green
- exact artifact: `/tmp/cratedigger-656-live-fix-21dc6b06c3-0d8b132c2c10.626_et5f`
- artifact output SHA-256: `7384562f47fb7262a68a2a168f8a3c1f5f5d4ffb4499c205461bab75fda222fa`
- pre-push generated-test fuzz burst: every generated module green
- pre-push `nix flake check`: all checks passed, including module VM

Refs #656
