### PR TITLE
Finish UI queue consolidation

### DIFF
--- a/docs/pipeline-db-schema.md
+++ b/docs/pipeline-db-schema.md
@@ -175,7 +175,7 @@ Rollback to pre-018 code requires queue reconciliation first: stop import
 workers and reset queued or running `evidence_ready` rows to queued `waiting`
 rows so old preview code recomputes them. Do not bulk-convert them to
 `would_import`; that would restore preview-decision authority.
-The Recents Queue endpoint lists only active `queued`/`running` jobs; terminal
+The Recents Imports endpoint lists only active `queued`/`running` jobs; terminal
 `completed`/`failed` rows remain durable audit history and must not be rendered
 as live queue work.
 

--- a/docs/webui-primer.md
+++ b/docs/webui-primer.md
@@ -49,7 +49,7 @@ Browser → https://music.ablz.au
 | `/api/wrong-matches/converge` | POST | Queue every wrong-match candidate within a release's loosen threshold and delete the rest |
 | `/api/wrong-matches/triage` | POST | Evidence-only full-queue Wrong Matches cleanup; requires `{"confirm_all_wrong_matches": true}` |
 | `/api/import-jobs` | GET | List recent import queue jobs |
-| `/api/import-jobs/timeline` | GET | List active queued/running import jobs in Recents queue order |
+| `/api/import-jobs/timeline` | GET | List active queued/running import jobs in importer order, with server-classified display fields |
 | `/api/import-jobs/<id>` | GET | Poll a single import queue job |
 | `/api/library/artist?name=...` | GET | Albums by artist from beets library (MB vs Discogs source) |
 | `/api/discogs/search?q=...` | GET | Search Discogs mirror (artist or release mode via `type=` param) |
@@ -91,16 +91,20 @@ Browser → https://music.ablz.au
   - Releases already in pipeline DB or beets library are badged
   - Click release metadata to open MB release page in new tab
 - **Add button** — adds release to pipeline DB (same logic as `pipeline-cli add`)
-- **Pipeline tab** — status dashboard (wanted/imported/manual counts + wanted list)
+- **Pipeline tab** — operational Dashboard + Long Tail views. The old global
+  request Queue subview was removed in #575 PR5: request state and actions live
+  on Browse's unified artist/release rows, while diagnostic API/CLI routes
+  remain available.
 - **Wrong Matches tab** — the old Complete-folder manual-import page is gone;
   the tab now opens straight into Wrong Matches. Import actions queue work and
   poll `import_jobs`, so long beets imports do not block the web request.
   Failed queued force-imports remove the reviewed wrong-match source from the
   actionable list while preserving the failed job/download audit.
