### PR TITLE
Reveal owned exceptional release types

### DIFF
--- a/docs/webui-primer.md
+++ b/docs/webui-primer.md
@@ -88,6 +88,10 @@ Browser → https://music.ablz.au
     into the visible list with a `promo`/`bootleg` provenance chip
     (`splitPressings` in `web/js/discography.js`; an owned pressing is never
     hidden, whatever its status)
+  - Exceptional artist-page sections stay quiet unless they contain something
+    owned. An in-library Bootleg-only or other-source-only row opens its outer
+    section and only the Albums/EPs/Singles/Other type buckets containing
+    in-library rows; a pipeline request alone never auto-expands them.
   - Releases already in pipeline DB or beets library are badged
   - Click release metadata to open MB release page in new tab
 - **Add button** — adds release to pipeline DB (same logic as `pipeline-cli add`)

--- a/tests/test_js_artist_page.mjs
+++ b/tests/test_js_artist_page.mjs
@@ -20,7 +20,12 @@
  * Run with: node tests/test_js_artist_page.mjs
  */
 
-import { classifyArtistRows, renderArtistSections, renderOtherSourceSection } from '../web/js/artist_page.js';
+import {
+  classifyArtistRows,
+  ownedTypeSections,
+  renderArtistSections,
+  renderOtherSourceSection,
+} from '../web/js/artist_page.js';
 
 let passed = 0;
 let failed = 0;
@@ -50,6 +55,13 @@ function assertExcludes(haystack, needle, msg) {
     failed++;
     console.error(`  FAIL: ${msg} - unexpectedly found '${needle}'`);
   }
+}
+
+function bodyIsOpenAfter(html, marker) {
+  const start = html.indexOf(marker);
+  if (start < 0) return false;
+  const body = html.slice(start).match(/<div class="type-body([^"]*)">/);
+  return Boolean(body && body[1].split(/\s+/).includes('open'));
 }
 
 const ARTIST_ID = 'aaaaaaaa-1111-2222-3333-444444444444';
@@ -278,6 +290,83 @@ console.log('renderOtherSourceSection — complement rows force the other source
     'empty bucket -> empty string');
   const mbSide = renderOtherSourceSection([rows[0]], { artistName: ARTIST_NAME, source: 'mb' });
   assertContains(mbSide, 'Only on MusicBrainz', 'mb complement label');
+}
+
+console.log('owned exceptional sections open only their owned release types');
+{
+  // Live Deloris shape: an owned unofficial RG with no primary type lands
+  // in Bootleg-only → Other. An unowned Album remains present but collapsed.
+  const sections = classify([
+    rg('owned-bootleg', {
+      title: 'The Point In The War When We Knew We Were Lost',
+      has_official: false,
+      in_library: true,
+      type: null,
+    }),
+    rg('unowned-bootleg', {
+      title: 'Audience Tape',
+      has_official: false,
+      in_library: false,
+      type: 'Album',
+      pipeline_status: 'wanted',
+    }),
+  ]);
+  assertEqual(ownedTypeSections(sections.bootlegs).join(','), 'Other',
+    'strict library ownership selects only the Deloris Other bucket');
+  const html = renderArtistSections(sections, {
+    artistId: ARTIST_ID,
+    artistName: ARTIST_NAME,
+  });
+  assertEqual(bodyIsOpenAfter(html, 'Bootleg-only releases'), true,
+    'owned bootleg opens the outer exceptional section');
+  assertEqual(bodyIsOpenAfter(html, 'Other <span class="type-count">'), true,
+    'the owned bootleg type opens');
+  assertEqual(bodyIsOpenAfter(html, 'Albums <span class="type-count">'), false,
+    'unowned bootleg type remains collapsed even with an active request');
+
+  const complement = renderOtherSourceSection([
+    rg('discogs-album', { in_library: true, type: 'Album' }),
+    rg('discogs-other', { in_library: true, type: 'Other' }),
+    rg('discogs-single', {
+      in_library: false,
+      type: 'Single',
+      pipeline_status: 'wanted',
+    }),
+  ], { artistName: ARTIST_NAME, source: 'discogs' });
+  assertEqual(bodyIsOpenAfter(complement, 'Only on Discogs'), true,
+    'owned complement row opens the outer source-only section');
+  assertEqual(bodyIsOpenAfter(complement, 'Albums <span class="type-count">'), true,
+    'owned complement Album type opens');
+  assertEqual(bodyIsOpenAfter(complement, 'Other <span class="type-count">'), true,
+    'owned complement Other type opens');
+  assertEqual(bodyIsOpenAfter(complement, 'Singles <span class="type-count">'), false,
+    'pipeline-only complement type remains collapsed');
+}
+
+console.log('unowned exceptional sections stay fully collapsed');
+{
+  const sections = classify([
+    rg('queued-bootleg', {
+      has_official: false,
+      in_library: false,
+      pipeline_status: 'wanted',
+    }),
+  ]);
+  const html = renderArtistSections(sections, {
+    artistId: ARTIST_ID,
+    artistName: ARTIST_NAME,
+  });
+  assertEqual(bodyIsOpenAfter(html, 'Bootleg-only releases'), false,
+    'an active request alone does not auto-expand Bootleg-only');
+
+  const complement = renderOtherSourceSection([
+    rg('queued-discogs', {
+      in_library: false,
+      pipeline_status: 'wanted',
+    }),
+  ], { artistName: ARTIST_NAME, source: 'discogs' });
+  assertEqual(bodyIsOpenAfter(complement, 'Only on Discogs'), false,
+    'an active request alone does not auto-expand the complement');
 }
 
 console.log('renderArtistSections — section headers, counts, defaults');

