### PR TITLE
Surface artist appearances outside mainline albums

### DIFF
--- a/docs/webui-primer.md
+++ b/docs/webui-primer.md
@@ -70,13 +70,18 @@ Browser → https://music.ablz.au
   Discography / Analysis / Library / Compare sub-tabs are gone), sectioned by
   availability: **In library / In flight / Missing / Appearances /
   Bootleg-only releases**, each grouped by type (Albums, EPs, Singles, etc.).
-  Ownership ("own work" vs Appearances) uses artist-credit matching; Missing =
-  official own-work release groups the beets library doesn't hold; In flight =
+  Appearance provenance comes from each source rather than title heuristics:
+  MusicBrainz release groups discovered through the `track_artist` release
+  browse and Discogs rows from `/artists/<id>/appearances` are kept out of
+  mainline Albums even when they are VA compilations. Ownership matching is a
+  fallback for non-primary release-group credits. Missing = official own-work
+  release groups the beets library doesn't hold; In flight =
   requests currently `downloading` or `manual` (`wanted` is ambient after the
   full-library backfill and stays a badge). Two slow feeds decorate the page
   after the fast render, without re-rendering: `/api/artist/compare` appends an
-  "Only on Discogs/MusicBrainz" complement section (silently skipped on hosts
-  without the Discogs mirror), and `/api/artist/<id>/disambiguate` adds
+  "Only on Discogs/MusicBrainz" complement section, with source-only
+  appearances under a distinct **Appears on** bucket (silently skipped on
+  hosts without the Discogs mirror), and `/api/artist/<id>/disambiguate` adds
   unique-track / covered-by chips to rows plus colour-dot recordings
   breakdowns inside expanded release groups (MB artists only). Expanding an
   in-library pressing's detail offers a lazy **Library detail** panel (path,
@@ -89,8 +94,8 @@ Browser → https://music.ablz.au
     (`splitPressings` in `web/js/discography.js`; an owned pressing is never
     hidden, whatever its status)
   - Exceptional artist-page sections stay quiet unless they contain something
-    owned. An in-library Bootleg-only or other-source-only row opens its outer
-    section and only the Albums/EPs/Singles/Other type buckets containing
+    owned. An in-library Bootleg-only, appearance, or other-source-only row
+    opens its exceptional section and only the type buckets containing
     in-library rows; a pipeline request alone never auto-expands them.
   - Releases already in pipeline DB or beets library are badged
   - Click release metadata to open MB release page in new tab

--- a/tests/test_discogs_api.py
+++ b/tests/test_discogs_api.py
@@ -488,6 +488,7 @@ class TestGetArtistReleases(unittest.TestCase):
         self.assertEqual(album["artist_credit"], "Radiohead")
         self.assertEqual(album["primary_artist_id"], "3840")
         self.assertEqual(album["secondary_types"], [])
+        self.assertIs(album["is_appearance"], False)
         self.assertNotIn("is_masterless", album)  # only set when True
 
         masterless = next(r for r in results if r["title"] == "Stupid Car (demo)")
@@ -520,6 +521,7 @@ class TestGetArtistReleases(unittest.TestCase):
         comp = next(r for r in results if r["title"] == "Indie 1996")
         self.assertEqual(comp["primary_artist_id"], "194")
         self.assertEqual(comp["artist_credit"], "Various")
+        self.assertIs(comp["is_appearance"], True)
         # The JS classifier reads primary_artist_id !== artist_id to route into
         # the Appearances section — so it must NOT equal the queried artist id.
         self.assertNotEqual(comp["primary_artist_id"], "3840")
@@ -555,6 +557,7 @@ class TestGetArtistReleases(unittest.TestCase):
         pablo = next(r for r in results if r["id"] == "13344")
         self.assertEqual(pablo["artist_credit"], "Radiohead")
         self.assertEqual(pablo["primary_artist_id"], "3840")
+        self.assertIs(pablo["is_appearance"], False)
 
 
 class TestGetArtistName(unittest.TestCase):

--- a/tests/test_js_artist_page.mjs
+++ b/tests/test_js_artist_page.mjs
@@ -6,8 +6,8 @@
  *  I1 Partition totality — every input release-group lands in exactly one
  *     of {inLibrary, missing, appearances, bootlegs}; nothing dropped,
  *     nothing duplicated.
