### PR TITLE
Handle symbol artist identities and long metadata paths

### DIFF
--- a/lib/processing_paths.py
+++ b/lib/processing_paths.py
@@ -11,6 +11,8 @@ from typing import Protocol, Sequence
 AUTO_IMPORT_STAGING_SUBDIR = "auto-import"
 POST_VALIDATION_STAGING_SUBDIR = "post-validation"
 DUPLICATE_REMOVE_GUARD_SUBDIR = "duplicate-remove-guard"
+MAX_PATH_COMPONENT_BYTES = 255
+_TRUNCATED_COMPONENT_HASH_CHARS = 12
 
 
 class CanonicalFolderFile(Protocol):
@@ -56,6 +58,33 @@ class SourceDirectoryAlbum(Protocol):
 def sanitize_processing_folder_name(folder_name: str) -> str:
     """Sanitize a filesystem path component for local processing paths."""
     return re.sub(r'[<>:."/\\|?*]', "", folder_name).strip()
+
+
+def _bounded_processing_component(value: str, *, suffix: str = "") -> str:
+    """Fit one sanitized staging component within ext4's byte limit.
+
+    Truncation works on UTF-8 bytes and decodes with ``errors="ignore"`` so
+    it never cuts a multibyte code point in half. A digest of the complete
+    sanitized value prevents two long names with the same retained prefix
+    from collapsing onto one directory. ``suffix`` is reserved verbatim for
+    request ownership markers such as `` [request-42]``.
+    """
+    sanitized = sanitize_processing_folder_name(value)
+    complete = f"{sanitized}{suffix}"
+    if len(complete.encode("utf-8")) <= MAX_PATH_COMPONENT_BYTES:
+        return complete
+
+    digest = hashlib.sha256(sanitized.encode("utf-8")).hexdigest()[
+        :_TRUNCATED_COMPONENT_HASH_CHARS
+    ]
+    reserved = f"~{digest}{suffix}"
+    max_prefix_bytes = MAX_PATH_COMPONENT_BYTES - len(reserved.encode("utf-8"))
+    if max_prefix_bytes < 0:
+        raise ValueError("processing path suffix exceeds filesystem limit")
+    prefix = sanitized.encode("utf-8")[:max_prefix_bytes].decode(
+        "utf-8", errors="ignore",
+    ).rstrip()
+    return f"{prefix}{reserved}"
 
 
 def normalize_source_dirs(values: Sequence[object]) -> list[str]:
@@ -206,10 +235,11 @@ def stage_to_ai_path(
     auto_import: bool | None = None,
 ) -> str:
     """Return the beets staging destination for an album."""
