### PR TITLE
perf: finish cold large-artist compare before timeout

### DIFF
--- a/docs/discogs-mirror.md
+++ b/docs/discogs-mirror.md
@@ -33,6 +33,7 @@ A self-hosted mirror of the Discogs music database, serving a JSON API at `https
 | GET | `/api/masters/{id}` | Master release with all child releases |
 | GET | `/api/artists/{id}` | Artist profile, aliases, name variations |
 | GET | `/api/artists/{id}/masters?page=1&per_page=100` | Paginated primary-credit masters and masterless releases; each row includes required sorted/deduplicated `primary_types` (`Album`, `EP`, `Single`) aggregated across every child pressing, with `[]` meaning unknown |
+| GET | `/api/artists/{id}/masters/all` | All primary-credit masters and masterless releases in the same strict response shape, projected set-wise for cold large-artist reads |
 | GET | `/api/artists/{id}/appearances` | Track-credit appearances in the same strict row shape as `/masters`, including required `primary_types` |
 | GET | `/api/labels?name=X&page=1&per_page=25` | Label search with release counts and parent-label context |
 | GET | `/api/labels/{id}` | Label profile, direct release count, parent, and direct sub-labels |
@@ -50,6 +51,15 @@ the mirror's 15 second recursive CTE statement timeout. Cratedigger's
 on HTTP 503 or timeout-class upstream failures and returns
 `sub_labels_dropped=true` so the UI can show direct releases instead of failing
 the label page.
+
+Cratedigger artist pages use the explicit `/masters/all` route plus
+`/appearances`. They never turn a bulk read into a query option on the legacy
+paginated route and never fall back to page walking: an older mirror therefore
+fails loudly instead of silently returning the first page. The normalized
+catalogue and the outer cross-source compare skeleton have independent 24-hour
+Redis keys. Concurrent cold misses for either key are process-local
+single-flight fills, with deep-copied results per request so live overlays
+cannot mutate another caller's metadata.
 
 ### API Examples
 

--- a/docs/discogs-mirror.md
+++ b/docs/discogs-mirror.md
@@ -55,11 +55,14 @@ the label page.
 Cratedigger artist pages use the explicit `/masters/all` route plus
 `/appearances`. They never turn a bulk read into a query option on the legacy
 paginated route and never fall back to page walking: an older mirror therefore
-fails loudly instead of silently returning the first page. The normalized
-catalogue and the outer cross-source compare skeleton have independent 24-hour
-Redis keys. Concurrent cold misses for either key are process-local
-single-flight fills, with deep-copied results per request so live overlays
-cannot mutate another caller's metadata.
+fails loudly instead of silently returning the first page. Both bulk envelopes
+are accepted only when `page == 1` and the result count equals `total`;
+`per_page` remains informational. The normalized catalogue and the outer
+cross-source compare skeleton have independent 24-hour Redis keys. Concurrent
+cold misses for either key are process-local single-flight fills, with
+deep-copied results per request so live overlays cannot mutate another caller's
+metadata. A client disconnect during the fill does not cancel it, so the next
+request can consume the completed cache entry without refetching.
 
 ### API Examples
 

--- a/docs/webui-primer.md
+++ b/docs/webui-primer.md
@@ -53,7 +53,7 @@ Browser → https://music.ablz.au
 | `/api/import-jobs/<id>` | GET | Poll a single import queue job |
 | `/api/library/artist?name=...` | GET | Albums by artist from beets library (MB vs Discogs source) |
 | `/api/discogs/search?q=...` | GET | Search Discogs mirror (artist or release mode via `type=` param) |
-| `/api/discogs/artist/<id>` | GET | Artist's releases grouped by master (via `/api/artists/{id}/releases`) |
+| `/api/discogs/artist/<id>` | GET | Artist's complete releases grouped by master (via mirror `/masters/all` + `/appearances`) |
 | `/api/discogs/master/<id>` | GET | All pressings within a Discogs master release |
 | `/api/discogs/release/<id>` | GET | Full Discogs release details with tracks |
 
@@ -97,6 +97,10 @@ Browser → https://music.ablz.au
   despite MB (2000) and Discogs (2001) date disagreement. Reissues and
   remasters remain child pressings inside their existing MB release group or
   Discogs master; this display merge does not split them.
+  The pure metadata fill uses the mirror's bulk artist endpoint and is
+  single-flight per cache key inside the threaded web process, so concurrent
+  cold requests share one MB/Discogs/merge pass while every caller still gets
+  an isolated copy for its live library and pipeline overlays.
 - **Release editions** — when you expand a release group, shows all editions sorted by date
   - Official releases first, bootleg/promo collapsed — EXCEPT pressings that
     are in the library or have a pipeline request, which are always hoisted

--- a/tests/test_discogs_api.py
+++ b/tests/test_discogs_api.py
@@ -499,6 +499,43 @@ class TestGetArtistReleases(unittest.TestCase):
 
     EMPTY_APPEARANCES = {"results": [], "total": 0, "page": 1, "per_page": 1}
 
+    def _assert_incomplete_envelope_rejected(
+        self, *, endpoint: str, payload: dict,
+    ) -> None:
+        responses = {
+            "/masters": self.MASTERS_DATA,
+            "/appearances": self.EMPTY_APPEARANCES,
+        }
+        responses[endpoint] = payload
+        with _mock_urlopen_by_url(responses), self.assertRaises(
+            web.discogs.DiscogsArtistCatalogueIncomplete,
+        ):
+            get_artist_releases(3840)
+
+    def test_rejects_truncated_masters_envelope(self):
+        self._assert_incomplete_envelope_rejected(
+            endpoint="/masters",
+            payload={**self.MASTERS_DATA, "total": 4},
+        )
+
+    def test_rejects_nonfirst_masters_page(self):
+        self._assert_incomplete_envelope_rejected(
+            endpoint="/masters",
+            payload={**self.MASTERS_DATA, "page": 2},
+        )
+
+    def test_rejects_truncated_appearances_envelope(self):
+        self._assert_incomplete_envelope_rejected(
+            endpoint="/appearances",
+            payload={**self.EMPTY_APPEARANCES, "total": 1},
+        )
+
+    def test_rejects_nonfirst_appearances_page(self):
+        self._assert_incomplete_envelope_rejected(
+            endpoint="/appearances",
+            payload={**self.EMPTY_APPEARANCES, "page": 2},
+        )
+
     def test_normalizes_master_discography(self):
         with _mock_urlopen_by_url({
             "/masters": self.MASTERS_DATA,

--- a/tests/test_discogs_api.py
+++ b/tests/test_discogs_api.py
@@ -503,12 +503,24 @@ class TestGetArtistReleases(unittest.TestCase):
         with _mock_urlopen_by_url({
             "/masters": self.MASTERS_DATA,
             "/appearances": self.EMPTY_APPEARANCES,
-        }) as mock:
+        }) as mock, patch(
+            "web.discogs._cache.memoize_meta",
+            side_effect=lambda _key, fetch: fetch(),
+        ) as memo:
             results = get_artist_releases(3840)
 
         called_urls = [c.args[0].full_url for c in mock.call_args_list]
-        self.assertTrue(any("/api/artists/3840/masters" in u for u in called_urls))
-        self.assertTrue(any("/api/artists/3840/appearances" in u for u in called_urls))
+        self.assertEqual(
+            called_urls,
+            [
+                "https://discogs-mirror.test/api/artists/3840/masters/all",
+                "https://discogs-mirror.test/api/artists/3840/appearances",
+            ],
+            "cold artist metadata must use one explicit fail-loud bulk request",
+        )
+        self.assertEqual(
+            memo.call_args.args[0], "discogs:artist:3840:releases:v5",
+        )
 
         self.assertEqual(len(results), 3)
 
@@ -593,6 +605,54 @@ class TestGetArtistReleases(unittest.TestCase):
         self.assertEqual(pablo["artist_credit"], "Radiohead")
         self.assertEqual(pablo["primary_artist_id"], "3840")
         self.assertIs(pablo["is_appearance"], False)
+
+    def test_duplicate_primary_credit_rows_keep_first_projection(self):
+        """Duplicate release_artist credits are one catalogue identity."""
+        duplicate = {
+            **self.MASTERS_DATA,
+            "results": [
+                self.MASTERS_DATA["results"][0],
+                {
+                    **self.MASTERS_DATA["results"][0],
+                    "title": "duplicate credit must not replace the first",
+                },
+            ],
+            "total": 2,
+        }
+        with _mock_urlopen_by_url({
+            "/masters": duplicate,
+            "/appearances": self.EMPTY_APPEARANCES,
+        }):
+            results = get_artist_releases(3840)
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["title"], "Creep")
+
+    def test_master_and_same_numeric_masterless_release_both_survive(self):
+        """Master and release ids occupy separate Discogs namespaces."""
+        masters = {
+            **self.MASTERS_DATA,
+            "results": [
+                self.MASTERS_DATA["results"][0],
+                {
+                    **self.MASTERS_DATA["results"][2],
+                    "id": "release-21481",
+                },
+            ],
+            "total": 2,
+        }
+        with _mock_urlopen_by_url({
+            "/masters": masters,
+            "/appearances": self.EMPTY_APPEARANCES,
+        }):
+            results = get_artist_releases(3840)
+
+        collisions = [row for row in results if row["id"] == "21481"]
+        self.assertEqual(len(collisions), 2)
+        self.assertEqual(
+            [row.get("is_masterless", False) for row in collisions],
+            [False, True],
+        )
 
     def test_missing_primary_types_is_rejected_at_boundary(self):
         invalid = {

--- a/tests/test_discogs_artist_bulk_generated.py
+++ b/tests/test_discogs_artist_bulk_generated.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Generated contract for Discogs' bulk artist-catalogue consumer.
+
+The mirror returns primary-credit and track-appearance rows separately. The
+consumer must conserve every unique Discogs catalogue identity, keep master
+and release namespaces distinct, let a primary credit shadow only the same
+appearance identity, validate the complete wire boundary, and retain the
+existing stable ``(first_release_date, id)`` ordering.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+from copy import deepcopy
+from typing import Any
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import msgspec
+import tests._hypothesis_profiles  # noqa: F401
+from hypothesis import given
+from hypothesis import strategies as st
+
+from web.discogs import get_artist_releases
+
+
+_PRIMARY_TYPES = ("Album", "EP", "Single")
+_ROW_FIELDS = (
+    "id",
+    "title",
+    "type",
+    "primary_types",
+    "first_release_date",
+    "artist_credit",
+    "primary_artist_id",
+    "is_masterless",
+)
+_ENVELOPE_FIELDS = ("results", "total", "page", "per_page")
+
+
+@st.composite
+def _artist_rows(draw: st.DrawFn) -> dict[str, Any]:
+    release_id = draw(st.integers(min_value=1, max_value=8))
+    masterless = draw(st.booleans())
+    return {
+        "id": f"release-{release_id}" if masterless else release_id,
+        "title": draw(st.text(max_size=20)),
+        "type": draw(st.sampled_from((*_PRIMARY_TYPES, "Other"))),
+        "primary_types": draw(st.lists(
+            st.sampled_from(_PRIMARY_TYPES), max_size=3, unique=True,
+        )),
+        "first_release_date": draw(st.sampled_from(("", "1963", "2001-02-03"))),
+        "artist_credit": draw(st.text(max_size=20)),
+        "primary_artist_id": draw(st.one_of(
+            st.none(), st.integers(min_value=1, max_value=8),
+        )),
+        "is_masterless": masterless,
+    }
+
+
+def _expected_row(raw: dict[str, Any], *, appearance: bool) -> dict[str, Any]:
+    masterless = raw["is_masterless"]
+    raw_id = raw["id"]
+    bare_id = (
+        raw_id.removeprefix("release-")
+        if masterless and isinstance(raw_id, str)
+        else str(raw_id)
+    )
+    row = {
+        "id": bare_id,
+        "title": raw["title"],
+        "type": raw["type"],
+        "primary_types": list(raw["primary_types"]),
+        "secondary_types": [],
+        "first_release_date": raw["first_release_date"],
+        "artist_credit": raw["artist_credit"],
+        "primary_artist_id": (
+            str(raw["primary_artist_id"])
+            if raw["primary_artist_id"] is not None
+            else ""
+        ),
+        "is_appearance": appearance,
+    }
+    if masterless:
+        row["is_masterless"] = True
+        row["discogs_release_id"] = bare_id
+    return row
+
+
+def _identity(row: dict[str, Any]) -> tuple[str, str]:
+    namespace = "release" if row.get("is_masterless") is True else "master"
+    return namespace, row["id"]
+
+
+def _expected_catalogue(
+    primary: list[dict[str, Any]],
+    appearances: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    selected: dict[tuple[str, str], dict[str, Any]] = {}
+    for raw in primary:
+        row = _expected_row(raw, appearance=False)
+        selected.setdefault(_identity(row), row)
+    for raw in appearances:
+        row = _expected_row(raw, appearance=True)
+        selected.setdefault(_identity(row), row)
+    return sorted(
+        selected.values(),
+        key=lambda row: (row["first_release_date"] or "", row["id"]),
+    )
+
+
+def assert_catalogue_projection(
+    expected: list[dict[str, Any]], actual: list[dict[str, Any]],
+) -> None:
+    """Check conservation, provenance, fields, and stable ordering together."""
+    if actual != expected:
+        raise AssertionError(f"catalogue projection drifted: {actual!r} != {expected!r}")
+
+
+def _response(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "results": rows,
+        "total": len(rows),
+        "page": 1,
+        "per_page": max(1, len(rows)),
+    }
+
+
+def _run_consumer(
+    primary: list[dict[str, Any]], appearances: list[dict[str, Any]],
+    *, primary_response: dict[str, Any] | None = None,
+) -> list[dict[str, Any]]:
+    def get(url: str) -> dict[str, Any]:
+        if url.endswith("/masters/all"):
+            return primary_response if primary_response is not None else _response(primary)
+        if url.endswith("/appearances"):
+            return _response(appearances)
+        raise AssertionError(f"unexpected legacy or fallback URL: {url}")
+
+    with patch("web.discogs.DISCOGS_API_BASE", "https://mirror.test"), patch(
+        "web.discogs._get", side_effect=get,
+    ), patch(
+        "web.discogs._cache.memoize_meta",
+        side_effect=lambda _key, fetch: fetch(),
+    ):
+        return get_artist_releases(82730)
+
+
+class TestGeneratedBulkCatalogue(unittest.TestCase):
+    @given(
+        primary=st.lists(_artist_rows(), max_size=8),
+        appearances=st.lists(_artist_rows(), max_size=8),
+    )
+    def test_catalogue_is_conserved_and_stably_normalized(
+        self,
+        primary: list[dict[str, Any]],
+        appearances: list[dict[str, Any]],
+    ) -> None:
+        expected = _expected_catalogue(primary, appearances)
+        actual = _run_consumer(primary, appearances)
+        assert_catalogue_projection(expected, actual)
+
+    @given(row=_artist_rows(), missing=st.sampled_from(_ROW_FIELDS))
+    def test_every_required_row_field_is_strict(
+        self, row: dict[str, Any], missing: str,
+    ) -> None:
+        invalid = deepcopy(row)
+        invalid.pop(missing)
+        with self.assertRaises(msgspec.ValidationError):
+            _run_consumer([invalid], [])
+
+    @given(row=_artist_rows(), corrupt=st.sampled_from(_ROW_FIELDS))
+    def test_every_row_field_rejects_wrong_types(
+        self, row: dict[str, Any], corrupt: str,
+    ) -> None:
+        invalid = deepcopy(row)
+        wrong: dict[str, Any] = {
+            "id": [],
+            "title": 7,
+            "type": 7,
+            "primary_types": [7],
+            "first_release_date": 7,
+            "artist_credit": 7,
+            "primary_artist_id": "7",
+            "is_masterless": "false",
+        }
+        invalid[corrupt] = wrong[corrupt]
+        with self.assertRaises(msgspec.ValidationError):
+            _run_consumer([invalid], [])
+
+    @given(
+        rows=st.lists(_artist_rows(), max_size=4),
+        field=st.sampled_from(_ENVELOPE_FIELDS),
+        remove=st.booleans(),
+    )
+    def test_bulk_envelope_is_complete_and_strict(
+        self, rows: list[dict[str, Any]], field: str, remove: bool,
+    ) -> None:
+        invalid = _response(rows)
+        if remove:
+            invalid.pop(field)
+        else:
+            wrong: dict[str, Any] = {
+                "results": {},
+                "total": "0",
+                "page": "1",
+                "per_page": "100",
+            }
+            invalid[field] = wrong[field]
+        with self.assertRaises(msgspec.ValidationError):
+            _run_consumer([], [], primary_response=invalid)
+
+
+class TestBulkCatalogueCheckerKnownBad(unittest.TestCase):
+    def test_checker_rejects_a_dropped_identity(self) -> None:
+        expected = _expected_catalogue(
+            [{
+                "id": 4,
+                "title": "Master",
+                "type": "Album",
+                "primary_types": ["Album"],
+                "first_release_date": "1964",
+                "artist_credit": "Artist",
+                "primary_artist_id": 1,
+                "is_masterless": False,
+            }],
+            [],
+        )
+        with self.assertRaises(AssertionError):
+            assert_catalogue_projection(expected, [])
+
+    def test_checker_rejects_unstable_order(self) -> None:
+        expected = _expected_catalogue(
+            [
+                {
+                    "id": row_id,
+                    "title": str(row_id),
+                    "type": "Album",
+                    "primary_types": ["Album"],
+                    "first_release_date": date,
+                    "artist_credit": "Artist",
+                    "primary_artist_id": 1,
+                    "is_masterless": False,
+                }
+                for row_id, date in ((2, "1964"), (1, "1963"))
+            ],
+            [],
+        )
+        with self.assertRaises(AssertionError):
+            assert_catalogue_projection(expected, list(reversed(expected)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_discogs_artist_bulk_generated.py
+++ b/tests/test_discogs_artist_bulk_generated.py
@@ -23,7 +23,7 @@ import tests._hypothesis_profiles  # noqa: F401
 from hypothesis import given
 from hypothesis import strategies as st
 
-from web.discogs import get_artist_releases
+from web.discogs import DiscogsArtistCatalogueIncomplete, get_artist_releases
 
 
 _PRIMARY_TYPES = ("Album", "EP", "Single")
@@ -119,6 +119,12 @@ def assert_catalogue_projection(
         raise AssertionError(f"catalogue projection drifted: {actual!r} != {expected!r}")
 
 
+def assert_complete_semantic_envelope(payload: dict[str, Any]) -> None:
+    """Independent oracle for the mirror's one-page completeness contract."""
+    if payload["page"] != 1 or len(payload["results"]) != payload["total"]:
+        raise AssertionError(f"incomplete bulk envelope: {payload!r}")
+
+
 def _response(rows: list[dict[str, Any]]) -> dict[str, Any]:
     return {
         "results": rows,
@@ -131,12 +137,17 @@ def _response(rows: list[dict[str, Any]]) -> dict[str, Any]:
 def _run_consumer(
     primary: list[dict[str, Any]], appearances: list[dict[str, Any]],
     *, primary_response: dict[str, Any] | None = None,
+    appearance_response: dict[str, Any] | None = None,
 ) -> list[dict[str, Any]]:
     def get(url: str) -> dict[str, Any]:
         if url.endswith("/masters/all"):
             return primary_response if primary_response is not None else _response(primary)
         if url.endswith("/appearances"):
-            return _response(appearances)
+            return (
+                appearance_response
+                if appearance_response is not None
+                else _response(appearances)
+            )
         raise AssertionError(f"unexpected legacy or fallback URL: {url}")
 
     with patch("web.discogs.DISCOGS_API_BASE", "https://mirror.test"), patch(
@@ -212,8 +223,48 @@ class TestGeneratedBulkCatalogue(unittest.TestCase):
         with self.assertRaises(msgspec.ValidationError):
             _run_consumer([], [], primary_response=invalid)
 
+    @given(
+        rows=st.lists(_artist_rows(), max_size=4),
+        endpoint=st.sampled_from(("masters", "appearances")),
+        violation=st.sampled_from(("later_page", "wrong_total")),
+    )
+    def test_semantically_incomplete_envelope_fails_loudly(
+        self,
+        rows: list[dict[str, Any]],
+        endpoint: str,
+        violation: str,
+    ) -> None:
+        invalid = _response(rows)
+        if violation == "later_page":
+            invalid["page"] = 2
+        else:
+            invalid["total"] = len(rows) + 1
+
+        with self.assertRaises(AssertionError):
+            assert_complete_semantic_envelope(invalid)
+
+        kwargs = (
+            {"primary_response": invalid}
+            if endpoint == "masters"
+            else {"appearance_response": invalid}
+        )
+        with self.assertRaises(DiscogsArtistCatalogueIncomplete):
+            _run_consumer(rows, rows, **kwargs)
+
 
 class TestBulkCatalogueCheckerKnownBad(unittest.TestCase):
+    def test_envelope_checker_rejects_a_later_page(self) -> None:
+        invalid = _response([])
+        invalid["page"] = 2
+        with self.assertRaises(AssertionError):
+            assert_complete_semantic_envelope(invalid)
+
+    def test_envelope_checker_rejects_a_false_total(self) -> None:
+        invalid = _response([])
+        invalid["total"] = 1
+        with self.assertRaises(AssertionError):
+            assert_complete_semantic_envelope(invalid)
+
     def test_checker_rejects_a_dropped_identity(self) -> None:
         expected = _expected_catalogue(
             [{

--- a/tests/test_web_cache.py
+++ b/tests/test_web_cache.py
@@ -18,9 +18,12 @@ from __future__ import annotations
 
 import os
 import sys
+import threading
 import time
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
+from unittest.mock import patch
 
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -94,6 +97,16 @@ class FakeRedis:
         pattern = match or "*"
         keys = [k for k in self._store if fnmatch.fnmatch(k, pattern)]
         return 0, keys
+
+
+class RaisingRedis(FakeRedis):
+    """Redis client whose reads and writes both fail like a lost socket."""
+
+    def get(self, key: str) -> str | None:
+        raise ConnectionError(f"read failed for {key}")
+
+    def setex(self, key: str, ttl: int, value: str) -> None:
+        raise ConnectionError(f"write failed for {key}")
 
 
 class _CacheTestBase(unittest.TestCase):
@@ -270,6 +283,265 @@ class TestMemoizeMetaFresh(_CacheTestBase):
         self.assertEqual(third, {"title": "Corrected Title"})
         self.assertEqual(calls, [1, 2],
                          "cache must have been repopulated by fresh=True")
+
+
+class _FlightAbort(BaseException):
+    """A non-Exception failure used to pin BaseException cleanup."""
+
+
+class TestMemoizeMetaSingleFlight(_CacheTestBase):
+    """Concurrent cold metadata misses share one isolated cache fill."""
+
+    def test_overlapping_misses_execute_one_fill_and_isolate_waiters(self) -> None:
+        entered = threading.Event()
+        release = threading.Event()
+        calls: list[int] = []
+        original = {"rows": [{"id": "one"}]}
+
+        def fetch() -> dict[str, list[dict[str, str]]]:
+            calls.append(1)
+            entered.set()
+            self.assertTrue(release.wait(timeout=5))
+            return original
+
+        started = threading.Barrier(4)
+
+        def call() -> object:
+            started.wait(timeout=5)
+            return self.cache.memoize_meta("artist:one", fetch)
+
+        with ThreadPoolExecutor(max_workers=3) as pool:
+            futures = [pool.submit(call) for _ in range(3)]
+            started.wait(timeout=5)
+            self.assertTrue(entered.wait(timeout=5))
+            time.sleep(0.02)
+            release.set()
+            results = [future.result(timeout=5) for future in futures]
+
+        self.assertEqual(calls, [1])
+        self.assertTrue(all(result == original for result in results))
+        self.assertTrue(
+            any(result is original for result in results),
+            "the elected leader should retain the fetch result it owns",
+        )
+        self.assertEqual(len({id(result) for result in results}), 3)
+        result_rows = [result["rows"] for result in results]  # type: ignore[index]
+        self.assertEqual(len({id(rows) for rows in result_rows}), 3)
+        result_rows[0][0]["overlay"] = "request-one"
+        self.assertNotIn("overlay", result_rows[1][0])
+        self.assertNotIn("overlay", result_rows[2][0])
+
+    def test_leader_rechecks_cache_after_election(self) -> None:
+        cached = {"source": "just-finished"}
+        reads = [None, cached]
+
+        with patch.object(
+            self.cache,
+            "meta_get",
+            side_effect=lambda _key: reads.pop(0),
+        ), patch.object(self.cache, "meta_set") as meta_set:
+            result = self.cache.memoize_meta(
+                "artist:stale-miss",
+                lambda: self.fail("stale leader must re-read Redis"),
+            )
+
+        self.assertEqual(result, cached)
+        meta_set.assert_not_called()
+
+    def test_failure_wakes_followers_and_next_call_retries(self) -> None:
+        entered = threading.Event()
+        release = threading.Event()
+        failure = RuntimeError("mirror exploded")
+        calls = 0
+
+        def fail() -> object:
+            nonlocal calls
+            calls += 1
+            entered.set()
+            self.assertTrue(release.wait(timeout=5))
+            raise failure
+
+        started = threading.Barrier(4)
+
+        def call() -> object:
+            started.wait(timeout=5)
+            return self.cache.memoize_meta("artist:failure", fail)
+
+        with ThreadPoolExecutor(max_workers=3) as pool:
+            futures = [pool.submit(call) for _ in range(3)]
+            started.wait(timeout=5)
+            self.assertTrue(entered.wait(timeout=5))
+            time.sleep(0.02)
+            release.set()
+            raised: list[BaseException] = []
+            for future in futures:
+                with self.assertRaises(RuntimeError) as ctx:
+                    future.result(timeout=5)
+                raised.append(ctx.exception)
+
+        self.assertEqual(calls, 1)
+        self.assertTrue(all(exc is failure for exc in raised))
+        recovered = self.cache.memoize_meta(
+            "artist:failure", lambda: {"ok": True},
+        )
+        self.assertEqual(recovered, {"ok": True})
+
+    def test_baseexception_cleans_up_flight_for_retry(self) -> None:
+        failure = _FlightAbort("stop this fill")
+
+        with self.assertRaises(_FlightAbort) as ctx:
+            self.cache.memoize_meta(
+                "artist:abort", lambda: (_ for _ in ()).throw(failure),
+            )
+        self.assertIs(ctx.exception, failure)
+        self.assertEqual(
+            self.cache.memoize_meta("artist:abort", lambda: {"retry": True}),
+            {"retry": True},
+        )
+
+    def test_redis_down_shares_overlap_but_later_call_refetches(self) -> None:
+        self.cache._redis = None
+        entered = threading.Event()
+        release = threading.Event()
+        calls = 0
+
+        def fetch() -> dict[str, int]:
+            nonlocal calls
+            calls += 1
+            entered.set()
+            self.assertTrue(release.wait(timeout=5))
+            return {"fill": calls}
+
+        started = threading.Barrier(4)
+
+        def call() -> object:
+            started.wait(timeout=5)
+            return self.cache.memoize_meta("artist:no-redis", fetch)
+
+        with ThreadPoolExecutor(max_workers=3) as pool:
+            futures = [pool.submit(call) for _ in range(3)]
+            started.wait(timeout=5)
+            self.assertTrue(entered.wait(timeout=5))
+            time.sleep(0.02)
+            release.set()
+            results = [future.result(timeout=5) for future in futures]
+
+        self.assertEqual(calls, 1)
+        self.assertEqual(results, [{"fill": 1}] * 3)
+        release.set()
+        self.assertEqual(
+            self.cache.memoize_meta("artist:no-redis", fetch), {"fill": 2},
+        )
+
+    def test_redis_command_failures_share_overlap_then_retry(self) -> None:
+        self.cache._redis = RaisingRedis()
+        entered = threading.Event()
+        release = threading.Event()
+        calls = 0
+
+        def fetch() -> dict[str, int]:
+            nonlocal calls
+            calls += 1
+            entered.set()
+            self.assertTrue(release.wait(timeout=5))
+            return {"fill": calls}
+
+        started = threading.Barrier(3)
+
+        def call() -> object:
+            started.wait(timeout=5)
+            return self.cache.memoize_meta("artist:redis-errors", fetch)
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            futures = [pool.submit(call) for _ in range(2)]
+            started.wait(timeout=5)
+            self.assertTrue(entered.wait(timeout=5))
+            time.sleep(0.02)
+            release.set()
+            results = [future.result(timeout=5) for future in futures]
+
+        self.assertEqual(results, [{"fill": 1}, {"fill": 1}])
+        self.assertEqual(calls, 1)
+        self.assertEqual(
+            self.cache.memoize_meta("artist:redis-errors", fetch), {"fill": 2},
+        )
+
+    def test_distinct_keys_fill_in_parallel(self) -> None:
+        both_entered = threading.Event()
+        release = threading.Event()
+        entered: set[str] = set()
+        lock = threading.Lock()
+
+        def fetch(key: str) -> dict[str, str]:
+            with lock:
+                entered.add(key)
+                if len(entered) == 2:
+                    both_entered.set()
+            self.assertTrue(release.wait(timeout=5))
+            return {"key": key}
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            futures = [
+                pool.submit(self.cache.memoize_meta, key, lambda k=key: fetch(k))
+                for key in ("artist:a", "artist:b")
+            ]
+            self.assertTrue(
+                both_entered.wait(timeout=5),
+                "a registry-wide lock serialized independent metadata keys",
+            )
+            release.set()
+            results = [future.result(timeout=5) for future in futures]
+
+        self.assertCountEqual(results, [{"key": "artist:a"}, {"key": "artist:b"}])
+
+    def test_fresh_calls_bypass_singleflight(self) -> None:
+        calls = 0
+
+        def fetch() -> dict[str, int]:
+            nonlocal calls
+            calls += 1
+            return {"fill": calls}
+
+        first = self.cache.memoize_meta("artist:fresh", fetch, fresh=True)
+        second = self.cache.memoize_meta("artist:fresh", fetch, fresh=True)
+        self.assertEqual(first, {"fill": 1})
+        self.assertEqual(second, {"fill": 2})
+
+    def test_abandoned_waiter_does_not_cancel_leader(self) -> None:
+        entered = threading.Event()
+        release = threading.Event()
+        calls = 0
+
+        def fetch() -> dict[str, bool]:
+            nonlocal calls
+            calls += 1
+            entered.set()
+            self.assertTrue(release.wait(timeout=5))
+            return {"filled": True}
+
+        leader = threading.Thread(
+            target=self.cache.memoize_meta,
+            args=("artist:abandoned", fetch),
+            daemon=True,
+        )
+        leader.start()
+        self.assertTrue(entered.wait(timeout=5))
+
+        # A follower represents a request whose client has disconnected. We
+        # deliberately stop observing it; the leader must still finish/cache.
+        abandoned = threading.Thread(
+            target=self.cache.memoize_meta,
+            args=("artist:abandoned", fetch),
+            daemon=True,
+        )
+        abandoned.start()
+        time.sleep(0.02)
+        release.set()
+        leader.join(timeout=5)
+        abandoned.join(timeout=5)
+        self.assertFalse(leader.is_alive())
+        self.assertEqual(calls, 1)
+        self.assertEqual(self.cache.meta_get("artist:abandoned"), {"filled": True})
 
 
 class TestRedisMetrics(_CacheTestBase):

--- a/tests/test_web_cache_generated.py
+++ b/tests/test_web_cache_generated.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Generated invariants for process-local metadata single-flight.
+
+Across arbitrary cold/warm waves and cache keys, each cold key is fetched once,
+every caller receives the value for its own key, and mutable results never
+alias. Deterministic tests in ``test_web_cache`` pin stale-miss, failure,
+BaseException, Redis-down, fresh-bypass, and abandoned-waiter paths.
+"""
+from __future__ import annotations
+
+import os
+import sys
+import threading
+import time
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import tests._hypothesis_profiles  # noqa: F401
+from hypothesis import given
+from hypothesis import strategies as st
+
+from tests.test_web_cache import FakeRedis
+from web import cache
+
+
+class _GeneratedAbort(BaseException):
+    """Non-Exception generated leader failure."""
+
+
+def assert_singleflight_wave(
+    expected_fetches: dict[str, int],
+    actual_fetches: dict[str, int],
+    requested_keys: list[str],
+    results: list[dict[str, Any]],
+) -> None:
+    """Check fetch multiplicity, key routing, and caller-owned values."""
+    if actual_fetches != expected_fetches:
+        raise AssertionError(
+            f"expected fetches {expected_fetches!r}, got {actual_fetches!r}")
+    if [result["key"] for result in results] != requested_keys:
+        raise AssertionError("a caller received another cache key's value")
+    if len({id(result) for result in results}) != len(results):
+        raise AssertionError("mutable result dictionaries alias across callers")
+    rows = [result["rows"] for result in results]
+    if len({id(value) for value in rows}) != len(rows):
+        raise AssertionError("nested mutable results alias across callers")
+
+
+class TestGeneratedMetadataSingleFlight(unittest.TestCase):
+    def setUp(self) -> None:
+        self._saved_redis = cache._redis
+        cache._redis = FakeRedis()
+
+    def tearDown(self) -> None:
+        cache._redis = self._saved_redis
+
+    @given(
+        waves=st.lists(
+            st.lists(
+                st.sampled_from(("artist:a", "artist:b", "artist:c")),
+                min_size=1,
+                max_size=6,
+            ),
+            min_size=1,
+            max_size=4,
+        ),
+        clear_before=st.lists(st.booleans(), min_size=1, max_size=4),
+    )
+    def test_arbitrary_key_and_caller_waves_share_one_cold_fill(
+        self, waves: list[list[str]], clear_before: list[bool],
+    ) -> None:
+        redis = cache._redis
+        assert isinstance(redis, FakeRedis)
+        redis._store.clear()
+        fetches: dict[str, int] = {}
+        expected_fetches: dict[str, int] = {}
+        warm: set[str] = set()
+        lock = threading.Lock()
+
+        for wave_number, keys in enumerate(waves):
+            if clear_before[wave_number % len(clear_before)]:
+                redis._store.clear()
+                warm.clear()
+
+            expected_wave_fetches = set(keys) - warm
+            for key in expected_wave_fetches:
+                expected_fetches[key] = expected_fetches.get(key, 0) + 1
+
+            start = threading.Barrier(len(keys) + 1)
+
+            def call(key: str) -> dict[str, Any]:
+                start.wait(timeout=5)
+
+                def fetch() -> dict[str, Any]:
+                    with lock:
+                        fetches[key] = fetches.get(key, 0) + 1
+                        fill = fetches[key]
+                    # Keep the leader in-flight so duplicate-key callers
+                    # exercise the follower path instead of a later warm hit.
+                    time.sleep(0.002)
+                    return {"key": key, "rows": [{"fill": fill}]}
+
+                return cache.memoize_meta(key, fetch)
+
+            with ThreadPoolExecutor(max_workers=len(keys)) as pool:
+                futures = [pool.submit(call, key) for key in keys]
+                start.wait(timeout=5)
+                results = [future.result(timeout=5) for future in futures]
+
+            assert_singleflight_wave(
+                expected_fetches, fetches, keys, results,
+            )
+            warm.update(keys)
+
+    @given(
+        key=st.sampled_from(("artist:a", "artist:b", "artist:c")),
+        cached=st.recursive(
+            st.one_of(st.none(), st.booleans(), st.integers(), st.text(max_size=8)),
+            lambda children: st.one_of(
+                st.lists(children, max_size=4),
+                st.dictionaries(st.text(max_size=5), children, max_size=4),
+            ),
+            max_leaves=8,
+        ).filter(lambda value: value is not None),
+    )
+    def test_stale_miss_recheck_returns_arbitrary_just_filled_value(
+        self, key: str, cached: Any,
+    ) -> None:
+        reads = [None, cached]
+        with patch.object(
+            cache, "meta_get", side_effect=lambda _key: reads.pop(0),
+        ), patch.object(cache, "meta_set") as meta_set:
+            result = cache.memoize_meta(
+                key, lambda: self.fail("stale miss performed a duplicate fill"),
+            )
+        self.assertEqual(result, cached)
+        meta_set.assert_not_called()
+
+    @given(
+        key=st.sampled_from(("artist:a", "artist:b", "artist:c")),
+        callers=st.integers(min_value=1, max_value=5),
+        abort=st.booleans(),
+    )
+    def test_failure_wave_is_shared_and_arbitrary_keys_retry(
+        self, key: str, callers: int, abort: bool,
+    ) -> None:
+        redis = cache._redis
+        assert isinstance(redis, FakeRedis)
+        redis._store.clear()
+        failure: BaseException = (
+            _GeneratedAbort("abort") if abort else RuntimeError("failure")
+        )
+        fetches = 0
+        started = threading.Barrier(callers + 1)
+
+        def call() -> Any:
+            started.wait(timeout=5)
+
+            def fail() -> Any:
+                nonlocal fetches
+                fetches += 1
+                time.sleep(0.002)
+                raise failure
+
+            return cache.memoize_meta(key, fail)
+
+        with ThreadPoolExecutor(max_workers=callers) as pool:
+            futures = [pool.submit(call) for _ in range(callers)]
+            started.wait(timeout=5)
+            raised: list[BaseException] = []
+            for future in futures:
+                try:
+                    future.result(timeout=5)
+                except BaseException as exc:
+                    raised.append(exc)
+
+        self.assertEqual(fetches, 1)
+        self.assertEqual(len(raised), callers)
+        self.assertTrue(all(exc is failure for exc in raised))
+        self.assertEqual(
+            cache.memoize_meta(key, lambda: {"retry": key}),
+            {"retry": key},
+        )
+
+    @given(
+        key=st.sampled_from(("artist:a", "artist:b", "artist:c")),
+        callers=st.integers(min_value=1, max_value=5),
+    )
+    def test_redis_down_shares_each_overlap_then_refetches(
+        self, key: str, callers: int,
+    ) -> None:
+        cache._redis = None
+        fetches = 0
+        started = threading.Barrier(callers + 1)
+
+        def call() -> dict[str, Any]:
+            started.wait(timeout=5)
+
+            def fetch() -> dict[str, Any]:
+                nonlocal fetches
+                fetches += 1
+                time.sleep(0.002)
+                return {"key": key, "rows": []}
+
+            return cache.memoize_meta(key, fetch)
+
+        with ThreadPoolExecutor(max_workers=callers) as pool:
+            futures = [pool.submit(call) for _ in range(callers)]
+            started.wait(timeout=5)
+            results = [future.result(timeout=5) for future in futures]
+
+        self.assertEqual(fetches, 1)
+        self.assertEqual(len({id(result) for result in results}), callers)
+
+        def later_fetch() -> dict[str, Any]:
+            nonlocal fetches
+            fetches += 1
+            return {"key": key, "rows": []}
+
+        cache.memoize_meta(key, later_fetch)
+        self.assertEqual(fetches, 2)
+
+
+class TestSingleFlightCheckerKnownBad(unittest.TestCase):
+    def test_checker_rejects_duplicate_fetch(self) -> None:
+        with self.assertRaises(AssertionError):
+            assert_singleflight_wave(
+                {"artist:a": 1},
+                {"artist:a": 2},
+                ["artist:a", "artist:a"],
+                [
+                    {"key": "artist:a", "rows": []},
+                    {"key": "artist:a", "rows": []},
+                ],
+            )
+
+    def test_checker_rejects_mutable_alias(self) -> None:
+        shared: dict[str, Any] = {"key": "artist:a", "rows": []}
+        with self.assertRaises(AssertionError):
+            assert_singleflight_wave(
+                {"artist:a": 1},
+                {"artist:a": 1},
+                ["artist:a", "artist:a"],
+                [shared, shared],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/web/test_routes_browse.py
+++ b/tests/web/test_routes_browse.py
@@ -361,6 +361,7 @@ class TestBrowseRouteContracts(_FakeDbWebServerCase):
             "id": "21491",
             "title": "OK Computer",
             "type": "Album",
+            "primary_types": ["Album"],
             "secondary_types": [],
             "first_release_date": "1997",
             "artist_credit": "Radiohead",
@@ -630,12 +631,14 @@ class TestBrowseRouteContracts(_FakeDbWebServerCase):
             "id": "8317023",
             "title": "Feather Figure/Elastic Bones",
             "type": "EP",
+            "primary_types": ["EP"],
             "secondary_types": [],
             "first_release_date": "2005-06-00",
             "artist_credit": "Deloris",
             "primary_artist_id": "361476",
             "is_masterless": True,
             "discogs_release_id": "8317023",
+            "is_appearance": False,
         }
         self.db.seed_request(make_request_row(
             id=8838,
@@ -933,6 +936,11 @@ class TestDiscogsBrowseRouteContracts(_FakeDbWebServerCase):
     DISCOGS_ARTIST_REQUIRED_FIELDS = {
         "artist_id", "artist_name", "release_groups",
     }
+    DISCOGS_ARTIST_ROW_REQUIRED_FIELDS = {
+        "id", "title", "type", "primary_types", "secondary_types",
+        "first_release_date", "artist_credit", "primary_artist_id",
+        "is_appearance", "has_official",
+    }
 
     def test_discogs_routes_return_503_mirror_required_when_base_unset(self):
         """R13: no mirror configured -> a clear mirror-required 503 from the
@@ -992,6 +1000,7 @@ class TestDiscogsBrowseRouteContracts(_FakeDbWebServerCase):
                     "id": "21491",
                     "title": "OK Computer",
                     "type": "Album",
+                    "primary_types": ["Album"],
                     "secondary_types": [],
                     "first_release_date": "1997",
                     "artist_credit": "Radiohead",
@@ -1004,6 +1013,12 @@ class TestDiscogsBrowseRouteContracts(_FakeDbWebServerCase):
         self.assertEqual(status, 200)
         _assert_required_fields(self, data, self.DISCOGS_ARTIST_REQUIRED_FIELDS,
                                 "discogs artist response")
+        _assert_required_fields(
+            self,
+            data["release_groups"][0],
+            self.DISCOGS_ARTIST_ROW_REQUIRED_FIELDS,
+            "discogs artist row",
+        )
         self.assertIs(data["release_groups"][0]["is_appearance"], False)
 
     def test_discogs_artist_masterless_pipeline_overlay(self):
@@ -1026,12 +1041,14 @@ class TestDiscogsBrowseRouteContracts(_FakeDbWebServerCase):
                     "id": "8317023",
                     "title": "Feather Figure/Elastic Bones",
                     "type": "EP",
+                    "primary_types": ["EP"],
                     "secondary_types": [],
                     "first_release_date": "2005-06-00",
                     "artist_credit": "Deloris",
                     "primary_artist_id": "361476",
                     "is_masterless": True,
                     "discogs_release_id": "8317023",
+                    "is_appearance": False,
                 },
             ]
             status, data = self._get("/api/discogs/artist/361476?name=Deloris")

--- a/tests/web/test_server_cache.py
+++ b/tests/web/test_server_cache.py
@@ -344,6 +344,7 @@ class TestAnalysisSkeletonCachedSeparately(_CachedServerCase):
         }
         discogs_rg = {
             "id": "21491", "title": "OK Computer", "type": "Album",
+            "primary_types": ["Album"],
             "secondary_types": [], "first_release_date": "1997",
             "artist_credit": "Radiohead", "primary_artist_id": "3840",
         }
@@ -372,10 +373,12 @@ class TestAnalysisSkeletonCachedSeparately(_CachedServerCase):
 
         meta_keys = [k for k in fake._store if k.startswith("meta:")
                      and "compare" in k]
-        self.assertTrue(
+        self.assertEqual(
             meta_keys,
-            "expected a compare skeleton under meta:, got: "
-            f"{sorted(fake._store.keys())}")
+            [f"meta:artist:compare:v4:{self.ARTIST_ID}:3840"],
+            "the bulk-consumer deployment must create a naturally cold "
+            "compare key without reusing a pre-bulk skeleton",
+        )
 
     def test_compare_artist_names_are_canonical_not_user_supplied(self) -> None:
         """Codex round 4: previously the compare skeleton cached
@@ -390,6 +393,7 @@ class TestAnalysisSkeletonCachedSeparately(_CachedServerCase):
         }
         discogs_rg = {
             "id": "21491", "title": "OK Computer", "type": "Album",
+            "primary_types": ["Album"],
             "secondary_types": [], "first_release_date": "1997",
             "artist_credit": "Radiohead", "primary_artist_id": "3840",
         }
@@ -453,6 +457,7 @@ class TestAnalysisSkeletonCachedSeparately(_CachedServerCase):
         }
         discogs_rg = {
             "id": "21491", "title": "OK Computer", "type": "Album",
+            "primary_types": ["Album"],
             "secondary_types": [], "first_release_date": "1997",
             "artist_credit": "Radiohead", "primary_artist_id": "3840",
         }

--- a/tests/web/test_server_threading.py
+++ b/tests/web/test_server_threading.py
@@ -74,6 +74,65 @@ class TestConcurrentRequests(_WebServerCase):
             slow_thread.join(timeout=5)
             self.assertEqual(slow_result["resp"], {"slow": True})
 
+    def test_concurrent_cold_compare_requests_execute_one_metadata_fill(self):
+        """The real threaded HTTP route shares one cold compare skeleton."""
+        from tests.test_web_cache import FakeRedis
+        from web import cache
+
+        artist_id = "664c3e0e-42d8-48c1-b209-1efca19c0325"
+        entered = threading.Event()
+        release = threading.Event()
+        results: list[tuple[int, dict]] = []
+        saved_redis = cache._redis
+        cache._redis = FakeRedis()
+
+        def mb_releases(_artist_id: str) -> list[dict]:
+            entered.set()
+            if not release.wait(timeout=5):
+                raise AssertionError("compare fill was not released")
+            return []
+
+        try:
+            with patch("web.server.mb_api") as mock_mb, patch(
+                "web.routes.browse.discogs_api",
+            ) as mock_discogs, patch(
+                "web.server.get_library_artist", return_value=[],
+            ):
+                mock_mb.get_artist_release_groups.side_effect = mb_releases
+                mock_mb.get_official_release_group_ids.return_value = set()
+                mock_mb.get_artist_name.return_value = "Test Artist"
+                mock_discogs.get_artist_releases.return_value = []
+                mock_discogs.get_artist_name.return_value = "Test Artist"
+
+                path = (
+                    "/api/artist/compare?name=Test%20Artist&"
+                    f"mbid={artist_id}&discogs_id=3840"
+                )
+                first = threading.Thread(
+                    target=lambda: results.append(self._get(path)), daemon=True,
+                )
+                second = threading.Thread(
+                    target=lambda: results.append(self._get(path)), daemon=True,
+                )
+                first.start()
+                self.assertTrue(entered.wait(timeout=5))
+                second.start()
+                # The first route remains parked in the metadata fill while
+                # the second reaches the same cache key and becomes a waiter.
+                time.sleep(0.05)
+                release.set()
+                first.join(timeout=5)
+                second.join(timeout=5)
+
+                self.assertFalse(first.is_alive())
+                self.assertFalse(second.is_alive())
+                self.assertEqual([status for status, _body in results], [200, 200])
+                self.assertEqual(mock_mb.get_artist_release_groups.call_count, 1)
+                self.assertEqual(mock_discogs.get_artist_releases.call_count, 1)
+        finally:
+            release.set()
+            cache._redis = saved_redis
+
 
 class TestKeepAlive(_WebServerCase):
     """HTTP/1.1 keep-alive: one connection, many requests."""

--- a/tests/web/test_server_threading.py
+++ b/tests/web/test_server_threading.py
@@ -2,7 +2,7 @@
 
 The production server is a ``ThreadingHTTPServer`` speaking HTTP/1.1
 keep-alive, with per-thread pipeline/beets DB handles. These tests pin
-the three load-bearing properties:
+the four load-bearing properties:
 
 1. A slow request must not block other requests (the head-of-line
    blocking that made one wedged route a 9-hour outage in #233).
@@ -11,10 +11,14 @@ the three load-bearing properties:
 3. ``_db()`` hands each thread its own ``PipelineDB`` when a DSN is
    configured, while the injected-handle path (this very harness)
    keeps returning the shared object.
+4. A client abort after becoming a metadata-flight leader cannot cancel
+   the fill; the next HTTP request reads the completed cache entry.
 """
 import configparser
 import http.client
 import os
+import socket
+import struct
 import sys
 import threading
 import time
@@ -131,6 +135,100 @@ class TestConcurrentRequests(_WebServerCase):
                 self.assertEqual(mock_discogs.get_artist_releases.call_count, 1)
         finally:
             release.set()
+            cache._redis = saved_redis
+
+    def test_aborted_compare_leader_finishes_fill_for_next_http_request(self):
+        """A real client RST cannot cancel its route's metadata fill."""
+        from tests.test_web_cache import FakeRedis
+        from web import cache
+        from web import server as srv
+
+        artist_id = "664c3e0e-42d8-48c1-b209-1efca19c0325"
+        path = (
+            "/api/artist/compare?name=Test%20Artist&"
+            f"mbid={artist_id}&discogs_id=3840"
+        )
+        compare_key = f"meta:artist:compare:v4:{artist_id}:3840"
+        entered = threading.Event()
+        release = threading.Event()
+        cache_written = threading.Event()
+        disconnect_logged = threading.Event()
+        saved_redis = cache._redis
+        client: socket.socket | None = None
+
+        class SignallingRedis(FakeRedis):
+            def setex(self, key: str, ttl: int, value: str) -> None:
+                super().setex(key, ttl, value)
+                if key == compare_key:
+                    cache_written.set()
+
+        def mb_releases(_artist_id: str) -> list[dict]:
+            entered.set()
+            if not release.wait(timeout=5):
+                raise AssertionError("aborted leader fill was not released")
+            return []
+
+        def record_warning(message: str, *args: object, **_kwargs: object) -> None:
+            if message.startswith("Client disconnect on GET"):
+                disconnect_logged.set()
+
+        cache._redis = SignallingRedis()
+        try:
+            with patch("web.server.mb_api") as mock_mb, patch(
+                "web.routes.browse.discogs_api",
+            ) as mock_discogs, patch(
+                "web.server.get_library_artist", return_value=[],
+            ), patch.object(
+                srv.log, "warning", side_effect=record_warning,
+            ):
+                mock_mb.get_artist_release_groups.side_effect = mb_releases
+                mock_mb.get_official_release_group_ids.return_value = set()
+                mock_mb.get_artist_name.return_value = "Test Artist"
+                mock_discogs.get_artist_releases.return_value = []
+                mock_discogs.get_artist_name.return_value = "Test Artist"
+
+                client = socket.create_connection(
+                    ("127.0.0.1", self.port), timeout=5,
+                )
+                client.sendall(
+                    (
+                        f"GET {path} HTTP/1.1\r\n"
+                        f"Host: 127.0.0.1:{self.port}\r\n"
+                        "Connection: close\r\n\r\n"
+                    ).encode()
+                )
+                self.assertTrue(entered.wait(timeout=5))
+
+                # Abort while the production route is the elected cache-fill
+                # leader. SO_LINGER(0) emits a TCP RST, making the later body
+                # write fail instead of allowing a buffered graceful close.
+                client.setsockopt(
+                    socket.SOL_SOCKET,
+                    socket.SO_LINGER,
+                    struct.pack("ii", 1, 0),
+                )
+                client.close()
+                client = None
+                release.set()
+
+                self.assertTrue(
+                    cache_written.wait(timeout=5),
+                    "leader did not populate the compare cache after abort",
+                )
+                self.assertTrue(
+                    disconnect_logged.wait(timeout=5),
+                    "server did not observe the aborted response write",
+                )
+
+                status, body = self._get(path)
+                self.assertEqual(status, 200)
+                self.assertEqual(body["mb_artist"]["name"], "Test Artist")
+                self.assertEqual(mock_mb.get_artist_release_groups.call_count, 1)
+                self.assertEqual(mock_discogs.get_artist_releases.call_count, 1)
+        finally:
+            release.set()
+            if client is not None:
+                client.close()
             cache._redis = saved_redis
 
 

--- a/web/cache.py
+++ b/web/cache.py
@@ -11,8 +11,10 @@ an error.
 
 from __future__ import annotations
 
+import copy
 import json
 import logging
+import threading
 from typing import Any, Callable
 
 log = logging.getLogger(__name__)
@@ -39,6 +41,19 @@ _GROUP_PATTERNS: dict[str, list[str]] = {
 }
 
 _redis: object | None = None
+
+
+class _MetadataFlight:
+    """One in-process fill shared by callers of the same metadata key."""
+
+    def __init__(self) -> None:
+        self.done = threading.Event()
+        self.result: Any = None
+        self.error: BaseException | None = None
+
+
+_metadata_flights: dict[str, _MetadataFlight] = {}
+_metadata_flights_lock = threading.Lock()
 
 
 def _int_or_none(value: Any) -> int | None:
@@ -156,8 +171,10 @@ def memoize_meta(key: str, fetch_fn: Callable[[], Any], ttl: int = TTL_MB,
                  *, fresh: bool = False) -> Any:
     """Return cached `meta:<key>` or call `fetch_fn()` and cache the result.
 
-    With Redis absent (CLI context, tests), degrades to pass-through —
-    every call runs `fetch_fn()` and nothing is cached.
+    Concurrent non-fresh misses for the same key share one process-local
+    fill. This still works when Redis is absent: overlapping callers share
+    the in-flight result, while a later call retries because nothing was
+    persisted.
 
     `fresh=True` skips the cache read and re-fetches live, then repopulates
     the cache with the fresh result. Use this on write paths (e.g. POST
@@ -165,13 +182,57 @@ def memoize_meta(key: str, fetch_fn: Callable[[], Any], ttl: int = TTL_MB,
     would silently bake stale artist/title/track data into the pipeline
     DB. Every `fresh=True` call still warms the cache for subsequent GETs.
     """
-    if not fresh:
+    if fresh:
+        result = fetch_fn()
+        meta_set(key, result, ttl)
+        return result
+
+    cached = meta_get(key)
+    if cached is not None:
+        return cached
+
+    with _metadata_flights_lock:
+        flight = _metadata_flights.get(key)
+        if flight is None:
+            flight = _MetadataFlight()
+            _metadata_flights[key] = flight
+            leader = True
+        else:
+            leader = False
+
+    if not leader:
+        flight.done.wait()
+        if flight.error is not None:
+            raise flight.error
+        # The leader publishes a cache-shaped snapshot, never its mutable
+        # working object. Every follower owns a separate nested copy so a
+        # route overlay cannot leak into another caller's response.
+        return copy.deepcopy(flight.result)
+
+    try:
+        # Close the stale-miss race: another process or a just-completed
+        # local flight may have populated Redis between our first miss and
+        # election. Only the elected leader performs this second read.
         cached = meta_get(key)
         if cached is not None:
+            flight.result = copy.deepcopy(cached)
             return cached
-    result = fetch_fn()
-    meta_set(key, result, ttl)
-    return result
+
+        result = fetch_fn()
+        snapshot = copy.deepcopy(result)
+        meta_set(key, snapshot, ttl)
+        flight.result = snapshot
+        return result
+    except BaseException as exc:
+        # BaseException is deliberate: SystemExit/KeyboardInterrupt-style
+        # termination must not strand followers or poison the key forever.
+        flight.error = exc
+        raise
+    finally:
+        with _metadata_flights_lock:
+            if _metadata_flights.get(key) is flight:
+                del _metadata_flights[key]
+            flight.done.set()
 
 
 # ── Invalidation ──────────────────────────────────────────────────────
@@ -209,5 +270,4 @@ def invalidate_groups(*groups: str) -> None:
         patterns = _GROUP_PATTERNS.get(group, [])
         for pattern in patterns:
             invalidate_pattern(pattern)
-
 

--- a/web/discogs.py
+++ b/web/discogs.py
@@ -356,39 +356,30 @@ def get_artist_releases(artist_id: int) -> list[dict]:
 
     Merges two mirror endpoints:
 
-    * ``/api/artists/{id}/masters`` — releases where the artist is on the
-      master/release-level credit. Paginated; we walk all pages.
+    * ``/api/artists/{id}/masters/all`` — every release where the artist is
+      on the master/release-level credit, in one fail-loud bulk response.
     * ``/api/artists/{id}/appearances`` — releases where the artist appears
       only via a track-level credit (compilations, guest spots, samplers).
       Single response, no pagination.
 
-    Dedupe by ``id``: a master that already came back from ``/masters`` (i.e.
-    the artist is a primary credit on at least one of its releases) wins —
-    we don't downgrade it to an appearance even when it ALSO has releases
-    where the artist is only a track-level credit (cf. the Wilderness
-    "Sentimental Noise / Future Seats" split, which sits in the same master
-    as a Various-credited "Sentimental Noise" compilation).
+    Dedupe inside the separate master/release id namespaces: a primary-credit
+    identity from ``/masters/all`` wins over the same appearance identity, so
+    we don't downgrade own work when it also has track-only credits. A master
+    and a masterless release with the same numeric id remain distinct.
     """
     def _fetch() -> list[dict]:
-        entries: dict[str, dict] = {}
+        entries: dict[tuple[str, str], dict] = {}
 
-        page = 1
-        while True:
-            raw = _get(
-                f"{_api_base()}/api/artists/{artist_id}/masters?per_page=100&page={page}"
+        masters = msgspec.convert(
+            _get(f"{_api_base()}/api/artists/{artist_id}/masters/all"),
+            type=_DiscogsArtistMastersResponse,
+        )
+        for r in masters.results:
+            entry = _normalize_artist_master_entry(
+                r, is_appearance=False,
             )
-            data = msgspec.convert(raw, type=_DiscogsArtistMastersResponse)
-            results = data.results
-            if not results:
-                break
-            for r in results:
-                entry = _normalize_artist_master_entry(
-                    r, is_appearance=False,
-                )
-                entries.setdefault(entry["id"], entry)
-            if page * data.per_page >= data.total:
-                break
-            page += 1
+            namespace = "release" if entry.get("is_masterless") else "master"
+            entries.setdefault((namespace, entry["id"]), entry)
 
         appearances = msgspec.convert(
             _get(f"{_api_base()}/api/artists/{artist_id}/appearances"),
@@ -398,14 +389,15 @@ def get_artist_releases(artist_id: int) -> list[dict]:
             entry = _normalize_artist_master_entry(
                 r, is_appearance=True,
             )
-            entries.setdefault(entry["id"], entry)
+            namespace = "release" if entry.get("is_masterless") else "master"
+            entries.setdefault((namespace, entry["id"]), entry)
 
         return sorted(
             entries.values(),
             key=lambda e: (e.get("first_release_date") or "", e.get("id", "")),
         )
 
-    return _cache.memoize_meta(f"discogs:artist:{artist_id}:releases:v4", _fetch)
+    return _cache.memoize_meta(f"discogs:artist:{artist_id}:releases:v5", _fetch)
 
 
 def get_master_releases(master_id: int) -> dict:

--- a/web/discogs.py
+++ b/web/discogs.py
@@ -305,6 +305,22 @@ class _DiscogsArtistMastersResponse(msgspec.Struct):
     per_page: int
 
 
+class DiscogsArtistCatalogueIncomplete(RuntimeError):
+    """A bulk artist endpoint returned only part of its claimed catalogue."""
+
+
+def _require_complete_artist_catalogue(
+    response: _DiscogsArtistMastersResponse, *, endpoint: str,
+) -> None:
+    """Reject semantic pagination/truncation that still passes wire typing."""
+    row_count = len(response.results)
+    if response.page != 1 or row_count != response.total:
+        raise DiscogsArtistCatalogueIncomplete(
+            f"incomplete Discogs artist {endpoint} response: "
+            f"page={response.page}, rows={row_count}, total={response.total}"
+        )
+
+
 def _normalize_artist_master_entry(
     r: _DiscogsArtistMasterEntry,
     *,
@@ -374,6 +390,7 @@ def get_artist_releases(artist_id: int) -> list[dict]:
             _get(f"{_api_base()}/api/artists/{artist_id}/masters/all"),
             type=_DiscogsArtistMastersResponse,
         )
+        _require_complete_artist_catalogue(masters, endpoint="masters/all")
         for r in masters.results:
             entry = _normalize_artist_master_entry(
                 r, is_appearance=False,
@@ -385,6 +402,7 @@ def get_artist_releases(artist_id: int) -> list[dict]:
             _get(f"{_api_base()}/api/artists/{artist_id}/appearances"),
             type=_DiscogsArtistMastersResponse,
         )
+        _require_complete_artist_catalogue(appearances, endpoint="appearances")
         for r in appearances.results:
             entry = _normalize_artist_master_entry(
                 r, is_appearance=True,

--- a/web/routes/browse.py
+++ b/web/routes/browse.py
@@ -575,7 +575,7 @@ def get_artist_compare(h: BaseHTTPRequestHandler, params: dict[str, list[str]]) 
 
     # Skeleton key is the resolved (mbid, discogs_id) pair — display
     # names are stamped on outside the cache from the canonical APIs.
-    cache_key = f"artist:compare:v3:{mbid or 'none'}:{discogs_id or 'none'}"
+    cache_key = f"artist:compare:v4:{mbid or 'none'}:{discogs_id or 'none'}"
     skeleton = _cache.memoize_meta(
         cache_key,
         lambda: _build_compare_skeleton(mbid, discogs_id),


### PR DESCRIPTION
## Summary

- replace the cold artist page walk with the explicit fail-loud Discogs bulk contract at `/api/artists/{id}/masters/all`, keeping `/appearances` separate
- validate both bulk envelopes semantically before caching: `page == 1` and `len(results) == total`; `per_page` remains informational
- conserve master and masterless release namespaces, primary-over-appearance shadowing, duplicate-credit collapse, structural types, and stable catalogue ordering through the strict `msgspec` boundary
- add process-local keyed single-flight for non-fresh metadata fills, including a post-election Redis recheck, shared `BaseException` cleanup, Redis-down overlap sharing, independent-key concurrency, and isolated deep copies for mutable route overlays
- prove through the production threaded HTTP handler that a client RST after leader election does not cancel the fill: the cache is populated and the next request succeeds without a refetch
- advance the normalized Discogs artist cache to `v5` and the outer comparison skeleton to `v4`, creating natural cold keys on deployment

The required mirror contract shipped first in https://github.com/abl030/discogs-api/pull/10 and is live on doc2.

## Verification

- exact clean suite artifact: 5,819 tests on `cba28b87d823c8b4c6e637e45e8decd40345ba9c` (`/tmp/issue-680-consumer-3981e70238-cba28b87d823.1gxsgm30`), independently verified against that HEAD
- full-repo pyright: 0 errors
- dead-code sweep: clean
- focused contracts: 25 tests covering strict bulk consumption, generated semantic completeness, and real threaded HTTP single-flight/disconnect behavior
- generated bulk catalogue and single-flight properties: deterministic suite tier plus separate 20,000-example fuzz bursts, with planted semantic-envelope, duplicate-fetch, mutable-alias, dropped-identity, and unstable-order violations
- pre-push randomized generated-test shards and `nix flake check`: green

Issue: https://github.com/abl030/cratedigger/issues/680
