### PR TITLE
Keep bare codecs distinct from quality contracts

### DIFF
--- a/tests/test_js_history.mjs
+++ b/tests/test_js_history.mjs
@@ -577,6 +577,25 @@ console.log('renderDownloadHistoryItem() does not fabricate output when format i
     'fixed output row remains present');
 }
 
+console.log('renderDownloadHistoryItem() calls only explicit quality labels contracts');
+{
+  const legacyMp3 = renderDownloadHistoryFixture({
+    outcome: 'success',
+    created_at: '2026-07-13T00:29:00+00:00',
+    final_format: 'MP3',
+  });
+  assertContains(legacyMp3, 'Stored as', 'legacy stored format still renders');
+  assertContains(legacyMp3, '>MP3<', 'bare MP3 remains a codec fact');
+  assertExcludes(legacyMp3, 'MP3 contract', 'bare MP3 is not a quality contract');
+
+  const explicitOpus = renderDownloadHistoryFixture({
+    outcome: 'success',
+    created_at: '2026-07-13T01:06:00+00:00',
+    final_format: 'opus 128',
+  });
+  assertContains(explicitOpus, 'OPUS 128 contract', 'numeric target is a contract');
+}
+
 console.log('renderEvidenceStrip() shows research V0 probes with the from-lossy qualifier');
 {
   // V0 runs on everything; the strip shows whichever probe each side has,

--- a/web/js/history.js
+++ b/web/js/history.js
@@ -367,7 +367,13 @@ export function renderDownloadHistoryItem(h) {
   rows.push(['Output', materializedOutputPhrase(h, true) || '—']);
 
   if (h.final_format) {
-    rows.push(['Stored as', `${esc(String(h.final_format).toUpperCase())} contract`]);
+    const finalFormat = String(h.final_format);
+    const explicitContract = h.comparison_basis?.new_metric === 'contract'
+      || /(?:\bv\d+\b|\b\d+\b)/i.test(finalFormat);
+    rows.push([
+      'Stored as',
+      `${esc(finalFormat.toUpperCase())}${explicitContract ? ' contract' : ''}`,
+    ]);
   }
 
   if (outcome === 'force_import') {


### PR DESCRIPTION
## Summary

- label only explicit numeric/V-level storage targets as contracts
- preserve bare historical codec facts such as `MP3` without inventing a contract
- add the live-screenshot regression pin for bare MP3 versus `OPUS 128`

## Verification

- 141 history JS assertions
- full suite: 5,661 tests; artifact `/tmp/fix-materialized-bitrate-evidence-f34eb0f9c7-222bb2ade60b.2oqtz6wj`
- randomized generated-test push burst and `nix flake check`: green
- independent sub-agent review: clean