--- a/tests/test_js_grouping.mjs
+++ b/tests/test_js_grouping.mjs
@@ -106,6 +106,24 @@ const closedHtml = renderTypedSections(rows, (r) => '', { defaultOpen: null });
 assertEqual(closedHtml.includes('<div class="type-body open">'), false,
   'no section is open when defaultOpen=null');
 
+console.log('renderTypedSections() with multiple explicit open sections');
+const selectedHtml = renderTypedSections(rows, (r) => `<div>${r.title}</div>`, {
+  defaultOpen: null,
+  openSections: ['EPs', 'Singles'],
+});
+function typeIsOpen(html, type) {
+  const start = html.indexOf(`${type} <span class="type-count">`);
+  if (start < 0) return false;
+  const body = html.slice(start).match(/<div class="type-body([^"]*)">/);
+  return Boolean(body && body[1].split(/\s+/).includes('open'));
+}
+assertEqual(typeIsOpen(selectedHtml, 'Albums'), false,
+  'Albums stays closed when it is not selected');
+assertEqual(typeIsOpen(selectedHtml, 'EPs'), true,
+  'EPs opens when selected');
+assertEqual(typeIsOpen(selectedHtml, 'Singles'), true,
+  'Singles opens when selected');
+
 console.log('renderTypedSections() empty input');
 const emptyHtml = renderTypedSections([], (r) => '');
 assertEqual(emptyHtml, '', 'empty input -> empty output');