-    artist_dir = sanitize_processing_folder_name(artist)
-    album_dir = sanitize_processing_folder_name(title)
-    if request_id is not None:
-        album_dir = f"{album_dir} [request-{request_id}]"
+    artist_dir = _bounded_processing_component(artist)
+    request_suffix = (
+        f" [request-{request_id}]" if request_id is not None else ""
+    )
+    album_dir = _bounded_processing_component(title, suffix=request_suffix)
     return os.path.join(
         stage_to_ai_root(staging_dir=staging_dir, auto_import=auto_import),
         artist_dir,

--- a/tests/test_artist_identity_search_generated.py
+++ b/tests/test_artist_identity_search_generated.py
@@ -1,0 +1,82 @@
+"""Generated contract for exact-search related-identity merging."""
+
+from __future__ import annotations
+
+import unittest
+
+from hypothesis import example, given, strategies as st
+
+import tests._hypothesis_profiles  # noqa: F401
+from web.artist_search import merge_exact_artist_identities
+
+
+def assert_identity_merge(
+    merged: list[dict], exact_id: str, related_ids: list[str], limit: int,
+) -> None:
+    ids = [str(row["id"]) for row in merged]
+    if not ids or ids[0] != exact_id:
+        raise AssertionError("the exact artist did not remain first")
+    if len(ids) != len(set(ids)):
+        raise AssertionError("artist identities were not deduplicated")
+    if len(ids) > limit:
+        raise AssertionError("artist identity results exceeded the limit")
+    expected_related = [rid for rid in related_ids if rid != exact_id]
+    expected_related = list(dict.fromkeys(expected_related))
+    available = max(0, limit - 1)
+    expected_related = expected_related[:available]
+    if ids[1:1 + len(expected_related)] != expected_related:
+        raise AssertionError("related identities were not adjacent to the exact hit")
+
+
+_ID = st.text(
+    alphabet=st.characters(whitelist_categories=("Ll", "Lu", "Nd")),
+    min_size=1,
+    max_size=8,
+)
+
+
+class TestIdentityMergeProperties(unittest.TestCase):
+    @given(
+        other_ids=st.lists(_ID, unique=True, max_size=30),
+        related_ids=st.lists(_ID, max_size=15),
+        limit=st.integers(min_value=1, max_value=20),
+    )
+    @example(other_ids=["other"], related_ids=["related"], limit=20)
+    @example(
+        other_ids=["related", "other"],
+        related_ids=["related", "related", "exact"],
+        limit=20,
+    )
+    def test_exact_and_related_identity_contract(
+        self, other_ids: list[str], related_ids: list[str], limit: int,
+    ) -> None:
+        exact_id = "exact"
+        base = [
+            {"id": value, "name": value, "disambiguation": "", "score": 1}
+            for value in other_ids if value != exact_id
+        ]
+        base.insert(
+            len(base) // 2,
+            {"id": exact_id, "name": "Exact", "disambiguation": "", "score": 100},
+        )
+        related = [
+            {"id": value, "name": value, "disambiguation": "", "score": 99}
+            for value in related_ids
+        ]
+
+        merged = merge_exact_artist_identities(
+            base, exact_id=exact_id, related=related, limit=limit,
+        )
+
+        assert_identity_merge(merged, exact_id, related_ids, limit)
+
+
+class TestIdentityMergeCheckerTrips(unittest.TestCase):
+    def test_checker_rejects_related_identity_after_unrelated_hit(self) -> None:
+        bad = [{"id": "exact"}, {"id": "other"}, {"id": "related"}]
+        with self.assertRaises(AssertionError):
+            assert_identity_merge(bad, "exact", ["related"], 20)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_discogs_api.py
+++ b/tests/test_discogs_api.py
@@ -384,7 +384,7 @@ class TestSearchArtists(unittest.TestCase):
             results = search_artists("Radiohead")
 
         # Verify the new endpoint was hit (not the old release-search hack)
-        called_url = mock.call_args[0][0].full_url
+        called_url = mock.call_args_list[0][0][0].full_url
         self.assertIn("/api/artists?name=", called_url)
         self.assertNotIn("/api/search?artist=", called_url)
 
@@ -404,6 +404,34 @@ class TestSearchArtists(unittest.TestCase):
         self.assertTrue(cache_key.startswith("discogs:search:artists:"))
         self.assertIn(f":#{len(long_query)}:", cache_key)
         self.assertLess(len(cache_key), len(f"discogs:search:artists:{long_query}"))
+
+    def test_exact_four_tet_search_surfaces_symbol_alias(self):
+        symbol_name = "⣎⡇ꉺლ༽இ•̛)ྀ◞ ༎ຶ ༽ৣৢ؞ৢ؞ؖ ꉺლ"
+        search_data = {
+            "results": [
+                {"id": 3543, "name": "Four Tet", "score": 1.0},
+                {"id": 2039081, "name": "The Urge Four Tet", "score": 0.09},
+            ],
+        }
+        detail = {
+            "id": 3543,
+            "name": "Four Tet",
+            "aliases": [
+                {"id": 60342, "name": "Kieran Hebden"},
+                {"id": 6400214, "name": symbol_name},
+            ],
+        }
+        with _mock_urlopen_by_url({
+            "/api/artists?name=Four%20Tet": search_data,
+            "/api/artists/3543": detail,
+        }):
+            results = search_artists("Four Tet")
+
+        self.assertEqual(
+            [row["id"] for row in results[:4]],
+            ["3543", "60342", "6400214", "2039081"],
+        )
+        self.assertEqual(results[2]["name"], symbol_name)
 
 
 def _mock_urlopen_by_url(responses: dict):

--- a/tests/test_mb_api.py
+++ b/tests/test_mb_api.py
@@ -13,7 +13,7 @@ import urllib.parse
 from unittest.mock import MagicMock, patch
 
 from lib.va_identity import MB_VA_ARTIST_MBID
-from web.mb import search_release_groups
+from web.mb import search_artists, search_release_groups
 
 
 def _mock_urlopen(response_data):
@@ -54,6 +54,21 @@ def _requested_query(mock_urlopen: MagicMock) -> str:
     url = mock_urlopen.call_args[0][0].full_url
     qs = urllib.parse.urlparse(url).query
     return urllib.parse.parse_qs(qs)["query"][0]
+
+
+def _mock_urlopen_by_url(responses: dict[str, dict]):
+    """Return canned JSON selected by a substring of each requested URL."""
+    def _side_effect(req, *args, **kwargs):
+        for needle, payload in responses.items():
+            if needle in req.full_url:
+                mock_resp = MagicMock()
+                mock_resp.read.return_value = json.dumps(payload).encode()
+                mock_resp.__enter__ = lambda s: s
+                mock_resp.__exit__ = MagicMock(return_value=False)
+                return mock_resp
+        raise AssertionError(f"unexpected URL: {req.full_url}")
+
+    return patch("web.mb.urllib.request.urlopen", side_effect=_side_effect)
 
 
 class TestSearchReleaseGroupsVaRewrite(unittest.TestCase):
@@ -101,6 +116,58 @@ class TestSearchReleaseGroupsVaRewrite(unittest.TestCase):
         self.assertEqual(results[0]["artist_name"], "Various Artists")
         self.assertEqual(results[0]["primary_type"], "Album")
         self.assertEqual(results[0]["score"], 100)
+
+
+class TestSearchArtistsRelatedIdentities(unittest.TestCase):
+    def test_exact_four_tet_search_surfaces_symbol_identity(self) -> None:
+        four_tet_id = "3bcff06f-675a-451f-9075-99e8657047e8"
+        person_id = "cb661251-3bc2-4373-bd7c-4b1531275c4c"
+        symbol_id = "2d9745dd-5dc6-4145-9453-fec582cfa9b8"
+        symbol_name = "⣎⡇ꉺლ༽இ•̛)ྀ◞ ༎ຶ ༽ৣৢ؞ৢ؞ؖ ꉺლ"
+        responses = {
+            "/artist?query=Four%20Tet": {
+                "artists": [
+                    {"id": four_tet_id, "name": "Four Tet", "score": 100},
+                    {"id": "other", "name": "Four Tops", "score": 45},
+                ],
+            },
+            f"/artist/{four_tet_id}": {
+                "id": four_tet_id,
+                "name": "Four Tet",
+                "relations": [{
+                    "type": "is person",
+                    "direction": "backward",
+                    "artist": {"id": person_id, "name": "Kieran Hebden"},
+                }],
+            },
+            f"/artist/{person_id}": {
+                "id": person_id,
+                "name": "Kieran Hebden",
+                "relations": [
+                    {
+                        "type": "is person", "direction": "forward",
+                        "artist": {"id": four_tet_id, "name": "Four Tet"},
+                    },
+                    {
+                        "type": "is person", "direction": "forward",
+                        "artist": {
+                            "id": symbol_id, "name": symbol_name,
+                            "disambiguation": "Kieran Hebden",
+                        },
+                    },
+                ],
+            },
+        }
+
+        with _mock_urlopen_by_url(responses):
+            results = search_artists("Four Tet")
+
+        self.assertEqual(
+            [row["id"] for row in results],
+            [four_tet_id, person_id, symbol_id, "other"],
+        )
+        self.assertEqual(results[2]["name"], symbol_name)
+        self.assertEqual(results[2]["disambiguation"], "Kieran Hebden")
 
 
 if __name__ == "__main__":

--- a/tests/test_processing_paths.py
+++ b/tests/test_processing_paths.py
@@ -1,5 +1,7 @@
 """Tests for ``lib/processing_paths.py``."""
 
+import os
+import tempfile
 import unittest
 
 from lib.grab_list import DownloadFile, GrabListEntry
@@ -7,6 +9,7 @@ from lib.processing_paths import (
     attempt_fingerprint,
     canonical_folder_for_row,
     canonical_processing_path,
+    stage_to_ai_path,
 )
 
 
@@ -149,6 +152,57 @@ class TestCanonicalFolderForRow(unittest.TestCase):
             canonical_folder_for_row(_row(files=files), "/tmp/downloads"),
             "/tmp/downloads/Test Artist - Test Album (2020) "
             f"[{fingerprint}]",
+        )
+
+
+class TestStageToAiPathComponentLimit(unittest.TestCase):
+    """Long Unicode metadata must remain stageable on ext4."""
+
+    def test_four_tet_style_title_fits_and_can_be_created(self):
+        artist = "⣎⡇ꉺლ༽இ•̛)ྀ◞ ༎ຶ ༽ৣৢ؞ৢ؞ؖ ꉺლ"
+        # The real release title is 365 UTF-8 bytes and is dominated by
+        # combining marks. This smaller readable fixture preserves that
+        # filesystem shape without copying the whole title into the test.
+        title = "ʅ" + "͡" * 182
+
+        with tempfile.TemporaryDirectory() as staging_dir:
+            path = stage_to_ai_path(
+                artist=artist,
+                title=title,
+                staging_dir=staging_dir,
+                request_id=42,
+                auto_import=True,
+            )
+            album_component = os.path.basename(path)
+
+            self.assertLessEqual(len(album_component.encode("utf-8")), 255)
+            self.assertTrue(album_component.endswith(" [request-42]"))
+            os.makedirs(path)
+            self.assertTrue(os.path.isdir(path))
+
+    def test_long_titles_with_the_same_prefix_remain_distinct(self):
+        common = "ʅ" + "͡" * 180
+        first = stage_to_ai_path(
+            artist="Artist", title=f"{common}A", staging_dir="/staging",
+            request_id=42, auto_import=True,
+        )
+        second = stage_to_ai_path(
+            artist="Artist", title=f"{common}B", staging_dir="/staging",
+            request_id=42, auto_import=True,
+        )
+
+        self.assertNotEqual(first, second)
+
+    def test_short_path_is_unchanged(self):
+        self.assertEqual(
+            stage_to_ai_path(
+                artist="Test Artist",
+                title="Test Album",
+                staging_dir="/staging",
+                request_id=42,
+                auto_import=True,
+            ),
+            "/staging/auto-import/Test Artist/Test Album [request-42]",
         )
 
 

