### PR TITLE
Pair artist releases by structural type evidence

### DIFF
--- a/docs/discogs-mirror.md
+++ b/docs/discogs-mirror.md
@@ -32,7 +32,8 @@ A self-hosted mirror of the Discogs music database, serving a JSON API at `https
 | GET | `/api/releases/{id}` | Full release: tracks, genres, styles, identifiers |
 | GET | `/api/masters/{id}` | Master release with all child releases |
 | GET | `/api/artists/{id}` | Artist profile, aliases, name variations |
-| GET | `/api/artists/{id}/releases?page=1&per_page=100` | Paginated releases for an artist (includes masterless) |
+| GET | `/api/artists/{id}/masters?page=1&per_page=100` | Paginated primary-credit masters and masterless releases; each row includes required sorted/deduplicated `primary_types` (`Album`, `EP`, `Single`) aggregated across every child pressing, with `[]` meaning unknown |
+| GET | `/api/artists/{id}/appearances` | Track-credit appearances in the same strict row shape as `/masters`, including required `primary_types` |
 | GET | `/api/labels?name=X&page=1&per_page=25` | Label search with release counts and parent-label context |
 | GET | `/api/labels/{id}` | Label profile, direct release count, parent, and direct sub-labels |
 | GET | `/api/labels/{id}/releases?page=1&per_page=100&include_sublabels=true` | Paginated releases for a label, optionally including recursive sub-label releases |

--- a/docs/webui-primer.md
+++ b/docs/webui-primer.md
@@ -87,6 +87,16 @@ Browser → https://music.ablz.au
   in-library pressing's detail offers a lazy **Library detail** panel (path,
   download history, status / min-bitrate / intent controls) fetched from
   `/api/beets/album/<id>`.
+  Cross-source pairing is conservative: normalized titles and appearance
+  provenance must agree; known Album/EP/Single sets must overlap; exact years
+  may pair when a type is genuinely unknown; and an adjacent-year discrepancy
+  pairs only with positive type overlap. Discogs structural evidence comes
+  from the mirror's master-wide `primary_types`, never its representative
+  pressing's legacy scalar `type`. This preserves the Beatles' distinct
+  *Twist and Shout* Album/EP/Single works while pairing *The Pointless Gift*
+  despite MB (2000) and Discogs (2001) date disagreement. Reissues and
+  remasters remain child pressings inside their existing MB release group or
+  Discogs master; this display merge does not split them.
 - **Release editions** — when you expand a release group, shows all editions sorted by date
   - Official releases first, bootleg/promo collapsed — EXCEPT pressings that
     are in the library or have a pipeline request, which are always hoisted

--- a/lib/artist_compare.py
+++ b/lib/artist_compare.py
@@ -4,7 +4,8 @@ Pure functions — no I/O. The web layer fetches both source's discographies
 and hands them to merge_discographies(), which buckets them into:
 
   - 'both'        : (mb_rg, discogs_master) pairs that appear to be the same
-                    logical album (matched on normalized title + year ±tol)
+                    logical work (matched on title, provenance, structural
+                    type evidence, and a conservative date rule)
   - 'mb_only'     : MB release groups with no Discogs counterpart
   - 'discogs_only': Discogs masters with no MB counterpart
 
@@ -164,18 +165,62 @@ def annotate_in_library(
             master["in_library"] = False
 
 
-def _dedupe_within_source(rows: list[dict]) -> list[dict]:
-    """Collapse same-normalized-title + same-year + same-type duplicates.
+_STRUCTURAL_TYPES = frozenset({"Album", "EP", "Single"})
+
+
+def _mb_structural_types(row: dict) -> frozenset[str]:
+    """Return recognized MB structural evidence; Other/blank is unknown."""
+    type_ = row.get("type")
+    return frozenset({type_}) if type_ in _STRUCTURAL_TYPES else frozenset()
+
+
+def _discogs_structural_types(row: dict) -> frozenset[str]:
+    """Return Discogs master-wide type evidence from the mirror contract.
+
+    The legacy scalar ``type`` describes one representative pressing and can
+    be misleading. It is display metadata only and must never authorize a
+    merge across years or a structural boundary.
+    """
+    return frozenset(
+        type_ for type_ in row.get("primary_types", [])
+        if type_ in _STRUCTURAL_TYPES
+    )
+
+
+def _dedupe_type_identity(
+    row: dict, *, source: str
+) -> tuple[str, frozenset[str] | str]:
+    """Use structural evidence, falling back to scalar within one source.
+
+    The scalar fallback only prevents distinct unknown-type rows from being
+    collapsed by the within-source pre-pass. It is never cross-source match
+    evidence and cannot authorize an adjacent-year pairing.
+    """
+    structural_types = (
+        _mb_structural_types(row)
+        if source == "mb"
+        else _discogs_structural_types(row)
+    )
+    if structural_types:
+        return ("structural", structural_types)
+    return ("scalar-fallback", str(row.get("type") or "").lower())
+
+
+def _dedupe_within_source(rows: list[dict], *, source: str) -> list[dict]:
+    """Collapse duplicates only within one provenance/type identity.
 
     Only case-only or punctuation-only title variants of the SAME
-    release (same year, same type) collapse — "Twist And Shout" Album
+    release (same year, same structural set and appearance provenance)
+    collapse — "Twist And Shout" Album
     1964 and "Twist and Shout" Album 1964 become one. Legitimately
     different release groups (EP 1963 vs Album 1964 of the same name,
     or re-releases in different years) stay separate.
 
     Keep first (input order) as canonical. Missing title: passthrough.
     """
-    seen: set[tuple[str, int | None, str]] = set()
+    seen: set[
+        tuple[str, int | None, tuple[str, frozenset[str] | str], bool]
+    ] = set()
     result: list[dict] = []
     for r in rows:
         norm = normalize_title(r.get("title", ""))
@@ -183,8 +228,8 @@ def _dedupe_within_source(rows: list[dict]) -> list[dict]:
             result.append(r)
             continue
         year = extract_year(r.get("first_release_date", ""))
-        type_ = (r.get("type") or "").lower()
-        key = (norm, year, type_)
+        type_identity = _dedupe_type_identity(r, source=source)
+        key = (norm, year, type_identity, bool(r.get("is_appearance")))
         if key in seen:
             continue
         seen.add(key)
@@ -196,27 +241,40 @@ def merge_discographies(
     mb_groups: list[dict],
     discogs_groups: list[dict],
 ) -> CompareBuckets:
-    """Bucket MB + Discogs release groups by exact title+year match.
+    """Bucket MB release groups and Discogs masters conservatively.
 
-    Pre-pass: collapse within-source same-title+year+type duplicates
+    Pre-pass: collapse within-source same-title+year+structural-type duplicates
     via _dedupe_within_source so the cross-source merge sees one row
     per logical album per source.
 
     Match rule:
       1. Normalized title equality is required.
-      2. Years must match exactly (or both be unknown for a weak
-         title-only fallback). Any year mismatch, even by 1 year, splits
-         into two rows — the alternative (tolerance) produced false
-         positives like MB "Twist and Shout" Album 1964 matching
-         Discogs "Twist And Shout" EP 1963.
-      3. Among exact-year candidates, prefer the one with matching type
-         (Album↔Album beats Album↔EP) so MB Album 1964 picks Discogs
-         Album 1964 over Discogs EP 1964 when both exist.
+      2. Appearance provenance must agree. A VA compilation appearance never
+         pairs with the artist's mainline work.
+      3. Recognized, nonempty structural sets must overlap. MB contributes
+         its scalar Album/EP/Single type; Discogs contributes only the
+         mirror's master-wide ``primary_types`` set. The legacy Discogs
+         scalar is one representative pressing and is not evidence.
+      4. Exact known years may pair when types are not known-disjoint. Both
+         unknown years retain the weak title fallback. Adjacent known years
+         may pair only with positive overlapping structural evidence;
+         partial-unknown and larger deltas stay separate.
+      5. Candidate rank is exact year, then adjacent year, then both-unknown;
+         overlapping evidence breaks ties. Equal ranks keep Discogs input
+         order for one MB row; across the whole cohort the stable tie policy
+         is MB input order, then Discogs input order.
+
+    The historical Beatles bug came from a blind year tolerance: MB "Twist
+    and Shout" Album 1964 paired with a Discogs EP from 1963. Structural
+    boundaries now prevent that while allowing "The Pointless Gift" Album
+    2000/2001 to pair. This does not split remasters or reissues: MusicBrainz
+    release groups and Discogs masters have already grouped their child
+    pressings before this display-only cross-source merge runs.
 
     Each Discogs entry can match at most one MB entry.
     """
-    mb_groups = _dedupe_within_source(mb_groups)
-    discogs_groups = _dedupe_within_source(discogs_groups)
+    mb_groups = _dedupe_within_source(mb_groups, source="mb")
+    discogs_groups = _dedupe_within_source(discogs_groups, source="discogs")
 
     by_norm: dict[str, list[int]] = defaultdict(list)
     for i, d in enumerate(discogs_groups):
@@ -224,48 +282,69 @@ def merge_discographies(
         if norm:
             by_norm[norm].append(i)
 
-    matched: set[int] = set()
-    both: list[dict] = []
-    mb_only: list[dict] = []
-
-    for m in mb_groups:
+    candidate_edges: list[tuple[tuple[int, int], int, int]] = []
+    for mi, m in enumerate(mb_groups):
         norm = normalize_title(m.get("title", ""))
         m_year = extract_year(m.get("first_release_date", ""))
-        m_type = (m.get("type") or "").lower()
+        m_types = _mb_structural_types(m)
+        m_appearance = bool(m.get("is_appearance"))
 
-        # Score each available candidate; highest wins. A negative score
-        # disqualifies. Exact year required (or both unknown).
-        best_idx: int | None = None
-        best_score = -1
         for di in by_norm.get(norm, []):
-            if di in matched:
-                continue
             d = discogs_groups[di]
             d_year = extract_year(d.get("first_release_date", ""))
-            d_type = (d.get("type") or "").lower()
-
-            if m_year is None and d_year is None:
-                score = 1  # weakest — title-only match, years unknown
-            elif m_year is not None and d_year is not None and m_year == d_year:
-                score = 10  # exact year match
-            else:
-                # Year mismatch (including partial-unknown). Reject.
+            d_types = _discogs_structural_types(d)
+            if m_appearance != bool(d.get("is_appearance")):
                 continue
 
-            # Type match bonus — only affects tie-breaking among
-            # otherwise-equal candidates.
-            if m_type and d_type and m_type == d_type:
-                score += 5
+            type_overlap = bool(m_types & d_types)
+            if m_types and d_types and not type_overlap:
+                continue
 
-            if score > best_score:
-                best_score = score
-                best_idx = di
+            if m_year is None and d_year is None:
+                year_score = 1  # weakest — title-only match, years unknown
+            elif m_year is not None and d_year is not None and m_year == d_year:
+                year_score = 3
+            elif (
+                m_year is not None
+                and d_year is not None
+                and abs(m_year - d_year) == 1
+                and m_types
+                and d_types
+                and type_overlap
+            ):
+                year_score = 2
+            else:
+                continue
 
-        if best_idx is not None:
-            matched.add(best_idx)
-            both.append({"mb": m, "discogs": discogs_groups[best_idx]})
+            score = (year_score, int(type_overlap))
+            candidate_edges.append((score, mi, di))
+
+    # Highest-confidence edges claim their rows first across the whole title
+    # cohort. This keeps a later MB exact-year edge from losing its Discogs
+    # row to an earlier MB adjacent-year edge. Equal confidence is stable by
+    # MB input order, then Discogs input order.
+    candidate_edges.sort(
+        key=lambda edge: (-edge[0][0], -edge[0][1], edge[1], edge[2])
+    )
+    matched_mb: set[int] = set()
+    matched_discogs: set[int] = set()
+    mb_to_discogs: dict[int, int] = {}
+    for _score, mi, di in candidate_edges:
+        if mi in matched_mb or di in matched_discogs:
+            continue
+        matched_mb.add(mi)
+        matched_discogs.add(di)
+        mb_to_discogs[mi] = di
+
+    both: list[dict] = []
+    mb_only: list[dict] = []
+    for mi, m in enumerate(mb_groups):
+        if mi in mb_to_discogs:
+            both.append({"mb": m, "discogs": discogs_groups[mb_to_discogs[mi]]})
         else:
             mb_only.append(m)
 
-    discogs_only = [d for i, d in enumerate(discogs_groups) if i not in matched]
+    discogs_only = [
+        d for i, d in enumerate(discogs_groups) if i not in matched_discogs
+    ]
     return CompareBuckets(both=both, mb_only=mb_only, discogs_only=discogs_only)

--- a/tests/test_artist_compare.py
+++ b/tests/test_artist_compare.py
@@ -15,12 +15,44 @@ from lib.artist_compare import (
 )
 
 
-def _mb(title: str, year: str = "", id: str = "rg") -> dict:
-    return {"id": id, "title": title, "first_release_date": year, "type": "Album"}
+def _mb(
+    title: str,
+    year: str = "",
+    id: str = "rg",
+    *,
+    type_: str = "Album",
+    is_appearance: bool = False,
+) -> dict:
+    return {
+        "id": id,
+        "title": title,
+        "first_release_date": year,
+        "type": type_,
+        "is_appearance": is_appearance,
+    }
 
 
-def _dg(title: str, year: str = "", id: str = "1") -> dict:
-    return {"id": id, "title": title, "first_release_date": year, "type": "Album"}
+def _dg(
+    title: str,
+    year: str = "",
+    id: str = "1",
+    *,
+    type_: str = "Album",
+    primary_types: list[str] | None = None,
+    is_appearance: bool = False,
+) -> dict:
+    return {
+        "id": id,
+        "title": title,
+        "first_release_date": year,
+        "type": type_,
+        "primary_types": (
+            [type_]
+            if primary_types is None and type_ in {"Album", "EP", "Single"}
+            else (primary_types or [])
+        ),
+        "is_appearance": is_appearance,
+    }
 
 
 class TestNormalizeTitle(unittest.TestCase):
@@ -64,9 +96,7 @@ class TestMergeDiscographies(unittest.TestCase):
         self.assertEqual(result.mb_only, [])
         self.assertEqual(result.discogs_only, [])
 
-    def test_any_year_mismatch_splits(self):
-        """Exact year required. Year-tolerance produced false positives
-        like MB Album 1964 matching Discogs EP 1963 for 'Twist and Shout'."""
+    def test_year_delta_greater_than_one_splits(self):
         result = merge_discographies(
             [_mb("A Working Title in Green", "2002")],
             [_dg("A Working Title In Green", "2000")],
@@ -189,21 +219,17 @@ class TestMergeDiscographies(unittest.TestCase):
         """EP 1963 and Album 1963 of the same name are legitimately
         different release groups even when the title normalises to the
         same thing. Dedup must NOT collapse them."""
-        ep = {**_dg("Twist And Shout", "1963", id="dg-ep"), "type": "EP"}
-        album = {**_dg("Twist And Shout", "1963", id="dg-album"), "type": "Album"}
+        ep = _dg("Twist And Shout", "1963", id="dg-ep", type_="EP")
+        album = _dg("Twist And Shout", "1963", id="dg-album", type_="Album")
         result = merge_discographies([], [ep, album])
         self.assertEqual(len(result.discogs_only), 2)
 
     def test_beatles_mb_album_picks_discogs_album_over_ep(self):
-        """The root user bug: MB 'Twist and Shout' Album 1964 was
-        matching Discogs 'Twist And Shout' EP 1963 (within year
-        tolerance, first in input order) instead of Discogs Album 1964.
-        Exact-year requirement + same-type scoring fixes it."""
-        mb = {**_mb("Twist and Shout", "1964", id="mb-album"), "type": "Album"}
-        dg_ep_63 = {**_dg("Twist And Shout", "1963", id="dg-ep"), "type": "EP"}
-        dg_single_64 = {**_dg("Twist And Shout", "1964", id="dg-single"), "type": "Single"}
-        dg_album_64 = {**_dg("Twist And Shout", "1964", id="dg-album"), "type": "Album"}
-        # EP comes first in input order — previously would have matched.
+        """Structural type boundaries preserve the three distinct works."""
+        mb = _mb("Twist and Shout", "1964", id="mb-album", type_="Album")
+        dg_ep_63 = _dg("Twist And Shout", "1963", id="dg-ep", type_="EP")
+        dg_single_64 = _dg("Twist And Shout", "1964", id="dg-single", type_="Single")
+        dg_album_64 = _dg("Twist And Shout", "1964", id="dg-album", type_="Album")
         result = merge_discographies([mb], [dg_ep_63, dg_single_64, dg_album_64])
         self.assertEqual(len(result.both), 1)
         self.assertEqual(result.both[0]["discogs"]["id"], "dg-album")
@@ -211,14 +237,151 @@ class TestMergeDiscographies(unittest.TestCase):
         self.assertEqual({r["id"] for r in result.discogs_only},
                          {"dg-ep", "dg-single"})
 
-    def test_exact_year_without_same_type_still_matches(self):
-        """When only one exact-year candidate exists, it matches even
-        if types don't match — type is a preference, not a requirement."""
-        mb = {**_mb("Side Project", "2020", id="mb-1"), "type": "Album"}
-        dg = {**_dg("Side Project", "2020", id="dg-1"), "type": "EP"}
+    def test_known_disjoint_exact_year_stays_separate(self):
+        mb = _mb("Side Project", "2020", id="mb-1", type_="Album")
+        dg = _dg("Side Project", "2020", id="dg-1", type_="EP")
         result = merge_discographies([mb], [dg])
+        self.assertEqual(result.both, [])
+
+    def test_pointless_gift_adjacent_album_years_pair(self):
+        result = merge_discographies(
+            [_mb("The Pointless Gift", "2000-12-05", id="mb-pointless")],
+            [_dg("The Pointless Gift", "2001", id="dg-pointless")],
+        )
         self.assertEqual(len(result.both), 1)
-        self.assertEqual(result.both[0]["discogs"]["id"], "dg-1")
+        self.assertEqual(result.both[0]["discogs"]["id"], "dg-pointless")
+
+    def test_mixed_discogs_types_overlap_mb_single(self):
+        result = merge_discographies(
+            [_mb("Mystery of Love", "2017", type_="Single")],
+            [_dg("Mystery of Love", "2018", primary_types=["EP", "Single"])],
+        )
+        self.assertEqual(len(result.both), 1)
+
+    def test_unknown_discogs_type_exact_year_can_pair(self):
+        result = merge_discographies(
+            [_mb("Compilation", "2004")],
+            [_dg("Compilation", "2004", type_="Album", primary_types=[])],
+        )
+        self.assertEqual(len(result.both), 1)
+
+    def test_legacy_discogs_scalar_does_not_authorize_adjacent_year(self):
+        result = merge_discographies(
+            [_mb("Compilation", "2004")],
+            [_dg("Compilation", "2005", type_="Album", primary_types=[])],
+        )
+        self.assertEqual(result.both, [])
+
+    def test_appearance_and_mainline_never_pair(self):
+        result = merge_discographies(
+            [_mb("Indie Sampler", "2001", is_appearance=True)],
+            [_dg("Indie Sampler", "2001", is_appearance=False)],
+        )
+        self.assertEqual(result.both, [])
+
+    def test_exact_year_candidate_beats_adjacent_year(self):
+        result = merge_discographies(
+            [_mb("Airbag", "1998", type_="EP")],
+            [
+                _dg("Airbag", "1997", id="adjacent", type_="EP"),
+                _dg("Airbag", "1998", id="exact", type_="EP"),
+            ],
+        )
+        self.assertEqual(result.both[0]["discogs"]["id"], "exact")
+
+    def test_exact_edge_beats_earlier_mb_adjacent_edge(self):
+        result = merge_discographies(
+            [
+                _mb("Airbag", "1997", id="adjacent-mb", type_="EP"),
+                _mb("Airbag", "1998", id="exact-mb", type_="EP"),
+            ],
+            [_dg("Airbag", "1998", id="discogs", type_="EP")],
+        )
+        self.assertEqual(result.both[0]["mb"]["id"], "exact-mb")
+        self.assertEqual(result.mb_only[0]["id"], "adjacent-mb")
+
+    def test_stable_first_input_tie_policy(self):
+        result = merge_discographies(
+            [_mb("Same", "2000")],
+            [
+                _dg("Same", "2000", id="first", primary_types=["Album", "EP"]),
+                _dg("Same", "2000", id="second", primary_types=["Album", "Single"]),
+            ],
+        )
+        self.assertEqual(result.both[0]["discogs"]["id"], "first")
+
+    def test_overlapping_type_evidence_wins_exact_year_tie(self):
+        result = merge_discographies(
+            [_mb("Same", "2000", type_="Album")],
+            [
+                _dg("Same", "2000", id="unknown", primary_types=[]),
+                _dg("Same", "2000", id="overlap", primary_types=["Album"]),
+            ],
+        )
+        self.assertEqual(result.both[0]["discogs"]["id"], "overlap")
+
+    def test_within_source_dedup_keeps_appearance_boundary(self):
+        result = merge_discographies(
+            [],
+            [
+                _dg("Sampler", "2000", id="main", is_appearance=False),
+                _dg("Sampler", "2000", id="appearance", is_appearance=True),
+            ],
+        )
+        self.assertEqual(len(result.discogs_only), 2)
+
+    def test_within_source_dedup_keeps_different_structural_sets(self):
+        result = merge_discographies(
+            [],
+            [
+                _dg("Mixed Master", "2000", id="single", primary_types=["Single"]),
+                _dg("Mixed Master", "2000", id="mixed", primary_types=["EP", "Single"]),
+            ],
+        )
+        self.assertEqual(len(result.discogs_only), 2)
+
+    def test_discogs_unknown_types_keep_legacy_scalar_boundaries(self):
+        result = merge_discographies(
+            [],
+            [
+                _dg(
+                    "Unknown Evidence", "2000", id="album",
+                    type_="Album", primary_types=[],
+                ),
+                _dg(
+                    "Unknown Evidence", "2000", id="ep",
+                    type_="EP", primary_types=[],
+                ),
+            ],
+        )
+        self.assertEqual(len(result.discogs_only), 2)
+
+    def test_mb_within_source_dedup_keeps_type_and_appearance_boundaries(self):
+        result = merge_discographies(
+            [
+                _mb("Same", "2000", id="album", type_="Album"),
+                _mb("Same", "2000", id="ep", type_="EP"),
+                _mb(
+                    "Same", "2000", id="appearance", type_="Album",
+                    is_appearance=True,
+                ),
+            ],
+            [],
+        )
+        self.assertEqual(len(result.mb_only), 3)
+
+    def test_mb_unknown_types_keep_legacy_scalar_boundaries(self):
+        result = merge_discographies(
+            [
+                _mb("Unknown Evidence", "2000", id="other", type_="Other"),
+                _mb(
+                    "Unknown Evidence", "2000", id="compilation",
+                    type_="Compilation",
+                ),
+            ],
+            [],
+        )
+        self.assertEqual(len(result.mb_only), 2)
 
 
 class TestAnnotateInLibrary(unittest.TestCase):

--- a/tests/test_artist_compare_generated.py
+++ b/tests/test_artist_compare_generated.py
@@ -104,14 +104,21 @@ def assert_single_pairing(
         assert len(result.discogs_only) == 1
 
 
-def assert_partition_is_one_to_one(result: CompareBuckets) -> None:
-    """Every source identity appears once and no Discogs row pairs twice."""
+def assert_partition_is_one_to_one(
+    result: CompareBuckets,
+    *,
+    expected_mb_ids: set[str],
+    expected_discogs_ids: set[str],
+) -> None:
+    """Every expected post-dedupe identity appears exactly once."""
     mb_ids = [pair["mb"]["id"] for pair in result.both]
     mb_ids.extend(row["id"] for row in result.mb_only)
     discogs_ids = [pair["discogs"]["id"] for pair in result.both]
     discogs_ids.extend(row["id"] for row in result.discogs_only)
     assert len(mb_ids) == len(set(mb_ids))
     assert len(discogs_ids) == len(set(discogs_ids))
+    assert set(mb_ids) == expected_mb_ids
+    assert set(discogs_ids) == expected_discogs_ids
 
 
 def assert_wire_payload_rejected(payload: dict) -> None:
@@ -152,7 +159,24 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
             discogs_only=[],
         )
         with self.assertRaises(AssertionError):
-            assert_partition_is_one_to_one(bad)
+            assert_partition_is_one_to_one(
+                bad,
+                expected_mb_ids={"m1", "m2"},
+                expected_discogs_ids={"d"},
+            )
+
+    def test_partition_checker_rejects_silently_dropped_identities(self) -> None:
+        bad = CompareBuckets(
+            both=[{"mb": {"id": "m1"}, "discogs": {"id": "d1"}}],
+            mb_only=[],
+            discogs_only=[],
+        )
+        with self.assertRaises(AssertionError):
+            assert_partition_is_one_to_one(
+                bad,
+                expected_mb_ids={"m1", "m2"},
+                expected_discogs_ids={"d1", "d2"},
+            )
 
     def test_wire_checker_rejects_known_bad_checker_input(self) -> None:
         valid = {
@@ -220,7 +244,11 @@ class TestArtistCompareGenerated(unittest.TestCase):
             discogs_appearance=discogs_appearance,
         )
         assert_single_pairing(result, expected_pair=expected)
-        assert_partition_is_one_to_one(result)
+        assert_partition_is_one_to_one(
+            result,
+            expected_mb_ids={"mb"},
+            expected_discogs_ids={"discogs"},
+        )
 
     @given(
         year=st.integers(min_value=1901, max_value=2099),
@@ -240,7 +268,11 @@ class TestArtistCompareGenerated(unittest.TestCase):
         rows = [adjacent, exact] if reverse else [exact, adjacent]
         result = merge_discographies([mb], rows)
         assert result.both[0]["discogs"]["id"] == "exact"
-        assert_partition_is_one_to_one(result)
+        assert_partition_is_one_to_one(
+            result,
+            expected_mb_ids={"mb"},
+            expected_discogs_ids={"exact", "adjacent"},
+        )
 
     @given(
         year=st.integers(min_value=1901, max_value=2099),
@@ -268,6 +300,11 @@ class TestArtistCompareGenerated(unittest.TestCase):
         )
         assert result.both[0]["mb"]["id"] == "exact-mb"
         assert result.mb_only[0]["id"] == "adjacent-mb"
+        assert_partition_is_one_to_one(
+            result,
+            expected_mb_ids={"adjacent-mb", "exact-mb"},
+            expected_discogs_ids={"discogs"},
+        )
 
     @given(
         year=st.integers(min_value=1900, max_value=2100),
@@ -288,6 +325,11 @@ class TestArtistCompareGenerated(unittest.TestCase):
         rows = [unknown, overlapping] if reverse else [overlapping, unknown]
         result = merge_discographies([mb], rows)
         assert result.both[0]["discogs"]["id"] == "overlap"
+        assert_partition_is_one_to_one(
+            result,
+            expected_mb_ids={"mb"},
+            expected_discogs_ids={"overlap", "unknown"},
+        )
 
     @given(
         year=st.integers(min_value=1900, max_value=2100),
@@ -312,6 +354,11 @@ class TestArtistCompareGenerated(unittest.TestCase):
         rows = [second, first] if reverse else [first, second]
         result = merge_discographies([mb], rows)
         assert result.both[0]["discogs"]["id"] == rows[0]["id"]
+        assert_partition_is_one_to_one(
+            result,
+            expected_mb_ids={"mb"},
+            expected_discogs_ids={"first", "second"},
+        )
 
     @given(
         first_types=_STRUCTURAL_SET,
@@ -365,6 +412,14 @@ class TestArtistCompareGenerated(unittest.TestCase):
             else 2
         )
         assert len(result.discogs_only) == expected_count
+        expected_discogs_ids = (
+            {"first"} if expected_count == 1 else {"first", "second"}
+        )
+        assert_partition_is_one_to_one(
+            result,
+            expected_mb_ids=set(),
+            expected_discogs_ids=expected_discogs_ids,
+        )
 
     @given(
         first_type=_DISPLAY_TYPE,
@@ -412,6 +467,14 @@ class TestArtistCompareGenerated(unittest.TestCase):
             else 2
         )
         assert len(result.mb_only) == expected_count
+        expected_mb_ids = (
+            {"first"} if expected_count == 1 else {"first", "second"}
+        )
+        assert_partition_is_one_to_one(
+            result,
+            expected_mb_ids=expected_mb_ids,
+            expected_discogs_ids=set(),
+        )
 
     @given(
         invalid_element=st.one_of(

--- a/tests/test_artist_compare_generated.py
+++ b/tests/test_artist_compare_generated.py
@@ -1,0 +1,481 @@
+"""Generated policy patrol for MB/Discogs artist-discography pairing."""
+
+from __future__ import annotations
+
+import unittest
+from typing import Literal
+
+import msgspec
+from hypothesis import example, given, strategies as st
+
+import tests._hypothesis_profiles  # noqa: F401 - registers suite/push/fuzz
+from lib.artist_compare import CompareBuckets, merge_discographies
+from web.discogs import (
+    _DiscogsArtistMasterEntry,
+    _DiscogsArtistMastersResponse,
+)
+
+
+StructuralType = Literal["Album", "EP", "Single"]
+_STRUCTURAL_TYPES: tuple[StructuralType, ...] = ("Album", "EP", "Single")
+
+
+def _mb(
+    *,
+    year: int | None,
+    type_: str,
+    appearance: bool,
+    id_: str = "mb",
+) -> dict:
+    return {
+        "id": id_,
+        "title": "Shared Title",
+        "first_release_date": str(year) if year is not None else "",
+        "type": type_,
+        "is_appearance": appearance,
+    }
+
+
+def _discogs(
+    *,
+    year: int | None,
+    types: list[StructuralType],
+    appearance: bool,
+    id_: str = "discogs",
+    scalar_type: str = "Other",
+) -> dict:
+    return {
+        "id": id_,
+        "title": "Shared Title",
+        "first_release_date": str(year) if year is not None else "",
+        "type": scalar_type,
+        "primary_types": types,
+        "is_appearance": appearance,
+    }
+
+
+def _mb_types(type_: str) -> frozenset[str]:
+    return frozenset({type_}) if type_ in _STRUCTURAL_TYPES else frozenset()
+
+
+def _dedupe_type_identity(
+    structural_types: frozenset[str], scalar_type: str
+) -> tuple[str, frozenset[str] | str]:
+    if structural_types:
+        return ("structural", structural_types)
+    return ("scalar-fallback", scalar_type.lower())
+
+
+def _pair_is_allowed(
+    *,
+    mb_year: int | None,
+    discogs_year: int | None,
+    mb_types: frozenset[str],
+    discogs_types: frozenset[str],
+    mb_appearance: bool,
+    discogs_appearance: bool,
+) -> bool:
+    if mb_appearance != discogs_appearance:
+        return False
+    overlap = bool(mb_types & discogs_types)
+    if mb_types and discogs_types and not overlap:
+        return False
+    if mb_year is None or discogs_year is None:
+        return mb_year is None and discogs_year is None
+    delta = abs(mb_year - discogs_year)
+    if delta == 0:
+        return True
+    return delta == 1 and bool(mb_types) and bool(discogs_types) and overlap
+
+
+def assert_single_pairing(
+    result: CompareBuckets,
+    *,
+    expected_pair: bool,
+) -> None:
+    """A one-row world must either pair once or preserve both source rows."""
+    if expected_pair:
+        assert len(result.both) == 1
+        assert result.mb_only == []
+        assert result.discogs_only == []
+    else:
+        assert result.both == []
+        assert len(result.mb_only) == 1
+        assert len(result.discogs_only) == 1
+
+
+def assert_partition_is_one_to_one(result: CompareBuckets) -> None:
+    """Every source identity appears once and no Discogs row pairs twice."""
+    mb_ids = [pair["mb"]["id"] for pair in result.both]
+    mb_ids.extend(row["id"] for row in result.mb_only)
+    discogs_ids = [pair["discogs"]["id"] for pair in result.both]
+    discogs_ids.extend(row["id"] for row in result.discogs_only)
+    assert len(mb_ids) == len(set(mb_ids))
+    assert len(discogs_ids) == len(set(discogs_ids))
+
+
+def assert_wire_payload_rejected(payload: dict) -> None:
+    """An invalid artist response must fail strict boundary validation."""
+    try:
+        msgspec.convert(payload, type=_DiscogsArtistMastersResponse)
+    except msgspec.ValidationError:
+        return
+    raise AssertionError("invalid artist response crossed the wire boundary")
+
+
+_STRUCTURAL_SET = st.sets(
+    st.sampled_from(_STRUCTURAL_TYPES), min_size=0, max_size=3
+).map(lambda values: sorted(values, key=_STRUCTURAL_TYPES.index))
+_YEAR = st.one_of(st.none(), st.integers(min_value=1900, max_value=2100))
+_MB_TYPE = st.sampled_from((*_STRUCTURAL_TYPES, "Other", ""))
+_DISPLAY_TYPE = st.sampled_from(
+    (*_STRUCTURAL_TYPES, "Other", "Compilation", "")
+)
+
+
+class TestInvariantCheckersTripOnViolations(unittest.TestCase):
+    def test_single_pairing_checker_rejects_hidden_source_row(self) -> None:
+        with self.assertRaises(AssertionError):
+            assert_single_pairing(
+                CompareBuckets(both=[], mb_only=[], discogs_only=[]),
+                expected_pair=False,
+            )
+
+    def test_partition_checker_rejects_reused_discogs_identity(self) -> None:
+        row = {"id": "d"}
+        bad = CompareBuckets(
+            both=[
+                {"mb": {"id": "m1"}, "discogs": row},
+                {"mb": {"id": "m2"}, "discogs": row},
+            ],
+            mb_only=[],
+            discogs_only=[],
+        )
+        with self.assertRaises(AssertionError):
+            assert_partition_is_one_to_one(bad)
+
+    def test_wire_checker_rejects_known_bad_checker_input(self) -> None:
+        valid = {
+            "results": [{
+                "id": 1,
+                "title": "Valid",
+                "type": "Album",
+                "primary_types": ["Album"],
+                "first_release_date": "2000",
+                "artist_credit": "Artist",
+                "primary_artist_id": 1,
+                "is_masterless": False,
+            }],
+            "total": 1,
+            "page": 1,
+            "per_page": 100,
+        }
+        with self.assertRaises(AssertionError):
+            assert_wire_payload_rejected(valid)
+
+
+class TestArtistCompareGenerated(unittest.TestCase):
+    @example(
+        mb_year=2000,
+        discogs_year=2001,
+        mb_type="Album",
+        discogs_types=[],
+        mb_appearance=False,
+        discogs_appearance=False,
+        misleading_scalar="Album",
+    )
+    @given(
+        mb_year=_YEAR,
+        discogs_year=_YEAR,
+        mb_type=_MB_TYPE,
+        discogs_types=_STRUCTURAL_SET,
+        mb_appearance=st.booleans(),
+        discogs_appearance=st.booleans(),
+        misleading_scalar=st.sampled_from((*_STRUCTURAL_TYPES, "Other", "")),
+    )
+    def test_pairing_matches_independent_policy_oracle(
+        self,
+        mb_year: int | None,
+        discogs_year: int | None,
+        mb_type: str,
+        discogs_types: list[StructuralType],
+        mb_appearance: bool,
+        discogs_appearance: bool,
+        misleading_scalar: str,
+    ) -> None:
+        mb = _mb(year=mb_year, type_=mb_type, appearance=mb_appearance)
+        discogs = _discogs(
+            year=discogs_year,
+            types=discogs_types,
+            appearance=discogs_appearance,
+            scalar_type=misleading_scalar,
+        )
+        result = merge_discographies([mb], [discogs])
+        expected = _pair_is_allowed(
+            mb_year=mb_year,
+            discogs_year=discogs_year,
+            mb_types=_mb_types(mb_type),
+            discogs_types=frozenset(discogs_types),
+            mb_appearance=mb_appearance,
+            discogs_appearance=discogs_appearance,
+        )
+        assert_single_pairing(result, expected_pair=expected)
+        assert_partition_is_one_to_one(result)
+
+    @given(
+        year=st.integers(min_value=1901, max_value=2099),
+        type_=st.sampled_from(_STRUCTURAL_TYPES),
+        reverse=st.booleans(),
+    )
+    def test_exact_year_candidate_always_beats_adjacent(
+        self, year: int, type_: StructuralType, reverse: bool
+    ) -> None:
+        mb = _mb(year=year, type_=type_, appearance=False)
+        exact = _discogs(
+            year=year, types=[type_], appearance=False, id_="exact"
+        )
+        adjacent = _discogs(
+            year=year + 1, types=[type_], appearance=False, id_="adjacent"
+        )
+        rows = [adjacent, exact] if reverse else [exact, adjacent]
+        result = merge_discographies([mb], rows)
+        assert result.both[0]["discogs"]["id"] == "exact"
+        assert_partition_is_one_to_one(result)
+
+    @given(
+        year=st.integers(min_value=1901, max_value=2099),
+        type_=st.sampled_from(_STRUCTURAL_TYPES),
+    )
+    def test_exact_edge_precedes_earlier_mb_adjacent_edge(
+        self, year: int, type_: StructuralType
+    ) -> None:
+        result = merge_discographies(
+            [
+                _mb(
+                    year=year - 1,
+                    type_=type_,
+                    appearance=False,
+                    id_="adjacent-mb",
+                ),
+                _mb(
+                    year=year,
+                    type_=type_,
+                    appearance=False,
+                    id_="exact-mb",
+                ),
+            ],
+            [_discogs(year=year, types=[type_], appearance=False)],
+        )
+        assert result.both[0]["mb"]["id"] == "exact-mb"
+        assert result.mb_only[0]["id"] == "adjacent-mb"
+
+    @given(
+        year=st.integers(min_value=1900, max_value=2100),
+        type_=st.sampled_from(_STRUCTURAL_TYPES),
+        reverse=st.booleans(),
+    )
+    def test_overlapping_evidence_beats_unknown_type_on_year_tie(
+        self, year: int, type_: StructuralType, reverse: bool
+    ) -> None:
+        mb = _mb(year=year, type_=type_, appearance=False)
+        overlapping = _discogs(
+            year=year, types=[type_], appearance=False, id_="overlap"
+        )
+        unknown = _discogs(
+            year=year, types=[], appearance=False, id_="unknown",
+            scalar_type=type_,
+        )
+        rows = [unknown, overlapping] if reverse else [overlapping, unknown]
+        result = merge_discographies([mb], rows)
+        assert result.both[0]["discogs"]["id"] == "overlap"
+
+    @given(
+        year=st.integers(min_value=1900, max_value=2100),
+        reverse=st.booleans(),
+    )
+    def test_equal_candidate_rank_uses_stable_input_order(
+        self, year: int, reverse: bool
+    ) -> None:
+        mb = _mb(year=year, type_="Album", appearance=False)
+        first = _discogs(
+            year=year,
+            types=["Album", "EP"],
+            appearance=False,
+            id_="first",
+        )
+        second = _discogs(
+            year=year,
+            types=["Album", "Single"],
+            appearance=False,
+            id_="second",
+        )
+        rows = [second, first] if reverse else [first, second]
+        result = merge_discographies([mb], rows)
+        assert result.both[0]["discogs"]["id"] == rows[0]["id"]
+
+    @given(
+        first_types=_STRUCTURAL_SET,
+        second_types=_STRUCTURAL_SET,
+        first_appearance=st.booleans(),
+        second_appearance=st.booleans(),
+        first_year=_YEAR,
+        second_year=_YEAR,
+        first_scalar=_DISPLAY_TYPE,
+        second_scalar=_DISPLAY_TYPE,
+    )
+    def test_within_source_dedupe_respects_type_and_appearance_boundaries(
+        self,
+        first_types: list[StructuralType],
+        second_types: list[StructuralType],
+        first_appearance: bool,
+        second_appearance: bool,
+        first_year: int | None,
+        second_year: int | None,
+        first_scalar: str,
+        second_scalar: str,
+    ) -> None:
+        rows = [
+            _discogs(
+                year=first_year,
+                types=first_types,
+                appearance=first_appearance,
+                id_="first",
+                scalar_type=first_scalar,
+            ),
+            _discogs(
+                year=second_year,
+                types=second_types,
+                appearance=second_appearance,
+                id_="second",
+                scalar_type=second_scalar,
+            ),
+        ]
+        result = merge_discographies([], rows)
+        expected_count = (
+            1
+            if (
+                first_year == second_year
+                and first_types == second_types
+                and (
+                    bool(first_types)
+                    or first_scalar.lower() == second_scalar.lower()
+                )
+                and first_appearance == second_appearance
+            )
+            else 2
+        )
+        assert len(result.discogs_only) == expected_count
+
+    @given(
+        first_type=_DISPLAY_TYPE,
+        second_type=_DISPLAY_TYPE,
+        first_appearance=st.booleans(),
+        second_appearance=st.booleans(),
+        first_year=_YEAR,
+        second_year=_YEAR,
+    )
+    def test_mb_within_source_dedupe_uses_recognized_type_and_provenance(
+        self,
+        first_type: str,
+        second_type: str,
+        first_appearance: bool,
+        second_appearance: bool,
+        first_year: int | None,
+        second_year: int | None,
+    ) -> None:
+        rows = [
+            _mb(
+                year=first_year,
+                type_=first_type,
+                appearance=first_appearance,
+                id_="first",
+            ),
+            _mb(
+                year=second_year,
+                type_=second_type,
+                appearance=second_appearance,
+                id_="second",
+            ),
+        ]
+        result = merge_discographies(rows, [])
+        expected_count = (
+            1
+            if (
+                first_year == second_year
+                and _dedupe_type_identity(
+                    _mb_types(first_type), first_type
+                ) == _dedupe_type_identity(
+                    _mb_types(second_type), second_type
+                )
+                and first_appearance == second_appearance
+            )
+            else 2
+        )
+        assert len(result.mb_only) == expected_count
+
+    @given(
+        invalid_element=st.one_of(
+            st.integers(), st.none(), st.booleans(), st.lists(st.text(), max_size=2)
+        )
+    )
+    def test_wrong_primary_type_element_never_crosses_boundary(
+        self, invalid_element: object
+    ) -> None:
+        payload = {
+            "results": [{
+                "id": 1,
+                "title": "Invalid",
+                "type": "Album",
+                "primary_types": [invalid_element],
+                "first_release_date": "2000",
+                "artist_credit": "Artist",
+                "primary_artist_id": 1,
+                "is_masterless": False,
+            }],
+            "total": 1,
+            "page": 1,
+            "per_page": 100,
+        }
+        assert_wire_payload_rejected(payload)
+
+    @given(
+        missing=st.sampled_from(
+            (
+                "id",
+                "title",
+                "type",
+                "primary_types",
+                "first_release_date",
+                "artist_credit",
+                "primary_artist_id",
+                "is_masterless",
+            )
+        )
+    )
+    def test_missing_artist_row_field_never_crosses_boundary(
+        self, missing: str
+    ) -> None:
+        row = {
+            "id": 1,
+            "title": "Invalid",
+            "type": "Album",
+            "primary_types": ["Album"],
+            "first_release_date": "2000",
+            "artist_credit": "Artist",
+            "primary_artist_id": 1,
+            "is_masterless": False,
+        }
+        del row[missing]
+        assert_wire_payload_rejected({
+            "results": [row],
+            "total": 1,
+            "page": 1,
+            "per_page": 100,
+        })
+
+    def test_declared_wire_row_type_is_strict(self) -> None:
+        self.assertTrue(issubclass(_DiscogsArtistMasterEntry, msgspec.Struct))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_discogs_api.py
+++ b/tests/test_discogs_api.py
@@ -465,6 +465,7 @@ class TestGetArtistReleases(unittest.TestCase):
                 "id": 21481,
                 "title": "Creep",
                 "type": "EP",
+                "primary_types": ["EP", "Single"],
                 "first_release_date": "1992",
                 "artist_credit": "Radiohead",
                 "primary_artist_id": 3840,
@@ -474,6 +475,7 @@ class TestGetArtistReleases(unittest.TestCase):
                 "id": 13344,
                 "title": "Pablo Honey",
                 "type": "Album",
+                "primary_types": ["Album"],
                 "first_release_date": "1993",
                 "artist_credit": "Radiohead",
                 "primary_artist_id": 3840,
@@ -483,6 +485,7 @@ class TestGetArtistReleases(unittest.TestCase):
                 "id": "release-83182",
                 "title": "Stupid Car (demo)",
                 "type": "Other",
+                "primary_types": [],
                 "first_release_date": "1993",
                 "artist_credit": "Radiohead",
                 "primary_artist_id": 3840,
@@ -512,6 +515,7 @@ class TestGetArtistReleases(unittest.TestCase):
         album = next(r for r in results if r["title"] == "Pablo Honey")
         self.assertEqual(album["id"], "13344")
         self.assertEqual(album["type"], "Album")
+        self.assertEqual(album["primary_types"], ["Album"])
         self.assertEqual(album["first_release_date"], "1993")
         self.assertEqual(album["artist_credit"], "Radiohead")
         self.assertEqual(album["primary_artist_id"], "3840")
@@ -522,6 +526,7 @@ class TestGetArtistReleases(unittest.TestCase):
         masterless = next(r for r in results if r["title"] == "Stupid Car (demo)")
         self.assertEqual(masterless["id"], "83182")  # "release-" prefix stripped
         self.assertEqual(masterless["discogs_release_id"], "83182")
+        self.assertEqual(masterless["primary_types"], [])
         self.assertTrue(masterless["is_masterless"])
 
     def test_appearances_merged_and_classified_as_non_primary(self):
@@ -531,6 +536,7 @@ class TestGetArtistReleases(unittest.TestCase):
                     "id": 555,
                     "title": "Indie 1996",
                     "type": "Album",
+                    "primary_types": ["Album"],
                     "first_release_date": "1996",
                     "artist_credit": "Various",
                     "primary_artist_id": 194,
@@ -566,6 +572,7 @@ class TestGetArtistReleases(unittest.TestCase):
                     "id": 13344,  # same master id as Pablo Honey in /masters
                     "title": "Pablo Honey (Various comp version)",
                     "type": "Album",
+                    "primary_types": ["Album"],
                     "first_release_date": "1993",
                     "artist_credit": "Various",
                     "primary_artist_id": 194,
@@ -586,6 +593,82 @@ class TestGetArtistReleases(unittest.TestCase):
         self.assertEqual(pablo["artist_credit"], "Radiohead")
         self.assertEqual(pablo["primary_artist_id"], "3840")
         self.assertIs(pablo["is_appearance"], False)
+
+    def test_missing_primary_types_is_rejected_at_boundary(self):
+        invalid = {
+            **self.MASTERS_DATA,
+            "results": [
+                {
+                    key: value
+                    for key, value in self.MASTERS_DATA["results"][0].items()
+                    if key != "primary_types"
+                },
+            ],
+            "total": 1,
+        }
+        with _mock_urlopen_by_url({
+            "/masters": invalid,
+            "/appearances": self.EMPTY_APPEARANCES,
+        }):
+            with self.assertRaises(msgspec.ValidationError):
+                get_artist_releases(3840)
+
+    def test_wrong_primary_types_element_is_rejected_at_boundary(self):
+        invalid = {
+            **self.MASTERS_DATA,
+            "results": [
+                {
+                    **self.MASTERS_DATA["results"][0],
+                    "primary_types": [7],
+                },
+            ],
+            "total": 1,
+        }
+        with _mock_urlopen_by_url({
+            "/masters": invalid,
+            "/appearances": self.EMPTY_APPEARANCES,
+        }):
+            with self.assertRaises(msgspec.ValidationError):
+                get_artist_releases(3840)
+
+    def test_invalid_appearance_row_is_rejected_at_boundary(self):
+        invalid_appearances = {
+            "results": [{
+                "id": 555,
+                "title": "Sampler",
+                "type": "Album",
+                "primary_types": ["Compilation"],
+                "first_release_date": "2001",
+                "artist_credit": "Various",
+                "primary_artist_id": 194,
+                "is_masterless": False,
+            }],
+            "total": 1,
+            "page": 1,
+            "per_page": 1,
+        }
+        with _mock_urlopen_by_url({
+            "/masters": self.MASTERS_DATA,
+            "/appearances": invalid_appearances,
+        }):
+            with self.assertRaises(msgspec.ValidationError):
+                get_artist_releases(3840)
+
+    def test_null_primary_artist_id_normalizes_to_empty_string(self):
+        null_artist = {
+            **self.MASTERS_DATA,
+            "results": [{
+                **self.MASTERS_DATA["results"][0],
+                "primary_artist_id": None,
+            }],
+            "total": 1,
+        }
+        with _mock_urlopen_by_url({
+            "/masters": null_artist,
+            "/appearances": self.EMPTY_APPEARANCES,
+        }):
+            results = get_artist_releases(3840)
+        self.assertEqual(results[0]["primary_artist_id"], "")
 
 
 class TestGetArtistName(unittest.TestCase):

--- a/web/discogs.py
+++ b/web/discogs.py
@@ -282,8 +282,31 @@ def search_artists(query: str) -> list[dict]:
     )
 
 
+_DiscogsStructuralType = Literal["Album", "EP", "Single"]
+
+
+class _DiscogsArtistMasterEntry(msgspec.Struct):
+    """Strict row from an artist ``masters`` or ``appearances`` response."""
+    id: int | str
+    title: str
+    type: str
+    primary_types: list[_DiscogsStructuralType]
+    first_release_date: str
+    artist_credit: str
+    primary_artist_id: int | None
+    is_masterless: bool
+
+
+class _DiscogsArtistMastersResponse(msgspec.Struct):
+    """Strict response shared by artist masters and appearances endpoints."""
+    results: list[_DiscogsArtistMasterEntry]
+    total: int
+    page: int
+    per_page: int
+
+
 def _normalize_artist_master_entry(
-    r: dict,
+    r: _DiscogsArtistMasterEntry,
     *,
     is_appearance: bool,
 ) -> dict:
@@ -294,30 +317,36 @@ def _normalize_artist_master_entry(
     ``is_masterless=True`` + a ``discogs_release_id`` so the UI knows to expand
     via the release endpoint, not the master endpoint).
     """
-    raw_id = r.get("id")
-    is_masterless = bool(r.get("is_masterless"))
+    raw_id = r.id
+    is_masterless = r.is_masterless
     if is_masterless and isinstance(raw_id, str) and raw_id.startswith("release-"):
         bare_id = raw_id[len("release-"):]
         return {
             "id": bare_id,
-            "title": r.get("title", ""),
-            "type": r.get("type", ""),
+            "title": r.title,
+            "type": r.type,
+            "primary_types": list(r.primary_types),
             "secondary_types": [],
-            "first_release_date": r.get("first_release_date", ""),
-            "artist_credit": r.get("artist_credit", ""),
-            "primary_artist_id": str(r.get("primary_artist_id") or ""),
+            "first_release_date": r.first_release_date,
+            "artist_credit": r.artist_credit,
+            "primary_artist_id": (
+                str(r.primary_artist_id) if r.primary_artist_id is not None else ""
+            ),
             "is_appearance": is_appearance,
             "is_masterless": True,
             "discogs_release_id": bare_id,
         }
     return {
         "id": str(raw_id),
-        "title": r.get("title", ""),
-        "type": r.get("type", ""),
+        "title": r.title,
+        "type": r.type,
+        "primary_types": list(r.primary_types),
         "secondary_types": [],
-        "first_release_date": r.get("first_release_date", ""),
-        "artist_credit": r.get("artist_credit", ""),
-        "primary_artist_id": str(r.get("primary_artist_id") or ""),
+        "first_release_date": r.first_release_date,
+        "artist_credit": r.artist_credit,
+        "primary_artist_id": (
+            str(r.primary_artist_id) if r.primary_artist_id is not None else ""
+        ),
         "is_appearance": is_appearance,
     }
 
@@ -345,10 +374,11 @@ def get_artist_releases(artist_id: int) -> list[dict]:
 
         page = 1
         while True:
-            data = _get(
+            raw = _get(
                 f"{_api_base()}/api/artists/{artist_id}/masters?per_page=100&page={page}"
             )
-            results = data.get("results", [])
+            data = msgspec.convert(raw, type=_DiscogsArtistMastersResponse)
+            results = data.results
             if not results:
                 break
             for r in results:
@@ -356,15 +386,15 @@ def get_artist_releases(artist_id: int) -> list[dict]:
                     r, is_appearance=False,
                 )
                 entries.setdefault(entry["id"], entry)
-            total = data.get("total", 0)
-            if page * data.get("per_page", 100) >= total:
+            if page * data.per_page >= data.total:
                 break
             page += 1
 
-        appearances = _get(
-            f"{_api_base()}/api/artists/{artist_id}/appearances"
+        appearances = msgspec.convert(
+            _get(f"{_api_base()}/api/artists/{artist_id}/appearances"),
+            type=_DiscogsArtistMastersResponse,
         )
-        for r in appearances.get("results", []):
+        for r in appearances.results:
             entry = _normalize_artist_master_entry(
                 r, is_appearance=True,
             )
@@ -375,7 +405,7 @@ def get_artist_releases(artist_id: int) -> list[dict]:
             key=lambda e: (e.get("first_release_date") or "", e.get("id", "")),
         )
 
-    return _cache.memoize_meta(f"discogs:artist:{artist_id}:releases:v3", _fetch)
+    return _cache.memoize_meta(f"discogs:artist:{artist_id}:releases:v4", _fetch)
 
 
 def get_master_releases(master_id: int) -> dict:

--- a/web/routes/browse.py
+++ b/web/routes/browse.py
@@ -552,7 +552,10 @@ def get_artist_compare(h: BaseHTTPRequestHandler, params: dict[str, list[str]]) 
 
     Resolves both source artist IDs from the supplied name (and optional
     explicit IDs to skip the lookup), fetches each source's discography,
-    and fuzzy-merges by title+year via lib.artist_compare.merge_discographies.
+    and conservatively pairs rows via lib.artist_compare.merge_discographies:
+    normalized title and appearance provenance must agree, known structural
+    Album/EP/Single evidence cannot conflict, and a one-year source-date
+    difference is accepted only when both sources positively overlap on type.
 
     Returns three buckets so the UI can show what each source uniquely
     contributes plus the matched-on-both core catalog.
@@ -572,7 +575,7 @@ def get_artist_compare(h: BaseHTTPRequestHandler, params: dict[str, list[str]]) 
 
     # Skeleton key is the resolved (mbid, discogs_id) pair — display
     # names are stamped on outside the cache from the canonical APIs.
-    cache_key = f"artist:compare:v2:{mbid or 'none'}:{discogs_id or 'none'}"
+    cache_key = f"artist:compare:v3:{mbid or 'none'}:{discogs_id or 'none'}"
     skeleton = _cache.memoize_meta(
         cache_key,
         lambda: _build_compare_skeleton(mbid, discogs_id),


### PR DESCRIPTION
## Summary

- decode Discogs artist masters and appearances through strict `msgspec.Struct` wire contracts, including required master-wide `primary_types` and nullable `primary_artist_id`
- propagate `primary_types` into normalized rows and bump both Discogs artist-release and compare-skeleton metadata cache versions so pre-contract cached rows cannot survive
- keep appearance provenance as a hard boundary and reject cross-source pairs when known Album/EP/Single sets are disjoint
- allow exact-year pairs when types are not known-disjoint; allow adjacent-year pairs only with positive structural type overlap; keep partial-unknown and larger year deltas separate
- rank exact-year edges globally ahead of adjacent-year edges, then use stable MB/Discogs input order for equal scores
- preserve within-source type boundaries using recognized structural sets, with normalized scalar type only as a conservative dedupe identity when structural evidence is unknown; the scalar never authorizes cross-source or adjacent-year matching

This keeps the Beatles' distinct 1964 Album, 1963 EP, and 1964 Single works separate while pairing Deloris' *The Pointless Gift* despite the MB 2000 / Discogs 2001 date disagreement. Reissues and remasters remain grouped as child pressings inside their existing MB release group or Discogs master.

## Verification

- exact clean suite artifact: `/tmp/fix-artist-type-pairing-2654049d9b-db355ff8a21e.ce_c7dck`
- artifact verified against `db355ff8a21e83627041687d8f9c50a7641b2144`: 5,706/5,706 tests passed
- full-repository pyright: 0 errors
- Ruff/vulture dead-code gate: clean
- relevant Hypothesis fuzz profile: passed
- deterministic and generated invariants cover Pointless Gift, Beatles type boundaries, mixed Discogs type sets, known-disjoint exact years, unknown-type rules, appearance provenance, global candidate ranking, one-to-one stability, strict wire failures/null handling, and within-source fallback identities
- the generated partition checker requires exact post-dedupe MB and Discogs identity sets as well as uniqueness across every multi-row candidate-ranking and dedupe world; a planted silent MB+Discogs row-drop self-test proves the checker trips
- mutant qualification:
  - removing the known-disjoint guard is killed by deterministic and generated tests
  - allowing adjacent years without overlapping structural evidence is killed by deterministic and generated tests
- pre-push hook verified the exact suite artifact, completed the randomized generated-test push burst, and passed `nix flake check`

## Screenshot gate

The live-data dev-server screenshot loop was run against implementation commit `9695998c90c4ea1838a7e9ed7bb1010a14949608`; the follow-up commit is test-only. The PNGs were inspected directly:

- Deloris' *The Pointless Gift* appears as one paired row
- Deloris' Only-on-Discogs count moves from 10 to 9, with the other sections intact
- the Beatles' 1964 Album and 1963 EP remain visibly separate

## Operational observation

A cold Beatles stress load took roughly nine minutes because the existing adapter fetches 59 Discogs pages sequentially. This is an observed latency characteristic, not a correctness failure in this change; the completed view and pairing output were correct.

Refs #672