- *  I2 Bootleg precedence — !has_official → bootlegs, regardless of
- *     ownership or library state.
+ *  I2 Appearance provenance precedence — is_appearance rows never become
+ *     mainline albums or bootlegs; otherwise !has_official → bootlegs.
  *  I3 Appearance split — has_official && !own → appearances, where "own"
  *     is the exact port of the old renderArtistDiscography credit logic.
  *  I4 Library split — has_official && own && in_library === true →
@@ -25,6 +25,7 @@ import {
   ownedTypeSections,
   renderArtistSections,
   renderOtherSourceSection,
+  splitAppearanceRows,
 } from '../web/js/artist_page.js';
 
 let passed = 0;
@@ -78,6 +79,7 @@ function rg(id, overrides = {}) {
     artist_credit: ARTIST_NAME,
     primary_artist_id: ARTIST_ID,
     has_official: true,
+    is_appearance: false,
     in_library: false,
     ...overrides,
   };
@@ -150,6 +152,25 @@ console.log('I1 — partition totality: every rg in exactly one section');
   assertEqual(s.missing.map(r => r.id).join(','), 'b', 'own+official+not-in-library → missing');
   assertEqual(s.appearances.map(r => r.id).join(','), 'c,d', 'official non-own → appearances');
   assertEqual(s.bootlegs.map(r => r.id).join(','), 'e,f,g,h', 'I2: bootleg precedence beats own/library');
+}
+
+console.log('I2 — explicit appearance provenance beats bootleg and ownership');
+{
+  const s = classify([
+    rg('mb-va-comp', {
+      has_official: false,
+      in_library: true,
+      is_appearance: true,
+      artist_credit: 'Various Artists',
+      primary_artist_id: 'va',
+    }),
+  ]);
+  assertEqual(s.appearances.map(r => r.id).join(','), 'mb-va-comp',
+    'track appearance is classified as an appearance');
+  assertEqual(s.bootlegs.length, 0,
+    'missing direct-artist official status cannot turn an appearance into a bootleg');
+  assertEqual(s.inLibrary.length, 0,
+    'an owned compilation appearance is not promoted to the mainline library section');
 }
 
 console.log('I3 — ownership credit logic (port of renderArtistDiscography)');
@@ -290,6 +311,48 @@ console.log('renderOtherSourceSection — complement rows force the other source
     'empty bucket -> empty string');
   const mbSide = renderOtherSourceSection([rows[0]], { artistName: ARTIST_NAME, source: 'mb' });
   assertContains(mbSide, 'Only on MusicBrainz', 'mb complement label');
+}
+
+console.log('renderOtherSourceSection — appearances are not mainline albums');
+{
+  const rows = [
+    rg('discogs-own-album', {
+      title: 'The Pointless Gift',
+      in_library: true,
+    }),
+    rg('discogs-va-one', {
+      title: 'The Big Noise',
+      secondary_types: ['Compilation'],
+      artist_credit: 'Various',
+      primary_artist_id: '194',
+      is_appearance: true,
+    }),
+    rg('discogs-va-two', {
+      title: 'The Sandringham Sessions',
+      secondary_types: ['Compilation'],
+      artist_credit: 'Various',
+      primary_artist_id: '194',
+      is_appearance: true,
+    }),
+  ];
+  const split = splitAppearanceRows(rows);
+  assertEqual(split.mainline.map(row => row.id).join(','), 'discogs-own-album',
+    'only the artist-credited release remains mainline');
+  assertEqual(split.appearances.map(row => row.id).join(','),
+    'discogs-va-one,discogs-va-two', 'VA compilations stay findable as appearances');
+
+  const html = renderOtherSourceSection(rows, {
+    artistName: ARTIST_NAME,
+    source: 'discogs',
+  });
+  assertContains(html, 'Albums <span class="type-count">1</span>',
+    'mainline Albums count excludes VA compilations');
+  assertExcludes(html, 'Albums <span class="type-count">3</span>',
+    'VA compilations are not flattened into Albums');
+  assertContains(html, 'Appears on <span class="type-count">2</span>',
+    'appearance bucket remains discoverable');
+  assertContains(html, 'Compilations <span class="type-count">2</span>',
+    'appearance rows retain their release-type grouping');
 }
 
 console.log('owned exceptional sections open only their owned release types');

--- a/tests/test_mb_api.py
+++ b/tests/test_mb_api.py
@@ -13,7 +13,7 @@ import urllib.parse
 from unittest.mock import MagicMock, patch
 
 from lib.va_identity import MB_VA_ARTIST_MBID
