### PR TITLE
Fix terminal rejection evidence in Recents

### DIFF
--- a/tests/test_classified_entry_projection_generated.py
+++ b/tests/test_classified_entry_projection_generated.py
@@ -13,6 +13,7 @@ import unittest
 import msgspec
 from hypothesis import example, given, strategies as st
 
+from lib.quality import ImportResult, ValidationResult
 import tests._hypothesis_profiles  # noqa: F401
 from tests.helpers import make_request_row
 from tests.web._harness import _FakeDbWebServerCase
@@ -37,6 +38,26 @@ def assert_classified_fields_forwarded(
             "ClassifiedEntry projection drift: "
             f"pipeline_log_missing={sorted(missing_log)} "
             f"download_history_missing={sorted(missing_detail)}"
+        )
+
+
+def assert_mixed_source_projection_is_honest(
+    payload: Mapping[str, object],
+    expected_formats: tuple[str, str],
+) -> None:
+    """The terminal reject reason and every measured codec stay visible."""
+    expected_verdict = "Mixed lossless+lossy source"
+    if payload.get("verdict") != expected_verdict:
+        raise AssertionError(
+            "mixed-source verdict drift: "
+            f"expected={expected_verdict!r} actual={payload.get('verdict')!r}"
+        )
+    label = str(payload.get("downloaded_label") or "")
+    missing = [fmt.upper() for fmt in expected_formats if fmt.upper() not in label]
+    if missing:
+        raise AssertionError(
+            "mixed-source codec projection dropped formats: "
+            f"missing={missing!r} label={label!r}"
         )
 
 
@@ -71,6 +92,37 @@ class _ClassifiedEntryProjectionHarness(_FakeDbWebServerCase):
         self.assertEqual(status, 200)
         return response["log"][0], detail
 
+    def mixed_source_payload(
+        self,
+        *,
+        lossless_format: str,
+        lossy_format: str,
+        validation_scenario: str,
+    ) -> dict[str, object]:
+        self.db.delete_request(598)
+        self.db.seed_request(make_request_row(
+            id=598,
+            status="wanted",
+            mb_release_id="classified-entry-mixed-source",
+        ))
+        self.db.log_download(
+            598,
+            outcome="rejected",
+            soulseek_username="generated-peer",
+            filetype=f"{lossless_format}, {lossy_format}",
+            actual_filetype=f"{lossless_format}, {lossy_format}",
+            actual_min_bitrate=224,
+            import_result=ImportResult(decision="mixed_source").to_json(),
+            validation_result=ValidationResult(
+                valid=True,
+                distance=0.0928,
+                scenario=validation_scenario,
+            ).to_json(),
+        )
+        status, response = self._get("/api/pipeline/log?limit=1")
+        self.assertEqual(status, 200)
+        return response["log"][0]
+
 
 class TestClassifiedEntryProjectionPin(_ClassifiedEntryProjectionHarness):
     def test_every_classifier_field_reaches_both_outbound_surfaces(self) -> None:
@@ -95,6 +147,14 @@ class TestClassifiedEntryProjectionPin(_ClassifiedEntryProjectionHarness):
                 },
                 type=ClassifiedEntry,
             )
+
+    def test_slow_club_mixed_source_projection(self) -> None:
+        payload = self.mixed_source_payload(
+            lossless_format="flac",
+            lossy_format="ogg",
+            validation_scenario="strong_match",
+        )
+        assert_mixed_source_projection_is_honest(payload, ("flac", "ogg"))
 
 
 class TestGeneratedClassifiedEntryProjection(_ClassifiedEntryProjectionHarness):
@@ -124,6 +184,34 @@ class TestGeneratedClassifiedEntryProjection(_ClassifiedEntryProjectionHarness):
         )
         assert_classified_fields_forwarded(log_payload, detail_payload)
 