-- **Recents Queue subview** — Recents has History and Queue subviews. Queue
-  shows import jobs in beets-import order, with preview states (`waiting`,
-  `previewing`, `importable`, `uncertain`, `failed`) and preview messages
-  visible before the serial importer claims work.
+- **Recents Imports subview** — Recents has History, Downloading, and Imports
+  subviews. Imports shows active jobs in beets-import order. The server
+  classifies each job into the same `badge` / `badge_class` / `border_color` /
+  `summary` display contract as Recents history, while raw preview/import
+  states remain visible as forensic metadata.
 - **Recents evidence schema (#575 PR2)** — History list rows carry a compact
   monospace `IN … HAVE …` evidence strip (measured incoming bitrate/spectral/
   V0 probe vs on-disk at download time); rows with no measurements (download-
@@ -113,7 +117,9 @@ Browser → https://music.ablz.au
   evidence all reads positive never buries its reason below the grid (request
   8781: `mbid_missing` under a "transparent vs transparent" comparison). The
   expanded pipeline/Recents detail panel puts Download History above the
-  track list for the same reason. Force imports show `overridden` in the
+  track list for the same reason, shows the newest 10 attempts initially,
+  and puts older attempts plus track inventories behind disclosures. Force
+  imports show `overridden` in the
   Distance row instead of beets' misleading 0.000. Debug internals (Detail /
   Preview / Reason / Stages) sit behind a collapsed `forensics` toggle per
   attempt. Every bitrate says which statistic it is: the min-vs-min row is
@@ -260,7 +266,7 @@ GitHub nixosconfig is a frozen fallback and is never a deployment source.
 The web service auto-restarts when the Nix store path changes.
 
 After deploy, check `systemctl status cratedigger-import-preview-worker
-cratedigger-importer` and the worker journals. The Recents Queue subview shows
+cratedigger-importer` and the worker journals. The Recents Imports subview shows
 only active queued/running import jobs as they move from waiting preview, to
 previewing, to importable, to importing. Completed, failed, or preview-rejected
 rows are history/audit rows, not live queue rows.

--- a/tests/test_import_job_display.py
+++ b/tests/test_import_job_display.py
@@ -1,0 +1,108 @@
+"""Deterministic pins for import-job timeline display classification."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import unittest
+
+import msgspec
+
+from lib.import_queue import ImportJob
+from web.classify import ImportJobDisplay, classify_import_job_display
+
+
+def _job(
+    *,
+    status: str = "queued",
+    preview_status: str | None = "waiting",
+    message: str | None = None,
+    error: str | None = None,
+    preview_message: str | None = None,
+    preview_error: str | None = None,
+) -> ImportJob:
+    now = datetime(2026, 7, 13, tzinfo=timezone.utc)
+    return ImportJob(
+        id=575,
+        job_type="force_import",
+        status=status,
+        request_id=100,
+        dedupe_key="force_import:download_log:575",
+        payload={"failed_path": "/tmp/album"},
+        result=None,
+        message=message,
+        error=error,
+        attempts=0,
+        worker_id=None,
+        created_at=now,
+        updated_at=now,
+        started_at=None,
+        heartbeat_at=None,
+        completed_at=None,
+        preview_status=preview_status,
+        preview_message=preview_message,
+        preview_error=preview_error,
+    )
+
+
+class TestImportJobDisplay(unittest.TestCase):
+    def test_evidence_ready_first_row_is_the_next_check(self) -> None:
+        display = classify_import_job_display(
+            _job(
+                preview_status="evidence_ready",
+                preview_message="Evidence ready for final check: import",
+            ),
+            queue_position=0,
+        )
+        self.assertEqual(display.badge, "Next check")
+        self.assertEqual(display.badge_class, "badge-new")
+        self.assertEqual(display.border_color, "#1a4a2a")
+        self.assertEqual(display.summary, "Evidence ready for final check: import")
+
+    def test_running_import_wins_over_stale_preview_state(self) -> None:
+        display = classify_import_job_display(
+            _job(
+                status="running",
+                preview_status="measurement_failed",
+                preview_error="stale preview failure",
+                message="Importer owns this job",
+            ),
+            queue_position=4,
+        )
+        self.assertEqual(display.badge, "Importing")
+        self.assertEqual(display.badge_class, "badge-force")
+        self.assertEqual(display.border_color, "#36c")
+        self.assertEqual(display.summary, "Importer owns this job")
+
+    def test_measurement_failure_is_one_server_classified_contract(self) -> None:
+        display = classify_import_job_display(
+            _job(
+                preview_status="measurement_failed",
+                preview_error="snapshot stale",
+            ),
+            queue_position=3,
+        )
+        self.assertEqual(display.badge, "Measurement failed")
+        self.assertEqual(display.badge_class, "badge-failed")
+        self.assertEqual(display.border_color, "#a33")
+        self.assertEqual(display.summary, "snapshot stale")
+
+    def test_display_is_a_strict_wire_type(self) -> None:
+        self.assertTrue(issubclass(ImportJobDisplay, msgspec.Struct))
+        with self.assertRaises(msgspec.ValidationError):
+            msgspec.convert({
+                "badge": 42,
+                "badge_class": "badge-new",
+                "border_color": "#1a4a2a",
+                "summary": "ready",
+            }, type=ImportJobDisplay)
+
+    def test_terminal_job_is_rejected_from_the_active_timeline_classifier(self) -> None:
+        with self.assertRaisesRegex(ValueError, "active import job"):
+            classify_import_job_display(
+                _job(status="failed", preview_status="evidence_ready"),
+                queue_position=0,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_import_job_display_generated.py
+++ b/tests/test_import_job_display_generated.py
@@ -1,0 +1,89 @@
+"""Generated import-job display lifecycle property for issue #575 PR5."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import unittest
+
+from hypothesis import example, given, strategies as st
+
+from lib.import_queue import (
+    IMPORT_JOB_PREVIEW_STATUSES,
+    ImportJob,
+)
+import tests._hypothesis_profiles  # noqa: F401
+from web.classify import ImportJobDisplay, classify_import_job_display
+
+
+def _job(status: str, preview_status: str | None, text: str) -> ImportJob:
+    now = datetime(2026, 7, 13, tzinfo=timezone.utc)
+    return ImportJob(
+        id=575,
+        job_type="force_import",
+        status=status,
+        request_id=100,
+        dedupe_key="force_import:download_log:575",
+        payload={"failed_path": "/tmp/album"},
+        result=None,
+        message=text,
+        error=None,
+        attempts=0,
+        worker_id=None,
+        created_at=now,
+        updated_at=now,
+        started_at=None,
+        heartbeat_at=None,
+        completed_at=None,
+        preview_status=preview_status,
+        preview_message=f"preview {text}",
+        preview_error=f"preview error {text}",
+    )
+
+
+def assert_import_job_display_contract(display: object) -> None:
+    if not isinstance(display, ImportJobDisplay):
+        raise AssertionError("classifier did not return ImportJobDisplay")
+    if not display.badge or not display.badge_class or not display.border_color:
+        raise AssertionError("classifier returned an incomplete display contract")
+
+
+class TestGeneratedImportJobDisplay(unittest.TestCase):
+    @given(
+        status=st.sampled_from(["queued", "running"]),
+        preview_status=st.one_of(
+            st.none(), st.sampled_from(sorted(IMPORT_JOB_PREVIEW_STATUSES)),
+        ),
+        queue_position=st.integers(min_value=0, max_value=49),
+        text=st.text(min_size=1, max_size=40),
+    )
+    @example(
+        status="running",
+        preview_status="measurement_failed",
+        queue_position=49,
+        text="importer owns this job",
+    )
+    def test_every_active_lifecycle_world_has_one_complete_display_contract(
+        self,
+        status: str,
+        preview_status: str | None,
+        queue_position: int,
+        text: str,
+    ) -> None:
+        display = classify_import_job_display(
+            _job(status, preview_status, text),
+            queue_position=queue_position,
+        )
+        assert_import_job_display_contract(display)
+        if status == "running":
+            self.assertEqual(display.badge, "Importing")
+            self.assertEqual(display.summary, text)
+
+    def test_contract_checker_rejects_the_old_tuple_shape(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "ImportJobDisplay"):
+            assert_import_job_display_contract(
+                ("next check", "badge-new", "#1a4a2a"),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_js_pipeline.mjs
+++ b/tests/test_js_pipeline.mjs
@@ -1,5 +1,5 @@
 /**
- * Unit tests for web/js/pipeline.js queue/nav/search helpers.
+ * Unit tests for web/js/pipeline.js navigation/detail helpers.
  * Run with: node tests/test_js_pipeline.mjs
  */
 
@@ -27,15 +27,15 @@ function assertExcludes(haystack, needle, msg) {
   }
 }
 
-console.log('renderPipelineNav() refreshes the queue subtab');
+console.log('renderPipelineNav() has operational views only');
 {
-  state.pipelineView = 'queue';
+  state.pipelineView = 'dashboard';
   const html = __test__.renderPipelineNav();
-  assertContains(html, 'window.setPipelineView(\'queue\')', 'queue tab rendered');
+  assertExcludes(html, 'window.setPipelineView(\'queue\')', 'request queue tab removed');
   assertContains(html, 'window.setPipelineView(\'dashboard\')', 'dashboard tab rendered');
-  assertContains(html, 'window.loadPipeline()', 'queue refresh reloads pipeline queue');
+  assertContains(html, 'window.setPipelineView(\'long-tail\')', 'long-tail tab rendered');
+  assertContains(html, 'window.loadPipelineDashboard()', 'dashboard refresh reloads metrics');
   assertContains(html, 'subtab-refresh', 'refresh uses shared subtab layout');
-  assertExcludes(html, 'window.loadPipelineDashboard()">Refresh', 'queue refresh does not load dashboard');
 }
 console.log('renderPipelineNav() refreshes the dashboard subtab');
 {
@@ -44,57 +44,31 @@ console.log('renderPipelineNav() refreshes the dashboard subtab');
   assertContains(html, 'window.loadPipelineDashboard()', 'dashboard refresh reloads dashboard metrics');
   assertContains(html, 'subtab-refresh', 'refresh uses shared subtab layout');
 }
-console.log('renderPipelineListBody() flags the imported recency window');
+console.log('request detail caps history and collapses tracks');
 {
-  state.pipelineFilter = 'imported';
-  state.pipelineSearchResults = null;
-  state.pipelineData = {
-    counts: { imported: 6828 },
-    imported: [],
-    imported_total: 6828,
-    imported_truncated: true,
-  };
-  const html = __test__.renderPipelineListBody();
-  assertContains(html, 'most recent of 6828 imported',
-    'truncation note names the full imported count');
-  assertContains(html, 'search above', 'note points at the search box');
+  const history = Array.from({ length: 12 }, (_, id) => ({
+    id, created_at: '2026-07-13T00:00:00+00:00',
+  }));
+  const tracks = Array.from({ length: 18 }, (_, id) => ({ id, title: `Track ${id}` }));
+  const html = __test__.renderRequestEvidenceSections(history, tracks, []);
+  assertContains(html, 'Download History (12)', 'full history count remains visible');
+  assertContains(html, 'Show 2 older attempts', 'only older attempts move behind disclosure');
+  assertContains(html, '<details class="p-tracks"', 'library tracks are collapsed by default');
+  assertContains(html, 'In Library (18 tracks)', 'track disclosure keeps its count');
 }
-console.log('renderPipelineListBody() renders server search results across statuses');
-{
-  state.pipelineFilter = 'wanted';
-  state.pipelineData = { counts: {}, wanted: [], imported: [] };
-  state.pipelineSearchResults = [
-    {
-      id: 7, artist_name: 'The Mountain Goats', album_title: 'Tallahassee',
-      status: 'imported', source: 'request', year: 2002,
-      created_at: '2026-06-01T00:00:00+00:00',
-      updated_at: '2026-06-02T00:00:00+00:00',
-      mb_release_id: 'mbid-7', mb_release_group_id: 'rg-7',
-    },
-  ];
-  const html = __test__.renderPipelineListBody();
-  assertContains(html, 'The Mountain Goats', 'search result row rendered');
-  assertExcludes(html, 'most recent of', 'no truncation note while searching');
 
-  state.pipelineSearchResults = [];
-  const emptyHtml = __test__.renderPipelineListBody();
-  assertContains(emptyHtml, 'No matches', 'empty search shows No matches');
-  state.pipelineSearchResults = null;
-}
-console.log('clearPipelineSearch() makes filters and search mutually exclusive');
-{
-  state.pipelineFilter = 'imported';
-  state.pipelineSearchQuery = 'mountain';
-  state.pipelineSearchResults = [{ id: 1 }];
-  __test__.clearPipelineSearch();
-  if (state.pipelineSearchQuery === '' && state.pipelineSearchResults === null) {
-    passed++;
+console.log('request detail disclosure — generated count sweep');
+for (let count = 0; count <= 30; count++) {
+  const history = Array.from({ length: count }, (_, id) => ({
+    id, created_at: '2026-07-13T00:00:00+00:00',
+  }));
+  const html = __test__.renderRequestEvidenceSections(history, [], []);
+  const expectedOlder = Math.max(0, count - 10);
+  if (expectedOlder === 0) {
+    assertExcludes(html, 'older attempt', `${count} histories need no older disclosure`);
   } else {
-    failed++;
-    console.error('  FAIL: clearPipelineSearch did not reset search state');
+    assertContains(html, `Show ${expectedOlder} older attempt`, `${count} histories expose exact remainder`);
   }
-  const html = __test__.renderPipelineListBody();
-  assertExcludes(html, 'No matches', 'list body is back in filter mode after clear');
 }
 
 console.log('request 6039 current Quality uses average positive track bitrate');

--- a/tests/test_js_recents.mjs
+++ b/tests/test_js_recents.mjs
@@ -1,5 +1,5 @@
 /**
- * Unit tests for web/js/recents.js queue rendering helpers.
+ * Unit tests for web/js/recents.js activity rendering helpers.
  * Run with: node tests/test_js_recents.mjs
  */
 
@@ -29,13 +29,17 @@ function assertExcludes(haystack, needle, msg) {
   }
 }
 
-console.log('renderImportQueueItems() shows ready next row and preview detail');
+console.log('renderImportItems() consumes the server-classified display contract');
 {
-  const html = __test__.renderImportQueueItems([{
+  const html = __test__.renderImportItems([{
     id: 77,
     job_type: 'force_import',
     status: 'queued',
     preview_status: 'evidence_ready',
+    badge: 'Next check',
+    badge_class: 'badge-new',
+    border_color: '#1a4a2a',
+    summary: 'Evidence ready for final check: import',
     artist_name: 'Broadcast',
     album_title: 'Tender Buttons',
     preview_message: 'Evidence ready for final check: import',
@@ -43,7 +47,7 @@ console.log('renderImportQueueItems() shows ready next row and preview detail');
   }]);
   assertContains(html, 'Tender Buttons', 'album title rendered');
   assertContains(html, 'Broadcast', 'artist name rendered');
-  assertContains(html, 'next check', 'first ready row is marked next check');
+  assertContains(html, 'Next check', 'server badge is rendered verbatim');
   assertContains(html, 'preview: evidence_ready', 'preview state rendered');
   assertContains(html, 'stage2_import:import', 'stage chain rendered');
 }
@@ -54,7 +58,8 @@ console.log('renderRecentsSubnav() refreshes the active recents subtab');
   const html = __test__.renderRecentsSubnav();
   assertContains(html, 'window.setRecentsSub(\'history\')', 'history tab rendered');
   assertContains(html, 'window.setRecentsSub(\'downloading\')', 'downloading tab rendered');
-  assertContains(html, 'window.setRecentsSub(\'queue\')', 'queue tab rendered');
+  assertContains(html, 'window.setRecentsSub(\'imports\')', 'imports tab rendered');
+  assertContains(html, '>Imports<', 'ambiguous Queue label is gone');
   assertContains(html, 'window.loadRecents()', 'refresh reloads current recents subtab');
   assertContains(html, 'subtab-refresh', 'refresh uses shared subtab layout');
 }
@@ -139,13 +144,17 @@ console.log('matchRatesFromDashboardWindows() derives found enqueue rates from o
   }
 }
 
-console.log('renderImportQueueItems() shows uncertain preview failures without next styling');
+console.log('renderImportItems() shows server-classified uncertain preview failures');
 {
-  const html = __test__.renderImportQueueItems([{
+  const html = __test__.renderImportItems([{
     id: 78,
     job_type: 'manual_import',
     status: 'failed',
     preview_status: 'uncertain',
+    badge: 'Uncertain',
+    badge_class: 'badge-warn',
+    border_color: '#a93',
+    summary: 'Preview failed: path_missing',
     artist_name: 'Low',
     album_title: 'Things We Lost in the Fire',
     preview_message: 'Preview failed: path_missing',
@@ -155,17 +164,21 @@ console.log('renderImportQueueItems() shows uncertain preview failures without n
   assertExcludes(html, 'next check', 'uncertain rows are not marked next');
 }
 
-console.log('renderImportQueueItems() renders measurement_failed badge and red border');
+console.log('renderImportItems() renders server-classified measurement failure');
 {
   // Post-U5: preview emits preview_status='measurement_failed' instead of
   // 'uncertain'. The badge must be present (no blank pill) and the border
   // must be the same red as 'confident_reject' so operators see the failure
   // at a glance.
-  const html = __test__.renderImportQueueItems([{
+  const html = __test__.renderImportItems([{
     id: 79,
     job_type: 'force_import',
     status: 'failed',
     preview_status: 'measurement_failed',
+    badge: 'Measurement failed',
+    badge_class: 'badge-failed',
+    border_color: '#a33',
+    summary: 'Preview measurement failed: snapshot_stale',
     artist_name: 'Slowdive',
     album_title: 'Souvlaki',
     preview_message: 'Preview measurement failed: snapshot_stale',
@@ -177,13 +190,17 @@ console.log('renderImportQueueItems() renders measurement_failed badge and red b
   assertExcludes(html, 'next check', 'measurement_failed rows are not marked next');
 }
 
-console.log('renderImportQueueItems() prefers terminal import messages over stale preview messages');
+console.log('renderImportItems() trusts the server summary over stale raw messages');
 {
-  const html = __test__.renderImportQueueItems([{
+  const html = __test__.renderImportItems([{
     id: 731,
     job_type: 'automation_import',
     status: 'failed',
     preview_status: 'would_import',
+    badge: 'Importing',
+    badge_class: 'badge-force',
+    border_color: '#36c',
+    summary: 'Rejected: high_distance - distance=0.1611',
     artist_name: 'Muse',
     album_title: 'Origin Of Symmetry',
     preview_message: 'Preview gate disabled',
@@ -195,13 +212,17 @@ console.log('renderImportQueueItems() prefers terminal import messages over stal
     'stale preview message hidden for terminal rows');
 }
 
-console.log('renderImportQueueItems() surfaces failed force-import source cleanup');
+console.log('renderImportItems() surfaces failed force-import source cleanup');
 {
-  const html = __test__.renderImportQueueItems([{
+  const html = __test__.renderImportItems([{
     id: 40636,
     job_type: 'force_import',
     status: 'failed',
     preview_status: 'evidence_ready',
+    badge: 'Next check',
+    badge_class: 'badge-new',
+    border_color: '#1a4a2a',
+    summary: '',
     artist_name: 'Parts & Labor',
     album_title: 'Escapers Two',
     message: 'Rejected by persisted quality evidence: downgrade',

--- a/tests/test_js_search_plan.mjs
+++ b/tests/test_js_search_plan.mjs
@@ -159,11 +159,11 @@ console.log('captureOriginContext() / restoreOriginContext()');
 }
 
 {
-  const captured = captureOriginContext({ tab: 'pipeline', scrollY: 0, subView: 'queue' });
+  const captured = captureOriginContext({ tab: 'pipeline', scrollY: 0, subView: 'long-tail' });
   const restored = restoreOriginContext(captured);
   assertEqual(restored.tab, 'pipeline', 'pipeline tab round-trips');
   assertEqual(restored.scrollY, 0, 'scrollY=0 round-trips');
-  assertEqual(restored.subView, 'queue', 'pipeline queue subView round-trips');
+  assertEqual(restored.subView, 'long-tail', 'pipeline long-tail subView round-trips');
 }
 
 {
@@ -870,18 +870,18 @@ function withFakeWindow(impl) {
 }
 
 {
-  // Origin tab is pipeline+queue: pipelineView restored to queue.
+  // Origin tab is pipeline+long-tail: pipelineView restored to long-tail.
   withFakeWindow((win, calls) => {
     state.searchPlanDetailContext = {
       requestId: 100,
       originTab: 'pipeline',
       originScrollY: 64,
-      originSubView: 'queue',
+      originSubView: 'long-tail',
     };
     state.pipelineView = 'search-plan-detail';
     closeSearchPlanDetail();
-    assertEqual(state.pipelineView, 'queue',
-      'pipeline-origin: pipelineView restored to queue');
+    assertEqual(state.pipelineView, 'long-tail',
+      'pipeline-origin: pipelineView restored to long-tail');
     assert(calls.showTab.length === 1 && calls.showTab[0] === 'pipeline',
       'pipeline-origin: showTab("pipeline") called');
     assert(calls.scrollTo.length === 1 && calls.scrollTo[0] === 64,
@@ -924,7 +924,25 @@ function withFakeWindow(impl) {
 }
 
 {
-  // No origin context: fallback to pipeline/queue, no throw.
+  // PR5 renamed the importer subview to Imports; Back must restore it.
+  withFakeWindow((win, calls) => {
+    state.searchPlanDetailContext = {
+      requestId: 101,
+      originTab: 'recents',
+      originScrollY: 0,
+      originSubView: 'imports',
+    };
+    state.recentsSub = 'history';
+    closeSearchPlanDetail();
+    assertEqual(state.recentsSub, 'imports',
+      'recents-origin: Imports subview restored');
+    assert(calls.showTab[0] === 'recents',
+      'imports-origin: showTab("recents") called');
+  });
+}
+
+{
+  // No origin context: fallback to pipeline/dashboard, no throw.
   withFakeWindow((win, calls) => {
     state.searchPlanDetailContext = null;
     state.pipelineView = 'search-plan-detail';
@@ -935,8 +953,8 @@ function withFakeWindow(impl) {
       threw = true;
     }
     assert(!threw, 'no-origin: close does not throw');
-    assertEqual(state.pipelineView, 'queue',
-      'no-origin: fallback to pipelineView=queue');
+    assertEqual(state.pipelineView, 'dashboard',
+      'no-origin: fallback to pipelineView=dashboard');
     assert(calls.showTab.length === 1 && calls.showTab[0] === 'pipeline',
       'no-origin: fallback shows the pipeline tab');
   });
@@ -1919,8 +1937,8 @@ console.log('F12: tab-switch clears detail context');
     };
     // Switch to a different tab.
     showTab('browse');
-    assertEqual(state.pipelineView, 'queue',
-      'F12: switching away from pipeline resets pipelineView from search-plan-detail to queue');
+    assertEqual(state.pipelineView, 'dashboard',
+      'F12: switching away resets search-plan-detail to dashboard');
     assert(state.searchPlanDetailContext === null,
       'F12: detail context cleared when leaving search-plan-detail');
     // Now re-set and switch INTO pipeline directly — should also reset.
@@ -1930,8 +1948,8 @@ console.log('F12: tab-switch clears detail context');
       originScrollY: 0, originSubView: null,
     };
     showTab('pipeline');
-    assertEqual(state.pipelineView, 'queue',
-      'F12: switching into pipeline tab resets stuck search-plan-detail state to queue');
+    assertEqual(state.pipelineView, 'dashboard',
+      'F12: switching into pipeline resets stuck detail state to dashboard');
     assert(state.searchPlanDetailContext === null,
       'F12: switching into pipeline tab clears stale detail context');
     // Verify the openSearchPlanDetail flow does NOT trip the reset:

--- a/tests/test_web_recents.py
+++ b/tests/test_web_recents.py
@@ -567,10 +567,11 @@ class TestClassifyBadge(unittest.TestCase):
         ))
         self.assertEqual(result.badge, "Rejected")
         self.assertEqual(result.badge_class, "badge-rejected")
-        self.assertIn("source V0 avg 175kbps", result.verdict)
-        self.assertIn("existing source V0 avg 171kbps", result.verdict)
-        self.assertIn("not meaningfully better", result.verdict)
-        self.assertIn("searching continues", result.verdict)
+        self.assertEqual(
+            result.verdict,
+            "Suspect lossless source not better than on-disk copy; "
+            "searching continues",
+        )
 
     def test_rejected_lossless_source_locked(self):
         # Lossy candidate offered against an existing album whose original
@@ -591,11 +592,36 @@ class TestClassifyBadge(unittest.TestCase):
         ))
         self.assertEqual(result.badge, "Rejected")
         self.assertEqual(result.badge_class, "badge-rejected")
-        self.assertIn("Lossless-source locked", result.verdict)
-        self.assertIn("240", result.verdict)
-        self.assertIn(
-            "only another lossless source can override", result.verdict)
-        self.assertIn("searching continues", result.verdict)
+        self.assertEqual(
+            result.verdict,
+            "Lossless-source locked; only another lossless source can "
+            "override; searching continues",
+        )
+
+    def test_reject_verdicts_use_one_short_grammar_per_decision_class(self):
+        cases = {
+            "quality_downgrade": (
+                "Quality not better than on-disk copy; searching continues"
+            ),
+            "transcode_downgrade": (
+                "Transcode not better than on-disk copy; searching continues"
+            ),
+            "spectral_reject": (
+                "Spectral quality not better than on-disk copy; "
+                "searching continues"
+            ),
+        }
+        for scenario, expected in cases.items():
+            with self.subTest(scenario=scenario):
+                result = classify_log_entry(_entry(
+                    outcome="rejected",
+                    beets_scenario=scenario,
+                    actual_min_bitrate=176,
+                    existing_min_bitrate=240,
+                    spectral_bitrate=128,
+                    existing_spectral_bitrate=192,
+                ))
+                self.assertEqual(result.verdict, expected)
 
     def test_rejected_high_distance(self):
         result = classify_log_entry(_entry(
@@ -753,8 +779,10 @@ class TestClassifyVerdict(unittest.TestCase):
         result = classify_log_entry(_entry(
             outcome="rejected", beets_scenario="quality_downgrade",
             actual_min_bitrate=320, existing_min_bitrate=320))
-        self.assertIn("320", result.verdict)
-        self.assertIn("not", result.verdict.lower())
+        self.assertEqual(
+            result.verdict,
+            "Quality not better than on-disk copy; searching continues",
+        )
 
     def test_persisted_quality_downgrade_verdict_uses_import_result(self):
         """A successful validation headline cannot hide a later downgrade.
@@ -783,17 +811,22 @@ class TestClassifyVerdict(unittest.TestCase):
                 },
             },
         ))
-        self.assertNotEqual(result.verdict, "downgrade")
-        self.assertIn("159", result.verdict)
-        self.assertIn("192", result.verdict)
+        self.assertEqual(
+            result.verdict,
+            "Quality not better than on-disk copy; searching continues",
+        )
         self.assertIn("CondosInQueens", result.summary)
 
     def test_spectral_reject_verdict(self):
         result = classify_log_entry(_entry(
             outcome="rejected", beets_scenario="spectral_reject",
             spectral_bitrate=160, existing_spectral_bitrate=192))
-        self.assertIn("160", result.verdict)
-        self.assertIn("192", result.verdict)
+        self.assertEqual(
+            result.verdict,
+            "Spectral quality not better than on-disk copy; searching continues",
+        )
+        self.assertEqual(result.spectral_bitrate, 160)
+        self.assertEqual(result.existing_spectral_bitrate, 192)
 
     def test_spectral_reject_verdict_falls_back_to_min_bitrate(self):
         """When existing_spectral_bitrate is 0/None (genuine files have no cliff),
@@ -802,16 +835,19 @@ class TestClassifyVerdict(unittest.TestCase):
             outcome="rejected", beets_scenario="spectral_reject",
             spectral_bitrate=192, existing_spectral_bitrate=0,
             existing_min_bitrate=226))
-        self.assertIn("192", result.verdict)
-        self.assertIn("226", result.verdict)
-        self.assertNotIn("unknown", result.verdict)
+        self.assertEqual(
+            result.verdict,
+            "Spectral quality not better than on-disk copy; searching continues",
+        )
 
     def test_transcode_downgrade_verdict(self):
         result = classify_log_entry(_entry(
             outcome="rejected", beets_scenario="transcode_downgrade",
             actual_min_bitrate=197, existing_min_bitrate=320))
-        self.assertIn("197", result.verdict)
-        self.assertIn("transcode", result.verdict.lower())
+        self.assertEqual(
+            result.verdict,
+            "Transcode not better than on-disk copy; searching continues",
+        )
 
     def test_high_distance_verdict(self):
         result = classify_log_entry(_entry(
@@ -981,7 +1017,7 @@ class TestClassifySummary(unittest.TestCase):
             spectral_bitrate=160, existing_spectral_bitrate=192,
             soulseek_username="fakeflac"))
         self.assertIn("fakeflac", result.summary)
-        self.assertIn("160", result.summary)
+        self.assertIn("Spectral quality not better", result.summary)
 
     def test_summary_no_html(self):
         result = classify_log_entry(_entry(
@@ -1081,8 +1117,10 @@ class TestExceptionVerdicts(unittest.TestCase):
                 "existing_measurement": {"min_bitrate_kbps": 320},
             },
         ))
-        self.assertIn("239", result.verdict)
-        self.assertIn("320", result.verdict)
+        self.assertEqual(
+            result.verdict,
+            "Quality not better than on-disk copy; searching continues",
+        )
 
     def test_failed_falls_back_to_import_result_error(self):
         """ImportResult error text is surfaced when error_message is blank."""
@@ -1300,12 +1338,11 @@ class TestVerdictSpectralFallback(unittest.TestCase):
                 },
             },
         ))
-        # Avg is the container measurement.
-        self.assertIn("187", result.verdict)
-        self.assertIn("avg", result.verdict)
-        # Spectral is the estimated source-quality floor.
-        self.assertIn("96", result.verdict)
-        self.assertIn("spectral", result.verdict.lower())
+        self.assertEqual(
+            result.verdict,
+            "Quality not better than on-disk copy; searching continues",
+        )
+        self.assertEqual(result.spectral_bitrate, 96)
 
     def test_quality_downgrade_without_import_result_uses_container_bitrate(self):
         """When there's no import_result at all, fall back to bitrate field
@@ -1320,9 +1357,12 @@ class TestVerdictSpectralFallback(unittest.TestCase):
             bitrate=128000,
             import_result=None,
         ))
-        self.assertIn("128", result.verdict)
-        self.assertIn("96", result.verdict)
-        self.assertIn("spectral", result.verdict.lower())
+        self.assertEqual(
+            result.verdict,
+            "Quality not better than on-disk copy; searching continues",
+        )
+        self.assertEqual(result.downloaded_label, "MP3 128k")
+        self.assertEqual(result.spectral_bitrate, 96)
 
     def test_transcode_downgrade_uses_real_bitrate_not_spectral(self):
         """Same spectral fallback bug in transcode_downgrade scenario."""
@@ -1342,8 +1382,10 @@ class TestVerdictSpectralFallback(unittest.TestCase):
                 "existing_measurement": {"min_bitrate_kbps": 240},
             },
         ))
-        self.assertIn("192", result.verdict)
-        self.assertNotIn("96", result.verdict)
+        self.assertEqual(
+            result.verdict,
+            "Transcode not better than on-disk copy; searching continues",
+        )
 
     def test_vbr_downgrade_verdict_uses_avg_not_min(self):
         """Unter Null - The Failure Epiphany (req 1749) VBR-downgrade rendering.
@@ -1397,21 +1439,10 @@ class TestVerdictSpectralFallback(unittest.TestCase):
                 },
             },
         ))
-        # Verdict must show the real avg numbers that drove the decision.
-        self.assertIn("152", result.verdict,
-                      "verdict must cite new avg (152)")
-        self.assertIn("225", result.verdict,
-                      "verdict must cite existing avg (225), "
-                      "not the clamped min — otherwise '152 > 96 but "
-                      "rejected' reads as a contradiction")
-        self.assertIn("spectral", result.verdict.lower())
-        self.assertIn("96", result.verdict)
-        # And MUST NOT say "152 is not better than existing 96" — the old
-        # one-sided min-based comparison.
-        self.assertNotRegex(
+        self.assertEqual(
             result.verdict,
-            r"152kbps avg\s+is not better than existing 96",
-            "verdict must not emit the misleading min-based comparison")
+            "Quality not better than on-disk copy; searching continues",
+        )
 
     def test_quality_downgrade_shows_spectral_on_both_sides(self):
         """Ambient One live shape: raw avg rises, but spectral regresses.
@@ -1457,10 +1488,12 @@ class TestVerdictSpectralFallback(unittest.TestCase):
             },
         ))
 
-        self.assertIn("222kbps avg", result.verdict)
-        self.assertIn("spectral likely_transcode ~128kbps", result.verdict)
-        self.assertIn("existing 192kbps avg", result.verdict)
-        self.assertIn("spectral likely_transcode ~192kbps", result.verdict)
+        self.assertEqual(
+            result.verdict,
+            "Quality not better than on-disk copy; searching continues",
+        )
+        self.assertEqual(result.spectral_bitrate, 128)
+        self.assertEqual(result.existing_spectral_bitrate, 192)
 
     def test_transcode_classify_uses_real_bitrate_not_spectral(self):
         """_classify_transcode has the same or-chain bug for success transcodes."""
@@ -1497,8 +1530,7 @@ class TestVerdictSpectralFallback(unittest.TestCase):
                 "existing_measurement": {"min_bitrate_kbps": 128},
             },
         ))
-        self.assertIn("128", result.summary)
-        self.assertNotIn("96", result.summary)
+        self.assertIn("Quality not better than on-disk copy", result.summary)
         self.assertIn("nexus15", result.summary)
 
 
@@ -1869,7 +1901,7 @@ class TestClassifyComparisonBasis(unittest.TestCase):
             c.verdict,
             "Upgrade: MP3 avg 196k (good) → AAC avg 192k (transparent)")
 
-    def test_downgrade_verdict_renders_ranks(self):
+    def test_downgrade_verdict_keeps_basis_in_evidence_contract(self):
         basis = self._basis_dict(self._SAY_HELLO_EXISTING, self._SAY_HELLO_NEW)
         entry = _entry(
             outcome="rejected",
@@ -1882,10 +1914,10 @@ class TestClassifyComparisonBasis(unittest.TestCase):
         c = classify_log_entry(entry)
         self.assertEqual(
             c.verdict,
-            "MP3 avg 196k (good) — not better than existing "
-            "avg 288k (transparent)")
+            "Quality not better than on-disk copy; searching continues")
+        self.assertEqual(c.comparison_basis, basis)
 
-    def test_equivalent_tiebreak_reject_shows_tolerance(self):
+    def test_equivalent_tiebreak_reject_keeps_tolerance_in_basis(self):
         basis = self._basis_dict(
             dict(avg_bitrate_kbps=250, format="MP3"),
             dict(avg_bitrate_kbps=248, format="MP3"),
@@ -1901,7 +1933,10 @@ class TestClassifyComparisonBasis(unittest.TestCase):
         c = classify_log_entry(entry)
         self.assertEqual(
             c.verdict,
-            "Equivalent: MP3 avg 250k vs avg 248k (within 5k)")
+            "Quality not better than on-disk copy; searching continues")
+        self.assertIsNotNone(c.comparison_basis)
+        assert c.comparison_basis is not None
+        self.assertEqual(c.comparison_basis["tolerance_kbps"], 5)
 
     def test_verified_lossless_bypass_names_the_bypass(self):
         basis = self._bypass_basis_dict(

--- a/tests/test_web_recents_generated.py
+++ b/tests/test_web_recents_generated.py
@@ -1,0 +1,68 @@
+"""Generated copy-policy checks for Recents rejection verdicts."""
+
+from __future__ import annotations
+
+import unittest
+
+from hypothesis import example, given, strategies as st
+
+import tests._hypothesis_profiles  # noqa: F401
+from tests.test_web_recents import _entry
+from web.classify import classify_log_entry
+
+
+REJECT_SCENARIOS = (
+    "quality_downgrade",
+    "transcode_downgrade",
+    "spectral_reject",
+    "lossless_source_locked",
+    "suspect_lossless_downgrade",
+)
+
+
+def assert_short_searching_verdict(verdict: str) -> None:
+    if "searching continues" not in verdict.lower():
+        raise AssertionError("perpetual-search rejection lost its searching marker")
+    if any(char.isdigit() for char in verdict):
+        raise AssertionError("measurement leaked into short verdict grammar")
+
+
+class TestGeneratedRejectVerdictGrammar(unittest.TestCase):
+    @given(
+        scenario=st.sampled_from(REJECT_SCENARIOS),
+        incoming=st.integers(min_value=1, max_value=2_000),
+        existing=st.integers(min_value=1, max_value=2_000),
+    )
+    @example(
+        scenario="lossless_source_locked",
+        incoming=176,
+        existing=240,
+    )
+    def test_measurements_never_change_the_short_decision_class_copy(
+        self,
+        scenario: str,
+        incoming: int,
+        existing: int,
+    ) -> None:
+        result = classify_log_entry(_entry(
+            outcome="rejected",
+            beets_scenario=scenario,
+            actual_min_bitrate=incoming,
+            existing_min_bitrate=existing,
+            spectral_bitrate=incoming,
+            existing_spectral_bitrate=existing,
+            spectral_grade="suspect",
+            v0_probe_avg_bitrate=incoming,
+            existing_v0_probe_avg_bitrate=existing,
+        ))
+        assert_short_searching_verdict(result.verdict)
+
+    def test_checker_rejects_the_old_measurement_heavy_grammar(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "measurement leaked"):
+            assert_short_searching_verdict(
+                "176kbps is not better than existing 240kbps; searching continues",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/web/test_routes_pipeline.py
+++ b/tests/web/test_routes_pipeline.py
@@ -678,6 +678,13 @@ class TestPipelineRouteContracts(_FakeDbWebServerCase):
                                 "import jobs timeline item")
         _assert_required_fields(self, data["jobs"][0], {"artist_name", "album_title"},
                                 "import jobs timeline identity")
+        _assert_required_fields(
+            self,
+            data["jobs"][0],
+            {"badge", "badge_class", "border_color", "summary"},
+            "server-classified import job display",
+        )
+        self.assertEqual(data["jobs"][0]["badge"], "Waiting preview")
         # The identity join resolved through the seeded request row.
         self.assertEqual(data["jobs"][0]["artist_name"],
                          self.db.request(100)["artist_name"])

--- a/web/classify.py
+++ b/web/classify.py
@@ -12,8 +12,8 @@ from typing import Any, Optional
 
 import msgspec
 
-from lib.quality import (AudioQualityMeasurement, ImportResult,
-                         QualityComparisonBasis, dispatch_action)
+from lib.import_queue import ImportJob
+from lib.quality import ImportResult, QualityComparisonBasis, dispatch_action
 from lib.validation_envelope import decode_validation_envelope
 
 # ---------------------------------------------------------------------------
@@ -151,6 +151,15 @@ class ClassifiedEntry(msgspec.Struct):
     existing_spectral_error: str | None = None
 
 
+class ImportJobDisplay(msgspec.Struct, frozen=True):
+    """Server-owned display contract for one active importer job."""
+
+    badge: str
+    badge_class: str
+    border_color: str
+    summary: str
+
+
 class _Classification(msgspec.Struct, frozen=True):
     """Typed core outcome used to finish a ``ClassifiedEntry``."""
 
@@ -158,6 +167,67 @@ class _Classification(msgspec.Struct, frozen=True):
     badge_class: str
     border_color: str
     verdict: str
+
+
+def classify_import_job_display(
+    job: ImportJob,
+    *,
+    queue_position: int,
+) -> ImportJobDisplay:
+    """Classify importer work without duplicating lifecycle copy in JS."""
+    if job.status not in ("queued", "running"):
+        raise ValueError(
+            f"timeline display requires an active import job, got {job.status!r}"
+        )
+    if queue_position < 0:
+        raise ValueError("queue_position must be non-negative")
+    if job.status == "running":
+        return ImportJobDisplay(
+            badge="Importing",
+            badge_class="badge-force",
+            border_color="#36c",
+            summary=(
+                job.message or job.error or job.preview_message
+                or job.preview_error or ""
+            ),
+        )
+
+    preview = job.preview_status
+    if preview == "evidence_ready":
+        badge = "Next check" if queue_position == 0 else "Ready check"
+        badge_class, border_color = "badge-new", "#1a4a2a"
+    elif preview == "would_import":
+        badge = "Next legacy check" if queue_position == 0 else "Legacy ready"
+        badge_class, border_color = "badge-new", "#1a4a2a"
+    elif preview == "running":
+        badge, badge_class, border_color = "Previewing", "badge-warn", "#a93"
+    elif preview == "waiting":
+        badge, badge_class, border_color = (
+            "Waiting preview", "badge-library", "#1a3a5a")
+    elif preview == "confident_reject":
+        badge, badge_class, border_color = (
+            "Preview reject", "badge-failed", "#a33")
+    elif preview == "measurement_failed":
+        badge, badge_class, border_color = (
+            "Measurement failed", "badge-failed", "#a33")
+    elif preview == "uncertain":
+        badge, badge_class, border_color = "Uncertain", "badge-warn", "#a93"
+    elif preview == "error":
+        badge, badge_class, border_color = (
+            "Preview error", "badge-failed", "#a33")
+    else:
+        badge, badge_class, border_color = (
+            "Queued", "badge-library", "#1a3a5a")
+
+    return ImportJobDisplay(
+        badge=badge,
+        badge_class=badge_class,
+        border_color=border_color,
+        summary=(
+            job.preview_message or job.message or job.preview_error
+            or job.error or ""
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -745,106 +815,6 @@ def _downloaded_min_bitrate_kbps(entry: LogEntry) -> int | None:
     return None
 
 
-def _comparison_verdict(
-    new_kbps: int | None,
-    old_kbps: int | None,
-    prefix: str = "",
-    metric: str | None = None,
-    new_spectral_kbps: int | None = None,
-    old_spectral_kbps: int | None = None,
-    new_spectral_grade: str | None = None,
-    old_spectral_grade: str | None = None,
-) -> str:
-    """Build a '… is not better than existing …' verdict string.
-
-    ``metric`` ("avg" / "min") annotates the bitrates so the reader can see
-    which number drove the rank comparison. This matters when the backend's
-    spectral override clamped ``min`` but kept ``avg`` on a VBR existing —
-    without the label, a verdict like "152 is not better than 96" reads as
-    a contradiction (it's really "avg 152 is not better than avg 225" but
-    min was shown and looked inverted). Pass ``None`` to omit the label when
-    both sides come from the same raw min.
-    """
-    new_s = _measurement_phrase(
-        new_kbps,
-        metric,
-        spectral_kbps=new_spectral_kbps,
-        spectral_grade=new_spectral_grade,
-    )
-    old_s = _measurement_phrase(
-        old_kbps,
-        metric,
-        spectral_kbps=old_spectral_kbps,
-        spectral_grade=old_spectral_grade,
-    )
-    if prefix:
-        return f"{prefix} {new_s} — not better than existing {old_s}"
-    return f"{new_s} is not better than existing {old_s}"
-
-
-def _measurement_spectral_phrase(
-    spectral_kbps: int | None,
-    spectral_grade: str | None,
-) -> str | None:
-    if spectral_kbps is None and not spectral_grade:
-        return None
-    if spectral_grade and spectral_kbps is not None:
-        return f"spectral {spectral_grade} ~{spectral_kbps}kbps"
-    if spectral_grade:
-        return f"spectral {spectral_grade}"
-    return f"spectral ~{spectral_kbps}kbps"
-
-
-def _measurement_phrase(
-    bitrate_kbps: int | None,
-    metric: str | None,
-    *,
-    spectral_kbps: int | None = None,
-    spectral_grade: str | None = None,
-) -> str:
-    suffix = f" {metric}" if metric else ""
-    primary = (
-        f"{bitrate_kbps}kbps{suffix}"
-        if bitrate_kbps is not None
-        else "unknown"
-    )
-    spectral = _measurement_spectral_phrase(spectral_kbps, spectral_grade)
-    if spectral:
-        return f"{primary} ({spectral})"
-    return primary
-
-
-def _verdict_bitrate(
-    m: AudioQualityMeasurement | None,
-) -> tuple[int | None, str | None]:
-    """Pick the bitrate and metric label to display for a measurement.
-
-    Prefers ``avg_bitrate_kbps`` when present (production's default
-    ``cfg.bitrate_metric=avg``) and falls back to ``min_bitrate_kbps``,
-    then ``spectral_bitrate_kbps`` as a last resort. Returns the value
-    plus a metric label ("avg" / "min" / None) so the caller can annotate
-    the verdict string.
-
-    Returning avg when it exists is important after the 2026-04-21
-    CBR-conditional override fix: for VBR existing, ``avg_bitrate_kbps``
-    carries the real signal that drove the rank comparison while
-    ``min_bitrate_kbps`` has been clamped by the spectral override.
-    Displaying min alone produced contradictory-looking verdicts
-    ("new 152 is not better than existing 96"). Spectral is rendered as
-    separate context by ``_comparison_verdict`` so the selected real bitrate
-    and source-quality estimate remain visible together.
-    """
-    if m is None:
-        return None, None
-    if m.avg_bitrate_kbps is not None:
-        return m.avg_bitrate_kbps, "avg"
-    if m.min_bitrate_kbps is not None:
-        return m.min_bitrate_kbps, "min"
-    if m.spectral_bitrate_kbps is not None:
-        return m.spectral_bitrate_kbps, None
-    return None, None
-
-
 def _quality_verdict_from_import_result(entry: LogEntry) -> str | None:
     """Derive a quality comparison verdict from ImportResult JSONB.
 
@@ -855,70 +825,21 @@ def _quality_verdict_from_import_result(entry: LogEntry) -> str | None:
     if ir is None:
         return None
 
-    # The persisted basis is the decision's own story — render it verbatim
-    # instead of re-deriving a comparison from the measurements (request
-    # 6039: re-derivation is how the display learned to lie).
-    if (ir.comparison_basis is not None
-            and ir.decision in ("downgrade", "transcode_downgrade")):
-        verdict = _verdict_from_basis(ir.comparison_basis)
-        if ir.decision == "transcode_downgrade":
-            return f"Transcode — {verdict}"
-        return verdict
-
-    new_m = ir.new_measurement
-    existing_m = ir.existing_measurement
-    new_kbps, new_metric = _verdict_bitrate(new_m)
-    old_kbps, old_metric = _verdict_bitrate(existing_m)
-    # Prefer the richer metric label when sides disagree ("avg" > "min")
-    # so the string doesn't read "new 152kbps avg vs existing 96kbps min".
-    # That split is rare — both sides come from the same ImportResult —
-    # but falling back to None keeps the verdict readable in the edge case.
-    metric = new_metric if new_metric == old_metric else None
-
+    # Rejected rows already carry the complete measured comparison in the
+    # fixed IN/HAVE/Spectral/V0 evidence schema. Keep verdict prose to one
+    # short decision-class grammar so the same rejection never reads like
+    # four different policies depending on which evidence path produced it.
     if ir.decision == "downgrade":
-        return _comparison_verdict(
-            new_kbps, old_kbps, metric=metric,
-            new_spectral_kbps=(
-                new_m.spectral_bitrate_kbps if new_m is not None else None
-            ),
-            old_spectral_kbps=(
-                existing_m.spectral_bitrate_kbps
-                if existing_m is not None else None
-            ),
-            new_spectral_grade=(
-                new_m.spectral_grade if new_m is not None else None
-            ),
-            old_spectral_grade=(
-                existing_m.spectral_grade if existing_m is not None else None
-            ),
-        )
-
+        return "Quality not better than on-disk copy; searching continues"
     if ir.decision == "transcode_downgrade":
-        return _comparison_verdict(
-            new_kbps, old_kbps, prefix="Transcode at", metric=metric,
-            new_spectral_kbps=(
-                new_m.spectral_bitrate_kbps if new_m is not None else None
-            ),
-            old_spectral_kbps=(
-                existing_m.spectral_bitrate_kbps
-                if existing_m is not None else None
-            ),
-            new_spectral_grade=(
-                new_m.spectral_grade if new_m is not None else None
-            ),
-            old_spectral_grade=(
-                existing_m.spectral_grade if existing_m is not None else None
-            ),
-        )
-
-    if ir.decision == "suspect_lossless_downgrade":
+        return "Transcode not better than on-disk copy; searching continues"
+    if ir.decision in (
+        "suspect_lossless_downgrade",
+        "suspect_lossless_probe_missing",
+    ):
         return _provisional_verdict(entry, imported=False)
-
-    if ir.decision == "suspect_lossless_probe_missing":
-        return _provisional_verdict(entry, imported=False)
-
     if ir.decision == "lossless_source_locked":
-        return _lossless_source_locked_verdict(entry)
+        return _lossless_source_locked_verdict()
 
     if ir.error:
         return f"Import error: {ir.error}"
@@ -968,33 +889,25 @@ def _spectral_phrase(entry: LogEntry) -> str | None:
     return phrase
 
 
-def _lossless_source_locked_verdict(entry: LogEntry) -> str:
+def _lossless_source_locked_verdict() -> str:
     """Verdict copy for the lossless-source lock rejection.
 
     Fires when a lossy candidate is offered against an existing album whose
-    original lossless-source V0 probe is already recorded. The candidate
-    cannot produce comparable evidence — only another lossless-container
-    source can override the recorded probe.
+    original lossless-source V0 probe is already recorded. Measurements stay
+    in the fixed evidence schema; this sentence names only the policy reason.
     """
-    _, existing_avg, _ = _probe_values(entry)
-    new_kbps = _downloaded_min_bitrate_kbps(entry)
-    parts: list[str] = []
-    if new_kbps is not None:
-        spectral = _spectral_phrase(entry)
-        new_phrase = f"{new_kbps}kbps lossy candidate"
-        if spectral:
-            new_phrase += f" ({spectral})"
-        parts.append(new_phrase)
-    if existing_avg is not None:
-        parts.append(
-            f"existing has lossless-source V0 probe {existing_avg}kbps"
-        )
-    parts.append("only another lossless source can override")
-    parts.append("searching continues")
-    return "Lossless-source locked: " + "; ".join(parts)
+    return (
+        "Lossless-source locked; only another lossless source can override; "
+        "searching continues"
+    )
 
 
 def _provisional_verdict(entry: LogEntry, *, imported: bool) -> str:
+    if not imported:
+        return (
+            "Suspect lossless source not better than on-disk copy; "
+            "searching continues"
+        )
     candidate_avg, existing_avg, final_format = _probe_values(entry)
     parts: list[str] = []
     spectral = _spectral_phrase(entry)
@@ -1006,15 +919,11 @@ def _provisional_verdict(entry: LogEntry, *, imported: bool) -> str:
         parts.append(f"existing source V0 avg {existing_avg}kbps")
     else:
         parts.append("no comparable source probe")
-    if imported:
-        if final_format:
-            parts.append(f"stored as {final_format}")
-        parts.append("source denylisted")
-        parts.append("searching continues")
-        return "Provisional lossless source: " + "; ".join(parts)
-    parts.append("not meaningfully better")
+    if final_format:
+        parts.append(f"stored as {final_format}")
+    parts.append("source denylisted")
     parts.append("searching continues")
-    return "Suspect lossless source rejected: " + "; ".join(parts)
+    return "Provisional lossless source: " + "; ".join(parts)
 
 
 def _classify_provisional(entry: LogEntry) -> _Classification:
@@ -1091,46 +1000,16 @@ def _rejection_verdict(entry: LogEntry) -> str:
         if scenario.startswith("suspect_lossless"):
             return _provisional_verdict(entry, imported=False)
         if scenario == "lossless_source_locked":
-            return _lossless_source_locked_verdict(entry)
-        # Fallback: use real file bitrate, not spectral
-        new_kbps = _downloaded_min_bitrate_kbps(entry)
-        old_kbps = entry.existing_min_bitrate or entry.existing_spectral_bitrate
+            return _lossless_source_locked_verdict()
         if scenario == "transcode_downgrade":
-            return _comparison_verdict(
-                new_kbps,
-                old_kbps,
-                prefix="Transcode at",
-                new_spectral_kbps=entry.spectral_bitrate,
-                old_spectral_kbps=entry.existing_spectral_bitrate,
-                new_spectral_grade=entry.spectral_grade,
-            )
-        return _comparison_verdict(
-            new_kbps,
-            old_kbps,
-            new_spectral_kbps=entry.spectral_bitrate,
-            old_spectral_kbps=entry.existing_spectral_bitrate,
-            new_spectral_grade=entry.spectral_grade,
-        )
+            return "Transcode not better than on-disk copy; searching continues"
+        return "Quality not better than on-disk copy; searching continues"
 
     if scenario == "spectral_reject":
-        # Spectral scenario — spectral_bitrate IS the right field here
-        old_kbps = entry.existing_spectral_bitrate or entry.existing_min_bitrate
-        # New preimport_decide path (post 2026-05-16 hotfix #254) writes the
-        # bitrate numbers into beets_detail (e.g. "spectral 128kbps <= existing
-        # 192kbps") but leaves the typed spectral_bitrate / existing_spectral_*
-        # columns NULL on the row, because _route_preimport_decision_reject's
-        # synthesized DownloadInfo doesn't carry spectral facts. When the
-        # typed columns are absent but beets_detail has a real string, render
-        # that directly — the importer already wrote a good human-readable
-        # reason.
-        if (
-            entry.spectral_bitrate is None
-            and old_kbps is None
-            and entry.beets_detail
-        ):
-            return f"Spectral: {entry.beets_detail}"
-        return _comparison_verdict(
-            entry.spectral_bitrate, old_kbps, prefix="Spectral:")
+        return (
+            "Spectral quality not better than on-disk copy; "
+            "searching continues"
+        )
 
     if scenario == "high_distance":
         dist = (f"{float(entry.beets_distance):.3f}"

--- a/web/index.html
+++ b/web/index.html
@@ -321,6 +321,15 @@
   .sp-advance-form-error { color: #d88; font-size: 0.78em; flex-basis: 100%; padding: 2px 0; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
   .p-tracks { margin-top: 8px; }
   .p-history { margin-top: 8px; }
+  .p-tracks > summary,
+  .p-history-older > summary { cursor: pointer; user-select: none; color: #889; }
+  .p-tracks > summary:hover,
+  .p-tracks[open] > summary,
+  .p-history-older > summary:hover,
+  .p-history-older[open] > summary { color: #ccd; }
+  .p-history-older { margin: 6px 0 0 8px; }
+  .p-history-older > summary { font-size: 0.8em; }
+  .p-tracks > .lib-track:first-of-type { margin-top: 4px; }
   .p-hist-item { font-size: 0.75em; color: #777; padding: 6px 0; border-bottom: 1px solid #222; }
   .p-hist-header { display: flex; gap: 8px; align-items: center; margin-bottom: 3px; }
   /* One label/value pair per row (issue #575): the previous 4-column

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -9,7 +9,7 @@ import { state } from './state.js';
 import { searchArtists, cancelBrowseSearch, setSearchType, setBrowseSource, openBrowseArtist, closeBrowseArtist, reloadBrowseArtist, invalidateBrowseArtist, closeVaFallback } from './browse.js';
 import { loadReleaseGroup, addRelease, toggleReleaseDetail } from './discography.js';
 import { loadRecents, setRecentsFilter, setRecentsSub, renderRecentsItems } from './recents.js';
-import { loadPipeline, loadPipelineDashboard, setPipelineView, setFilter, renderPipeline, toggleCoverageMatchGraph, toggleDetail, deleteRequest, updateStatus, togglePipelineReplacedFilter, onPipelineSearchInput } from './pipeline.js';
+import { loadPipeline, loadPipelineDashboard, setPipelineView, renderPipeline, toggleCoverageMatchGraph, toggleDetail, deleteRequest, updateStatus } from './pipeline.js';
 import { loadLongTail, setLongTailBand, onLongTailSearchInput } from './long_tail.js';
 import { toggleLongTailDetail, toggleLongTailPeers, checkYoutube, pickYoutubeRescue, longTailAcceptSibling, longTailSetIntent, longTailSetImported, longTailDeleteRequest } from './long_tail_console.js';
 import { toggleLibDetail, toggleReleaseLibDetail, banSource, setLibQuality, upgradeAlbum, setIntent, confirmDeleteBeets, executeBeetsDeletion } from './library.js';
@@ -45,8 +45,8 @@ async function openReplacePickerAndHandle(options) {
     // logic stays accurate).
     invalidateActiveRgs();
     // Best-effort refetch on whichever tab the operator is most likely
-    // on. Pipeline is the canonical viewer of an album_requests row;
-    // wrong-matches and browse re-fetch on their own next interaction.
+    // on. Pipeline's operational views and Wrong Matches may expose state
+    // affected by the replacement; Browse refreshes on its next interaction.
     const pipeSection = document.getElementById('pipeline-section');
     if (pipeSection && pipeSection.classList.contains('active')) {
       loadPipeline();
@@ -81,12 +81,12 @@ function showTab(name) {
   // F12: Tab-switch reset for the search-plan detail subview. When the
   // operator is on the detail page and clicks a tab — including
   // re-clicking the Pipeline tab — clear the detail context so the
-  // dispatcher renders the queue/dashboard rather than re-running the
+  // dispatcher renders the operational view rather than re-running the
   // (now-stale) detail render. The `suppressDetailReset` flag carves
   // out an exception for `openSearchPlanDetail`'s internally-driven
   // showTab('pipeline') call (which has just set pipelineView).
   if (!suppressDetailReset && state.pipelineView === 'search-plan-detail') {
-    state.pipelineView = 'queue';
+    state.pipelineView = 'dashboard';
     state.searchPlanDetailContext = null;
   }
   document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
@@ -162,8 +162,6 @@ Object.assign(window, {
   loadPipeline,
   loadPipelineDashboard,
   setPipelineView,
-  setFilter,
-  onPipelineSearchInput,
   renderPipeline,
   toggleCoverageMatchGraph,
   toggleDetail,
@@ -223,7 +221,6 @@ Object.assign(window, {
   // Replace operator action — U9 binding so cross-module onclick
   // handlers in `release_actions.js` can call into the picker.
   openReplacePicker: openReplacePickerAndHandle,
-  togglePipelineReplacedFilter,
   toggleWrongMatchesReplacedFilter,
   // Long-tail YouTube rescue (U5) — the two-step flow. `checkYoutube` runs
   // the slow, side-effectful resolver GET (double-fire-guarded, stale-result

--- a/web/js/pipeline.js
+++ b/web/js/pipeline.js
@@ -1,25 +1,57 @@
 // @ts-check
 import { state, API, toast } from './state.js';
-import { esc, awstDate, qualityLabel, manualReasonLabel, renderForensicBlock } from './util.js';
+import { esc, qualityLabel, manualReasonLabel, renderForensicBlock } from './util.js';
 import { renderDownloadHistoryItem } from './history.js';
 import {
   renderBeetsTrackRow, renderExpectedTrackRow, renderDetailRow, renderExternalLinkRow, toggleExpand,
 } from './render_primitives.js';
 import { renderBadRipButton, renderReplaceButton } from './release_actions.js';
-import { renderSearchPlanButton, renderSearchPlanDetail } from './search_plan.js';
+import { renderSearchPlanDetail } from './search_plan.js';
 import { loadLongTail, renderLongTailBody } from './long_tail.js';
 import { restoreLongTailConsoles } from './long_tail_console.js';
 import { renderPipelineDashboard as renderDashboardCards } from './pipeline_dashboard.js';
+
+const VISIBLE_HISTORY_ATTEMPTS = 10;
+
+/**
+ * Render the evidence-heavy sections of a request detail panel.
+ *
+ * The newest attempts stay visible because they explain the current outcome.
+ * Older attempts and track inventories are useful audit context, but neither
+ * should push the decision story multiple screens below the click target.
+ *
+ * @param {Array<Object>} history
+ * @param {Array<Object>} beetsTracks
+ * @param {Array<Object>} expectedTracks
+ * @returns {string}
+ */
+export function renderRequestEvidenceSections(history, beetsTracks, expectedTracks) {
+  let html = '';
+  if (history.length > 0) {
+    const visible = history.slice(0, VISIBLE_HISTORY_ATTEMPTS);
+    const older = history.slice(VISIBLE_HISTORY_ATTEMPTS);
+    html += `<div class="p-history"><div class="p-detail-label" style="margin-bottom:4px;">Download History (${history.length})</div>`;
+    html += visible.map(renderDownloadHistoryItem).join('');
+    if (older.length > 0) {
+      const noun = older.length === 1 ? 'attempt' : 'attempts';
+      html += `<details class="p-history-older"><summary>Show ${older.length} older ${noun}</summary>${older.map(renderDownloadHistoryItem).join('')}</details>`;
+    }
+    html += '</div>';
+  }
+
+  if (beetsTracks.length > 0) {
+    html += `<details class="p-tracks"><summary class="p-detail-label">In Library (${beetsTracks.length} tracks)</summary>${beetsTracks.map(renderBeetsTrackRow).join('')}</details>`;
+  } else if (expectedTracks.length > 0) {
+    html += `<details class="p-tracks"><summary class="p-detail-label">Expected Tracks from MusicBrainz (${expectedTracks.length})</summary>${expectedTracks.map(renderExpectedTrackRow).join('')}</details>`;
+  }
+  return html;
+}
 
 /**
  * Load pipeline data from API and render.
  * @returns {Promise<void>}
  */
 export async function loadPipeline() {
-  if (state.pipelineView === 'dashboard') {
-    await loadPipelineDashboard();
-    return;
-  }
   if (state.pipelineView === 'long-tail') {
     // U3: the long-tail worklist owns its own fetch lifecycle. It paints
     // a loading affordance, fetches the banded cohort, then routes back
@@ -30,42 +62,22 @@ export async function loadPipeline() {
   if (state.pipelineView === 'search-plan-detail') {
     // U4: detail subview owns its own render lifecycle; openSearchPlanDetail
     // already kicked off the fetch when the subview was entered. Don't
-    // clobber it with a queue-list paint.
+    // clobber it with a dashboard paint.
     const ctx = state.searchPlanDetailContext;
     if (ctx && ctx.requestId) {
       await renderSearchPlanDetail(ctx.requestId);
     }
     return;
   }
-  const el = document.getElementById('pipeline-content');
-  el.innerHTML = `${renderPipelineNav()}<div class="loading">Loading...</div>`;
-  try {
-    // U10: opt-in toggle persists in localStorage. Default: filtered.
-    const includeReplaced = localStorage.getItem('pipeline.includeReplaced') === 'true';
-    clearPipelineSearch();
-    const url = `${API}/api/pipeline/all${includeReplaced ? '?include_replaced=true' : ''}`;
-    const r = await fetch(url);
-    if (!r.ok) throw new Error(`HTTP ${r.status}`);
-    state.pipelineData = await r.json();
-    renderPipeline();
-  } catch (e) { el.innerHTML = `${renderPipelineNav()}<div class="loading">Failed to load pipeline</div>`; }
+  state.pipelineView = 'dashboard';
+  await loadPipelineDashboard();
 }
 
 /**
- * Toggle "show replaced" filter (U10). Pipeline + Wrong Matches tabs
- * persist this preference independently in localStorage.
- */
-export function togglePipelineReplacedFilter() {
-  const current = localStorage.getItem('pipeline.includeReplaced') === 'true';
-  localStorage.setItem('pipeline.includeReplaced', String(!current));
-  loadPipeline();
-}
-
-/**
- * Switch between the Pipeline subviews — queue, dashboard, or
- * search-plan-detail. The third value is the per-request inspector,
+ * Switch between the operational Pipeline subviews — dashboard, long-tail,
+ * or search-plan-detail. The third value is the per-request inspector,
  * dispatched into `#pipeline-content` via `renderSearchPlanDetail`.
- * Unknown values fall back to `'queue'`.
+ * Unknown values fall back to `'dashboard'`.
  *
  * @param {string} view
  * @returns {void}
@@ -95,12 +107,8 @@ export function setPipelineView(view) {
     }
     return;
   }