-from web.mb import search_release_groups
+from web.mb import get_artist_release_groups, search_release_groups
 
 
 def _mock_urlopen(response_data):
@@ -23,6 +23,21 @@ def _mock_urlopen(response_data):
     mock_resp.__enter__ = lambda s: s
     mock_resp.__exit__ = MagicMock(return_value=False)
     return patch("web.mb.urllib.request.urlopen", return_value=mock_resp)
+
+
+def _mock_urlopen_by_fragment(responses):
+    """Return the payload whose URL fragment matches the request."""
+    def _side_effect(request, **_kwargs):
+        for fragment, payload in responses.items():
+            if fragment in request.full_url:
+                mock_resp = MagicMock()
+                mock_resp.read.return_value = json.dumps(payload).encode()
+                mock_resp.__enter__ = lambda s: s
+                mock_resp.__exit__ = MagicMock(return_value=False)
+                return mock_resp
+        raise AssertionError(f"no response for {request.full_url}")
+
+    return patch("web.mb.urllib.request.urlopen", side_effect=_side_effect)
 
 
 _EMPTY = {"releases": []}
@@ -101,6 +116,79 @@ class TestSearchReleaseGroupsVaRewrite(unittest.TestCase):
         self.assertEqual(results[0]["artist_name"], "Various Artists")
         self.assertEqual(results[0]["primary_type"], "Album")
         self.assertEqual(results[0]["score"], 100)