+    @given(
+        lossless_format=st.sampled_from(["flac", "alac", "wav", "aiff", "ape"]),
+        lossy_format=st.sampled_from(["mp3", "aac", "m4a", "ogg", "opus", "wma"]),
+        validation_scenario=st.sampled_from([
+            "strong_match", "medium_match", "validation_passed",
+        ]),
+    )
+    @example(
+        lossless_format="flac",
+        lossy_format="ogg",
+        validation_scenario="strong_match",
+    )
+    def test_terminal_mixed_source_decision_drives_every_projection_world(
+        self,
+        lossless_format: str,
+        lossy_format: str,
+        validation_scenario: str,
+    ) -> None:
+        payload = self.mixed_source_payload(
+            lossless_format=lossless_format,
+            lossy_format=lossy_format,
+            validation_scenario=validation_scenario,
+        )
+        assert_mixed_source_projection_is_honest(
+            payload,
+            (lossless_format, lossy_format),
+        )
+
 
 class TestClassifiedEntryProjectionCheckerTripsOnViolations(unittest.TestCase):
     def test_checker_rejects_a_missing_log_field(self) -> None:
@@ -139,6 +227,26 @@ class TestClassifiedEntryProjectionCheckerTripsOnViolations(unittest.TestCase):
         bad_detail.pop("summary")
         with self.assertRaisesRegex(AssertionError, "summary"):
             assert_classified_fields_forwarded(complete, bad_detail)
