### PR TITLE
Centralize attempted-import spectral audit boundary

### DIFF
--- a/lib/measurement.py
+++ b/lib/measurement.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
@@ -60,7 +61,7 @@ def spectral_analyze(folder: str, trim_seconds: int = 30) -> Any:
     return analyze_album(folder, trim_seconds=trim_seconds)
 
 
-def _spectral_analysis_detail(path: str) -> SpectralAnalysisDetail:
+def analyze_spectral_audit_path(path: str) -> SpectralAnalysisDetail:
     """Analyze one path into display-only attempt audit evidence."""
     grade: str | None = None
     bitrate_kbps: int | None = None
@@ -104,52 +105,101 @@ def collect_attempt_spectral_audit(
     existing_path: str | None,
 ) -> SpectralDetail:
     """Measure candidate and exact-release installed files independently."""
-    candidate = _spectral_analysis_detail(candidate_path)
+    candidate = analyze_spectral_audit_path(candidate_path)
     existing = (
-        _spectral_analysis_detail(existing_path)
+        analyze_spectral_audit_path(existing_path)
         if existing_path is not None
         else SpectralAnalysisDetail(attempted=False)
     )
     return SpectralDetail(candidate=candidate, existing=existing)
 
 
-def _collect_release_attempt_spectral_audit(
+SpectralDetailAnalyzer = Callable[[str], SpectralAnalysisDetail]
+
+
+@dataclass(frozen=True)
+class ExistingSpectralAuditLookup:
+    """Exact-release path, policy bitrate, and fail-soft lookup audit."""
+
+    path: str | None = None
+    min_bitrate_kbps: int | None = None
+    failure: SpectralAnalysisDetail | None = None
+
+
+ExistingSpectralResolver = Callable[
+    [str],
+    ExistingSpectralAuditLookup,
+]
+
+
+def _fail_soft_spectral_analysis(
+    path: str,
+    analyzer: SpectralDetailAnalyzer,
+) -> SpectralAnalysisDetail:
+    try:
+        return analyzer(path)
+    except Exception as exc:
+        logger.exception("SPECTRAL AUDIT: failed for %s", path)
+        return SpectralAnalysisDetail(
+            attempted=True,
+            error=f"{type(exc).__name__}: {exc}",
+        )
+
+
+def collect_release_attempt_spectral_audit(
     candidate_path: str,
     mb_release_id: str,
-    cfg: "CratediggerConfig",
     *,
     existing_spectral_evidence: SpectralAnalysisDetail,
     preserve_existing_source_spectral: bool,
-) -> SpectralDetail:
-    """Collect both attempt sides, except for lossless-source derivatives.
+    analyzer: SpectralDetailAnalyzer,
+    existing_resolver: ExistingSpectralResolver,
+    candidate_detail: SpectralAnalysisDetail | None = None,
+) -> tuple[SpectralDetail, ExistingSpectralAuditLookup]:
+    """Own conditional HAVE collection for every attempted-import adapter.
 
     A lossless source converted to Opus/V0 keeps the source-side spectral
     measurement as its authoritative HAVE provenance; analyzing that installed
     derivative can rewrite a transcode-like FLAC as apparently genuine. Every
     other exact-release copy is analyzed from the files currently on disk.
     """
-    if preserve_existing_source_spectral:
-        audit = collect_attempt_spectral_audit(candidate_path, None)
-        audit.existing = existing_spectral_evidence
-        return audit
-
-    existing_path, lookup_failure = resolve_existing_spectral_audit_path(
-        mb_release_id,
-        cfg,
+    candidate = (
+        candidate_detail
+        if candidate_detail is not None
+        else _fail_soft_spectral_analysis(candidate_path, analyzer)
     )
-    audit = collect_attempt_spectral_audit(candidate_path, existing_path)
-    if lookup_failure is not None:
-        audit.existing = lookup_failure
-    return audit
+    try:
+        lookup = (
+            existing_resolver(mb_release_id)
+            if mb_release_id
+            else ExistingSpectralAuditLookup()
+        )
+    except Exception as exc:
+        logger.exception("SPECTRAL AUDIT: exact-release lookup failed")
+        lookup = ExistingSpectralAuditLookup(
+            failure=SpectralAnalysisDetail(
+                attempted=True,
+                error=f"{type(exc).__name__}: {exc}",
+            ),
+        )
+    if preserve_existing_source_spectral:
+        existing = existing_spectral_evidence
+    elif lookup.failure is not None:
+        existing = lookup.failure
+    elif lookup.path is not None:
+        existing = _fail_soft_spectral_analysis(lookup.path, analyzer)
+    else:
+        existing = SpectralAnalysisDetail(attempted=False)
+    return SpectralDetail(candidate=candidate, existing=existing), lookup
 
 
-def resolve_existing_spectral_audit_path(
+def resolve_existing_spectral_audit(
     mb_release_id: str,
     cfg: "CratediggerConfig",
-) -> tuple[str | None, SpectralAnalysisDetail | None]:
+) -> ExistingSpectralAuditLookup:
     """Resolve exact-release files, preserving lookup failure as audit data."""
     if not mb_release_id:
-        return None, None
+        return ExistingSpectralAuditLookup()
     from lib.beets_db import BeetsDB
 
     try:
@@ -158,15 +208,27 @@ def resolve_existing_spectral_audit_path(
                 mb_release_id,
                 cfg.quality_ranks,
             )
-        if existing_info is not None and os.path.isdir(existing_info.album_path):
-            return existing_info.album_path, None
+        if existing_info is not None:
+            return ExistingSpectralAuditLookup(
+                path=(existing_info.album_path
+                      if os.path.isdir(existing_info.album_path or "") else None),
+                min_bitrate_kbps=existing_info.min_bitrate_kbps,
+            )
     except Exception as exc:
         logger.exception("SPECTRAL AUDIT: failed to resolve existing exact release")
-        return None, SpectralAnalysisDetail(
-            attempted=True,
-            error=f"{type(exc).__name__}: {exc}",
+        return ExistingSpectralAuditLookup(
+            failure=SpectralAnalysisDetail(
+                attempted=True,
+                error=f"{type(exc).__name__}: {exc}",
+            ),
         )
-    return None, None
+    return ExistingSpectralAuditLookup()
+
+
+def existing_spectral_resolver_for_config(
+    cfg: "CratediggerConfig",
+) -> ExistingSpectralResolver:
+    return lambda release_id: resolve_existing_spectral_audit(release_id, cfg)
 
 
 def spectral_detail_from_persisted_source(
@@ -342,56 +404,6 @@ def _needs_spectral_check(
     return avg_bitrate_kbps < vbr_threshold_kbps
 
 
-def _load_existing_quality(
-    mb_release_id: str,
-    cfg: "CratediggerConfig",
-    spectral_evidence: SpectralAnalysisDetail,
-    *,
-    preserve_existing_source_spectral: bool,
-) -> tuple[int | None, SpectralMeasurement | None, SpectralAnalysisDetail]:
-    """Look up existing bitrate and gather the correct HAVE spectral side.
-
-    Lossless-source derivatives use persisted pre-conversion provenance.
-    Every other exact-release copy is analyzed from its current files.
-    """
-    from lib.beets_db import BeetsDB
-
-    existing_min: int | None = None
-    existing_spectral: SpectralMeasurement | None = None
-    audit = SpectralAnalysisDetail(attempted=False)
-    if preserve_existing_source_spectral:
-        audit = spectral_evidence
-        existing_spectral = SpectralMeasurement.from_parts(
-            spectral_evidence.grade,
-            spectral_evidence.bitrate_kbps,
-        )
-    try:
-        with BeetsDB(library_root=getattr(cfg, "beets_directory", "")) as beets:
-            existing_info = beets.get_album_info(
-                mb_release_id, cfg.quality_ranks)
-        if existing_info:
-            existing_min = existing_info.min_bitrate_kbps
-            if (
-                not preserve_existing_source_spectral
-                and os.path.isdir(existing_info.album_path)
-            ):
-                audit = _spectral_analysis_detail(existing_info.album_path)
-                existing_spectral = SpectralMeasurement.from_parts(
-                    audit.grade,
-                    audit.bitrate_kbps,
-                )
-                logger.info(
-                    "SPECTRAL: existing on disk: grade=%s, "
-                    "estimated_bitrate=%skbps, beets_min=%skbps",
-                    audit.grade,
-                    audit.bitrate_kbps,
-                    existing_min,
-                )
-    except Exception:
-        logger.exception("SPECTRAL: failed to check existing files")
-    return existing_min, existing_spectral, audit
-
-
 def _persist_spectral_state(
     *,
     db: "PipelineDB",
@@ -529,6 +541,8 @@ def measure_preimport_state(
     preserve_existing_source_spectral: bool = False,
     propagate_download_to_existing: bool = True,
     precomputed_inspection: "LocalFileInspection | None" = None,
+    spectral_detail_analyzer: SpectralDetailAnalyzer | None = None,
+    existing_spectral_resolver: ExistingSpectralResolver | None = None,
 ) -> PreimportMeasurement:
     """Collect pre-import measurement facts. Returns ``PreimportMeasurement``.
 
@@ -579,6 +593,11 @@ def measure_preimport_state(
         existing_spectral_evidence
         or SpectralAnalysisDetail(attempted=False)
     )
+    audit_analyzer = spectral_detail_analyzer or analyze_spectral_audit_path
+    audit_resolver = (
+        existing_spectral_resolver
+        or existing_spectral_resolver_for_config(cfg)
+    )
     spectral_audit = SpectralDetail(
         candidate=SpectralAnalysisDetail(attempted=False),
         existing=persisted_existing,
@@ -595,15 +614,16 @@ def measure_preimport_state(
             logger.warning(
                 f"AUDIO CORRUPT: {label} "
                 f"({len(corrupt_files)} files failed ffmpeg decode)")
-            spectral_audit = _collect_release_attempt_spectral_audit(
+            spectral_audit = collect_release_attempt_spectral_audit(
                 path,
                 mb_release_id,
-                cfg,
                 existing_spectral_evidence=persisted_existing,
                 preserve_existing_source_spectral=(
                     preserve_existing_source_spectral
                 ),
-            )
+                analyzer=audit_analyzer,
+                existing_resolver=audit_resolver,
+            )[0]
             return PreimportMeasurement(
                 corrupt_files=corrupt_files,
                 audio_corrupt=audio_corrupt,
@@ -644,15 +664,16 @@ def measure_preimport_state(
                 logger.warning(
                     f"BAD HASH MATCH: {label} "
                     f"hash_id={match.bad_hash_id} track={match.track_path}")
-                spectral_audit = _collect_release_attempt_spectral_audit(
+                spectral_audit = collect_release_attempt_spectral_audit(
                     path,
                     mb_release_id,
-                    cfg,
                     existing_spectral_evidence=persisted_existing,
                     preserve_existing_source_spectral=(
                         preserve_existing_source_spectral
                     ),
-                )
+                    analyzer=audit_analyzer,
+                    existing_resolver=audit_resolver,
+                )[0]
                 return PreimportMeasurement(
                     corrupt_files=[],
                     audio_corrupt=False,
@@ -731,7 +752,18 @@ def measure_preimport_state(
         avg_bitrate_kbps=avg_bitrate_kbps,
         vbr_threshold_kbps=cfg.quality_ranks.mp3_vbr.excellent,
     ):
-        candidate_audit = _spectral_analysis_detail(path)
+        spectral_audit, existing_lookup = collect_release_attempt_spectral_audit(
+            path,
+            mb_release_id,
+            existing_spectral_evidence=persisted_existing,
+            preserve_existing_source_spectral=(
+                preserve_existing_source_spectral
+            ),
+            analyzer=audit_analyzer,
+            existing_resolver=audit_resolver,
+        )
+        candidate_audit = spectral_audit.candidate
+        assert candidate_audit is not None
         download_spectral = SpectralMeasurement.from_parts(
             candidate_audit.grade, candidate_audit.bitrate_kbps)
         if download_spectral is not None:
@@ -745,31 +777,19 @@ def measure_preimport_state(
                 f"suspect={candidate_audit.suspect_pct or 0:.0f}%, "
                 f"cliffs={cliff_count}")
 
-        existing_audit = persisted_existing
-        measured_existing_min: int | None = None
-        measured_existing: SpectralMeasurement | None = None
-        if mb_release_id:
-            measured_existing_min, measured_existing, existing_audit = (
-                _load_existing_quality(
-                    mb_release_id,
-                    cfg,
-                    persisted_existing,
-                    preserve_existing_source_spectral=(
-                        preserve_existing_source_spectral
-                    ),
-                )
-            )
+        existing_audit = spectral_audit.existing
+        assert existing_audit is not None
+        measured_existing_min = existing_lookup.min_bitrate_kbps
+        measured_existing = SpectralMeasurement.from_parts(
+            existing_audit.grade,
+            existing_audit.bitrate_kbps,
+        )
         # Preserve the old policy input: an existing spectral measurement was
         # considered only when candidate spectral analysis succeeded. The
         # independently gathered existing audit remains display-only.
         if download_spectral is not None:
             existing_min_bitrate = measured_existing_min
             existing_spectral = measured_existing
-        spectral_audit = SpectralDetail(
-            candidate=candidate_audit,
-            existing=existing_audit,
-        )
-
         # --- Fall back to persisted spectral state when BeetsDB couldn't walk ---
         beets_knows_album = existing_min_bitrate is not None
         if (download_spectral is not None
@@ -799,18 +819,17 @@ def measure_preimport_state(
         # Normal harness-bound codecs collect the candidate inside
         # import_one.py before conversion. Fill only HAVE here so the attempt
         # remains two-sided without paying for a duplicate candidate scan.
-        _, _, existing_audit = _load_existing_quality(
+        spectral_audit = collect_release_attempt_spectral_audit(
+            path,
             mb_release_id,
-            cfg,
-            persisted_existing,
+            existing_spectral_evidence=persisted_existing,
             preserve_existing_source_spectral=(
                 preserve_existing_source_spectral
             ),
-        )
-        spectral_audit = SpectralDetail(
-            candidate=spectral_audit.candidate,
-            existing=existing_audit,
-        )
+            analyzer=audit_analyzer,
+            existing_resolver=audit_resolver,
+            candidate_detail=spectral_audit.candidate,
+        )[0]
 
     # --- Persist spectral state to DB (issue #90 propagation) ---
     # This MUST fire on every measurement where spectral was collected,

--- a/scripts/import_preview_worker.py
+++ b/scripts/import_preview_worker.py
@@ -21,7 +21,7 @@ REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 if REPO_ROOT not in sys.path:
     sys.path.insert(0, REPO_ROOT)
 
-from lib.config import CratediggerConfig, read_runtime_config
+from lib.config import read_runtime_config
 from lib.dispatch import _record_preview_measurement_failed
 from lib.import_preview import (
     PREVIEW_VERDICT_EVIDENCE_READY,
@@ -44,8 +44,12 @@ from lib.import_queue import (
 )
 from lib.pipeline_db import DEFAULT_DSN, PipelineDB
 from lib.measurement import (
-    collect_attempt_spectral_audit,
-    resolve_existing_spectral_audit_path,
+    ExistingSpectralAuditLookup,
+    ExistingSpectralResolver,
+    SpectralDetailAnalyzer,
+    analyze_spectral_audit_path,
+    collect_release_attempt_spectral_audit,
+    existing_spectral_resolver_for_config,
 )
 from lib.quality import (
     ActiveDownloadState,
@@ -53,7 +57,6 @@ from lib.quality import (
     MeasurementFailure,
     ImportResult,
     SpectralAnalysisDetail,
-    SpectralDetail,
 )
 from lib.quality_evidence import (
     EvidenceBuildResult,
@@ -448,85 +451,15 @@ def _handle_measurement_failed(
     return None
 
 
-SpectralAuditCollector = Callable[
-    [str, str | None],
-    SpectralDetail,
-]
-ExistingSpectralPathResolver = Callable[
-    [str, CratediggerConfig],
-    tuple[str | None, SpectralAnalysisDetail | None],
-]
 PreviewFn = Callable[[Any, ImportJob], ImportPreviewResult]
-
-
-def _collect_reused_evidence_spectral_audit(
-    db: Any,
-    request_id: int | None,
-    source_path: str,
-    collector: SpectralAuditCollector,
-    existing_path_resolver: ExistingSpectralPathResolver,
-) -> SpectralDetail:
-    """Collect reused-candidate audit with the same conditional HAVE rule."""
-    persisted_existing = SpectralAnalysisDetail(attempted=False)
-    preserve_have_source = False
-    existing_path: str | None = None
-    lookup_failure: SpectralAnalysisDetail | None = None
-    if request_id is not None:
-        try:
-            req = db.get_request(request_id) or {}
-            current_evidence, persisted_existing, _ = (
-                load_persisted_existing_spectral(
-                    db,
-                    request_id,
-                    req,
-                )
-            )
-            preserve_have_source = preserve_existing_source_spectral(
-                current_evidence,
-            )
-            if not preserve_have_source:
-                existing_path, lookup_failure = (
-                    existing_path_resolver(
-                        str(req.get("mb_release_id") or ""),
-                        read_runtime_config(),
-                    )
-                )
-        except Exception:
-            logger.exception(
-                "Unable to resolve reused HAVE audit for request %s",
-                request_id,
-            )
-    try:
-        audit = collector(source_path, existing_path)
-        if preserve_have_source:
-            audit.existing = persisted_existing
-        elif lookup_failure is not None:
-            audit.existing = lookup_failure
-        return audit
-    except Exception as exc:
-        logger.exception(
-            "Reused-evidence spectral audit failed for %s", source_path)
-        error = f"{type(exc).__name__}: {exc}"
-        return SpectralDetail(
-            candidate=SpectralAnalysisDetail(attempted=True, error=error),
-            existing=(
-                persisted_existing
-                if preserve_have_source
-                else lookup_failure or SpectralAnalysisDetail(attempted=False)
-            ),
-        )
 
 
 def process_claimed_preview_job(
     db: Any,
     job: ImportJob,
     *,
-    spectral_audit_collector: SpectralAuditCollector = (
-        collect_attempt_spectral_audit
-    ),
-    existing_path_resolver: ExistingSpectralPathResolver = (
-        resolve_existing_spectral_audit_path
-    ),
+    spectral_detail_analyzer: SpectralDetailAnalyzer | None = None,
+    existing_spectral_resolver: ExistingSpectralResolver | None = None,
     preview_fn: PreviewFn | None = None,
 ) -> ImportJob | None:
     # Front-gate: if stored candidate evidence already passes the cheap
@@ -540,13 +473,53 @@ def process_claimed_preview_job(
         and front_gate_result.evidence is not None
         and front_gate_source is not None
     ):
-        audit = _collect_reused_evidence_spectral_audit(
-            db,
-            job.request_id,
+        persisted_existing = SpectralAnalysisDetail(attempted=False)
+        preserve_have_source = False
+        mb_release_id = ""
+        if job.request_id is not None:
+            try:
+                req = db.get_request(job.request_id) or {}
+                mb_release_id = str(req.get("mb_release_id") or "")
+                current_evidence, persisted_existing, _ = (
+                    load_persisted_existing_spectral(
+                        db,
+                        job.request_id,
+                        req,
+                    )
+                )
+                preserve_have_source = preserve_existing_source_spectral(
+                    current_evidence,
+                )
+            except Exception:
+                logger.exception(
+                    "Unable to load reused HAVE evidence for request %s",
+                    job.request_id,
+                )
+        audit_resolver = existing_spectral_resolver
+        if audit_resolver is None:
+            try:
+                audit_cfg = read_runtime_config()
+            except Exception as exc:
+                logger.exception("Unable to load config for reused HAVE audit")
+                failed_lookup = ExistingSpectralAuditLookup(
+                    failure=SpectralAnalysisDetail(
+                        attempted=True,
+                        error=f"{type(exc).__name__}: {exc}",
+                    ),
+                )
+                audit_resolver = lambda _release_id: failed_lookup
+            else:
+                audit_resolver = existing_spectral_resolver_for_config(audit_cfg)
+        audit = collect_release_attempt_spectral_audit(
             front_gate_source,
-            spectral_audit_collector,
-            existing_path_resolver,
-        )
+            mb_release_id,
+            existing_spectral_evidence=persisted_existing,
+            preserve_existing_source_spectral=preserve_have_source,
+            analyzer=(
+                spectral_detail_analyzer or analyze_spectral_audit_path
+            ),
+            existing_resolver=audit_resolver,
+        )[0]
         reused_payload = _reused_evidence_preview_payload(
             job,
             front_gate_result.evidence,

--- a/tests/test_import_queue.py
+++ b/tests/test_import_queue.py
@@ -2138,7 +2138,7 @@ class TestImportPreviewWorkerFrontGate(unittest.TestCase):
     def test_force_job_valid_evidence_skips_measurement(self):
         """AE4 force/manual: matching snapshot + valid evidence → no measurement."""
         from scripts import import_preview_worker
-        from lib.quality import SpectralAnalysisDetail, SpectralDetail
+        from lib.quality import SpectralAnalysisDetail
 
         with tempfile.TemporaryDirectory() as source:
             with open(os.path.join(source, "01.mp3"), "wb") as handle:
@@ -2177,18 +2177,12 @@ class TestImportPreviewWorkerFrontGate(unittest.TestCase):
             # Seed download_log_candidate evidence — force/manual path uses it.
             self._seed_evidence_for_download_log(db, download_log_id, source)
 
-            audit_calls: list[tuple[str, str | None]] = []
-            def collect_audit(
-                path: str,
-                existing_path: str | None,
-            ) -> SpectralDetail:
-                audit_calls.append((path, existing_path))
-                return SpectralDetail(
-                    candidate=SpectralAnalysisDetail(
-                        attempted=True,
-                        grade="likely_transcode",
-                    ),
-                    existing=SpectralAnalysisDetail(attempted=False),
+            audit_calls: list[str] = []
+            def analyze(path: str) -> SpectralAnalysisDetail:
+                audit_calls.append(path)
+                return SpectralAnalysisDetail(
+                    attempted=True,
+                    grade="likely_transcode",
                 )
 
             with patch(
@@ -2199,14 +2193,13 @@ class TestImportPreviewWorkerFrontGate(unittest.TestCase):
                 updated = import_preview_worker.process_claimed_preview_job(
                     db,
                     claimed,
-                    spectral_audit_collector=collect_audit,
+                    spectral_detail_analyzer=analyze,
                 )
 
         preview.assert_not_called()
         preimport.assert_not_called()
         self.assertEqual(len(audit_calls), 1)
-        self.assertEqual(audit_calls[0][0], source)
-        self.assertIsNone(audit_calls[0][1])
+        self.assertEqual(audit_calls[0], source)
         assert updated is not None
         self.assertEqual(updated.status, "queued")
         self.assertEqual(updated.preview_status, "evidence_ready")
@@ -2229,7 +2222,8 @@ class TestImportPreviewWorkerFrontGate(unittest.TestCase):
     def test_reused_evidence_scans_ordinary_have_path(self):
         """Front-gate reuse still analyzes non-lossless-converted HAVE."""
         from scripts import import_preview_worker
-        from lib.quality import SpectralAnalysisDetail, SpectralDetail
+        from lib.measurement import ExistingSpectralAuditLookup
+        from lib.quality import SpectralAnalysisDetail
 
         with tempfile.TemporaryDirectory() as source, \
              tempfile.TemporaryDirectory() as existing:
@@ -2267,20 +2261,14 @@ class TestImportPreviewWorkerFrontGate(unittest.TestCase):
             claimed = db.claim_next_import_preview_job(worker_id="preview")
             assert claimed is not None
             self._seed_evidence_for_download_log(db, download_log_id, source)
-            calls: list[tuple[str, str | None]] = []
+            calls: list[str] = []
 
-            def collect_audit(path: str, existing_path: str | None):
-                calls.append((path, existing_path))
-                return SpectralDetail(
-                    candidate=SpectralAnalysisDetail(
-                        attempted=True,
-                        grade="genuine",
-                    ),
-                    existing=SpectralAnalysisDetail(
-                        attempted=True,
-                        grade="suspect",
-                        bitrate_kbps=128,
-                    ),
+            def analyze(path: str) -> SpectralAnalysisDetail:
+                calls.append(path)
+                return SpectralAnalysisDetail(
+                    attempted=True,
+                    grade="suspect" if path == existing else "genuine",
+                    bitrate_kbps=128 if path == existing else None,
                 )
 
             with patch(
@@ -2290,14 +2278,13 @@ class TestImportPreviewWorkerFrontGate(unittest.TestCase):
                 updated = import_preview_worker.process_claimed_preview_job(
                     db,
                     claimed,
-                    spectral_audit_collector=collect_audit,
-                    existing_path_resolver=lambda _mbid, _cfg: (
-                        existing,
-                        None,
+                    spectral_detail_analyzer=analyze,
+                    existing_spectral_resolver=lambda _mbid: (
+                        ExistingSpectralAuditLookup(path=existing)
                     ),
                 )
 
-        self.assertEqual(calls, [(source, existing)])
+        self.assertEqual(calls, [source, existing])
         assert updated is not None and updated.preview_result is not None
         import_result = ImportResult.from_dict(cast(
             dict[str, Any],
@@ -2310,7 +2297,8 @@ class TestImportPreviewWorkerFrontGate(unittest.TestCase):
     def test_have_lookup_failure_still_analyzes_candidate(self):
         """A DB failure on HAVE provenance must not suppress the WANT scan."""
         from scripts import import_preview_worker
-        from lib.quality import SpectralAnalysisDetail, SpectralDetail
+        from lib.measurement import ExistingSpectralAuditLookup
+        from lib.quality import SpectralAnalysisDetail
 
         class HaveLookupFailureDB(FakePipelineDB):
             def get_request_current_evidence_id(self, request_id: int):
@@ -2338,19 +2326,20 @@ class TestImportPreviewWorkerFrontGate(unittest.TestCase):
             self._seed_evidence_for_download_log(db, download_log_id, source)
             calls: list[str] = []
 
-            def collect_audit(path, existing_path):
+            def analyze(path: str) -> SpectralAnalysisDetail:
                 calls.append(path)
-                self.assertIsNone(existing_path)
-                return SpectralDetail(
-                    candidate=SpectralAnalysisDetail(
-                        attempted=True, grade="likely_transcode"),
-                    existing=SpectralAnalysisDetail(attempted=False),
+                return SpectralAnalysisDetail(
+                    attempted=True,
+                    grade="likely_transcode",
                 )
 
             updated = import_preview_worker.process_claimed_preview_job(
                 db,
                 claimed,
-                spectral_audit_collector=collect_audit,
+                spectral_detail_analyzer=analyze,
+                existing_spectral_resolver=lambda _mbid: (
+                    ExistingSpectralAuditLookup()
+                ),
             )
 
         self.assertEqual(calls, [source])
@@ -2392,13 +2381,14 @@ class TestImportPreviewWorkerFrontGate(unittest.TestCase):
             assert claimed is not None
             self._seed_evidence_for_download_log(db, download_log_id, source)
 
-            def raising_collector(*args: Any, **kwargs: Any):
+            def raising_analyzer(path: str):
+                del path
                 raise RuntimeError("spectral backend unavailable")
 
             updated = import_preview_worker.process_claimed_preview_job(
                 db,
                 claimed,
-                spectral_audit_collector=raising_collector,
+                spectral_detail_analyzer=raising_analyzer,
             )
 
         assert updated is not None

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -5573,6 +5573,7 @@ class TestPreviewFrontGateSlice(unittest.TestCase):
         )
         from scripts import import_preview_worker
         from lib.dispatch import dispatch_import_from_db
+        from lib.measurement import ExistingSpectralAuditLookup
         from lib.quality import SpectralAnalysisDetail, SpectralDetail
         from tests.helpers import noop_quality_gate
 
@@ -5620,16 +5621,13 @@ class TestPreviewFrontGateSlice(unittest.TestCase):
                     "measure_preimport_state must not be called when evidence is valid"
                 )
 
-            audit_calls: list[
-                tuple[str, str | None]
-            ] = []
+            audit_calls: list[str] = []
 
-            def collect_audit(
-                path: str,
-                existing_path: str | None,
-            ) -> SpectralDetail:
-                audit_calls.append((path, existing_path))
-                return audit
+            def analyze(path: str) -> SpectralAnalysisDetail:
+                audit_calls.append(path)
+                detail = audit.existing if path == "existing" else audit.candidate
+                assert detail is not None
+                return detail
 
             with patch(
                 "scripts.import_preview_worker.measure_and_persist_candidate_evidence",
@@ -5641,10 +5639,13 @@ class TestPreviewFrontGateSlice(unittest.TestCase):
                 updated = import_preview_worker.process_claimed_preview_job(
                     cast(Any, db),
                     claimed,
-                    spectral_audit_collector=collect_audit,
+                    spectral_detail_analyzer=analyze,
+                    existing_spectral_resolver=lambda _mbid: (
+                        ExistingSpectralAuditLookup(path="existing")
+                    ),
                 )
 
-            self.assertEqual(len(audit_calls), 1)
+            self.assertEqual(audit_calls, [source, "existing"])
             assert updated is not None
             assert updated.preview_result is not None
             preview_ir = ImportResult.from_dict(
@@ -5751,16 +5752,12 @@ class TestPreviewFrontGateSlice(unittest.TestCase):
                 existing=SpectralAnalysisDetail(attempted=False),
             )
 
-            audit_calls: list[
-                tuple[str, str | None]
-            ] = []
+            audit_calls: list[str] = []
 
-            def collect_audit(
-                path: str,
-                existing_path: str | None,
-            ) -> SpectralDetail:
-                audit_calls.append((path, existing_path))
-                return audit
+            def analyze(path: str) -> SpectralAnalysisDetail:
+                audit_calls.append(path)
+                assert audit.candidate is not None
+                return audit.candidate
 
             with patch(
                 "scripts.import_preview_worker.measure_and_persist_candidate_evidence",
@@ -5775,7 +5772,7 @@ class TestPreviewFrontGateSlice(unittest.TestCase):
                 updated = import_preview_worker.process_claimed_preview_job(
                     cast(Any, db),
                     claimed,
-                    spectral_audit_collector=collect_audit,
+                    spectral_detail_analyzer=analyze,
                 )
 
             self.assertEqual(len(audit_calls), 1)

--- a/tests/test_measurement.py
+++ b/tests/test_measurement.py
@@ -22,6 +22,73 @@ from tests.fakes import FakePipelineDB
 class TestAttemptSpectralAudit(unittest.TestCase):
     """Attempt audit scans ordinary HAVE and preserves lossless provenance."""
 
+    def test_shared_owner_keeps_lookup_and_analyzer_failures_independent(self):
+        from lib.measurement import (
+            ExistingSpectralAuditLookup,
+            collect_release_attempt_spectral_audit,
+        )
+        from lib.quality import SpectralAnalysisDetail
+
+        persisted = SpectralAnalysisDetail(attempted=False)
+
+        def resolve(_mbid):
+            return ExistingSpectralAuditLookup(path="existing")
+
+        def candidate_fails(path: str) -> SpectralAnalysisDetail:
+            if path == "candidate":
+                raise RuntimeError("candidate failed")
+            return SpectralAnalysisDetail(attempted=True, grade="suspect")
+
+        candidate_failure = collect_release_attempt_spectral_audit(
+            "candidate",
+            "mbid",
+            existing_spectral_evidence=persisted,
+            preserve_existing_source_spectral=False,
+            analyzer=candidate_fails,
+            existing_resolver=resolve,
+        )[0]
+        assert candidate_failure.candidate is not None
+        assert candidate_failure.existing is not None
+        self.assertIn("candidate failed", candidate_failure.candidate.error or "")
+        self.assertEqual(candidate_failure.existing.grade, "suspect")
+
+        def existing_fails(path: str) -> SpectralAnalysisDetail:
+            if path == "existing":
+                raise RuntimeError("existing failed")
+            return SpectralAnalysisDetail(attempted=True, grade="genuine")
+
+        existing_failure = collect_release_attempt_spectral_audit(
+            "candidate",
+            "mbid",
+            existing_spectral_evidence=persisted,
+            preserve_existing_source_spectral=False,
+            analyzer=existing_fails,
+            existing_resolver=resolve,
+        )[0]
+        assert existing_failure.candidate is not None
+        assert existing_failure.existing is not None
+        self.assertEqual(existing_failure.candidate.grade, "genuine")
+        self.assertIn("existing failed", existing_failure.existing.error or "")
+
+        def lookup_fails(_mbid):
+            raise RuntimeError("lookup failed")
+
+        lookup_failure = collect_release_attempt_spectral_audit(
+            "candidate",
+            "mbid",
+            existing_spectral_evidence=persisted,
+            preserve_existing_source_spectral=False,
+            analyzer=lambda _path: SpectralAnalysisDetail(
+                attempted=True,
+                grade="genuine",
+            ),
+            existing_resolver=lookup_fails,
+        )[0]
+        assert lookup_failure.candidate is not None
+        assert lookup_failure.existing is not None
+        self.assertEqual(lookup_failure.candidate.grade, "genuine")
+        self.assertIn("lookup failed", lookup_failure.existing.error or "")
+
     def test_ordinary_existing_mp3_is_scanned_on_disk(self):
         """Non-lossless-converted HAVE is measured from the exact files."""
         from lib.beets_db import AlbumInfo
@@ -177,7 +244,7 @@ class TestAttemptSpectralAudit(unittest.TestCase):
 
     def test_malformed_track_preserves_album_facts_and_prior_track_detail(self):
         from lib.config import CratediggerConfig
-        from lib.measurement import _spectral_analysis_detail, measure_preimport_state
+        from lib.measurement import analyze_spectral_audit_path, measure_preimport_state
 
         result = SimpleNamespace(
             grade="suspect", estimated_bitrate_kbps=160,
@@ -196,7 +263,7 @@ class TestAttemptSpectralAudit(unittest.TestCase):
             ],
         )
         with patch("lib.measurement.spectral_analyze", return_value=result):
-            detail = _spectral_analysis_detail("/candidate")
+            detail = analyze_spectral_audit_path("/candidate")
 
         self.assertEqual(detail.grade, "suspect")
         self.assertEqual(detail.bitrate_kbps, 160)

--- a/tests/test_spectral_attempt_audit_generated.py
+++ b/tests/test_spectral_attempt_audit_generated.py
@@ -63,6 +63,181 @@ def _have_scan_boundary_holds(
     return analyzer_calls == expected
 
 
+def _run_have_boundary_through_both_adapters(
+    *,
+    converted_from: str | None,
+    lossless_v0_lineage: bool,
+    persisted_grade: str,
+    persisted_bitrate: int | None,
+    scanned_grade: str,
+    scanned_bitrate: int | None,
+):
+    """Drive normal measurement and reused front-gate through one boundary."""
+    from lib.config import CratediggerConfig
+    from lib.import_queue import (
+        IMPORT_JOB_FORCE,
+        force_import_dedupe_key,
+        force_import_payload,
+    )
+    from lib.import_preview import preserve_existing_source_spectral
+    from lib.measurement import (
+        ExistingSpectralAuditLookup,
+        LocalFileInspection,
+        measure_preimport_state,
+    )
+    from lib.quality import (
+        V0_SOURCE_LINEAGE_LOSSLESS_SOURCE,
+        AlbumQualityV0Metric,
+        AudioQualityMeasurement,
+        ImportResult,
+        SpectralAnalysisDetail,
+    )
+    from lib.quality_evidence import snapshot_audio_files
+    from scripts.import_preview_worker import process_claimed_preview_job
+    from tests.fakes import FakePipelineDB
+    from tests.helpers import make_album_quality_evidence, make_request_row
+
+    request_id = 42
+    mbid = "mbid-42"
+    cfg = CratediggerConfig(audio_check_mode="off")
+    current_evidence = make_album_quality_evidence(
+        mb_release_id=mbid,
+        measurement=AudioQualityMeasurement(
+            min_bitrate_kbps=320,
+            avg_bitrate_kbps=320,
+            median_bitrate_kbps=320,
+            format="MP3",
+            spectral_grade=persisted_grade,
+            spectral_bitrate_kbps=persisted_bitrate,
+            was_converted_from=converted_from,
+        ),
+        v0_metric=(
+            AlbumQualityV0Metric(
+                min_bitrate_kbps=200,
+                avg_bitrate_kbps=228,
+                median_bitrate_kbps=225,
+                source_lineage=V0_SOURCE_LINEAGE_LOSSLESS_SOURCE,
+                source_provenance="generated",
+            )
+            if lossless_v0_lineage
+            else None
+        ),
+    )
+    preserve_source = preserve_existing_source_spectral(current_evidence)
+    persisted = SpectralAnalysisDetail(
+        attempted=True,
+        grade=persisted_grade,
+        bitrate_kbps=persisted_bitrate,
+    )
+
+    with tempfile.TemporaryDirectory() as candidate, \
+         tempfile.TemporaryDirectory() as existing:
+        Path(candidate, "01.mp3").write_bytes(b"candidate")
+        Path(existing, "01.mp3").write_bytes(b"existing")
+
+        normal_calls: list[str] = []
+        reused_calls: list[str] = []
+
+        def analyzer_for(calls: list[str]):
+            def analyze(path: str) -> SpectralAnalysisDetail:
+                role = "existing" if path == existing else "candidate"
+                calls.append(role)
+                return SpectralAnalysisDetail(
+                    attempted=True,
+                    grade=scanned_grade if role == "existing" else "genuine",
+                    bitrate_kbps=(
+                        scanned_bitrate if role == "existing" else None
+                    ),
+                )
+            return analyze
+
+        def resolve_existing(
+            requested_mbid: str,
+        ) -> ExistingSpectralAuditLookup:
+            assert requested_mbid == mbid
+            return ExistingSpectralAuditLookup(
+                path=existing,
+                min_bitrate_kbps=320,
+            )
+
+        with _silence_logs():
+            measured = measure_preimport_state(
+                path=candidate,
+                mb_release_id=mbid,
+                label="Gespenst - The Saint",
+                download_filetype="mp3",
+                download_min_bitrate_bps=219_000,
+                download_is_vbr=False,
+                cfg=cfg,
+                existing_spectral_evidence=persisted,
+                preserve_existing_source_spectral=preserve_source,
+                precomputed_inspection=LocalFileInspection(
+                    filetype="mp3",
+                    min_bitrate_bps=219_000,
+                    is_vbr=False,
+                ),
+                spectral_detail_analyzer=analyzer_for(normal_calls),
+                existing_spectral_resolver=resolve_existing,
+            )
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=request_id, mb_release_id=mbid))
+        db.upsert_album_quality_evidence(current_evidence)
+        stored_current = db.find_album_quality_evidence(
+            mb_release_id=mbid,
+            snapshot_fingerprint=current_evidence.snapshot_fingerprint,
+        )
+        assert stored_current is not None and stored_current.id is not None
+        db.set_request_current_evidence(request_id, stored_current.id)
+        download_log_id = db.log_download(request_id, outcome="rejected")
+        job = db.enqueue_import_job(
+            IMPORT_JOB_FORCE,
+            request_id=request_id,
+            dedupe_key=force_import_dedupe_key(download_log_id),
+            payload=force_import_payload(
+                download_log_id=download_log_id,
+                failed_path=candidate,
+                source_username="generated",
+            ),
+        )
+        candidate_evidence = make_album_quality_evidence(
+            mb_release_id=mbid,
+            source_path=candidate,
+            files=snapshot_audio_files(candidate),
+        )
+        db.upsert_album_quality_evidence(candidate_evidence)
+        stored_candidate = db.find_album_quality_evidence(
+            mb_release_id=mbid,
+            snapshot_fingerprint=candidate_evidence.snapshot_fingerprint,
+        )
+        assert stored_candidate is not None and stored_candidate.id is not None
+        db.set_download_log_candidate_evidence(
+            download_log_id,
+            stored_candidate.id,
+        )
+        claimed = db.claim_next_import_preview_job(worker_id="generated")
+        assert claimed is not None and claimed.id == job.id
+        with _silence_logs():
+            updated = process_claimed_preview_job(
+                db,
+                claimed,
+                spectral_detail_analyzer=analyzer_for(reused_calls),
+                existing_spectral_resolver=resolve_existing,
+            )
+        assert updated is not None and updated.preview_result is not None
+        reused = ImportResult.from_dict(
+            updated.preview_result["import_result"]
+        ).spectral
+
+    return (
+        preserve_source,
+        normal_calls,
+        reused_calls,
+        measured.spectral_audit,
+        reused,
+    )
+
+
 def _authoritative_have_matches(detail, grade, bitrate) -> bool:
     return (
         detail.attempted == (grade is not None or bitrate is not None)
@@ -272,6 +447,30 @@ class TestAttemptAuditCheckerQualification(unittest.TestCase):
 
 
 class TestAttemptAuditGenerated(unittest.TestCase):
+    def test_gespenst_mp3_scans_exact_have_through_both_adapters(self):
+        (
+            preserve_source,
+            normal_calls,
+            reused_calls,
+            normal_audit,
+            reused_audit,
+        ) = _run_have_boundary_through_both_adapters(
+            converted_from=None,
+            lossless_v0_lineage=False,
+            persisted_grade="genuine",
+            persisted_bitrate=320,
+            scanned_grade="suspect",
+            scanned_bitrate=128,
+        )
+
+        self.assertFalse(preserve_source)
+        self.assertEqual(normal_calls, ["candidate", "existing"])
+        self.assertEqual(reused_calls, ["candidate", "existing"])
+        for audit in (normal_audit, reused_audit):
+            assert audit.existing is not None
+            self.assertEqual(audit.existing.grade, "suspect")
+            self.assertEqual(audit.existing.bitrate_kbps, 128)
+
     def test_authoritative_evidence_checker_rejects_scalar_fallback_mutant(self):
         req = {
             "current_spectral_grade": "likely_transcode",
@@ -350,6 +549,7 @@ class TestAttemptAuditGenerated(unittest.TestCase):
             st.none(),
             st.sampled_from((
                 "flac", "FLAC", "alac", "wav", "m4a", "mp3", "aac",
+                "opus",
             )),
         ),
         lossless_v0_lineage=st.booleans(),
@@ -375,61 +575,21 @@ class TestAttemptAuditGenerated(unittest.TestCase):
         scanned_grade: str,
         scanned_bitrate: int | None,
     ):
-        from lib.beets_db import AlbumInfo
-        from lib.config import CratediggerConfig
-        from lib.import_preview import preserve_existing_source_spectral
-        from lib.measurement import LocalFileInspection, measure_preimport_state
-        from lib.quality import (
-            LOSSLESS_CODECS,
-            V0_SOURCE_LINEAGE_LOSSLESS_SOURCE,
-            AlbumQualityV0Metric,
-            AudioQualityMeasurement,
-            SpectralAnalysisDetail,
-        )
-        from tests.fakes import FakeBeetsDB
-        from tests.helpers import make_album_quality_evidence
+        from lib.quality import LOSSLESS_CODECS
 
-        beets = FakeBeetsDB()
-        beets.set_album_info("mbid", AlbumInfo(
-            album_id=1,
-            track_count=1,
-            min_bitrate_kbps=320,
-            avg_bitrate_kbps=320,
-            median_bitrate_kbps=320,
-            is_cbr=True,
-            album_path="existing",
-            format="MP3",
-        ))
-        persisted = SpectralAnalysisDetail(
-            attempted=True,
-            grade=persisted_grade,
-            bitrate_kbps=persisted_bitrate,
-        )
-        current_evidence = make_album_quality_evidence(
-            mb_release_id="mbid",
-            measurement=AudioQualityMeasurement(
-                min_bitrate_kbps=320,
-                avg_bitrate_kbps=320,
-                median_bitrate_kbps=320,
-                format="MP3",
-                spectral_grade=persisted_grade,
-                spectral_bitrate_kbps=persisted_bitrate,
-                was_converted_from=converted_from,
-            ),
-            v0_metric=(
-                AlbumQualityV0Metric(
-                    min_bitrate_kbps=200,
-                    avg_bitrate_kbps=228,
-                    median_bitrate_kbps=225,
-                    source_lineage=V0_SOURCE_LINEAGE_LOSSLESS_SOURCE,
-                    source_provenance="generated",
-                )
-                if lossless_v0_lineage
-                else None
-            ),
-        )
-        preserve_existing_source = preserve_existing_source_spectral(
-            current_evidence,
+        (
+            preserve_existing_source,
+            normal_calls,
+            reused_calls,
+            normal_audit,
+            reused_audit,
+        ) = _run_have_boundary_through_both_adapters(
+            converted_from=converted_from,
+            lossless_v0_lineage=lossless_v0_lineage,
+            persisted_grade=persisted_grade,
+            persisted_bitrate=persisted_bitrate,
+            scanned_grade=scanned_grade,
+            scanned_bitrate=scanned_bitrate,
         )
         self.assertEqual(
             preserve_existing_source,
@@ -441,56 +601,19 @@ class TestAttemptAuditGenerated(unittest.TestCase):
                 )
             ),
         )
-        calls: list[str] = []
-
-        def analyze(path: str, trim_seconds: int = 30):
-            del trim_seconds
-            calls.append(path)
-            return SimpleNamespace(
-                grade=(scanned_grade if path == "existing" else "genuine"),
-                estimated_bitrate_kbps=(
-                    scanned_bitrate if path == "existing" else None
-                ),
-                suspect_pct=0.0,
-                tracks=[],
-            )
-
-        with patch("lib.beets_db.BeetsDB", return_value=beets), patch(
-            "lib.measurement.spectral_analyze", side_effect=analyze,
-        ), patch(
-            "lib.measurement._iter_audio_files",
-            return_value=[Path("candidate", "01.mp3")],
-        ), patch("lib.measurement.os.path.isdir", return_value=True):
-            measured = measure_preimport_state(
-                path="candidate",
-                mb_release_id="mbid",
-                label="generated",
-                download_filetype="mp3",
-                download_min_bitrate_bps=219_000,
-                download_is_vbr=False,
-                cfg=CratediggerConfig(audio_check_mode="off"),
-                existing_spectral_evidence=persisted,
-                preserve_existing_source_spectral=preserve_existing_source,
-                precomputed_inspection=LocalFileInspection(
-                    filetype="mp3",
-                    min_bitrate_bps=219_000,
-                    is_vbr=False,
-                ),
-            )
-
-        self.assertTrue(_have_scan_boundary_holds(
-            calls,
-            preserve_existing_source=preserve_existing_source,
-        ))
-        assert measured.spectral_audit.existing is not None
-        if preserve_existing_source:
-            self.assertEqual(measured.spectral_audit.existing, persisted)
-        else:
-            self.assertEqual(measured.spectral_audit.existing.grade, scanned_grade)
-            self.assertEqual(
-                measured.spectral_audit.existing.bitrate_kbps,
-                scanned_bitrate,
-            )
+        for calls in (normal_calls, reused_calls):
+            self.assertTrue(_have_scan_boundary_holds(
+                calls,
+                preserve_existing_source=preserve_existing_source,
+            ))
+        for audit in (normal_audit, reused_audit):
+            assert audit.existing is not None
+            if preserve_existing_source:
+                self.assertEqual(audit.existing.grade, persisted_grade)
+                self.assertEqual(audit.existing.bitrate_kbps, persisted_bitrate)
+            else:
+                self.assertEqual(audit.existing.grade, scanned_grade)
+                self.assertEqual(audit.existing.bitrate_kbps, scanned_bitrate)
 
     @given(
         mode=st.sampled_from((


### PR DESCRIPTION
## Outcome

Centralizes conditional attempted-import HAVE spectral collection in one production owner shared by normal preview measurement and reused-candidate front-gate previews.

- ordinary installed copies analyze the exact requested Beets release path
- FLAC-, ALAC-, WAV-, and lossless-lineage M4A-derived copies retain persisted pre-conversion evidence without analyzing the derivative
- candidate analysis, HAVE analysis, evidence lookup, and exact-release lookup remain independent fail-soft audit facts
- persisted evidence and exact-release resolution stay outside the owner behind typed explicit inputs
- duplicate normal/reused orchestration and vocabulary are deleted with no compatibility wrapper

Production code is net negative: 186 lines added and 194 removed (-8 LOC).

## Regression coverage

- deterministic Gespenst-shaped MP3 pin drives both adapters through the shared owner
- generated provenance property drives both adapters across FLAC, ALAC, WAV, ambiguous M4A, MP3, AAC, and Opus worlds
- known-bad blanket-persisted and blanket-scan checker self-tests remain qualified
- explicit lookup/candidate/HAVE analyzer failure pins prove independent fail-soft audit data

## Latest-main integration

- base: `b1322e36d69e1a72daae2a690eb165ec37ebaeeb` (PR #671)
- head: `f1565ebced8a146420781cb063d7d699422828f4`
- integrated with an SSH-signed merge commit; no rebase
- PR #671 changes artist-search and processing-path files and has no file overlap with this PR's six issue files

## Verification

- RED: cross-adapter Gespenst pin failed because `ExistingSpectralAuditLookup` and the shared owner boundary did not exist
- combined affected focused set after latest-main integration: 101 tests passed
- issue-specific dedicated `CRATEDIGGER_HYPOTHESIS_PROFILE=fuzz`: 11 tests passed in 722.558s before the disjoint latest-main merge
- full pyright after latest-main integration: 0 errors, 0 warnings
- dead-code checks after latest-main integration: clean
- exact-HEAD full suite: 5,666 tests passed; artifact `/tmp/cratedigger-issue-667-5a6b6d5ed7-f1565ebced8a.wp6as0e5`
- exact artifact verification: passed for `f1565ebced8a146420781cb063d7d699422828f4`
- pre-push randomized generated burst: passed at exact head
- `nix flake check`: passed at exact head

Refs #667