--- a/tests/test_processing_paths_generated.py
+++ b/tests/test_processing_paths_generated.py
@@ -1,0 +1,116 @@
+"""Generated filesystem-boundary checks for processing paths.
+
+Invariant: every component emitted by ``stage_to_ai_path`` fits ext4's
+255-byte component cap, preserves its request suffix, is deterministic, and
+does not collapse distinct overlong metadata onto one staging directory.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+
+from hypothesis import example, given, strategies as st
+
+import tests._hypothesis_profiles  # noqa: F401
+from lib.processing_paths import stage_to_ai_path
+
+
+_UNICODE_METADATA = st.text(
+    alphabet=st.characters(blacklist_categories=("Cs",), max_codepoint=0x2FFFF),
+    max_size=400,
+)
+
+
+def assert_stage_path_safe(path: str, staging_dir: str, request_id: int) -> None:
+    """Check the staging component-size, suffix, and containment contract."""
+    relative = os.path.relpath(path, staging_dir)
+    if relative == os.pardir or relative.startswith(f"{os.pardir}{os.sep}"):
+        raise AssertionError(f"stage path escaped its root: {path!r}")
+    components = relative.split(os.sep)
+    for component in components:
+        size = len(component.encode("utf-8"))
+        if size > 255:
+            raise AssertionError(
+                f"stage component is {size} bytes, exceeds ext4's 255-byte cap"
+            )
+    suffix = f" [request-{request_id}]"
+    if not components[-1].endswith(suffix):
+        raise AssertionError(
+            f"album component {components[-1]!r} lost request suffix {suffix!r}"
+        )
+
+
+def assert_distinct_stage_paths(first: str, second: str) -> None:
+    """Check that distinct metadata did not collapse to one directory."""
+    if first == second:
+        raise AssertionError(f"distinct metadata collapsed to {first!r}")
+
+
+class TestStagePathProperties(unittest.TestCase):
+    @given(
+        artist=_UNICODE_METADATA,
+        title=_UNICODE_METADATA,
+        request_id=st.integers(min_value=1, max_value=2**63 - 1),
+        auto_import=st.booleans(),
+    )
+    @example(
+        artist="⣎⡇ꉺლ༽இ•̛)ྀ◞ ༎ຶ ༽ৣৢ؞ৢ؞ؖ ꉺლ",
+        title="ʅ" + "͡" * 182,
+        request_id=42,
+        auto_import=True,
+    )
+    def test_components_are_bounded_suffix_preserved_and_deterministic(
+        self, artist: str, title: str, request_id: int, auto_import: bool,
+    ) -> None:
+        kwargs = {
+            "artist": artist,
+            "title": title,
+            "staging_dir": "/staging",
+            "request_id": request_id,
+            "auto_import": auto_import,
+        }
+        first = stage_to_ai_path(**kwargs)
+        second = stage_to_ai_path(**kwargs)
+
+        assert_stage_path_safe(first, "/staging", request_id)
+        self.assertEqual(first, second)
+
+    @given(
+        artist=_UNICODE_METADATA,
+        title=_UNICODE_METADATA,
+        request_id=st.integers(min_value=1, max_value=2**63 - 1),
+    )
+    @example(
+        artist="Artist",
+        title="ʅ" + "͡" * 182,
+        request_id=42,
+    )
+    def test_distinct_titles_remain_distinct(
+        self, artist: str, title: str, request_id: int,
+    ) -> None:
+        common = {
+            "artist": artist,
+            "staging_dir": "/staging",
+            "request_id": request_id,
+            "auto_import": True,
+        }
+        first = stage_to_ai_path(title=f"{title}A", **common)
+        second = stage_to_ai_path(title=f"{title}B", **common)
+
+        assert_distinct_stage_paths(first, second)
+
+
+class TestInvariantCheckersTripOnViolations(unittest.TestCase):
+    def test_stage_path_checker_rejects_overlong_component(self):
+        bad = f"/staging/auto-import/Artist/{'x' * 256} [request-42]"
+        with self.assertRaises(AssertionError):
+            assert_stage_path_safe(bad, "/staging", 42)
+
+    def test_distinctness_checker_rejects_collapsed_paths(self):
+        with self.assertRaises(AssertionError):
+            assert_distinct_stage_paths("/same", "/same")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/artist_search.py
+++ b/web/artist_search.py
@@ -1,0 +1,38 @@
+"""Shared exact-artist search enrichment.
+
+MusicBrainz and Discogs expose related identities differently, but both
+adapters normalize them to the same artist-hit shape before calling this
+pure merge. Release catalogs remain separate; this only makes canonical
+alternate identities discoverable beside an exact search hit.
+"""
+
+from __future__ import annotations
+
+
+def merge_exact_artist_identities(
+    base: list[dict],
+    *,
+    exact_id: str,
+    related: list[dict],
+    limit: int = 20,
+) -> list[dict]:
+    """Keep the exact hit first, then related identities, then other hits."""
+    exact = next(
+        (row for row in base if str(row.get("id", "")) == exact_id),
+        None,
+    )
+    if exact is None:
+        return base[:limit]
+
+    ordered = [exact, *related, *base]
+    merged: list[dict] = []
+    seen: set[str] = set()
+    for row in ordered:
+        row_id = str(row.get("id", ""))
+        if not row_id or row_id in seen:
+            continue
+        seen.add(row_id)
+        merged.append(row)
+        if len(merged) >= limit:
+            break
+    return merged

--- a/web/discogs.py
+++ b/web/discogs.py
@@ -23,6 +23,7 @@ from typing import Literal
 import msgspec
 
 from web import cache as _cache
+from web.artist_search import merge_exact_artist_identities
 
 # Mirror-REQUIRED (tier-2 plan U6, R13): these endpoints (/api/search,
 # /api/masters/<id>, ...) and the msgspec response Structs are the Rust
@@ -243,7 +244,7 @@ def search_artists(query: str) -> list[dict]:
     def _fetch() -> list[dict]:
         q = urllib.parse.quote(query)
         data = _get(f"{_api_base()}/api/artists?name={q}&per_page=20")
-        return [
+        results = [
             {
                 "id": str(r["id"]),
                 "name": r.get("name", ""),
@@ -252,9 +253,33 @@ def search_artists(query: str) -> list[dict]:
             }
             for r in data.get("results", [])
         ]
+        exact = next((
+            row for row in results
+            if row["name"].casefold() == query.casefold()
+        ), None)
+        if exact is None:
+            return results
+        try:
+            detail = _get(f"{_api_base()}/api/artists/{exact['id']}")
+        except (urllib.error.HTTPError, urllib.error.URLError):
+            return results
+        related = [
+            {
+                "id": str(alias["id"]),
+                "name": alias.get("name", ""),
+                "disambiguation": "",
+                "score": max(0, exact["score"] - 1),
+            }
+            for alias in detail.get("aliases", [])
+        ]
+        return merge_exact_artist_identities(
+            results, exact_id=exact["id"], related=related,
+        )
 
     cache_query = _search_cache_query_part(query)
-    return _cache.memoize_meta(f"discogs:search:artists:{cache_query}", _fetch)
+    return _cache.memoize_meta(
+        f"discogs:search:artists:v2:{cache_query}", _fetch,
+    )
 
 
 def _normalize_artist_master_entry(r: dict) -> dict:

--- a/web/mb.py
+++ b/web/mb.py
@@ -20,6 +20,7 @@ import urllib.error
 # Use the `web.` package-qualified path to keep the web metadata cache
 # separate from the pipeline's peer-cache implementation.
 from web import cache as _cache
+from web.artist_search import merge_exact_artist_identities
 
 # Default: public MusicBrainz (functional but rate-limited ~1 req/s).
 # Production points this at the local mirror via the module's
@@ -103,22 +104,78 @@ def search_release_groups(query):
     return _cache.memoize_meta(f"mb:search:release_groups:{query}", _fetch)
 
 
+def _artist_search_hit(artist: dict, *, score: int) -> dict:
+    return {
+        "id": artist["id"],
+        "name": artist.get("name", ""),
+        "disambiguation": artist.get("disambiguation", ""),
+        "score": score,
+    }
+
+
+def _related_artist_identity_hits(artist_id: str, *, score: int) -> list[dict]:
+    """Resolve canonical MusicBrainz ``is person`` identity siblings."""
+    detail = _get(
+        f"{MB_API_BASE}/artist/{artist_id}?inc=artist-rels&fmt=json"
+    )
+    relations = detail.get("relations", [])
+    identity_artists: list[dict] = []
+
+    # A persona such as Four Tet points backward to the underlying person.
+    person = next((
+        rel.get("artist")
+        for rel in relations
+        if rel.get("type") == "is person"
+        and rel.get("direction") == "backward"
+        and rel.get("artist")
+    ), None)
+    if person:
+        identity_artists.append(person)
+        detail = _get(
+            f"{MB_API_BASE}/artist/{person['id']}?inc=artist-rels&fmt=json"
+        )
+        relations = detail.get("relations", [])
+
+    # The person entity points forward to each separately catalogued persona.
+    identity_artists.extend(
+        rel["artist"]
+        for rel in relations
+        if rel.get("type") == "is person"
+        and rel.get("direction") == "forward"
+        and rel.get("artist")
+    )
+    return [
+        _artist_search_hit(artist, score=score)
+        for artist in identity_artists
+    ]
+
+
 def search_artists(query):
     """Search for artists by name. Returns list of {id, name, disambiguation, score}."""
     def _fetch() -> list[dict]:
         q = urllib.parse.quote(query)
         data = _get(f"{MB_API_BASE}/artist?query={q}&fmt=json&limit=20")
-        return [
-            {
-                "id": a["id"],
-                "name": a.get("name", ""),
-                "disambiguation": a.get("disambiguation", ""),
-                "score": a.get("score", 0),
-            }
+        results = [
+            _artist_search_hit(a, score=a.get("score", 0))
             for a in data.get("artists", [])
         ]
+        exact = next((
+            row for row in results
+            if row["name"].casefold() == query.casefold()
+        ), None)
+        if exact is None:
+            return results
+        try:
+            related = _related_artist_identity_hits(
+                exact["id"], score=max(0, exact["score"] - 1),
+            )
+        except (urllib.error.HTTPError, urllib.error.URLError):
+            return results
+        return merge_exact_artist_identities(
+            results, exact_id=exact["id"], related=related,
+        )
 
-    return _cache.memoize_meta(f"mb:search:artists:{query}", _fetch)
+    return _cache.memoize_meta(f"mb:search:artists:v2:{query}", _fetch)
 
 
 def get_artist_release_groups(artist_mbid):


### PR DESCRIPTION
## Summary

- enrich exact MusicBrainz and Discogs artist searches with canonical related identities, so Four Tet surfaces the symbol persona without merging release catalogs
- bound UTF-8 staging path components with deterministic hashes while preserving request ownership suffixes
- add deterministic and generated regression coverage for both behaviors

## Verification

- `pyright`: clean
- full suite: 5,664 tests passed
- pre-push generated-test fuzz burst: passed
- `nix flake check`: passed

The branch also includes current `main` so the artist-appearance work remains intact.