+
+    def test_mixed_source_checker_rejects_validation_scenario_as_verdict(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "verdict drift"):
+            assert_mixed_source_projection_is_honest(
+                {
+                    "verdict": "strong_match",
+                    "downloaded_label": "FLAC + OGG",
+                },
+                ("flac", "ogg"),
+            )
+
+    def test_mixed_source_checker_rejects_a_dropped_codec(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "dropped formats"):
+            assert_mixed_source_projection_is_honest(
+                {
+                    "verdict": "Mixed lossless+lossy source",
+                    "downloaded_label": "FLAC",
+                },
+                ("flac", "ogg"),
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_web_recents.py
+++ b/tests/test_web_recents.py
@@ -757,13 +757,13 @@ class TestClassifyVerdict(unittest.TestCase):
         self.assertIn("not", result.verdict.lower())
 
     def test_persisted_quality_downgrade_verdict_uses_import_result(self):
-        """Auto-import rows may store the quality-pipeline decision as the
-        scenario. Recents must still show the comparison, not bare
-        "downgrade".
+        """A successful validation headline cannot hide a later downgrade.
+
+        This is the post-validation-envelope shape that regressed in PR #623.
         """
         result = classify_log_entry(_entry(
             outcome="rejected",
-            beets_scenario="downgrade",
+            beets_scenario="strong_match",
             soulseek_username="CondosInQueens",
             import_result={
                 "version": 2,
@@ -1122,6 +1122,16 @@ class TestExceptionVerdicts(unittest.TestCase):
 
 class TestDownloadedLabel(unittest.TestCase):
 
+    def test_mixed_source_preserves_every_downloaded_codec(self):
+        """The Slow Club live row carried ``flac, ogg`` but rendered FLAC."""
+        result = classify_log_entry(_entry(
+            outcome="rejected",
+            actual_filetype="flac, ogg",
+            actual_min_bitrate=224,
+            import_result=ImportResult(decision="mixed_source").to_json(),
+        ))
+        self.assertEqual(result.downloaded_label, "FLAC + OGG")
+
     def test_mp3_download(self):
         """MP3 320 download gets a label."""
         result = classify_log_entry(_entry(
@@ -1162,6 +1172,33 @@ class TestDownloadedLabel(unittest.TestCase):
             bitrate=155000, actual_filetype="mp3"))
         self.assertTrue(hasattr(result, "downloaded_label"))
         self.assertIn("155", result.downloaded_label)
+
+
+class TestRejectedDecisionProjection(unittest.TestCase):
+
+    def test_mixed_source_decision_overrides_successful_validation_headline(self):
+        """Live row 36844 matched its pressing, then failed mixed-source policy."""
+        result = classify_log_entry(_entry(
+            outcome="rejected",
+            beets_scenario="strong_match",
+            actual_filetype="flac, ogg",
+            actual_min_bitrate=224,
+            import_result=ImportResult(decision="mixed_source").to_json(),
+        ))
+        self.assertEqual(result.verdict, "Mixed lossless+lossy source")
+        self.assertEqual(
+            result.summary,
+            "Mixed lossless+lossy source · testuser",
+        )
+
+    def test_non_reject_import_decision_does_not_hide_later_failure(self):
+        """A successful import-stage token cannot replace a later reject."""
+        result = classify_log_entry(_entry(
+            outcome="rejected",
+            beets_scenario="nested_layout",
+            import_result=ImportResult(decision="import").to_json(),
+        ))
+        self.assertIn("Nested folder layout", result.verdict)
 
 
 # ============================================================================

--- a/web/classify.py
+++ b/web/classify.py
@@ -13,7 +13,7 @@ from typing import Any, Optional
 import msgspec
 
 from lib.quality import (AudioQualityMeasurement, ImportResult,
-                         QualityComparisonBasis)
+                         QualityComparisonBasis, dispatch_action)
 from lib.validation_envelope import decode_validation_envelope
 
 # ---------------------------------------------------------------------------
@@ -618,6 +618,18 @@ def _entry_decision(entry: LogEntry) -> str | None:
     return entry.beets_scenario
 
 
+def _entry_rejection_decision(entry: LogEntry) -> str | None:
+    """Prefer an ImportResult only when it actually records a rejection."""
+    ir = _parse_import_result(entry)
+    if (
+        ir is not None
+        and ir.decision
+        and dispatch_action(ir.decision).record_rejection
+    ):
+        return ir.decision
+    return entry.beets_scenario
+
+
 def _entry_comparison_basis(entry: LogEntry) -> QualityComparisonBasis | None:
     ir = _parse_import_result(entry)
     if ir is None:
@@ -1056,7 +1068,13 @@ def _rejection_verdict(entry: LogEntry) -> str:
     LogEntry fields only when JSONB is unavailable — and never use
     spectral_bitrate as a proxy for actual file bitrate.
     """
-    scenario = entry.beets_scenario
+    # Validation and import decisions describe different stages. A candidate
+    # can be a strong pressing match and still be rejected by the importer
+    # (for example, a folder containing both FLAC and OGG tracks). The final
+    # ImportResult decision owns the rejection headline; beets_scenario is the
+    # fallback for validation-only rejects and remains available as forensic
+    # evidence in the row payload.
+    scenario = _entry_rejection_decision(entry)
 
     # Quality comparison scenarios — delegate to ImportResult when available
     if scenario in (
@@ -1121,6 +1139,9 @@ def _rejection_verdict(entry: LogEntry) -> str:
 
     if scenario == "audio_corrupt":
         return "Corrupt audio files detected"
+
+    if scenario == "mixed_source":
+        return "Mixed lossless+lossy source"
 
     if scenario == "duplicate_remove_guard_failed":
         ir = _parse_import_result(entry)
@@ -1203,6 +1224,15 @@ def _build_downloaded_label(entry: LogEntry) -> str:
     fmt = entry.actual_filetype or entry.filetype or ""
     if not fmt:
         return ""
+
+    # A comma-separated attempt format is a mixed-codec album, not one codec
+    # with a meaningful shared bitrate tier. Preserve every measured format so
+    # a mixed-source safety rejection can never render as an all-FLAC source.
+    formats = list(dict.fromkeys(
+        part.strip().upper() for part in fmt.split(",") if part.strip()
+    ))
+    if len(formats) > 1:
+        return " + ".join(formats)
 
     br_kbps = _downloaded_min_bitrate_kbps(entry) or 0
 


### PR DESCRIPTION
## What changed

- make the terminal ImportResult rejection decision own rejected-row headlines, while preserving later validation-only failures
- render every codec in a mixed-source attempt instead of collapsing `flac, ogg` to `FLAC`
- add deterministic and generated coverage for the exact Slow Club shape and other lossless/lossy combinations

## Root cause

The validation-envelope refactor correctly preserved `strong_match` as the pressing-match result, but Recents treated that intermediate result as the terminal rejection reason. Its bitrate formatter also assumed one codec and silently took the first comma-separated format.

The underlying `mixed_source` quality rejection was correct; this is a display projection fix.

## Verification

- 154 focused tests
- 5,632 full-suite tests
- pyright: 0 errors
- randomized generated-test push profile
- `nix flake check`
- live-db Playwright screenshots of download-log 36844, collapsed and expanded

## Review note

A final adversarial pass found and fixed an edge where blindly preferring ImportResult could hide a later validation-only rejection when the stored import decision was successful.