-  state.pipelineView = 'queue';
-  if (state.pipelineData) {
-    renderPipeline();
-  } else {
-    loadPipeline();
-  }
+  state.pipelineView = 'dashboard';
+  loadPipelineDashboard();
 }
 
 export function toggleCoverageMatchGraph(scope = 'hourly') {
@@ -131,35 +139,10 @@ export async function loadPipelineDashboard() {
 }
 
 /**
- * Set the pipeline filter and re-render.
- * @param {string} f
- */
-export function setFilter(f) {
-  state.pipelineFilter = f;
-  // Filter and search are mutually exclusive: clicking a count card
-  // abandons the active search so the clicked filter actually shows.
-  clearPipelineSearch();
-  renderPipeline();
-}
-
-/**
- * Reset the server-side search state (input text + results). Bumps the
- * in-flight token so a fetch resolving late discards itself.
- * @returns {void}
- */
-export function clearPipelineSearch() {
-  state.pipelineSearchQuery = '';
-  state.pipelineSearchResults = null;
-  pipelineSearchToken += 1;
-  if (pipelineSearchTimer != null) clearTimeout(pipelineSearchTimer);
-}
-
-/**
  * Render the pipeline view from cached data.
  *
  * Dispatches on `state.pipelineView`:
- *   * `'queue'` (default)  → list of pipeline rows
- *   * `'dashboard'`        → metrics dashboard
+ *   * `'dashboard'` (default) → metrics dashboard
  *   * `'long-tail'`        → banded long-tail triage worklist
  *   * `'search-plan-detail'` → per-request inspector (U4)
  */
@@ -182,149 +165,15 @@ export function renderPipeline() {
     if (ctx && ctx.requestId) {
       void renderSearchPlanDetail(ctx.requestId);
     } else if (el) {
-      // Defensive: subview entered without a context. Fall back to
-      // queue so the operator is never stranded.
-      state.pipelineView = 'queue';
+      // Defensive: subview entered without a context. Fall back to the
+      // dashboard so the operator is never stranded.
+      state.pipelineView = 'dashboard';
+      void loadPipelineDashboard();
     }
     return;
   }
-  const data = state.pipelineData;
-  if (!data) return;
-  const counts = data.counts || {};
-  const total = Object.values(counts).reduce((a, b) => a + b, 0);
-
-  // Wanted bucket includes downloading — mid-acquisition is a sub-state
-  // of wanted. The status badge on each row keeps them visually distinct.
-  const wantedTotal = (counts.wanted || 0) + (counts.downloading || 0);
-  el.innerHTML = `
-    ${renderPipelineNav()}
-    <div class="status-card">
-      <div class="status-counts">
-        <div class="count ${state.pipelineFilter === 'wanted' ? 'active' : ''}" onclick="window.setFilter('wanted')">
-          <div class="count-num">${wantedTotal}</div><div class="count-label">Wanted</div>
-        </div>
-        <div class="count ${state.pipelineFilter === 'manual' ? 'active' : ''}" onclick="window.setFilter('manual')">
-          <div class="count-num">${counts.manual || 0}</div><div class="count-label">Manual</div>
-        </div>
-        <div class="count ${state.pipelineFilter === 'imported' ? 'active' : ''}" onclick="window.setFilter('imported')">
-          <div class="count-num">${counts.imported || 0}</div><div class="count-label">Imported</div>
-        </div>
-        <div class="count ${state.pipelineFilter === 'all' ? 'active' : ''}" onclick="window.setFilter('all')">
-          <div class="count-num">${total}</div><div class="count-label">All</div>
-        </div>
-      </div>
-    </div>
-    <div class="lt-search">
-      <input type="text" id="pipeline-search-input" class="lt-search-input"
-        placeholder="Search every request by artist or album…"
-        value="${esc(state.pipelineSearchQuery || '')}"
-        oninput="window.onPipelineSearchInput(this.value)">
-    </div>
-    <div id="pipeline-list">${renderPipelineListBody()}</div>
-  `;
-}
-
-/**
- * Build the artist-grouped list body for the current filter (or the
- * active server-side search results). Kept separate from
- * renderPipeline so a search keystroke can repaint only #pipeline-list
- * and the input keeps focus/caret.
- *
- * @returns {string}
- */
-function renderPipelineListBody() {
-  const data = state.pipelineData || {};
-  const searching = state.pipelineSearchResults != null;
-
-  let items = [];
-  if (searching) {
-    items = state.pipelineSearchResults || [];
-  } else if (state.pipelineFilter === 'all') {
-    items = [...(data.wanted || []), ...(data.downloading || []), ...(data.imported || []), ...(data.manual || [])];
-  } else if (state.pipelineFilter === 'wanted') {
-    // Downloading is a sub-state of wanted — same album, mid-acquisition.
-    // The status badge on each row still distinguishes them visually.
-    items = [...(data.wanted || []), ...(data.downloading || [])];
-  } else {
-    items = data[state.pipelineFilter] || [];
-  }
-
-  // The imported bucket is a recency window (#426); say so whenever the
-  // truncated bucket is part of the current view.
-  const showsImported = !searching
-    && (state.pipelineFilter === 'imported' || state.pipelineFilter === 'all');
-  const truncationNote = showsImported && data.imported_truncated
-    ? `<div class="loading">Showing the ${(data.imported || []).length} most recent of ${data.imported_total} imported — search above to find the rest.</div>`
-    : '';
-
-  // Group by artist
-  const byArtist = {};
-  for (const item of items) {
-    const artist = item.artist_name || 'Unknown';
-    if (!byArtist[artist]) byArtist[artist] = [];
-    byArtist[artist].push(item);
-  }
-  // Sort artists alphabetically, albums by year within each
-  const artists = Object.keys(byArtist).sort((a, b) => a.localeCompare(b));
-  for (const a of artists) {
-    byArtist[a].sort((x, y) => (x.year || 0) - (y.year || 0));
-  }
-
-  return `
-    ${truncationNote}
-    ${artists.map(artist => `
-      <div class="p-group-header" onclick="this.nextElementSibling.classList.toggle('collapsed')">
-        ${esc(artist)} <span style="color:#555;font-weight:400;">${byArtist[artist].length}</span>
-      </div>
-      <div class="p-group-body">
-        ${byArtist[artist].map(item => renderPipelineItem(item)).join('')}
-      </div>
-    `).join('')}
-    ${artists.length === 0 ? `<div class="loading">${searching ? 'No matches' : 'No items'}</div>` : ''}
-  `;
-}
-
-// Module-scoped debounce + stale-response token for the server-side
-// pipeline search (#426). web.md: fetch-on-input UIs must stamp
-// requests and discard stale responses before rendering.
-let pipelineSearchTimer = null;
-let pipelineSearchToken = 0;
-const PIPELINE_SEARCH_DEBOUNCE_MS = 250;
-
-/**
- * Handle a keystroke in the pipeline search box: debounce, fetch
- * server-side results across every status, repaint only the list body.
- * @param {string} value
- * @returns {void}
- */
-export function onPipelineSearchInput(value) {
-  const q = String(value == null ? '' : value);
-  state.pipelineSearchQuery = q;
-  if (pipelineSearchTimer != null) clearTimeout(pipelineSearchTimer);
-  const repaint = () => {
-    const listEl = document.getElementById('pipeline-list');
-    if (listEl) listEl.innerHTML = renderPipelineListBody();
-  };
-  if (q.trim().length < 2) {
-    state.pipelineSearchResults = null;
-    repaint();
-    return;
-  }
-  pipelineSearchTimer = /** @type {any} */ (setTimeout(async () => {
-    const token = ++pipelineSearchToken;
-    try {
-      const r = await fetch(`${API}/api/pipeline/search?q=${encodeURIComponent(q.trim())}`);
-      if (!r.ok) throw new Error(`HTTP ${r.status}`);
-      const data = await r.json();
-      if (token !== pipelineSearchToken) return;
-      state.pipelineSearchResults = data.items || [];
-      repaint();
-    } catch (e) {
-      if (token !== pipelineSearchToken) return;
-      state.pipelineSearchResults = [];
-      repaint();
-    }
-  }, PIPELINE_SEARCH_DEBOUNCE_MS));
+  state.pipelineView = 'dashboard';
+  void loadPipelineDashboard();
 }
 
 function renderPipelineNav() {
@@ -336,61 +185,10 @@ function renderPipelineNav() {
 
   return `
     <div class="pipeline-subtabs">
-      <button class="p-btn ${state.pipelineView === 'queue' ? 'active-status' : ''}" onclick="window.setPipelineView('queue')">Queue</button>
       <button class="p-btn ${state.pipelineView === 'dashboard' ? 'active-status' : ''}" onclick="window.setPipelineView('dashboard')">Dashboard</button>
       <button class="p-btn ${state.pipelineView === 'long-tail' ? 'active-status' : ''}" onclick="window.setPipelineView('long-tail')">Long Tail</button>
       <button class="p-btn subtab-refresh" onclick="${refreshAction}">Refresh</button>
     </div>
-  `;
-}
-
-export function renderPipelineItem(item) {
-  const statusBadge = item.status === 'wanted' ? '<span class="badge badge-wanted">wanted</span>'
-    : item.status === 'downloading' ? '<span class="badge badge-downloading">downloading</span>'
-    : item.status === 'imported' ? '<span class="badge badge-imported">imported</span>'
-    : '<span class="badge badge-manual">manual</span>';
-  const srcClass = 'src-' + (item.source || 'request');
-  const year = item.year || '?';
-  const fmt = item.format || '?';
-  const country = item.country || '';
-  const date = awstDate(item.created_at || '');
-  const attempts = [];
-  if (item.search_attempts) attempts.push(`${item.search_attempts} search`);
-  if (item.download_attempts) attempts.push(`${item.download_attempts} dl`);
-  if (item.validation_attempts) attempts.push(`${item.validation_attempts} val`);
-  const attemptStr = attempts.length ? attempts.join(', ') : '';
-  const dist = item.beets_distance != null ? `dist ${item.beets_distance.toFixed(3)}` : '';
-  // Last download verdict for context (e.g. why a wanted album is stuck)
-  const lastVerdict = item.last_verdict || '';
-  const lastColor = item.last_outcome === 'success' || item.last_outcome === 'force_import'
-    ? '#6d6' : item.last_outcome === 'rejected' ? '#d88' : '#aa8';
-
-  // Search-plan inspector button — Pipeline rows always have a request
-  // id by construction, so the conditional in renderSearchPlanButton is
-  // a no-op here, but routing through the same helper keeps the toolbar
-  // wiring consistent across Browse / Pipeline / Recents.
-  const spBtn = renderSearchPlanButton({ pipelineId: item.id });
-
-  return `
-    <div class="p-item ${srcClass}" onclick="window.toggleDetail(${item.id})">
-      <div class="p-top">
-        <div>
-          <div class="p-title">${esc(item.album_title)}${statusBadge}</div>
-        </div>
-        <div class="p-row-actions">${spBtn}<span style="font-size:0.75em;color:#666;">#${item.id}</span></div>
-      </div>
-      <div class="p-meta">
-        <span>${year}</span>
-        <span>${fmt}</span>
-        ${country ? `<span>${country}</span>` : ''}
-        <span>${item.source}</span>
-        <span>${date}</span>
-        ${attemptStr ? `<span>${attemptStr}</span>` : ''}
-        ${dist ? `<span>${dist}</span>` : ''}
-      </div>
-      ${lastVerdict ? `<div class="p-meta" style="margin-top:2px;"><span style="color:${lastColor};">last: ${esc(lastVerdict)}</span>${item.download_count > 1 ? `<span>(${item.download_count} attempts)</span>` : ''}</div>` : ''}
-    </div>
-    <div class="p-detail" id="detail-${item.id}"></div>
   `;
 }
 
@@ -430,27 +228,7 @@ export async function toggleDetail(elId, requestId) {
     const beetsTracks = data.beets_tracks || [];
     html += renderCurrentQualityRow(req, beetsTracks);
 
-    // Download history — before the track list. The history is why the
-    // operator expanded the row (a Recents card IS a download event); on
-    // mobile a 14-track library listing pushed a rejection's story three
-    // screens down, so the detail read as a healthy library album
-    // (request 8781: mbid_missing invisible without scrolling).
-    if (history.length > 0) {
-      html += '<div class="p-history"><div class="p-detail-label" style="margin-bottom:4px;">Download History (' + history.length + ')</div>';
-      html += history.map(renderDownloadHistoryItem).join('');
-      html += '</div>';
-    }
-
-    // Tracks — labeled to clarify what we're looking at
-    if (beetsTracks.length > 0) {
-      html += '<div class="p-tracks"><div class="p-detail-label" style="margin-bottom:4px;">In Library (' + beetsTracks.length + ' tracks)</div>';
-      html += beetsTracks.map(renderBeetsTrackRow).join('');
-      html += '</div>';
-    } else if (tracks.length > 0) {
-      html += '<div class="p-tracks"><div class="p-detail-label" style="margin-bottom:4px;">Expected Tracks from MusicBrainz (' + tracks.length + ')</div>';
-      html += tracks.map(renderExpectedTrackRow).join('');
-      html += '</div>';
-    }
+    html += renderRequestEvidenceSections(history, beetsTracks, tracks);
 
     // Search forensics (last_search) — variant tag + top-3 candidates from
     // the most recent search_log row. Collapsed by default; click expands.
@@ -580,8 +358,7 @@ export async function updateStatus(id, newStatus) {
 }
 
 export const __test__ = {
-  renderPipelineListBody,
-  clearPipelineSearch,
   renderPipelineNav,
   renderCurrentQualityRow,
+  renderRequestEvidenceSections,
 };

--- a/web/js/recents.js
+++ b/web/js/recents.js
@@ -17,7 +17,7 @@ export function setRecentsFilter(f) {
 }
 
 /**
- * Switch Recents between history and import queue timeline.
+ * Switch Recents between history, active downloads, and importer work.
  * @param {string} sub
  */
 export function setRecentsSub(sub) {
@@ -29,7 +29,7 @@ function renderRecentsSubnav() {
   return `<div class="pipeline-subtabs">
     <button class="p-btn ${state.recentsSub === 'history' ? 'active-status' : ''}" onclick="window.setRecentsSub('history')">History</button>
     <button class="p-btn ${state.recentsSub === 'downloading' ? 'active-status' : ''}" onclick="window.setRecentsSub('downloading')">Downloading</button>
-    <button class="p-btn ${state.recentsSub === 'queue' ? 'active-status' : ''}" onclick="window.setRecentsSub('queue')">Queue</button>
+    <button class="p-btn ${state.recentsSub === 'imports' ? 'active-status' : ''}" onclick="window.setRecentsSub('imports')">Imports</button>
     <button class="p-btn subtab-refresh" onclick="window.loadRecents()">Refresh</button>
   </div>`;
 }
@@ -131,41 +131,6 @@ function renderRecentsDateHeader(date, matchRates) {
   </div>`;
 }
 
-function queueBadge(job, index) {
-  if (job.status === 'completed') return ['completed', 'badge-new'];
-  if (job.status === 'failed') return ['failed', 'badge-failed'];
-  if (job.status === 'running') return ['importing', 'badge-force'];
-  if (job.preview_status === 'evidence_ready') {
-    return [index === 0 ? 'next check' : 'ready check', 'badge-new'];
-  }
-  if (job.preview_status === 'would_import') {
-    return [index === 0 ? 'next legacy check' : 'legacy ready', 'badge-new'];
-  }
-  if (job.preview_status === 'running') return ['previewing', 'badge-warn'];
-  if (job.preview_status === 'waiting') return ['waiting preview', 'badge-library'];
-  if (job.preview_status === 'confident_reject') return ['preview reject', 'badge-failed'];
-  if (job.preview_status === 'measurement_failed') return ['measurement failed', 'badge-failed'];
-  if (job.preview_status === 'uncertain') return ['uncertain', 'badge-warn'];
-  if (job.preview_status === 'error') return ['preview error', 'badge-failed'];
-  return [job.status || 'queued', 'badge-library'];
-}
-
-function queueBorderColor(job) {
-  if (job.status === 'failed'
-      || ['confident_reject', 'measurement_failed', 'error'].includes(job.preview_status)) return '#a33';
-  if (job.preview_status === 'uncertain' || job.preview_status === 'running') return '#a93';
-  if (job.preview_status === 'evidence_ready' || job.preview_status === 'would_import' || job.status === 'completed') return '#1a4a2a';
-  if (job.status === 'running') return '#36c';
-  return '#1a3a5a';
-}
-
-function queueMessage(job) {
-  if (job.status === 'completed' || job.status === 'failed') {
-    return job.message || job.error || job.preview_message || job.preview_error || '';
-  }
-  return job.preview_message || job.message || job.preview_error || job.error || '';
-}
-
 function jobCleanupChip(job) {
   const cleanup = job && job.result && typeof job.result === 'object'
     ? job.result.cleanup
@@ -183,17 +148,18 @@ function jobCleanupChip(job) {
 }
 
 /**
- * Render import queue timeline rows.
+ * Render active importer timeline rows.
  * @param {Array<Object>} jobs
  * @returns {string}
  */
-export function renderImportQueueItems(jobs) {
-  if (jobs.length === 0) return '<div class="loading">No queued imports</div>';
-  return jobs.map((job, index) => {
-    const [badge, badgeClass] = queueBadge(job, index);
+export function renderImportItems(jobs) {
+  if (jobs.length === 0) return '<div class="loading">No active imports</div>';
+  return jobs.map((job) => {
+    const badge = job.badge || '';
+    const badgeClass = job.badge_class || '';
     const title = job.album_title || `Import job ${job.id}`;
     const artist = job.artist_name || job.job_type || '';
-    const message = queueMessage(job);
+    const message = job.summary || '';
     const stages = job.preview_result && Array.isArray(job.preview_result.stage_chain)
       ? job.preview_result.stage_chain.join(' · ')
       : '';
@@ -203,13 +169,13 @@ export function renderImportQueueItems(jobs) {
       job.status ? `import: ${job.status}` : '',
     ].filter(Boolean).join(' · ');
     const cleanupChip = jobCleanupChip(job);
-    // Search-plan inspector button — Recents queue rows render the
+    // Search-plan inspector button — Recents Imports rows render the
     // button when the import job is bound to a pipeline request. Orphan
     // imports (job.request_id null) get nothing — the conditional in
     // renderSearchPlanButton handles the absent case.
     const spBtn = renderSearchPlanButton({ pipelineId: job.request_id });
     return `
-      <div class="r-item" style="border-left-color:${queueBorderColor(job)}">
+      <div class="r-item" style="border-left-color:${esc(job.border_color || '#444')}">
         <div class="p-top">
           <div>
             <div class="p-title">${esc(title)} <span class="badge ${badgeClass}">${esc(badge)}</span>${cleanupChip}</div>
@@ -365,7 +331,7 @@ export function renderDownloadingItems(items) {
   }).join('');
 }
 
-async function loadImportQueue() {
+async function loadImports() {
   const el = document.getElementById('recents-content');
   el.innerHTML = renderRecentsSubnav() + '<div class="loading">Loading...</div>';
   try {
@@ -374,14 +340,14 @@ async function loadImportQueue() {
     const data = await r.json();
     const jobs = data.jobs || [];
     el.innerHTML = renderRecentsSubnav()
-      + renderImportQueueHeader(jobs, data.counts || {})
-      + renderImportQueueItems(jobs);
+      + renderImportsHeader(jobs, data.counts || {})
+      + renderImportItems(jobs);
   } catch (e) {
-    el.innerHTML = renderRecentsSubnav() + '<div class="loading">Failed to load queue</div>';
+    el.innerHTML = renderRecentsSubnav() + '<div class="loading">Failed to load imports</div>';
   }
 }
 
-function renderImportQueueHeader(jobs, counts) {
+function renderImportsHeader(jobs, counts) {
   const queued = Number(counts.queued || 0);
   const running = Number(counts.running || 0);
   const activeTotal = queued + running || jobs.length;
@@ -480,8 +446,8 @@ function renderRecentsCounts() {
  */
 export async function loadRecents() {
   const el = document.getElementById('recents-content');
-  if (state.recentsSub === 'queue') {
-    await loadImportQueue();
+  if (state.recentsSub === 'imports') {
+    await loadImports();
     return;
   }
   if (state.recentsSub === 'downloading') {
@@ -513,7 +479,7 @@ export const __test__ = {
   triageLabelText,
   renderDownloadingItems,
   normalizeYoutubeIngestItem,
-  renderImportQueueItems,
+  renderImportItems,
   renderRecentsCounts,
   renderRecentsDateHeader,
   renderRecentsSubnav,

--- a/web/js/search_plan.js
+++ b/web/js/search_plan.js
@@ -153,7 +153,7 @@ export function buildHistoryUrl(opts) {
  * @typedef {Object} OriginContextInput
  * @property {string} tab        Active tab when the operator clicked "Open detail" — `'browse'`, `'pipeline'`, `'recents'`, etc.
  * @property {number} scrollY    `window.scrollY` at click time.
- * @property {string|null} subView  Active sub-view (e.g. `'queue'` / `'dashboard'` on Pipeline). `null` for tabs with no sub-view.
+ * @property {string|null} subView  Active sub-view (e.g. `'dashboard'` / `'long-tail'` on Pipeline). `null` for tabs with no sub-view.
  */
 
 /**
@@ -621,7 +621,7 @@ export function snapshotActiveTab() {
   /** @type {string|null} */
   let subView = null;
   if (tab === 'pipeline') {
-    subView = state.pipelineView ?? 'queue';
+    subView = state.pipelineView ?? 'dashboard';
   } else if (tab === 'recents') {
     subView = state.recentsSub ?? 'history';
   }
@@ -692,7 +692,7 @@ export function openSearchPlanDetail(requestId, _originEl) {
  *
  * Reads `state.searchPlanDetailContext`. When null (operator refreshed,
  * lost the stash, or navigated here directly somehow), falls back to
- * the Pipeline queue view so the operator is never stranded.
+ * the Pipeline dashboard so the operator is never stranded.
  *
  * Mutations: clears `state.searchPlanDetailContext`, restores
  * `state.pipelineView` when the origin tab was Pipeline, schedules a
@@ -707,13 +707,13 @@ export function closeSearchPlanDetail() {
   bumpDetailGeneration();
   const ctx = state.searchPlanDetailContext;
   if (!ctx) {
-    // No stash — fall back to the Pipeline queue without throwing.
+    // No stash — fall back to the Pipeline dashboard without throwing.
     if (typeof console !== 'undefined' && console.warn) {
       console.warn(
-        'closeSearchPlanDetail: no origin context — falling back to pipeline/queue',
+        'closeSearchPlanDetail: no origin context — falling back to pipeline/dashboard',
       );
     }
-    state.pipelineView = 'queue';
+    state.pipelineView = 'dashboard';
     if (typeof window !== 'undefined') {
       const showTab = /** @type {(name: string) => void} */ (
         /** @type {any} */ (window).showTab);
@@ -724,18 +724,18 @@ export function closeSearchPlanDetail() {
   const { tab, scrollY, subView } = restoreOriginContext(ctx);
   if (tab === 'pipeline') {
     state.pipelineView = (subView === 'dashboard'
-      || subView === 'queue')
+      || subView === 'long-tail')
       ? subView
-      : 'queue';
+      : 'dashboard';
   } else {
     // Leave pipelineView alone on non-pipeline origins; the next time
     // the operator opens Pipeline they should land where they were last
-    // (queue by default).
+    // (dashboard by default).
     if (state.pipelineView === 'search-plan-detail') {
-      state.pipelineView = 'queue';
+      state.pipelineView = 'dashboard';
     }
     if (tab === 'recents'
-      && (subView === 'history' || subView === 'downloading' || subView === 'queue')) {
+      && (subView === 'history' || subView === 'downloading' || subView === 'imports')) {
       state.recentsSub = subView;
     }
   }

--- a/web/js/state.js
+++ b/web/js/state.js
@@ -18,7 +18,7 @@ import { invalidateActiveRgs } from './active_rgs.js';
  * @property {number} requestId        The pipeline request being inspected.
  * @property {string} originTab        Tab to restore — `'browse'`, `'pipeline'`, `'recents'`, etc.
  * @property {number} originScrollY    `window.scrollY` at click time.
- * @property {string|null} originSubView  Sub-view to restore (e.g. `'queue'`/`'dashboard'` on Pipeline). `null` for tabs with no sub-view.
+ * @property {string|null} originSubView  Sub-view to restore (e.g. `'dashboard'`/`'long-tail'` on Pipeline). `null` for tabs with no sub-view.
  */
 
 /**
@@ -40,7 +40,7 @@ import { invalidateActiveRgs } from './active_rgs.js';
  * @property {string} query             Current search-box substring filter.
  */
 
-/** @type {{ browseSource: string, browseSearchType: string, browseArtist: {id:string, name:string}|null, browseLabel: {id:string, name:string}|null, labelFilters: {yearMin:number|null, yearMax:number|null, format:string, hideHeld:boolean}, labelPage: number, browseCache: Object, pipelineData: Object|null, pipelineSearchQuery: string, pipelineSearchResults: Array<Object>|null, pipelineDashboardData: Object|null, pipelineView: string, pipelineFilter: string, pipelineMatchGraphOpen: boolean, pipelineHourlyMatchGraphOpen: boolean, pipelineDailyMatchGraphOpen: boolean, longTail: LongTailState, recentsCounts: {all:number, imported:number, rejected:number, matches_24h:number, matches_6h:number, matches_per_hour_24h:number, matches_per_hour_6h:number}, recentsFilter: string, recentsSub: 'history'|'downloading'|'queue', dsConstants: Object|null, disambData: Object|null, searchTimer: number|null, searchTargetId: string|null, searchTargetExpandId: string|null, searchTargetSource: string|null, searchPlanDetailContext: SearchPlanDetailContext|null }} */
+/** @type {{ browseSource: string, browseSearchType: string, browseArtist: {id:string, name:string}|null, browseLabel: {id:string, name:string}|null, labelFilters: {yearMin:number|null, yearMax:number|null, format:string, hideHeld:boolean}, labelPage: number, browseCache: Object, pipelineDashboardData: Object|null, pipelineView: string, pipelineMatchGraphOpen: boolean, pipelineHourlyMatchGraphOpen: boolean, pipelineDailyMatchGraphOpen: boolean, longTail: LongTailState, recentsCounts: {all:number, imported:number, rejected:number, matches_24h:number, matches_6h:number, matches_per_hour_24h:number, matches_per_hour_6h:number}, recentsFilter: string, recentsSub: 'history'|'downloading'|'imports', dsConstants: Object|null, disambData: Object|null, searchTimer: number|null, searchTargetId: string|null, searchTargetExpandId: string|null, searchTargetSource: string|null, searchPlanDetailContext: SearchPlanDetailContext|null }} */
 export const state = {
   browseSource: 'mb',
   browseSearchType: 'artist',
@@ -49,12 +49,8 @@ export const state = {
   labelFilters: { yearMin: null, yearMax: null, format: '', hideHeld: false },
   labelPage: 1,
   browseCache: {},
-  pipelineData: null,
-  pipelineSearchQuery: '',
-  pipelineSearchResults: null,
   pipelineDashboardData: null,
-  pipelineView: 'queue',
-  pipelineFilter: 'wanted',
+  pipelineView: 'dashboard',
   pipelineMatchGraphOpen: false,
   pipelineHourlyMatchGraphOpen: false,
   pipelineDailyMatchGraphOpen: false,

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -30,6 +30,7 @@ from web.download_history_view import (
     build_download_history_rows,
     classify_download_log_row,
 )
+from web.classify import classify_import_job_display
 from lib.quality import CandidateScore, top_candidates
 
 DEFAULT_PIPELINE_LOG_LIMIT = 50
@@ -352,8 +353,15 @@ def get_import_jobs_timeline(h, params: dict[str, list[str]]) -> None:
     db = _server()._db()
     jobs = db.list_import_job_timeline(limit=50)
     serialized = []
-    for job in jobs:
+    for queue_position, job in enumerate(jobs):
         item = _serialize_import_job(job)
+        item.update(cast(
+            dict[str, object],
+            msgspec.to_builtins(classify_import_job_display(
+                job,
+                queue_position=queue_position,
+            )),
+        ))
         request_id = item.get("request_id")
         if isinstance(request_id, (int, str)) and not isinstance(request_id, bool):
             req = db.get_request(int(request_id))
@@ -419,8 +427,8 @@ ROUTES: list[RouteRegistration] = [
     ),
     route(
         "GET", "/api/import-jobs/timeline", get_import_jobs_timeline,
-        "Recent import-queue jobs with request metadata attached "
-        "(timeline view).",
+        "Active import-queue jobs in claim order with request metadata and "
+        "server-classified display fields.",
         classified=True,
     ),
     route(


### PR DESCRIPTION
## Summary

- remove the redundant global Pipeline Queue UI while retaining Dashboard, Long Tail, and diagnostic API/CLI surfaces
- rename Recents Queue to Imports and make the server own its badge, color, and summary classification
- simplify rejection verdicts to one short grammar per decision class while keeping measurements in the fixed evidence rows
- cap expanded request history at 10 visible attempts, disclose older attempts, and collapse track inventories

Refs #575

## Verification

- `nix-shell --run "bash scripts/run_tests.sh"` — 5,642 passed
- exact clean-HEAD artifact verified for `16ec72e88041124d18b673bf632e785349740674`
- pre-push generated-test fuzz burst passed
- `nix flake check` — 129 checks passed, including module VM
- live-data browser pass at desktop and 390px mobile widths: Pipeline has Dashboard/Long Tail only; Recents has Imports; request #4514 shows 10 of 56 attempts with an older-attempt disclosure and collapsed track inventory