--- a/tests/test_owned_section_expansion_generated.py
+++ b/tests/test_owned_section_expansion_generated.py
@@ -1,0 +1,132 @@
+"""Generated ownership/type expansion invariant for artist-page exceptions."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import unittest
+
+from hypothesis import example, given, strategies as st
+
+import tests._hypothesis_profiles  # noqa: F401
+
+
+ROOT = Path(__file__).resolve().parents[1]
+TYPES = ("Album", "EP", "Single", "Other", None)
+SECONDARY_TYPES = (
+    (),
+    ("Compilation",),
+    ("Live",),
+    ("Remix",),
+    ("DJ-mix",),
+    ("Demo",),
+)
+
+
+def _expected_section(row: dict[str, object]) -> str:
+    secondary = row.get("secondary_types")
+    if isinstance(secondary, list):
+        for value, section in (
+            ("Compilation", "Compilations"),
+            ("Live", "Live"),
+            ("Remix", "Remixes"),
+            ("DJ-mix", "DJ Mixes"),
+            ("Demo", "Demos"),
+        ):
+            if value in secondary:
+                return section
+    row_type = row.get("type")
+    if not isinstance(row_type, str):
+        row_type = None
+    if row_type == "Album":
+        return "Albums"
+    if row_type == "EP":
+        return "EPs"
+    if row_type == "Single":
+        return "Singles"
+    return "Other"
+
+
+def _real_owned_type_sections(rows: list[dict[str, object]]) -> list[str]:
+    script = """
+import { ownedTypeSections } from './web/js/artist_page.js';
+let input = '';
+for await (const chunk of process.stdin) input += chunk;
+process.stdout.write(JSON.stringify(ownedTypeSections(JSON.parse(input))));
+"""
+    proc = subprocess.run(
+        ["node", "--input-type=module", "--eval", script],
+        cwd=ROOT,
+        input=json.dumps(rows),
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return json.loads(proc.stdout)
+
+
+def assert_owned_type_contract(
+    rows: list[dict[str, object]],
+    actual: list[str],
+) -> None:
+    expected = sorted({
+        _expected_section(row)
+        for row in rows
+        if row.get("in_library") is True
+    })
+    if sorted(actual) != expected:
+        raise AssertionError(
+            f"owned type expansion mismatch: expected={expected}, actual={actual}"
+        )
+
+
+row_strategy = st.builds(
+    lambda row_type, secondary_types, in_library, pipeline_status: {
+        "type": row_type,
+        "secondary_types": list(secondary_types),
+        "in_library": in_library,
+        "pipeline_status": pipeline_status,
+    },
+    row_type=st.sampled_from(TYPES),
+    secondary_types=st.sampled_from(SECONDARY_TYPES),
+    in_library=st.one_of(st.none(), st.booleans()),
+    pipeline_status=st.sampled_from([None, "wanted", "downloading", "imported"]),
+)
+
+
+class TestGeneratedOwnedSectionExpansion(unittest.TestCase):
+    @given(rows=st.lists(row_strategy, min_size=0, max_size=16))
+    @example(rows=[
+        {
+            "type": None,
+            "secondary_types": [],
+            "in_library": True,
+            "pipeline_status": "wanted",
+        },
+        {
+            "type": "Album",
+            "secondary_types": [],
+            "in_library": False,
+            "pipeline_status": "wanted",
+        },
+    ])
+    def test_only_types_with_owned_rows_auto_expand(
+        self,
+        rows: list[dict[str, object]],
+    ) -> None:
+        assert_owned_type_contract(rows, _real_owned_type_sections(rows))
+
+    def test_checker_rejects_pipeline_only_expansion(self) -> None:
+        rows = [{
+            "type": "Album",
+            "secondary_types": [],
+            "in_library": False,
+            "pipeline_status": "wanted",
+        }]
+        with self.assertRaisesRegex(AssertionError, "owned type expansion"):
+            assert_owned_type_contract(rows, ["Albums"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/js/artist_page.js
+++ b/web/js/artist_page.js
@@ -29,7 +29,7 @@
  *      from the source discography renders as an orphan album row
  *      inside the In library section.
  */
-import { renderTypedSections } from './grouping.js';
+import { classify, renderTypedSections, SECTION_ORDER } from './grouping.js';
 import { renderRgRow } from './discography.js';
 import { renderLibraryAlbumRow } from './library.js';
 
@@ -105,6 +105,23 @@ function sectionWrap(title, count, bodyHtml, opts = {}) {
 }
 
 /**
+ * Return the release-type sections containing at least one owned row.
+ *
+ * Strict ``in_library === true`` keeps wanted/downloading rows from opening
+ * exceptional buckets merely because the pipeline is still searching.
+ * SECTION_ORDER makes the result stable for rendering and tests.
+ *
+ * @param {Object[]} rows
+ * @returns {string[]}
+ */
+export function ownedTypeSections(rows) {
+  const owned = new Set((rows || [])
+    .filter(row => row.in_library === true)
+    .map(classify));
+  return SECTION_ORDER.filter(section => owned.has(section));
+}
+
+/**
  * Render the unified artist page body. Empty sections are omitted.
  * @param {{inLibrary: Object[], inFlight: Object[], missing: Object[],
  *          appearances: Object[], bootlegs: Object[]}} sections
@@ -114,8 +131,14 @@ function sectionWrap(title, count, bodyHtml, opts = {}) {
 export function renderArtistSections(sections, ctx) {
   const nameLC = (ctx.artistName || '').toLowerCase();
   const rgRow = (rg) => renderRgRow(rg, { artistName: ctx.artistName, nameLC });
-  const typed = (rgs, defaultOpen) => renderTypedSections(rgs, rgRow,
-    { defaultOpen: defaultOpen ? 'Albums' : null });
+  const typed = (rgs, defaultOpen, openSections) => renderTypedSections(
+    rgs,
+    rgRow,
+    {
+      defaultOpen: defaultOpen ? 'Albums' : null,
+      ...(openSections ? { openSections } : {}),
+    },
+  );
 
   let html = '';
   const orphans = sections.inLibraryOrphans || [];
@@ -144,8 +167,12 @@ export function renderArtistSections(sections, ctx) {
       typed(sections.appearances, false), { color: '#777' });
   }
   if (sections.bootlegs.length > 0) {
+    const ownedTypes = ownedTypeSections(sections.bootlegs);
     html += sectionWrap('Bootleg-only releases', sections.bootlegs.length,
-      typed(sections.bootlegs, false), { color: '#555' });
+      typed(sections.bootlegs, false, ownedTypes), {
+        color: '#555',
+        open: ownedTypes.length > 0,
+      });
   }
   return html;
 }
@@ -165,7 +192,15 @@ export function renderOtherSourceSection(rows, ctx) {
   const rgRow = (rg) => renderRgRow(rg, {
     artistName: ctx.artistName, nameLC, source: ctx.source,
   });
+  const ownedTypes = ownedTypeSections(rows);
   return sectionWrap(`Only on ${label}`, rows.length,
-    renderTypedSections(rows, rgRow, {}),
-    { color: '#a96', id: 'only-other-source' });
+    renderTypedSections(rows, rgRow, {
+      defaultOpen: null,
+      openSections: ownedTypes,
+    }),
+    {
+      color: '#a96',
+      id: 'only-other-source',
+      open: ownedTypes.length > 0,
+    });
 }

--- a/web/js/grouping.js
+++ b/web/js/grouping.js
@@ -56,6 +56,9 @@ export function classify(row) {
  *   intra-section sorting. Defaults to row.first_release_date.
  * @param {string|null} [opts.defaultOpen] - Section name to open by
  *   default. Pass null for none. Default 'Albums'.
+ * @param {string[]} [opts.openSections] - Exact sections to open. When
+ *   supplied, this takes precedence over defaultOpen and may name more than
+ *   one section.
  * @param {string} [opts.headerStyle] - Inline style on the type-header
  *   div. Useful for muting a "bootleg" group.
  * @returns {string}
@@ -64,6 +67,9 @@ export function renderTypedSections(rows, renderRow, opts = {}) {
   const classifier = opts.classify || classify;
   const dateOf = opts.dateOf || ((r) => String(r.first_release_date || ''));
   const defaultOpen = opts.defaultOpen === undefined ? 'Albums' : opts.defaultOpen;
+  const openSections = opts.openSections
+    ? new Set(opts.openSections)
+    : null;
   const headerStyle = opts.headerStyle || '';
 
   /** @type {Object<string, Object[]>} */
@@ -80,7 +86,7 @@ export function renderTypedSections(rows, renderRow, opts = {}) {
     .filter((s) => sections[s])
     .map((s) => {
       const items = sections[s];
-      const isOpen = s === defaultOpen;
+      const isOpen = openSections ? openSections.has(s) : s === defaultOpen;
       const hStyle = headerStyle ? ` style="${headerStyle}"` : '';
       return `
         <div class="type-section">


### PR DESCRIPTION
## Summary

- auto-open Bootleg-only when it contains an in-library release group
- within exceptional sections, open only release-type buckets containing owned rows
- apply the same ownership rule to Discogs-only / MusicBrainz-only complement sections
- keep pipeline-only exceptional rows collapsed to avoid ambient clutter

Follow-up to #575.

## Live acceptance case

Deloris now renders its owned unofficial split under open `Bootleg-only releases` → `Other`. Its `Only on Discogs` section opens the owned `Albums` and `Other` types while leaving `EPs` and `Singles` collapsed.

## Verification

- 5,649 tests passed from clean commit `aedb4b32a3ce24045ba135423890e1c057b0be90`
- pyright and dead-code gates passed
- generated ownership/type worlds and known-bad pipeline-only checker passed
- pre-push fuzz burst and flake checks passed
- real Deloris data rendered correctly at desktop and 390px mobile widths with no overflow