+
+
+class TestArtistReleaseGroupsWithAppearances(unittest.TestCase):
+    ARTIST_ID = "4fa9413b-7c10-4342-8ddb-b1cd8e82f9e1"
+    OWN_RG = "fdb22921-b4c5-3c49-b2d0-85cb69eec1f1"
+    APPEARANCE_RG = "2e3dd447-ac5e-3b60-b44c-f9e6000ba6e7"
+
+    DIRECT = {
+        "release-group-count": 1,
+        "release-groups": [{
+            "id": OWN_RG,
+            "title": "The Pointless Gift",
+            "primary-type": "Album",
+            "secondary-types": [],
+            "first-release-date": "2000-12-05",
+            "artist-credit": [{
+                "name": "Deloris",
+                "artist": {"id": ARTIST_ID, "name": "Deloris"},
+            }],
+        }],
+    }
+    TRACK_APPEARANCES = {
+        "release-count": 2,
+        "releases": [
+            {
+                "id": "appearance-release",
+                "release-group": {
+                    "id": APPEARANCE_RG,
+                    "title": "The Big Noise",
+                    "primary-type": "Album",
+                    "secondary-types": ["Compilation"],
+                    "first-release-date": "2003-09-06",
+                    "artist-credit": [{
+                        "name": "Artists in Support of Make Trade Fair",
+                        "artist": {
+                            "id": MB_VA_ARTIST_MBID,
+                            "name": "Various Artists",
+                        },
+                    }],
+                },
+            },
+            {
+                "id": "duplicate-own-release",
+                "release-group": DIRECT["release-groups"][0],
+            },
+        ],
+    }
+
+    def test_track_artist_release_groups_are_preserved_as_appearances(self):
+        with _mock_urlopen_by_fragment({
+            "/release-group?artist=": self.DIRECT,
+            "/release?track_artist=": self.TRACK_APPEARANCES,
+        }) as mock:
+            rows = get_artist_release_groups(self.ARTIST_ID)
+
+        called = [call.args[0].full_url for call in mock.call_args_list]
+        self.assertTrue(any("/release?track_artist=" in url for url in called))
+        self.assertEqual(len(rows), 2)
+        by_id = {row["id"]: row for row in rows}
+        self.assertIs(by_id[self.OWN_RG]["is_appearance"], False)
+        self.assertIs(by_id[self.APPEARANCE_RG]["is_appearance"], True)
+        self.assertEqual(
+            by_id[self.APPEARANCE_RG]["artist_credit"],
+            "Artists in Support of Make Trade Fair",
+        )
+        self.assertEqual(
+            by_id[self.APPEARANCE_RG]["primary_artist_id"],
+            MB_VA_ARTIST_MBID,
+        )
+        self.assertEqual(
+            by_id[self.APPEARANCE_RG]["secondary_types"],
+            ["Compilation"],
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_owned_section_expansion_generated.py
+++ b/tests/test_owned_section_expansion_generated.py
@@ -66,6 +66,31 @@ process.stdout.write(JSON.stringify(ownedTypeSections(JSON.parse(input))));
     return json.loads(proc.stdout)
 
 
+def _real_appearance_split(
+    rows: list[dict[str, object]],
+) -> dict[str, list[int]]:
+    indexed = [{**row, "_index": index} for index, row in enumerate(rows)]
+    script = """
+import { splitAppearanceRows } from './web/js/artist_page.js';
+let input = '';
+for await (const chunk of process.stdin) input += chunk;
+const split = splitAppearanceRows(JSON.parse(input));
+process.stdout.write(JSON.stringify({
+  mainline: split.mainline.map(row => row._index),
+  appearances: split.appearances.map(row => row._index),
+}));
+"""
+    proc = subprocess.run(
+        ["node", "--input-type=module", "--eval", script],
+        cwd=ROOT,
+        input=json.dumps(indexed),
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return json.loads(proc.stdout)
+
+
 def assert_owned_type_contract(
     rows: list[dict[str, object]],
     actual: list[str],
@@ -81,17 +106,39 @@ def assert_owned_type_contract(
         )
 
 
+def assert_appearance_partition(
+    rows: list[dict[str, object]],
+    actual: dict[str, list[int]],
+) -> None:
+    expected_appearances = [
+        index for index, row in enumerate(rows)
+        if row.get("is_appearance") is True
+    ]
+    expected_mainline = [
+        index for index, row in enumerate(rows)
+        if row.get("is_appearance") is not True
+    ]
+    if actual != {
+        "mainline": expected_mainline,
+        "appearances": expected_appearances,
+    }:
+        raise AssertionError("appearance provenance leaked across the partition")
+
+
 row_strategy = st.builds(
-    lambda row_type, secondary_types, in_library, pipeline_status: {
+    lambda row_type, secondary_types, in_library, pipeline_status,
+           is_appearance: {
         "type": row_type,
         "secondary_types": list(secondary_types),
         "in_library": in_library,
         "pipeline_status": pipeline_status,
+        "is_appearance": is_appearance,
     },
     row_type=st.sampled_from(TYPES),
     secondary_types=st.sampled_from(SECONDARY_TYPES),
     in_library=st.one_of(st.none(), st.booleans()),
     pipeline_status=st.sampled_from([None, "wanted", "downloading", "imported"]),
+    is_appearance=st.one_of(st.none(), st.booleans()),
 )
 
 
@@ -126,6 +173,28 @@ class TestGeneratedOwnedSectionExpansion(unittest.TestCase):
         }]
         with self.assertRaisesRegex(AssertionError, "owned type expansion"):
             assert_owned_type_contract(rows, ["Albums"])
+
+    @given(rows=st.lists(row_strategy, min_size=0, max_size=16))
+    @example(rows=[{
+        "type": "Album",
+        "secondary_types": ["Compilation"],
+        "in_library": False,
+        "pipeline_status": None,
+        "is_appearance": True,
+    }])
+    def test_appearance_provenance_never_leaks_into_mainline(
+        self,
+        rows: list[dict[str, object]],
+    ) -> None:
+        assert_appearance_partition(rows, _real_appearance_split(rows))
+
+    def test_appearance_checker_rejects_flattened_compilation(self) -> None:
+        rows: list[dict[str, object]] = [{"is_appearance": True}]
+        with self.assertRaisesRegex(AssertionError, "appearance provenance"):
+            assert_appearance_partition(rows, {
+                "mainline": [0],
+                "appearances": [],
+            })
 
 
 if __name__ == "__main__":

--- a/tests/web/test_routes_browse.py
+++ b/tests/web/test_routes_browse.py
@@ -33,7 +33,7 @@ class TestBrowseRouteContracts(_FakeDbWebServerCase):
     }
     ARTIST_RG_REQUIRED_FIELDS = {
         "id", "title", "type", "secondary_types", "first_release_date",
-        "artist_credit", "primary_artist_id", "has_official",
+        "artist_credit", "primary_artist_id", "has_official", "is_appearance",
     }
     LIBRARY_ALBUM_REQUIRED_FIELDS = set(LibraryAlbumRow.__struct_fields__)
     RELEASE_GROUP_REQUIRED_FIELDS = {
@@ -355,6 +355,7 @@ class TestBrowseRouteContracts(_FakeDbWebServerCase):
             "first_release_date": "1997-05-21",
             "artist_credit": "Radiohead",
             "primary_artist_id": self.ARTIST_ID,
+            "is_appearance": False,
         }
         discogs_rg = {
             "id": "21491",
@@ -364,6 +365,7 @@ class TestBrowseRouteContracts(_FakeDbWebServerCase):
             "first_release_date": "1997",
             "artist_credit": "Radiohead",
             "primary_artist_id": "3840",
+            "is_appearance": False,
         }
         with patch("web.server.mb_api") as mock_mb, \
                 patch("web.routes.browse.discogs_api") as mock_dg:
@@ -388,6 +390,8 @@ class TestBrowseRouteContracts(_FakeDbWebServerCase):
         self.assertEqual(data["discogs_only"], [])
         self.assertEqual(data["both"][0]["mb"]["id"], self.RG_ID)
         self.assertEqual(data["both"][0]["discogs"]["id"], "21491")
+        self.assertIs(data["both"][0]["mb"]["is_appearance"], False)
+        self.assertIs(data["both"][0]["discogs"]["is_appearance"], False)
         # Bootleg classification flows through to frontend.
         self.assertTrue(data["both"][0]["mb"]["has_official"])
 
@@ -434,6 +438,7 @@ class TestBrowseRouteContracts(_FakeDbWebServerCase):
             "first_release_date": "2024-01-01",
             "artist_credit": "Test Artist",
             "primary_artist_id": self.ARTIST_ID,
+            "is_appearance": False,
         }
         with patch("web.server.mb_api") as mock_mb:
             mock_mb.get_artist_release_groups.return_value = [release_group]
