### PR TITLE
Keep V0 probe minima under V0 labels

### DIFF
--- a/docs/webui-primer.md
+++ b/docs/webui-primer.md
@@ -151,7 +151,9 @@ Browser → https://music.ablz.au
   not be decoded renders `analysis failed`; this is distinct from a legacy
   row whose analysis was never attempted.
   V0 probes render for every candidate — research probes of lossy sources
-  qualified "(from lossy)" — matching the Wrong Matches convention.
+  qualified "(from lossy)" — matching the Wrong Matches convention. Probe
+  averages and minima stay under that V0 label (`V0 171k avg (min 165k)`);
+  a temporary probe minimum must never render as a FLAC/source minimum.
 - **Wrong Matches evidence provenance** — candidate rows keep the downloaded
   source codec, configured target contract, and temporary V0 probe separate.
   A lossless candidate destined for Opus therefore reads `FLAC → OPUS 128

--- a/tests/test_js_history.mjs
+++ b/tests/test_js_history.mjs
@@ -741,6 +741,51 @@ console.log('Gas: contract, V0 proof, and materialized Opus output stay distinct
   assertExcludes(detail, '>Min bitrate<', 'ambiguous unqualified row is gone');
 }
 
+console.log('Iron & Wine: the temporary V0 minimum never wears the FLAC label');
+{
+  const strip = renderEvidenceFixture({
+    outcome: 'rejected',
+    downloaded_label: 'FLAC',
+    filetype: 'flac',
+    slskd_filetype: 'flac',
+    actual_filetype: 'flac',
+    actual_min_bitrate: 165,
+    spectral_grade: 'likely_transcode',
+    spectral_bitrate: 96,
+    v0_probe_kind: 'lossless_source_v0',
+    v0_probe_min_bitrate: 165,
+    v0_probe_avg_bitrate: 171,
+    existing_format: 'Opus',
+    existing_min_bitrate: 114,
+    existing_spectral_grade: 'likely_transcode',
+    existing_v0_probe_kind: 'lossless_source_v0',
+    existing_v0_probe_min_bitrate: 223,
+    existing_v0_probe_avg_bitrate: 232,
+  });
+  assertContains(strip, 'IN</span> FLAC ·', 'source remains labelled FLAC');
+  assertExcludes(strip, 'FLAC · min 165k', 'V0 minimum is not a FLAC measurement');
+  assertContains(strip, 'V0 171k avg (min 165k)', 'candidate V0 owns its minimum');
+  assertContains(strip, 'Opus min 114k', 'materialized existing Opus keeps its real floor');
+  assertContains(strip, 'V0 232k avg (min 223k)', 'existing source V0 owns its minimum');
+
+  const detail = renderDownloadHistoryFixture({
+    outcome: 'rejected',
+    soulseek_username: 'donfulci',
+    created_at: '2026-07-13T01:01:00+00:00',
+    v0_probe_kind: 'lossless_source_v0',
+    v0_probe_min_bitrate: 165,
+    v0_probe_avg_bitrate: 171,
+    existing_v0_probe_kind: 'lossless_source_v0',
+    existing_v0_probe_min_bitrate: 223,
+    existing_v0_probe_avg_bitrate: 232,
+    verdict: 'Suspect lossless source not better than on-disk copy; searching continues',
+  });
+  assertContains(detail, '171kbps avg · min 165kbps',
+    'detail candidate V0 owns its minimum');
+  assertContains(detail, '232kbps avg · min 223kbps',
+    'detail existing V0 owns its minimum');
+}
+
 console.log('renderEvidenceStrip() marks spectral-clamped rank values with ~');
 {
   const strip = renderEvidenceFixture({

--- a/web/js/history.js
+++ b/web/js/history.js
@@ -15,10 +15,12 @@ import { awstDateTime, esc } from './util.js';
  *   still legible.
  * @param {number|string} avg
  * @param {string|undefined} kind
+ * @param {number|string|undefined} min
  * @returns {string}
  */
-function formatV0Probe(avg, kind) {
-  const base = `${esc(avg)}kbps avg`;
+function formatV0Probe(avg, kind, min = undefined) {
+  const floor = min !== null && min !== undefined ? ` · min ${esc(min)}kbps` : '';
+  const base = `${esc(avg)}kbps avg${floor}`;
   if (!kind || kind === 'lossless_source_v0') {
     return base;
   }
@@ -36,10 +38,12 @@ function formatV0Probe(avg, kind) {
  * qualified "(from lossy)" — same vocabulary as formatV0Probe.
  * @param {number|string} avg
  * @param {string|undefined} kind
+ * @param {number|string|undefined} min
  * @returns {string}
  */
-function stripV0Phrase(avg, kind) {
-  const base = `V0 ${esc(avg)}k avg`;
+function stripV0Phrase(avg, kind, min = undefined) {
+  const floor = min !== null && min !== undefined ? ` (min ${esc(min)}k)` : '';
+  const base = `V0 ${esc(avg)}k avg${floor}`;
   if (!kind || kind === 'lossless_source_v0') return base;
   if (kind === 'native_lossy_research_v0') return `${base} (from lossy)`;
   if (kind === 'on_disk_research_v0') return `${base} (on-disk re-encode)`;
@@ -178,7 +182,16 @@ export function renderEvidenceStrip(h) {
     // Labelled "min": bare numbers on a card that also shows avg-labelled
     // basis and V0 values invite exactly the min-vs-avg confusion the
     // basis exists to kill (request 8781 operator report).
-    if (h.actual_min_bitrate) inParts.push(`min ${esc(h.actual_min_bitrate)}k`);
+    const minIsLosslessSourceProbe = (
+      (h.v0_probe_kind === 'lossless_source_v0'
+        || h.v0_probe_kind === 'lossless_source')
+      && h.v0_probe_min_bitrate !== null
+      && h.v0_probe_min_bitrate !== undefined
+      && Number(h.actual_min_bitrate) === Number(h.v0_probe_min_bitrate)
+    );
+    if (h.actual_min_bitrate && !minIsLosslessSourceProbe) {
+      inParts.push(`min ${esc(h.actual_min_bitrate)}k`);
+    }
   }
   const materialized = materializedOutputPhrase(h);
   if (materialized) inParts.push(materialized);
@@ -200,7 +213,8 @@ export function renderEvidenceStrip(h) {
   // V0 on every candidate: whichever probe ran, show it (qualified when
   // it's a research probe of a lossy source, so lineages stay legible).
   if (h.v0_probe_avg_bitrate) {
-    inParts.push(stripV0Phrase(h.v0_probe_avg_bitrate, h.v0_probe_kind));
+    inParts.push(stripV0Phrase(
+      h.v0_probe_avg_bitrate, h.v0_probe_kind, h.v0_probe_min_bitrate));
   }
 
   const haveParts = [];
@@ -230,7 +244,9 @@ export function renderEvidenceStrip(h) {
   }
   if (h.existing_v0_probe_avg_bitrate) {
     haveParts.push(stripV0Phrase(
-      h.existing_v0_probe_avg_bitrate, h.existing_v0_probe_kind));
+      h.existing_v0_probe_avg_bitrate,
+      h.existing_v0_probe_kind,
+      h.existing_v0_probe_min_bitrate));
   }
 
   if (inParts.length === 0 && haveParts.length === 0) return '';
@@ -336,13 +352,16 @@ export function renderDownloadHistoryItem(h) {
   // V0-probe avg next to a container min bitrate reads as a fake
   // upgrade (e.g. "239kbps avg (was 92kbps)" compares two different
   // metrics). When there's no existing probe, the row shows the
-  // candidate alone; the Min bitrate row below already carries the
-  // min-vs-min comparison.
+  // candidate alone. Each probe owns its own optional minimum so a temporary
+  // V0 floor can never be mistaken for the source container's bitrate.
   if (h.v0_probe_avg_bitrate) {
-    const candidate = formatV0Probe(h.v0_probe_avg_bitrate, h.v0_probe_kind);
+    const candidate = formatV0Probe(
+      h.v0_probe_avg_bitrate, h.v0_probe_kind, h.v0_probe_min_bitrate);
     const was = h.existing_v0_probe_avg_bitrate
       ? formatV0Probe(
-        h.existing_v0_probe_avg_bitrate, h.existing_v0_probe_kind)
+        h.existing_v0_probe_avg_bitrate,
+        h.existing_v0_probe_kind,
+        h.existing_v0_probe_min_bitrate)
       : null;
     rows.push(['V0 probe', withWas(candidate, was)]);
   }


### PR DESCRIPTION
## Summary

- suppress a legacy source `min` only when lossless-source V0 provenance proves it is the probe minimum
- render both V0 average and minimum under the V0 label in compact and expanded history
- pin Iron & Wine / The Creek Drank the Cradle (`dl 36931`) so FLAC never claims the V0 165k floor

## Verification

- 148 history JS assertions and 25 payload-contract audit assertions
- full suite: 5,661 tests; artifact `/tmp/fix-materialized-bitrate-evidence-f34eb0f9c7-70e853a53d35.lr8uzwkj`
- randomized generated-test push burst and `nix flake check`: green
- independent sub-agent review: clean