@@ -444,6 +449,27 @@ class TestBrowseRouteContracts(_FakeDbWebServerCase):
         _assert_required_fields(self, data, {"release_groups"}, "artist response")
         _assert_required_fields(self, data["release_groups"][0], self.ARTIST_RG_REQUIRED_FIELDS,
                                 "artist release group")
+
+    def test_artist_track_appearance_remains_distinct_from_bootlegs(self):
+        appearance = {
+            "id": "2e3dd447-ac5e-3b60-b44c-f9e6000ba6e7",
+            "title": "The Big Noise",
+            "type": "Album",
+            "secondary_types": ["Compilation"],
+            "first_release_date": "2003-09-06",
+            "artist_credit": "Various Artists",
+            "primary_artist_id": "89ad4ac3-39f7-470e-963a-56509c546377",
+            "is_appearance": True,
+        }
+        with patch("web.server.mb_api") as mock_mb:
+            mock_mb.get_artist_release_groups.return_value = [appearance]
+            mock_mb.get_official_release_group_ids.return_value = set()
+            status, data = self._get(f"/api/artist/{self.ARTIST_ID}")
+
+        self.assertEqual(status, 200)
+        row = data["release_groups"][0]
+        self.assertIs(row["is_appearance"], True)
+        self.assertIs(row["has_official"], False)
 
     def test_artist_release_groups_transport_failure_is_clean_retryable_503(self):
         raw_reason = "[SSL: UNEXPECTED_EOF_WHILE_READING] private adapter detail"
@@ -970,6 +996,7 @@ class TestDiscogsBrowseRouteContracts(_FakeDbWebServerCase):
                     "first_release_date": "1997",
                     "artist_credit": "Radiohead",
                     "primary_artist_id": "3840",
+                    "is_appearance": False,
                 },
             ]
             status, data = self._get("/api/discogs/artist/3840")
@@ -977,6 +1004,7 @@ class TestDiscogsBrowseRouteContracts(_FakeDbWebServerCase):
         self.assertEqual(status, 200)
         _assert_required_fields(self, data, self.DISCOGS_ARTIST_REQUIRED_FIELDS,
                                 "discogs artist response")
+        self.assertIs(data["release_groups"][0]["is_appearance"], False)
 
     def test_discogs_artist_masterless_pipeline_overlay(self):
         """Masterless rows (id IS the release id) carry the request badge

--- a/web/discogs.py
+++ b/web/discogs.py
@@ -257,7 +257,11 @@ def search_artists(query: str) -> list[dict]:
     return _cache.memoize_meta(f"discogs:search:artists:{cache_query}", _fetch)
 
 
-def _normalize_artist_master_entry(r: dict) -> dict:
+def _normalize_artist_master_entry(
+    r: dict,
+    *,
+    is_appearance: bool,
+) -> dict:
     """Shape one row from /api/artists/{id}/{masters,appearances} into our schema.
 
     Masterless releases come back with id ``release-<n>``; we strip the prefix
@@ -277,6 +281,7 @@ def _normalize_artist_master_entry(r: dict) -> dict:
             "first_release_date": r.get("first_release_date", ""),
             "artist_credit": r.get("artist_credit", ""),
             "primary_artist_id": str(r.get("primary_artist_id") or ""),
+            "is_appearance": is_appearance,
             "is_masterless": True,
             "discogs_release_id": bare_id,
         }
@@ -288,6 +293,7 @@ def _normalize_artist_master_entry(r: dict) -> dict:
         "first_release_date": r.get("first_release_date", ""),
         "artist_credit": r.get("artist_credit", ""),
         "primary_artist_id": str(r.get("primary_artist_id") or ""),
+        "is_appearance": is_appearance,
     }
 
 
@@ -321,7 +327,9 @@ def get_artist_releases(artist_id: int) -> list[dict]:
             if not results:
                 break
             for r in results:
-                entry = _normalize_artist_master_entry(r)
+                entry = _normalize_artist_master_entry(
+                    r, is_appearance=False,
+                )
                 entries.setdefault(entry["id"], entry)
             total = data.get("total", 0)
             if page * data.get("per_page", 100) >= total:
@@ -332,7 +340,9 @@ def get_artist_releases(artist_id: int) -> list[dict]:
             f"{_api_base()}/api/artists/{artist_id}/appearances"
         )
         for r in appearances.get("results", []):
-            entry = _normalize_artist_master_entry(r)
+            entry = _normalize_artist_master_entry(
+                r, is_appearance=True,
+            )
             entries.setdefault(entry["id"], entry)
 
         return sorted(
@@ -340,7 +350,7 @@ def get_artist_releases(artist_id: int) -> list[dict]:
             key=lambda e: (e.get("first_release_date") or "", e.get("id", "")),
         )
 
-    return _cache.memoize_meta(f"discogs:artist:{artist_id}:releases:v2", _fetch)
+    return _cache.memoize_meta(f"discogs:artist:{artist_id}:releases:v3", _fetch)
 
 
 def get_master_releases(master_id: int) -> dict:

--- a/web/js/artist_page.js
+++ b/web/js/artist_page.js
@@ -20,7 +20,8 @@
  *
  * Sectioning invariants (see tests/test_js_artist_page.mjs):
  *   I1 every release-group lands in exactly one of {inLibrary, missing,
- *      appearances, bootlegs}; I2 bootleg precedence; I3 ownership via
+ *      appearances, bootlegs}; I2 explicit appearance provenance precedes
+ *      bootleg/ownership classification; I3 ownership via
  *      the credit rules; I4 in_library === true is the only inLibrary
  *      ticket; I5 inFlight is a lens over the library feed
  *      (downloading/manual only — "wanted" is ambient after the
@@ -47,7 +48,9 @@ export function classifyArtistRows({ artistId, artistName, releaseGroups, librar
     const credit = (rg.artist_credit || '').toLowerCase();
     const isOwn = rg.primary_artist_id === artistId
       || credit === nameLC || credit.startsWith(nameLC + ' /') || credit.startsWith(nameLC + ',') || !credit;
-    if (!rg.has_official) {
+    if (rg.is_appearance === true) {
+      appearances.push(rg);
+    } else if (!rg.has_official) {
       bootlegs.push(rg);
     } else if (!isOwn) {
       appearances.push(rg);
@@ -122,6 +125,22 @@ export function ownedTypeSections(rows) {
 }
 
 /**
+ * Partition source-complement rows without guessing from titles or VA names.
+ * Metadata adapters author ``is_appearance`` from their native provenance.
+ *
+ * @param {Object[]} rows
+ * @returns {{mainline: Object[], appearances: Object[]}}
+ */
+export function splitAppearanceRows(rows) {
+  const mainline = [];
+  const appearances = [];
+  for (const row of rows || []) {
+    (row.is_appearance === true ? appearances : mainline).push(row);
+  }
+  return { mainline, appearances };
+}
+
+/**
  * Render the unified artist page body. Empty sections are omitted.
  * @param {{inLibrary: Object[], inFlight: Object[], missing: Object[],
  *          appearances: Object[], bootlegs: Object[]}} sections
@@ -163,8 +182,12 @@ export function renderArtistSections(sections, ctx) {
       typed(sections.missing, true), { open: true });
   }
   if (sections.appearances.length > 0) {
+    const ownedTypes = ownedTypeSections(sections.appearances);
     html += sectionWrap('Appearances', sections.appearances.length,
-      typed(sections.appearances, false), { color: '#777' });
+      typed(sections.appearances, false, ownedTypes), {
+        color: '#777',
+        open: ownedTypes.length > 0,
+      });
   }
   if (sections.bootlegs.length > 0) {
     const ownedTypes = ownedTypeSections(sections.bootlegs);
@@ -192,15 +215,36 @@ export function renderOtherSourceSection(rows, ctx) {
   const rgRow = (rg) => renderRgRow(rg, {
     artistName: ctx.artistName, nameLC, source: ctx.source,
   });
-  const ownedTypes = ownedTypeSections(rows);
-  return sectionWrap(`Only on ${label}`, rows.length,
-    renderTypedSections(rows, rgRow, {
+  const { mainline, appearances } = splitAppearanceRows(rows);
+  const mainlineOwnedTypes = ownedTypeSections(mainline);
+  const appearanceOwnedTypes = ownedTypeSections(appearances);
+  let body = '';
+  if (mainline.length > 0) {
+    body += renderTypedSections(mainline, rgRow, {
       defaultOpen: null,
-      openSections: ownedTypes,
-    }),
+      openSections: mainlineOwnedTypes,
+    });
+  }
+  if (appearances.length > 0) {
+    body += sectionWrap(
+      'Appears on',
+      appearances.length,
+      renderTypedSections(appearances, rgRow, {
+        defaultOpen: null,
+        openSections: appearanceOwnedTypes,
+        headerStyle: 'color:#777;',
+      }),
+      {
+        color: '#777',
+        open: appearanceOwnedTypes.length > 0,
+      },
+    );
+  }
+  return sectionWrap(`Only on ${label}`, rows.length,
+    body,
     {
       color: '#a96',
       id: 'only-other-source',
-      open: ownedTypes.length > 0,
+      open: mainlineOwnedTypes.length > 0 || appearanceOwnedTypes.length > 0,
     });
 }

--- a/web/mb.py
+++ b/web/mb.py
@@ -121,10 +121,38 @@ def search_artists(query):
     return _cache.memoize_meta(f"mb:search:artists:{query}", _fetch)
 
 
+def _normalize_artist_release_group(
+    rg: dict,
+    *,
+    is_appearance: bool,
+) -> dict:
+    """Shape direct and track-appearance MB rows into one artist-page contract."""
+    ac = rg.get("artist-credit", [])
+    credit_name = " / ".join(a.get("name", "?") for a in ac) if ac else ""
+    primary_artist_id = ac[0].get("artist", {}).get("id") if ac else None
+    return {
+        "id": rg["id"],
+        "title": rg.get("title", ""),
+        "type": rg.get("primary-type", ""),
+        "secondary_types": rg.get("secondary-types", []),
+        "first_release_date": rg.get("first-release-date", ""),
+        "artist_credit": credit_name,
+        "primary_artist_id": primary_artist_id,
+        "is_appearance": is_appearance,
+    }
+
+
 def get_artist_release_groups(artist_mbid):
-    """Get all release groups for an artist. Returns list of {id, title, type, first_release_date}."""
+    """Get directly credited release groups plus track-level appearances.
+
+    MusicBrainz has no combined artist-discography endpoint. Direct work comes
+    from the release-group artist browse; VA compilations and guest spots come
+    from the release ``track_artist`` browse. Direct rows win deduplication so
+    a release group is never downgraded merely because another pressing also
+    contains an appearance.
+    """
     def _fetch() -> list[dict]:
-        results = []
+        entries: dict[str, dict] = {}
         offset = 0
         while True:
             data = _get(
@@ -132,26 +160,46 @@ def get_artist_release_groups(artist_mbid):
                 f"&inc=artist-credits&fmt=json&limit=100&offset={offset}"
             )
             for rg in data.get("release-groups", []):
-                ac = rg.get("artist-credit", [])
-                credit_name = " / ".join(a.get("name", "?") for a in ac) if ac else ""
-                # Extract primary artist ID from credit for reliable own-work detection
-                primary_artist_id = ac[0].get("artist", {}).get("id") if ac else None
-                results.append({
-                    "id": rg["id"],
-                    "title": rg.get("title", ""),
-                    "type": rg.get("primary-type", ""),
-                    "secondary_types": rg.get("secondary-types", []),
-                    "first_release_date": rg.get("first-release-date", ""),
-                    "artist_credit": credit_name,
-                    "primary_artist_id": primary_artist_id,
-                })
+                entry = _normalize_artist_release_group(
+                    rg, is_appearance=False,
+                )
+                entries.setdefault(entry["id"], entry)
             total = data.get("release-group-count", 0)
             offset += 100
             if offset >= total:
                 break
-        return results
 
-    return _cache.memoize_meta(f"mb:artist:{artist_mbid}:release_groups", _fetch)
+        offset = 0
+        while True:
+            data = _get(
+                f"{MB_API_BASE}/release?track_artist={artist_mbid}"
+                "&inc=release-groups+artist-credits"
+                f"&fmt=json&limit=100&offset={offset}"
+            )
+            for release in data.get("releases", []):
+                rg = release.get("release-group")
+                if not isinstance(rg, dict) or not rg.get("id"):
+                    continue
+                entry = _normalize_artist_release_group(
+                    rg, is_appearance=True,
+                )
+                entries.setdefault(entry["id"], entry)
+            total = data.get("release-count", 0)
+            offset += 100
+            if offset >= total:
+                break
+
+        return sorted(
+            entries.values(),
+            key=lambda row: (
+                row.get("first_release_date") or "",
+                row.get("id") or "",
+            ),
+        )
+
+    return _cache.memoize_meta(
+        f"mb:artist:{artist_mbid}:release_groups:v2", _fetch,
+    )
 
 
 def get_official_release_group_ids(artist_mbid):

--- a/web/routes/browse.py
+++ b/web/routes/browse.py
@@ -572,7 +572,7 @@ def get_artist_compare(h: BaseHTTPRequestHandler, params: dict[str, list[str]]) 
 
     # Skeleton key is the resolved (mbid, discogs_id) pair — display
     # names are stamped on outside the cache from the canonical APIs.
-    cache_key = f"artist:compare:{mbid or 'none'}:{discogs_id or 'none'}"
+    cache_key = f"artist:compare:v2:{mbid or 'none'}:{discogs_id or 'none'}"
     skeleton = _cache.memoize_meta(
         cache_key,
         lambda: _build_compare_skeleton(mbid, discogs_id),
@@ -745,8 +745,8 @@ ROUTES: list[RouteRegistration] = [
     ),
     route(
         "GET", "/api/artist/compare", get_artist_compare,
-        "Side-by-side MB + Discogs discographies for one artist, "
-        "fuzzy-merged with in-library overlay.",
+        "Side-by-side MB + Discogs discographies and track appearances for "
+        "one artist, fuzzy-merged with in-library overlay.",
         classified=True,
     ),
     route(
@@ -756,7 +756,8 @@ ROUTES: list[RouteRegistration] = [
     ),
     pattern_route(
         "GET", r"^/api/artist/([a-f0-9-]+)$", get_artist,
-        "MB artist detail — release groups with library/pipeline overlay.",
+        "MB artist detail — direct release groups plus track appearances "
+        "with library/pipeline overlay.",
         classified=True,
     ),
     pattern_route(


### PR DESCRIPTION
## Summary

Follow-up to #575 based on the Deloris artist page.

- fetch MusicBrainz track-level appearances through the external `track_artist` browse and normalize them alongside direct release groups
- preserve the existing Discogs `/appearances` endpoint provenance instead of flattening those rows into the main discography
- render source-complement appearances under a distinct `Appears on` section, grouped by release type
- keep exceptional sections quiet, but auto-expand only appearance types that contain an in-library release
- make direct discography rows win deduplication when a release group appears through both paths

No Discogs API change is required: the owned API already exposes masters and appearances separately; the web adapter was discarding that distinction.

## Live verification

Using the live read-only DB, MusicBrainz mirror, and Discogs API through the local web dev server:

- Deloris now has two MusicBrainz `Appearances`: `Some Songs From Sodastream` and `The Big Noise`
- six Discogs VA compilations moved out of mainline `Albums` into `Only on Discogs > Appears on > Compilations`
- `Only on Discogs > Albums` now contains only the actual Deloris album (`The Pointless Gift`)
- owned exceptional rows still open only their occupied release type
- desktop and 390px mobile views had no content overflow or JS console errors

## Verification

- pyright: 0 errors
- dead-code sweep: clean
- focused backend/UI/generated tests: green
- full exact-commit suite: 5,653 passed, 0 skipped
- pre-push generated fuzz burst: green
- `nix flake check`: green
