### PR TITLE
test(web): make live-db artist comparison mirror-complete

### DIFF
--- a/docs/solutions/ui-dev-server-screenshot-loop.md
+++ b/docs/solutions/ui-dev-server-screenshot-loop.md
@@ -30,10 +30,24 @@ ssh -N -L 15432:10.20.0.11:5432 doc2 &
 # 2. Dev server, live read-only DB + per-thread beets handles
 export PIPELINE_DB_DSN="postgresql://cratedigger:$(ssh doc2 'sudo cat /run/secrets/cratedigger-pgpass' | grep '^PGPASSWORD=' | cut -d= -f2)@127.0.0.1:15432/cratedigger"
 setsid nix-shell --run "python3 scripts/web_dev_server.py --data live-db \
-  --host 127.0.0.1 --port 8096 --beets-db /mnt/virtio/Music/beets-library.db" \
+  --host 127.0.0.1 --port 8096 \
+  --beets-db /mnt/virtio/Music/beets-library.db \
+  --mb-api http://192.168.1.35:5200/ws/2 \
+  --discogs-api https://discogs.ablz.au" \
   > /tmp/devserver.log 2>&1 < /dev/null &
 
-# 3. Headless Chromium with CDP open (playwright-mcp managed-launch is
+# 3. Metadata precondition — do not accept screenshots until the changed
+#    cross-source route itself returns HTTP 200.
+COMPARE_STATUS="$(curl --silent --show-error --output /tmp/artist-compare.json \
+  --write-out '%{http_code}' --get \
+  --data-urlencode 'name=Deloris' \
+  http://127.0.0.1:8096/api/artist/compare)"
+test "$COMPARE_STATUS" = 200 || {
+  echo "artist compare precondition failed: HTTP $COMPARE_STATUS" >&2
+  exit 1
+}
+
+# 4. Headless Chromium with CDP open (playwright-mcp managed-launch is
 #    broken on doc1 — it tries to install a browser into the read-only
 #    nix store; the wrapper auto-ATTACHES when 9222 answers)
 /nix/store/<hash>-playwright-browsers/chromium-*/chrome-linux64/chrome \
@@ -41,18 +55,22 @@ setsid nix-shell --run "python3 scripts/web_dev_server.py --data live-db \
   --user-data-dir=/tmp/some-writable-profile --no-first-run about:blank &
 ```
 
-4. Spawn the **playwright agent** with a read-only brief: navigate
+5. Spawn the **playwright agent** with a read-only brief: navigate
    `http://127.0.0.1:8096`, exercise the changed surface, screenshot each
    state (viewport ~1000×900), and report what it sees. Explicitly forbid
    mutating buttons (delete / force import / converge / Replace / status
    toggles). Resume the SAME agent for later rounds (it keeps context).
-5. **The main agent must Read the PNGs itself.** The sub-agent's text
+6. **The main agent must Read the PNGs itself.** The sub-agent's text
    report is a summary — the centering root-cause and layout jank were
    found by looking at the pixels, not by reading the report.
-6. Fix → restart the dev server if Python changed (static `web/` files
+7. Fix → restart the dev server if Python changed (static `web/` files
    are served live; JS/HTML edits only need a browser reload) → rerun the
    round. Target the exact motivating row/card when the work started from
    an operator complaint.
+
+For artist-comparison work, run the HTTP precondition against the exact artist
+used for the screenshots before every acceptance round. A plausible MB-only
+page is not evidence that the Discogs half of the route ran.
 
 ## Gotchas (each cost a debugging detour once)
 

--- a/docs/web-dev-server.md
+++ b/docs/web-dev-server.md
@@ -3,7 +3,10 @@
 Use `scripts/web_dev_server.py` in two layers:
 
 - `--data live-db` runs local route code against a real read-only PostgreSQL
-  session and the backend host's filesystem.
+  session and the backend host's filesystem. Pass `--mb-api` and
+  `--discogs-api` to exercise the same metadata mirrors as production;
+  without `--discogs-api`, Discogs-backed and cross-source routes fail closed
+  with HTTP 503.
 - `--data prod-api` serves your checked-out frontend files locally while
   proxying `/api/*` to another read-only backend. Despite the name, it can
   target any remote base URL, not just prod.
@@ -21,7 +24,16 @@ Canonical remote-dev flow from any machine with SSH access:
    ```bash
    ssh -N -L 15432:10.20.0.11:5432 doc2
    PIPELINE_DB_DSN=postgresql://cratedigger@127.0.0.1:15432/cratedigger \
-     nix-shell --run "python3 scripts/web_dev_server.py --data live-db --host 127.0.0.1 --port 8096"
+     nix-shell --run "python3 scripts/web_dev_server.py --data live-db \
+       --host 127.0.0.1 --port 8096 \
+       --mb-api http://192.168.1.35:5200/ws/2 \
+       --discogs-api https://discogs.ablz.au"
+   ```
+   Before inspecting cross-source UI pixels, require its real route to pass:
+   ```bash
+   test "$(curl --silent --show-error --output /tmp/artist-compare.json \
+     --write-out '%{http_code}' --get --data-urlencode 'name=Deloris' \
+     http://127.0.0.1:8096/api/artist/compare)" = 200
    ```
 2. Tunnel that backend to your local machine if `8096` is not already reachable:
    ```bash

--- a/docs/webui-primer.md
+++ b/docs/webui-primer.md
@@ -224,7 +224,8 @@ Browser → https://music.ablz.au
 deploying `music.ablz.au`. The important split is:
 
 - `--data live-db` — run local route code against a read-only PostgreSQL
-  session and the backend host's filesystem.
+  session and the backend host's filesystem. Supply the metadata mirror bases;
+  missing Discogs configuration deliberately makes cross-source routes 503.
 - `--data prod-api` — serve local `web/` files while proxying `/api/*` to some
   other read-only backend.
 
@@ -238,7 +239,15 @@ A practical "develop anywhere" loop is:
 ```bash
 # backend host shell
 PIPELINE_DB_DSN=postgresql://cratedigger@127.0.0.1:15432/cratedigger \
-  nix-shell --run "python3 scripts/web_dev_server.py --data live-db --host 127.0.0.1 --port 8096"
+  nix-shell --run "python3 scripts/web_dev_server.py --data live-db \
+    --host 127.0.0.1 --port 8096 \
+    --mb-api http://192.168.1.35:5200/ws/2 \
+    --discogs-api https://discogs.ablz.au"
+
+# Required from a second backend-host shell before accepting screenshots.
+test "$(curl --silent --show-error --output /tmp/artist-compare.json \
+  --write-out '%{http_code}' --get --data-urlencode 'name=Deloris' \
+  http://127.0.0.1:8096/api/artist/compare)" = 200
 
 # local machine shell
 ssh -N -L 18096:127.0.0.1:8096 <backend-host>

--- a/scripts/web_dev_server.py
+++ b/scripts/web_dev_server.py
@@ -363,8 +363,9 @@ def _api_fixture_slug(path: str) -> str:
 def configure_live_db_metadata(config: DevConfig) -> None:
     """Replace process-global mirror origins for one live-db dev session."""
     from web import discogs, mb
+    from web.api_bases import PUBLIC_MB_WS2_BASE
 
-    mb.MB_API_BASE = config.mb_api or mb.DEFAULT_MB_API_BASE
+    mb.MB_API_BASE = config.mb_api or PUBLIC_MB_WS2_BASE
     discogs.DISCOGS_API_BASE = config.discogs_api
 
 

--- a/scripts/web_dev_server.py
+++ b/scripts/web_dev_server.py
@@ -65,6 +65,8 @@ class DevConfig:
     prod_base_url: str
     dsn: str | None
     beets_db: str | None
+    mb_api: str | None
+    discogs_api: str | None
     redis_host: str | None
     redis_port: int
 
@@ -358,12 +360,25 @@ def _api_fixture_slug(path: str) -> str:
     return path.strip("/").replace("/", "__")
 
 
+def configure_live_db_metadata(config: DevConfig) -> None:
+    """Replace process-global mirror origins for one live-db dev session."""
+    from web import discogs, mb
+
+    mb.MB_API_BASE = config.mb_api or mb.DEFAULT_MB_API_BASE
+    discogs.DISCOGS_API_BASE = config.discogs_api
+
+
 def configure_live_db(config: DevConfig) -> None:
     if not config.dsn:
         raise SystemExit("--dsn or PIPELINE_DB_DSN is required for --data live-db")
 
     import web.server as web_server
     from lib.pipeline_db import PipelineDB
+
+    # These adapters use module globals in production too. Assign BOTH for
+    # every live-db configuration, including missing values, so a second dev
+    # server in the same process cannot inherit a stale mirror from the first.
+    configure_live_db_metadata(config)
 
     def connect_readonly() -> None:
         if web_server.db is not None:
@@ -403,6 +418,8 @@ def build_config(args: argparse.Namespace) -> DevConfig:
         prod_base_url=args.prod_base_url,
         dsn=args.dsn,
         beets_db=args.beets_db,
+        mb_api=args.mb_api,
+        discogs_api=args.discogs_api,
         redis_host=args.redis_host,
         redis_port=args.redis_port,
     )
@@ -432,6 +449,22 @@ def main() -> None:
     parser.add_argument("--prod-base-url", default=PROD_BASE_URL)
     parser.add_argument("--dsn", default=os.environ.get("PIPELINE_DB_DSN"))
     parser.add_argument("--beets-db", default=os.environ.get("BEETS_DB_PATH"))
+    parser.add_argument(
+        "--mb-api",
+        default=None,
+        help=(
+            "live-db MusicBrainz API base including /ws/2 "
+            "(default: public MusicBrainz)"
+        ),
+    )
+    parser.add_argument(
+        "--discogs-api",
+        default=None,
+        help=(
+            "live-db Discogs mirror base; required for Discogs browse and "
+            "artist comparison"
+        ),
+    )
     parser.add_argument("--redis-host", default=None)
     parser.add_argument("--redis-port", type=int, default=6379)
     args = parser.parse_args()
@@ -447,6 +480,14 @@ def main() -> None:
         print(f"  proxy: {config.prod_base_url}")
     if config.data == "live-db":
         print("  live DB: read-only session")
+        if config.mb_api:
+            print(f"  MusicBrainz metadata: {config.mb_api}")
+        else:
+            print("  MusicBrainz metadata: public API fallback")
+        if config.discogs_api:
+            print(f"  Discogs metadata: {config.discogs_api}")
+        else:
+            print("  Discogs metadata: NOT CONFIGURED (compare returns HTTP 503)")
     print("  mutating API requests: blocked")
     print("  live reload: web/index.html, web/js/*.js, active fixtures")
     try:

--- a/tests/test_discogs_api.py
+++ b/tests/test_discogs_api.py
@@ -753,12 +753,19 @@ class TestGetArtistReleases(unittest.TestCase):
 
     def test_null_primary_artist_id_normalizes_to_empty_string(self):
         null_artist = {
-            **self.MASTERS_DATA,
             "results": [{
-                **self.MASTERS_DATA["results"][0],
+                "id": 60,
+                "title": "Mixed appearance master",
+                "type": "EP",
+                "primary_types": ["EP", "Single"],
+                "first_release_date": "2005",
+                "artist_credit": "",
                 "primary_artist_id": None,
+                "is_masterless": False,
             }],
             "total": 1,
+            "page": 1,
+            "per_page": 100,
         }
         with _mock_urlopen_by_url({
             "/masters": null_artist,

--- a/tests/test_discogs_fail_closed.py
+++ b/tests/test_discogs_fail_closed.py
@@ -1,0 +1,212 @@
+"""Fail-closed contract for every public cached Discogs adapter."""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import json
+import unittest
+import urllib.parse
+import urllib.request
+from collections.abc import Callable
+from typing import Any
+from unittest.mock import patch
+
+from tests.test_web_cache import FakeRedis
+from web import cache, discogs
+
+
+PUBLIC_CACHED_DISCOGS_ADAPTERS = (
+    "search_releases",
+    "search_artists",
+    "get_artist_releases",
+    "get_master_releases",
+    "get_release",
+    "get_artist_name",
+    "search_labels",
+    "get_label",
+    "get_label_releases",
+)
+
+
+class _JsonResponse:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self._body = json.dumps(payload).encode()
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self) -> _JsonResponse:
+        return self
+
+    def __exit__(self, *args: object) -> None:
+        return None
+
+
+class LeafDiscogsMirror:
+    """External HTTP-leaf fake; every adapter and cache call remains real."""
+
+    def __init__(self) -> None:
+        self.urls: list[str] = []
+
+    def urlopen(
+        self,
+        request: urllib.request.Request,
+        *args: object,
+        **kwargs: object,
+    ) -> _JsonResponse:
+        del args, kwargs
+        url = request.full_url
+        self.urls.append(url)
+        parsed = urllib.parse.urlparse(url)
+        path = parsed.path
+
+        if path == "/api/search":
+            payload = {"results": []}
+        elif path == "/api/artists":
+            payload = {"results": []}
+        elif path.endswith("/masters/all") or path.endswith("/appearances"):
+            payload = {"results": [], "total": 0, "page": 1, "per_page": 100}
+        elif path.startswith("/api/masters/"):
+            payload = {"releases": []}
+        elif path.startswith("/api/releases/"):
+            release_id = int(path.rsplit("/", 1)[1])
+            payload = {
+                "id": release_id,
+                "title": "Synthetic Release",
+                "country": "",
+                "released": "",
+                "master_id": None,
+                "artists": [],
+                "labels": [],
+                "formats": [],
+                "tracks": [],
+            }
+        elif path.startswith("/api/artists/"):
+            payload = {"name": "Synthetic Artist"}
+        elif path == "/api/labels":
+            payload = {
+                "results": [], "total": 0, "page": 1, "per_page": 25,
+            }
+        elif path.endswith("/releases") and path.startswith("/api/labels/"):
+            payload = {
+                "results": [],
+                "pagination": {"page": 1, "per_page": 100, "pages": 0, "items": 0},
+                "include_sublabels": True,
+            }
+        elif path.startswith("/api/labels/"):
+            label_id = int(path.rsplit("/", 1)[1])
+            payload = {
+                "id": label_id,
+                "name": "Synthetic Label",
+                "profile": None,
+                "contactinfo": None,
+                "data_quality": None,
+                "parent_label_id": None,
+                "parent_label_name": None,
+                "total_releases": 0,
+                "sub_labels": [],
+            }
+        else:
+            raise AssertionError(f"unexpected Discogs leaf URL: {url}")
+        return _JsonResponse(payload)
+
+
+def call_public_cached_adapter(
+    surface: str, *, query: str, entity_id: int,
+) -> object:
+    """Dispatch through the real public adapter selected by the matrix."""
+    if surface == "search_releases":
+        return discogs.search_releases(query)
+    if surface == "search_artists":
+        return discogs.search_artists(query)
+    if surface == "get_artist_releases":
+        return discogs.get_artist_releases(entity_id)
+    if surface == "get_master_releases":
+        return discogs.get_master_releases(entity_id)
+    if surface == "get_release":
+        return discogs.get_release(entity_id)
+    if surface == "get_artist_name":
+        return discogs.get_artist_name(entity_id)
+    if surface == "search_labels":
+        return discogs.search_labels(query)
+    if surface == "get_label":
+        return discogs.get_label(entity_id)
+    if surface == "get_label_releases":
+        return discogs.get_label_releases(entity_id)
+    raise AssertionError(f"uncovered Discogs adapter: {surface}")
+
+
+def assert_missing_discogs_blocks(call_adapter: Callable[[], object]) -> None:
+    """Reject a cached value unless configuration is checked first."""
+    try:
+        call_adapter()
+    except discogs.DiscogsMirrorNotConfigured:
+        return
+    raise AssertionError("warm Discogs metadata cache bypassed missing configuration")
+
+
+class TestPublicCachedDiscogsAdaptersFailClosed(unittest.TestCase):
+    def setUp(self) -> None:
+        self.saved_base = discogs.DISCOGS_API_BASE
+        self.saved_redis = cache._redis
+
+    def tearDown(self) -> None:
+        discogs.DISCOGS_API_BASE = self.saved_base
+        cache._redis = self.saved_redis
+
+    def test_matrix_covers_every_public_adapter_that_dispatches_metadata_cache(
+        self,
+    ) -> None:
+        tree = ast.parse(inspect.getsource(discogs))
+        discovered = {
+            node.name
+            for node in tree.body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name.startswith(("search_", "get_"))
+            and any(
+                isinstance(descendant, ast.Call)
+                and isinstance(descendant.func, ast.Attribute)
+                and descendant.func.attr == "memoize_meta"
+                for descendant in ast.walk(node)
+            )
+        }
+        self.assertEqual(discovered, set(PUBLIC_CACHED_DISCOGS_ADAPTERS))
+
+    def test_every_adapter_rejects_before_returning_its_warm_cache_entry(
+        self,
+    ) -> None:
+        for surface in PUBLIC_CACHED_DISCOGS_ADAPTERS:
+            with self.subTest(surface=surface):
+                mirror = LeafDiscogsMirror()
+                cache._redis = FakeRedis()
+                discogs.DISCOGS_API_BASE = "https://discogs-mirror.test"
+                with patch(
+                    "web.discogs.urllib.request.urlopen",
+                    side_effect=mirror.urlopen,
+                ):
+                    call_public_cached_adapter(
+                        surface, query="Deloris", entity_id=681,
+                    )
+                self.assertTrue(mirror.urls, surface)
+                self.assertGreater(cache._redis.dbsize(), 0, surface)  # type: ignore[union-attr]
+
+                discogs.DISCOGS_API_BASE = None
+
+                def call_warm_adapter() -> object:
+                    return call_public_cached_adapter(
+                        surface, query="Deloris", entity_id=681,
+                    )
+
+                assert_missing_discogs_blocks(call_warm_adapter)
+
+    def test_checker_rejects_a_silent_cached_return(self) -> None:
+        def return_cached_value() -> object:
+            return {"cached": True}
+
+        with self.assertRaises(AssertionError):
+            assert_missing_discogs_blocks(return_cached_value)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_discogs_fail_closed_generated.py
+++ b/tests/test_discogs_fail_closed_generated.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Generated fail-closed matrix for all cached Discogs adapters."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import patch
+
+from hypothesis import given, strategies as st
+
+import tests._hypothesis_profiles  # noqa: F401
+from tests.test_discogs_fail_closed import (
+    PUBLIC_CACHED_DISCOGS_ADAPTERS,
+    LeafDiscogsMirror,
+    assert_missing_discogs_blocks,
+    call_public_cached_adapter,
+)
+from tests.test_web_cache import FakeRedis
+from web import cache, discogs
+
+
+_QUERY = st.text(
+    alphabet=st.characters(min_codepoint=ord("a"), max_codepoint=ord("z")),
+    min_size=1,
+    max_size=24,
+)
+
+
+class TestGeneratedPublicDiscogsFailClosed(unittest.TestCase):
+    def setUp(self) -> None:
+        self.saved_base = discogs.DISCOGS_API_BASE
+        self.saved_redis = cache._redis
+
+    def tearDown(self) -> None:
+        discogs.DISCOGS_API_BASE = self.saved_base
+        cache._redis = self.saved_redis
+
+    @given(
+        query=_QUERY,
+        entity_id=st.integers(min_value=1, max_value=2_000_000_000),
+    )
+    def test_missing_configuration_precedes_every_arbitrary_warm_cache_entry(
+        self, query: str, entity_id: int,
+    ) -> None:
+        for surface in PUBLIC_CACHED_DISCOGS_ADAPTERS:
+            mirror = LeafDiscogsMirror()
+            cache._redis = FakeRedis()
+            discogs.DISCOGS_API_BASE = "https://discogs-mirror.test"
+            with patch(
+                "web.discogs.urllib.request.urlopen",
+                side_effect=mirror.urlopen,
+            ):
+                call_public_cached_adapter(
+                    surface, query=query, entity_id=entity_id,
+                )
+            if not mirror.urls or cache._redis.dbsize() == 0:  # type: ignore[union-attr]
+                raise AssertionError(f"{surface} did not populate its metadata cache")
+
+            discogs.DISCOGS_API_BASE = None
+
+            def call_warm_adapter() -> object:
+                return call_public_cached_adapter(
+                    surface, query=query, entity_id=entity_id,
+                )
+
+            assert_missing_discogs_blocks(call_warm_adapter)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_web_dev_server.py
+++ b/tests/test_web_dev_server.py
@@ -8,6 +8,8 @@ import os
 import sys
 import threading
 import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import urlparse
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 from unittest.mock import patch
@@ -15,7 +17,12 @@ from unittest.mock import patch
 sys.path.append(os.path.dirname(__file__))
 import conftest  # noqa: F401 — bootstraps TEST_DB_DSN for the live-db test
 
-from scripts.web_dev_server import DevConfig, DevHandler, DevHTTPServer
+from scripts.web_dev_server import (
+    DevConfig,
+    DevHandler,
+    DevHTTPServer,
+    create_server,
+)
 
 
 class WebDevServerTest(unittest.TestCase):
@@ -26,6 +33,8 @@ class WebDevServerTest(unittest.TestCase):
             prod_base_url="https://music.ablz.au",
             dsn=None,
             beets_db=None,
+            mb_api=None,
+            discogs_api=None,
             redis_host=None,
             redis_port=6379,
         )
@@ -109,6 +118,8 @@ class WebDevServerProxyTest(unittest.TestCase):
             prod_base_url="http://upstream.test",
             dsn=None,
             beets_db=None,
+            mb_api=None,
+            discogs_api=None,
             redis_host=None,
             redis_port=6379,
         )
@@ -175,6 +186,8 @@ class WebDevServerLiveDbErrorMappingTest(unittest.TestCase):
             prod_base_url="https://music.ablz.au",
             dsn=None,
             beets_db=None,
+            mb_api=None,
+            discogs_api=None,
             redis_host=None,
             redis_port=6379,
         )
@@ -209,6 +222,180 @@ class WebDevServerLiveDbErrorMappingTest(unittest.TestCase):
 
         with self.assertRaises(HTTPError) as raised:
             urlopen(f"{self.base}{probe_path}")
+        self.assertEqual(raised.exception.code, 503)
+
+
+class _MetadataMirrorServer(ThreadingHTTPServer):
+    daemon_threads = True
+
+    def __init__(self, kind: str):
+        super().__init__(("127.0.0.1", 0), _MetadataMirrorHandler)
+        self.kind = kind
+        self.requests: list[str] = []
+
+    @property
+    def origin(self) -> str:
+        return f"http://127.0.0.1:{self.server_port}"
+
+
+class _MetadataMirrorHandler(BaseHTTPRequestHandler):
+    server: _MetadataMirrorServer  # pyright: ignore[reportIncompatibleVariableOverride]
+
+    def log_message(self, format: str, *args: object) -> None:  # noqa: A002
+        return
+
+    def do_GET(self) -> None:
+        self.server.requests.append(self.path)
+        parsed = urlparse(self.path)
+        if self.server.kind == "mb":
+            if parsed.path == "/ws/2/release-group":
+                payload = {"release-groups": [], "release-group-count": 0}
+            elif parsed.path == "/ws/2/release":
+                payload = {"releases": [], "release-count": 0}
+            elif parsed.path == "/ws/2/artist/test-mbid":
+                payload = {"id": "test-mbid", "name": "Synthetic Artist"}
+            else:
+                self.send_error(404)
+                return
+        elif parsed.path in (
+            "/api/artists/60/masters/all",
+            "/api/artists/60/appearances",
+        ):
+            payload = {
+                "results": [], "total": 0, "page": 1, "per_page": 100,
+            }
+        elif parsed.path == "/api/artists/60":
+            payload = {"id": 60, "name": "Synthetic Artist"}
+        else:
+            self.send_error(404)
+            return
+
+        body = json.dumps(payload).encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+
+class WebDevServerLiveDbMetadataIntegrationTest(unittest.TestCase):
+    """The real live-db compare route must use its configured mirrors."""
+
+    def setUp(self) -> None:
+        import web.discogs
+        import web.mb
+        import web.server
+
+        self.dsn = os.environ.get("TEST_DB_DSN")
+        self.web_discogs = web.discogs
+        self.web_mb = web.mb
+        self.web_server = web.server
+        self.saved_metadata = (
+            web.mb.MB_API_BASE,
+            web.discogs.DISCOGS_API_BASE,
+        )
+        self.saved_server = (
+            web.server._db_dsn,
+            web.server.db,
+            web.server._try_reconnect_db,
+            web.server.beets_db_path,
+            web.server._beets,
+        )
+        self.running: list[tuple[ThreadingHTTPServer, threading.Thread]] = []
+
+    def tearDown(self) -> None:
+        for server, thread in reversed(self.running):
+            server.shutdown()
+            server.server_close()
+            thread.join(timeout=2)
+
+        if (
+            self.web_server.db is not None
+            and self.web_server.db is not self.saved_server[1]
+        ):
+            self.web_server.db.close()
+        (
+            self.web_server._db_dsn,
+            self.web_server.db,
+            self.web_server._try_reconnect_db,
+            self.web_server.beets_db_path,
+            self.web_server._beets,
+        ) = self.saved_server
+        (
+            self.web_mb.MB_API_BASE,
+            self.web_discogs.DISCOGS_API_BASE,
+        ) = self.saved_metadata
+
+    def _start(self, server: ThreadingHTTPServer) -> threading.Thread:
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        self.running.append((server, thread))
+        return thread
+
+    def _live_config(
+        self, *, mb_api: str | None, discogs_api: str | None,
+    ) -> DevConfig:
+        return DevConfig(
+            data="live-db",
+            scenario="peers",
+            prod_base_url="https://music.ablz.au",
+            dsn=self.dsn,
+            beets_db=None,
+            mb_api=mb_api,
+            discogs_api=discogs_api,
+            redis_host=None,
+            redis_port=6379,
+        )
+
+    def _start_live_server(self, config: DevConfig) -> str:
+        server = create_server("127.0.0.1", 0, config)
+        self._start(server)
+        return f"http://127.0.0.1:{server.server_port}"
+
+    def test_configured_compare_reaches_both_origins_then_missing_discogs_503s(
+        self,
+    ) -> None:
+        mb = _MetadataMirrorServer("mb")
+        discogs = _MetadataMirrorServer("discogs")
+        self._start(mb)
+        self._start(discogs)
+
+        base = self._start_live_server(self._live_config(
+            mb_api=f"{mb.origin}/ws/2",
+            discogs_api=discogs.origin,
+        ))
+        path = (
+            "/api/artist/compare?name=Synthetic%20Artist&"
+            "mbid=test-mbid&discogs_id=60"
+        )
+        with urlopen(f"{base}{path}") as response:
+            payload = json.loads(response.read())
+
+        self.assertEqual(response.status, 200)
+        self.assertEqual(payload["mb_artist"]["name"], "Synthetic Artist")
+        self.assertEqual(payload["discogs_artist"]["name"], "Synthetic Artist")
+        self.assertTrue(any(
+            request.startswith("/ws/2/release-group?artist=test-mbid&")
+            for request in mb.requests
+        ), mb.requests)
+        self.assertTrue(any(
+            request.startswith("/ws/2/release?track_artist=test-mbid&")
+            for request in mb.requests
+        ), mb.requests)
+        self.assertIn("/ws/2/artist/test-mbid?fmt=json", mb.requests)
+        self.assertIn("/api/artists/60/masters/all", discogs.requests)
+        self.assertIn("/api/artists/60/appearances", discogs.requests)
+        self.assertIn("/api/artists/60", discogs.requests)
+
+        # A second live-db configuration in the same process must clear the
+        # first session's Discogs origin. Otherwise screenshot QA can false-
+        # green after an earlier configured server populated the module global.
+        missing_base = self._start_live_server(self._live_config(
+            mb_api=f"{mb.origin}/ws/2",
+            discogs_api=None,
+        ))
+        with self.assertRaises(HTTPError) as raised:
+            urlopen(f"{missing_base}{path}")
         self.assertEqual(raised.exception.code, 503)
 
 
@@ -252,6 +439,8 @@ class ConfigureLiveDbReadOnlyTest(unittest.TestCase):
             prod_base_url="https://music.ablz.au",
             dsn=self.dsn,
             beets_db=None,
+            mb_api=None,
+            discogs_api=None,
             redis_host=None,
             redis_port=6379,
         )

--- a/tests/test_web_dev_server.py
+++ b/tests/test_web_dev_server.py
@@ -16,6 +16,7 @@ from unittest.mock import patch
 
 sys.path.append(os.path.dirname(__file__))
 import conftest  # noqa: F401 — bootstraps TEST_DB_DSN for the live-db test
+from tests.test_web_cache import FakeRedis
 
 from scripts.web_dev_server import (
     DevConfig,
@@ -283,13 +284,18 @@ class WebDevServerLiveDbMetadataIntegrationTest(unittest.TestCase):
 
     def setUp(self) -> None:
         import web.discogs
+        import web.cache
         import web.mb
         import web.server
 
         self.dsn = os.environ.get("TEST_DB_DSN")
         self.web_discogs = web.discogs
+        self.web_cache = web.cache
         self.web_mb = web.mb
         self.web_server = web.server
+        self.saved_redis = web.cache._redis
+        self.metadata_cache = FakeRedis()
+        web.cache._redis = self.metadata_cache
         self.saved_metadata = (
             web.mb.MB_API_BASE,
             web.discogs.DISCOGS_API_BASE,
@@ -325,6 +331,7 @@ class WebDevServerLiveDbMetadataIntegrationTest(unittest.TestCase):
             self.web_mb.MB_API_BASE,
             self.web_discogs.DISCOGS_API_BASE,
         ) = self.saved_metadata
+        self.web_cache._redis = self.saved_redis
 
     def _start(self, server: ThreadingHTTPServer) -> threading.Thread:
         thread = threading.Thread(target=server.serve_forever, daemon=True)
@@ -382,14 +389,26 @@ class WebDevServerLiveDbMetadataIntegrationTest(unittest.TestCase):
             request.startswith("/ws/2/release?track_artist=test-mbid&")
             for request in mb.requests
         ), mb.requests)
+        self.assertTrue(any(
+            request.startswith(
+                "/ws/2/release?artist=test-mbid&status=official&"
+            )
+            for request in mb.requests
+        ), mb.requests)
         self.assertIn("/ws/2/artist/test-mbid?fmt=json", mb.requests)
         self.assertIn("/api/artists/60/masters/all", discogs.requests)
         self.assertIn("/api/artists/60/appearances", discogs.requests)
         self.assertIn("/api/artists/60", discogs.requests)
+        self.assertTrue({
+            "meta:artist:compare:v4:test-mbid:60",
+            "meta:mb:artist:test-mbid:name",
+            "meta:discogs:artist:60:name",
+        }.issubset(self.metadata_cache._store))
 
         # A second live-db configuration in the same process must clear the
-        # first session's Discogs origin. Otherwise screenshot QA can false-
-        # green after an earlier configured server populated the module global.
+        # first session's Discogs origin and reject BEFORE reading the fully
+        # warm compare/name cache. Otherwise screenshot QA can false-green
+        # after an earlier configured server populated both process surfaces.
         missing_base = self._start_live_server(self._live_config(
             mb_api=f"{mb.origin}/ws/2",
             discogs_api=None,

--- a/tests/test_web_dev_server.py
+++ b/tests/test_web_dev_server.py
@@ -267,6 +267,18 @@ class _MetadataMirrorHandler(BaseHTTPRequestHandler):
             }
         elif parsed.path == "/api/artists/60":
             payload = {"id": 60, "name": "Synthetic Artist"}
+        elif parsed.path == "/api/releases/60":
+            payload = {
+                "id": 60,
+                "title": "Synthetic Release",
+                "country": "",
+                "released": "",
+                "master_id": None,
+                "artists": [{"id": 60, "name": "Synthetic Artist"}],
+                "labels": [],
+                "formats": [],
+                "tracks": [],
+            }
         else:
             self.send_error(404)
             return
@@ -405,6 +417,16 @@ class WebDevServerLiveDbMetadataIntegrationTest(unittest.TestCase):
             "meta:discogs:artist:60:name",
         }.issubset(self.metadata_cache._store))
 
+        resolve_path = "/api/browse/resolve?id=60&source=discogs&kind=release"
+        with urlopen(f"{base}{resolve_path}") as resolve_response:
+            resolve_payload = json.loads(resolve_response.read())
+        self.assertEqual(resolve_response.status, 200)
+        self.assertEqual(resolve_payload["source"], "discogs")
+        self.assertTrue({
+            "meta:discogs:release:60",
+            "meta:browse-resolve:discogs:release:60",
+        }.issubset(self.metadata_cache._store))
+
         # A second live-db configuration in the same process must clear the
         # first session's Discogs origin and reject BEFORE reading the fully
         # warm compare/name cache. Otherwise screenshot QA can false-green
@@ -416,6 +438,9 @@ class WebDevServerLiveDbMetadataIntegrationTest(unittest.TestCase):
         with self.assertRaises(HTTPError) as raised:
             urlopen(f"{missing_base}{path}")
         self.assertEqual(raised.exception.code, 503)
+        with self.assertRaises(HTTPError) as resolve_raised:
+            urlopen(f"{missing_base}{resolve_path}")
+        self.assertEqual(resolve_raised.exception.code, 503)
 
 
 class ConfigureLiveDbReadOnlyTest(unittest.TestCase):

--- a/tests/test_web_dev_server_generated.py
+++ b/tests/test_web_dev_server_generated.py
@@ -4,12 +4,20 @@
 from __future__ import annotations
 
 import unittest
+import urllib.parse
+from collections.abc import Callable
+from typing import Any
 
 from hypothesis import given, strategies as st
 
 import tests._hypothesis_profiles  # noqa: F401 - registers suite/push/fuzz
+from tests.test_web_cache import FakeRedis
+from web import cache
+from web.api_bases import PUBLIC_MB_ORIGIN
+import web.api_bases
 import web.discogs
 import web.mb
+from web.routes.browse import get_artist_compare
 from scripts.web_dev_server import (
     DevConfig,
     configure_live_db_metadata,
@@ -18,9 +26,33 @@ from scripts.web_dev_server import (
 
 def assert_metadata_wiring(config: DevConfig) -> None:
     """Configured origins must be exact and missing values must not stay stale."""
-    expected_mb = config.mb_api or web.mb.DEFAULT_MB_API_BASE
+    expected_mb = config.mb_api or urllib.parse.urljoin(
+        f"{PUBLIC_MB_ORIGIN.rstrip('/')}/", "ws/2",
+    )
     assert web.mb.MB_API_BASE == expected_mb
     assert web.discogs.DISCOGS_API_BASE == config.discogs_api
+
+
+def assert_missing_discogs_blocks(call_route: Callable[[], None]) -> None:
+    """A missing mirror must reject before any warm-cache route result."""
+    try:
+        call_route()
+    except web.discogs.DiscogsMirrorNotConfigured:
+        return
+    raise AssertionError("warm metadata cache bypassed missing Discogs config")
+
+
+class _RouteHandler:
+    def __init__(self) -> None:
+        self.payload: dict[str, Any] | None = None
+
+    def _json(self, payload: dict[str, Any], status: int = 200) -> None:
+        if status != 200:
+            raise AssertionError(f"unexpected route status {status}")
+        self.payload = payload
+
+    def _error(self, message: str, status: int = 400) -> None:
+        raise AssertionError(f"unexpected route error {status}: {message}")
 
 
 _HOST = st.text(
@@ -56,9 +88,11 @@ class TestLiveDbMetadataWiringGenerated(unittest.TestCase):
             web.mb.MB_API_BASE,
             web.discogs.DISCOGS_API_BASE,
         )
+        self.saved_redis = cache._redis
 
     def tearDown(self) -> None:
         web.mb.MB_API_BASE, web.discogs.DISCOGS_API_BASE = self.saved
+        cache._redis = self.saved_redis
 
     @given(
         stale_mb=_ORIGIN,
@@ -83,6 +117,35 @@ class TestLiveDbMetadataWiringGenerated(unittest.TestCase):
         )
         configure_live_db_metadata(config)
         assert_metadata_wiring(config)
+
+    @given(
+        mbid=_HOST,
+        discogs_id=st.integers(min_value=1, max_value=2_000_000_000),
+        artist_name=_HOST,
+    )
+    def test_missing_discogs_rejects_before_arbitrary_warm_compare_cache(
+        self, mbid: str, discogs_id: int, artist_name: str,
+    ) -> None:
+        config = _config(mb_api=None, discogs_api=None)
+        configure_live_db_metadata(config)
+        cache._redis = FakeRedis()
+        cache.meta_set(
+            f"artist:compare:v4:{mbid}:{discogs_id}",
+            {"both": [], "mb_only": [], "discogs_only": []},
+        )
+        cache.meta_set(f"mb:artist:{mbid}:name", artist_name)
+        cache.meta_set(f"discogs:artist:{discogs_id}:name", artist_name)
+        handler = _RouteHandler()
+        params = {
+            "name": [artist_name],
+            "mbid": [mbid],
+            "discogs_id": [str(discogs_id)],
+        }
+
+        assert_missing_discogs_blocks(
+            lambda: get_artist_compare(handler, params),  # type: ignore[arg-type]
+        )
+        self.assertIsNone(handler.payload)
 
 
 class TestMetadataWiringCheckerKnownBad(unittest.TestCase):
@@ -109,10 +172,27 @@ class TestMetadataWiringCheckerKnownBad(unittest.TestCase):
         self,
     ) -> None:
         config = _config(mb_api=None, discogs_api=None)
-        web.mb.MB_API_BASE = web.mb.DEFAULT_MB_API_BASE
+        web.mb.MB_API_BASE = urllib.parse.urljoin(
+            f"{PUBLIC_MB_ORIGIN.rstrip('/')}/", "ws/2",
+        )
         web.discogs.DISCOGS_API_BASE = "https://stale-discogs.test"
         with self.assertRaises(AssertionError):
             assert_metadata_wiring(config)
+
+    def test_missing_mb_uses_the_canonical_public_ws2_declaration(self) -> None:
+        config = _config(mb_api=None, discogs_api=None)
+        sentinel = "https://canonical-mb.test/custom-ws2"
+        saved_public_base = web.api_bases.PUBLIC_MB_WS2_BASE
+        try:
+            web.api_bases.PUBLIC_MB_WS2_BASE = sentinel
+            configure_live_db_metadata(config)
+        finally:
+            web.api_bases.PUBLIC_MB_WS2_BASE = saved_public_base
+        self.assertEqual(web.mb.MB_API_BASE, sentinel)
+
+    def test_warm_cache_guard_checker_rejects_a_silent_route(self) -> None:
+        with self.assertRaises(AssertionError):
+            assert_missing_discogs_blocks(lambda: None)
 
 
 if __name__ == "__main__":

--- a/tests/test_web_dev_server_generated.py
+++ b/tests/test_web_dev_server_generated.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Generated live-db metadata-mirror wiring contract."""
+
+from __future__ import annotations
+
+import unittest
+
+from hypothesis import given, strategies as st
+
+import tests._hypothesis_profiles  # noqa: F401 - registers suite/push/fuzz
+import web.discogs
+import web.mb
+from scripts.web_dev_server import (
+    DevConfig,
+    configure_live_db_metadata,
+)
+
+
+def assert_metadata_wiring(config: DevConfig) -> None:
+    """Configured origins must be exact and missing values must not stay stale."""
+    expected_mb = config.mb_api or web.mb.DEFAULT_MB_API_BASE
+    assert web.mb.MB_API_BASE == expected_mb
+    assert web.discogs.DISCOGS_API_BASE == config.discogs_api
+
+
+_HOST = st.text(
+    alphabet=st.characters(min_codepoint=ord("a"), max_codepoint=ord("z")),
+    min_size=1,
+    max_size=12,
+)
+_ORIGIN = st.builds(
+    lambda scheme, host, port: f"{scheme}://{host}.test:{port}",
+    st.sampled_from(("http", "https")),
+    _HOST,
+    st.integers(min_value=1, max_value=65535),
+)
+
+
+def _config(*, mb_api: str | None, discogs_api: str | None) -> DevConfig:
+    return DevConfig(
+        data="live-db",
+        scenario="generated",
+        prod_base_url="https://music.ablz.au",
+        dsn="postgresql://unused-by-metadata-wiring",
+        beets_db=None,
+        mb_api=mb_api,
+        discogs_api=discogs_api,
+        redis_host=None,
+        redis_port=6379,
+    )
+
+
+class TestLiveDbMetadataWiringGenerated(unittest.TestCase):
+    def setUp(self) -> None:
+        self.saved = (
+            web.mb.MB_API_BASE,
+            web.discogs.DISCOGS_API_BASE,
+        )
+
+    def tearDown(self) -> None:
+        web.mb.MB_API_BASE, web.discogs.DISCOGS_API_BASE = self.saved
+
+    @given(
+        stale_mb=_ORIGIN,
+        stale_discogs=_ORIGIN,
+        mb_origin=st.one_of(st.none(), _ORIGIN),
+        discogs_origin=st.one_of(st.none(), _ORIGIN),
+    )
+    def test_each_configuration_exactly_replaces_prior_process_state(
+        self,
+        stale_mb: str,
+        stale_discogs: str,
+        mb_origin: str | None,
+        discogs_origin: str | None,
+    ) -> None:
+        configure_live_db_metadata(_config(
+            mb_api=f"{stale_mb}/old-ws",
+            discogs_api=f"{stale_discogs}/old-api",
+        ))
+        config = _config(
+            mb_api=f"{mb_origin}/ws/2" if mb_origin else None,
+            discogs_api=discogs_origin,
+        )
+        configure_live_db_metadata(config)
+        assert_metadata_wiring(config)
+
+
+class TestMetadataWiringCheckerKnownBad(unittest.TestCase):
+    def setUp(self) -> None:
+        self.saved = (
+            web.mb.MB_API_BASE,
+            web.discogs.DISCOGS_API_BASE,
+        )
+
+    def tearDown(self) -> None:
+        web.mb.MB_API_BASE, web.discogs.DISCOGS_API_BASE = self.saved
+
+    def test_checker_rejects_swapped_origins(self) -> None:
+        config = _config(
+            mb_api="https://mb.test/ws/2",
+            discogs_api="https://discogs.test",
+        )
+        web.mb.MB_API_BASE = config.discogs_api or ""
+        web.discogs.DISCOGS_API_BASE = config.mb_api
+        with self.assertRaises(AssertionError):
+            assert_metadata_wiring(config)
+
+    def test_checker_rejects_stale_discogs_when_configuration_is_missing(
+        self,
+    ) -> None:
+        config = _config(mb_api=None, discogs_api=None)
+        web.mb.MB_API_BASE = web.mb.DEFAULT_MB_API_BASE
+        web.discogs.DISCOGS_API_BASE = "https://stale-discogs.test"
+        with self.assertRaises(AssertionError):
+            assert_metadata_wiring(config)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_web_dev_server_generated.py
+++ b/tests/test_web_dev_server_generated.py
@@ -3,8 +3,14 @@
 
 from __future__ import annotations
 
+import ast
+import inspect
+import json
+import threading
 import unittest
+import urllib.error
 import urllib.parse
+import urllib.request
 from collections.abc import Callable
 from typing import Any
 
@@ -17,9 +23,12 @@ from web.api_bases import PUBLIC_MB_ORIGIN
 import web.api_bases
 import web.discogs
 import web.mb
+import web.routes.browse
 from web.routes.browse import get_artist_compare
 from scripts.web_dev_server import (
     DevConfig,
+    DevHTTPServer,
+    DevHandler,
     configure_live_db_metadata,
 )
 
@@ -42,6 +51,87 @@ def assert_missing_discogs_blocks(call_route: Callable[[], None]) -> None:
     raise AssertionError("warm metadata cache bypassed missing Discogs config")
 
 
+_DISCOGS_ROUTE_CACHE_USERS = {
+    "get_artist_compare",
+    "get_browse_resolve",
+}
+
+
+def assert_discogs_route_cache_inventory(source: str) -> None:
+    """Every route-level cache with a transitive Discogs call guards first."""
+    tree = ast.parse(source)
+    functions = {
+        node.name: node
+        for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+    def calls_discogs(
+        node: ast.FunctionDef | ast.AsyncFunctionDef,
+        seen: set[str],
+    ) -> bool:
+        if node.name in seen:
+            return False
+        seen.add(node.name)
+        for descendant in ast.walk(node):
+            if not isinstance(descendant, ast.Call):
+                continue
+            fn = descendant.func
+            if (
+                isinstance(fn, ast.Attribute)
+                and isinstance(fn.value, ast.Name)
+                and fn.value.id == "discogs_api"
+                and fn.attr != "require_mirror_configured"
+            ):
+                return True
+            if (
+                isinstance(fn, ast.Name)
+                and fn.id in functions
+                and calls_discogs(functions[fn.id], seen)
+            ):
+                return True
+        return False
+
+    cached_routes: dict[str, ast.FunctionDef | ast.AsyncFunctionDef] = {}
+    for name, node in functions.items():
+        has_route_cache = any(
+            isinstance(descendant, ast.Call)
+            and isinstance(descendant.func, ast.Attribute)
+            and descendant.func.attr == "memoize_meta"
+            for descendant in ast.walk(node)
+        )
+        if has_route_cache and calls_discogs(node, set()):
+            cached_routes[name] = node
+
+    if set(cached_routes) != _DISCOGS_ROUTE_CACHE_USERS:
+        raise AssertionError(
+            "Discogs-dependent route cache inventory drifted: "
+            f"{sorted(cached_routes)} != {sorted(_DISCOGS_ROUTE_CACHE_USERS)}"
+        )
+
+    for name, node in cached_routes.items():
+        guard_lines = [
+            descendant.lineno
+            for descendant in ast.walk(node)
+            if isinstance(descendant, ast.Call)
+            and isinstance(descendant.func, ast.Attribute)
+            and isinstance(descendant.func.value, ast.Name)
+            and descendant.func.value.id == "discogs_api"
+            and descendant.func.attr == "require_mirror_configured"
+        ]
+        cache_lines = [
+            descendant.lineno
+            for descendant in ast.walk(node)
+            if isinstance(descendant, ast.Call)
+            and isinstance(descendant.func, ast.Attribute)
+            and descendant.func.attr == "memoize_meta"
+        ]
+        if not guard_lines or min(guard_lines) >= min(cache_lines):
+            raise AssertionError(
+                f"{name} must validate Discogs before route-cache dispatch"
+            )
+
+
 class _RouteHandler:
     def __init__(self) -> None:
         self.payload: dict[str, Any] | None = None
@@ -53,6 +143,11 @@ class _RouteHandler:
 
     def _error(self, message: str, status: int = 400) -> None:
         raise AssertionError(f"unexpected route error {status}: {message}")
+
+
+class _QuietDevHandler(DevHandler):
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+        del format, args
 
 
 _HOST = st.text(
@@ -146,6 +241,80 @@ class TestLiveDbMetadataWiringGenerated(unittest.TestCase):
             lambda: get_artist_compare(handler, params),  # type: ignore[arg-type]
         )
         self.assertIsNone(handler.payload)
+
+
+class TestBrowseResolveWarmCacheGenerated(unittest.TestCase):
+    def setUp(self) -> None:
+        self.saved_base = web.discogs.DISCOGS_API_BASE
+        self.saved_mb_base = web.mb.MB_API_BASE
+        self.saved_redis = cache._redis
+        configure_live_db_metadata(_config(mb_api=None, discogs_api=None))
+        cache._redis = FakeRedis()
+        self.server = DevHTTPServer(
+            ("127.0.0.1", 0),
+            _QuietDevHandler,
+            _config(mb_api=None, discogs_api=None),
+        )
+        self.thread = threading.Thread(
+            target=self.server.serve_forever,
+            daemon=True,
+        )
+        self.thread.start()
+        self.base = f"http://127.0.0.1:{self.server.server_port}"
+
+    def tearDown(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=2)
+        web.discogs.DISCOGS_API_BASE = self.saved_base
+        web.mb.MB_API_BASE = self.saved_mb_base
+        cache._redis = self.saved_redis
+
+    @given(
+        discogs_id=st.integers(min_value=1, max_value=2_000_000_000),
+        kind=st.sampled_from(("release", "master", "unknown")),
+        marker=_HOST,
+    )
+    def test_missing_discogs_returns_503_before_arbitrary_warm_resolver_cache(
+        self, discogs_id: int, kind: str, marker: str,
+    ) -> None:
+        cache._redis = FakeRedis()
+        cache_key = f"browse-resolve:discogs:{kind}:{discogs_id}"
+        cache.meta_set(cache_key, {
+            "source": "discogs",
+            "kind": "master" if kind == "master" else "release",
+            "artist_id": marker,
+            "artist_name": marker,
+            "is_va": False,
+            "expand_id": str(discogs_id),
+            "leaf_id": None if kind == "master" else str(discogs_id),
+        })
+        self.assertIn(f"meta:{cache_key}", cache._redis._store)  # type: ignore[union-attr]
+
+        url = (
+            f"{self.base}/api/browse/resolve?source=discogs&"
+            f"id={discogs_id}&kind={kind}"
+        )
+        with self.assertRaises(urllib.error.HTTPError) as raised:
+            urllib.request.urlopen(url, timeout=2)
+        self.assertEqual(raised.exception.code, 503)
+        raised.exception.close()
+
+
+class TestDiscogsRouteCacheInventory(unittest.TestCase):
+    def test_exact_discogs_dependent_route_cache_inventory_is_guarded(self) -> None:
+        assert_discogs_route_cache_inventory(inspect.getsource(web.routes.browse))
+
+    def test_checker_rejects_resolver_guard_removed(self) -> None:
+        source = inspect.getsource(web.routes.browse)
+        guard = (
+            '    if source == "discogs":\n'
+            "        discogs_api.require_mirror_configured()\n"
+        )
+        mutant = source.replace(guard, "", 1)
+        self.assertNotEqual(mutant, source)
+        with self.assertRaises(AssertionError):
+            assert_discogs_route_cache_inventory(mutant)
 
 
 class TestMetadataWiringCheckerKnownBad(unittest.TestCase):

--- a/web/api_bases.py
+++ b/web/api_bases.py
@@ -20,6 +20,9 @@ def mb_ws2_base(origin: str) -> str:
     return (origin or PUBLIC_MB_ORIGIN).rstrip("/") + "/ws/2"
 
 
+PUBLIC_MB_WS2_BASE = mb_ws2_base(PUBLIC_MB_ORIGIN)
+
+
 def configure_api_bases_from_runtime_config() -> None:
     """Point web.mb / web.discogs at the runtime config's mirror origins.
 

--- a/web/discogs.py
+++ b/web/discogs.py
@@ -193,13 +193,14 @@ def search_releases(query: str) -> list[dict]:
     keeps the raw passthrough — an artist_id pin with no title would make
     the mirror scan every one of artist 194's releases.
     """
+    api_base = require_mirror_configured()
     remainder, is_va = split_va_query(query)
     va_pin = is_va and bool(remainder)
     effective_query = remainder if va_pin else query
 
     def _fetch() -> list[dict]:
         q = urllib.parse.quote(effective_query)
-        url = f"{require_mirror_configured()}/api/search?title={q}&per_page=25"
+        url = f"{api_base}/api/search?title={q}&per_page=25"
         if va_pin:
             url += f"&artist_id={VA_ARTIST_ID}"
         data = _get(url)
@@ -243,9 +244,11 @@ def search_artists(query: str) -> list[dict]:
     Uses /api/artists?name=, which is a real ts_rank artist-name search —
     parity with MB's /ws/2/artist?query=.
     """
+    api_base = require_mirror_configured()
+
     def _fetch() -> list[dict]:
         q = urllib.parse.quote(query)
-        data = _get(f"{require_mirror_configured()}/api/artists?name={q}&per_page=20")
+        data = _get(f"{api_base}/api/artists?name={q}&per_page=20")
         results = [
             {
                 "id": str(r["id"]),
@@ -262,7 +265,7 @@ def search_artists(query: str) -> list[dict]:
         if exact is None:
             return results
         try:
-            detail = _get(f"{require_mirror_configured()}/api/artists/{exact['id']}")
+            detail = _get(f"{api_base}/api/artists/{exact['id']}")
         except (urllib.error.HTTPError, urllib.error.URLError):
             return results
         related = [
@@ -385,11 +388,13 @@ def get_artist_releases(artist_id: int) -> list[dict]:
     we don't downgrade own work when it also has track-only credits. A master
     and a masterless release with the same numeric id remain distinct.
     """
+    api_base = require_mirror_configured()
+
     def _fetch() -> list[dict]:
         entries: dict[tuple[str, str], dict] = {}
 
         masters = msgspec.convert(
-            _get(f"{require_mirror_configured()}/api/artists/{artist_id}/masters/all"),
+            _get(f"{api_base}/api/artists/{artist_id}/masters/all"),
             type=_DiscogsArtistMastersResponse,
         )
         _require_complete_artist_catalogue(masters, endpoint="masters/all")
@@ -401,7 +406,7 @@ def get_artist_releases(artist_id: int) -> list[dict]:
             entries.setdefault((namespace, entry["id"]), entry)
 
         appearances = msgspec.convert(
-            _get(f"{require_mirror_configured()}/api/artists/{artist_id}/appearances"),
+            _get(f"{api_base}/api/artists/{artist_id}/appearances"),
             type=_DiscogsArtistMastersResponse,
         )
         _require_complete_artist_catalogue(appearances, endpoint="appearances")
@@ -422,8 +427,10 @@ def get_artist_releases(artist_id: int) -> list[dict]:
 
 def get_master_releases(master_id: int) -> dict:
     """Get all releases (pressings) for a master. Mirrors mb.get_release_group_releases()."""
+    api_base = require_mirror_configured()
+
     def _fetch() -> dict:
-        data = _get(f"{require_mirror_configured()}/api/masters/{master_id}")
+        data = _get(f"{api_base}/api/masters/{master_id}")
         releases = []
         for r in data.get("releases", []):
             formats = r.get("formats", [])
@@ -459,8 +466,10 @@ def get_release(release_id: int, *, fresh: bool = False) -> dict:
     pipeline DB — a 24h cache hit would silently write stale
     artist/title/track data into `album_requests` / `request_tracks`.
     """
+    api_base = require_mirror_configured()
+
     def _fetch() -> dict:
-        data = _get(f"{require_mirror_configured()}/api/releases/{release_id}")
+        data = _get(f"{api_base}/api/releases/{release_id}")
         artists = data.get("artists", [])
         artist_name = _primary_artist_name(artists)
         artist_id = _primary_artist_id(artists)
@@ -498,8 +507,10 @@ def get_release(release_id: int, *, fresh: bool = False) -> dict:
 
 def get_artist_name(artist_id: int) -> str:
     """Look up an artist's name by Discogs ID."""
+    api_base = require_mirror_configured()
+
     def _fetch() -> str:
-        data = _get(f"{require_mirror_configured()}/api/artists/{artist_id}")
+        data = _get(f"{api_base}/api/artists/{artist_id}")
         return data.get("name", "")
 
     return _cache.memoize_meta(f"discogs:artist:{artist_id}:name", _fetch)
@@ -697,10 +708,12 @@ def search_labels(query: str, *, page: int = 1, per_page: int = 25) -> list[Labe
     stays lossless; on read we rehydrate via `msgspec.convert`. Per
     `.claude/rules/code-quality.md` § "Wire-boundary types".
     """
+    api_base = require_mirror_configured()
+
     def _fetch() -> list[dict]:
         q = urllib.parse.quote(query)
         raw = _get(
-            f"{require_mirror_configured()}/api/labels"
+            f"{api_base}/api/labels"
             f"?name={q}&page={page}&per_page={per_page}"
         )
         decoded = msgspec.convert(raw, type=_DiscogsLabelSearchResponse)
@@ -720,10 +733,11 @@ def get_label(label_id: int | str) -> LabelEntity:
     HTTPError on 404 (the caller surfaces the 404 as needed). Returns
     a typed `LabelEntity` on success.
     """
+    api_base = require_mirror_configured()
     label_id_str = _assert_discogs_label_id(label_id)
 
     def _fetch() -> dict:
-        raw = _get(f"{require_mirror_configured()}/api/labels/{label_id_str}")
+        raw = _get(f"{api_base}/api/labels/{label_id_str}")
         decoded = msgspec.convert(raw, type=_DiscogsLabelDetail)
         return msgspec.to_builtins(_label_entity_from_detail(decoded))
 
@@ -746,12 +760,13 @@ def get_label_releases(label_id: int | str, *, include_sublabels: bool = True,
     (str | None), `master_title`, `master_first_released`, `labels`,
     `formats`.
     """
+    api_base = require_mirror_configured()
     label_id_str = _assert_discogs_label_id(label_id)
 
     def _fetch() -> dict:
         sub_flag = "true" if include_sublabels else "false"
         raw = _get(
-            f"{require_mirror_configured()}/api/labels/{label_id_str}/releases"
+            f"{api_base}/api/labels/{label_id_str}/releases"
             f"?include_sublabels={sub_flag}&page={page}&per_page={per_page}",
             timeout=(
                 LABEL_RELEASES_INCLUDE_TIMEOUT_SECONDS

--- a/web/discogs.py
+++ b/web/discogs.py
@@ -1,6 +1,7 @@
 """Discogs mirror API helpers — shared between pipeline_cli and web server.
 
-All queries hit the local Discogs mirror (DISCOGS_API_BASE; mirror-required, see _api_base).
+All queries hit the local Discogs mirror (DISCOGS_API_BASE; mirror-required,
+see require_mirror_configured).
 Response shapes are normalized to match what the frontend expects,
 mirroring web/mb.py where possible.
 
@@ -45,7 +46,8 @@ class DiscogsMirrorNotConfigured(RuntimeError):
     fetch."""
 
 
-def _api_base() -> str:
+def require_mirror_configured() -> str:
+    """Return the mirror base or reject before any cached work is dispatched."""
     if not DISCOGS_API_BASE:
         raise DiscogsMirrorNotConfigured(
             "Discogs browse requires a Discogs mirror: this API speaks the "
@@ -197,7 +199,7 @@ def search_releases(query: str) -> list[dict]:
 
     def _fetch() -> list[dict]:
         q = urllib.parse.quote(effective_query)
-        url = f"{_api_base()}/api/search?title={q}&per_page=25"
+        url = f"{require_mirror_configured()}/api/search?title={q}&per_page=25"
         if va_pin:
             url += f"&artist_id={VA_ARTIST_ID}"
         data = _get(url)
@@ -243,7 +245,7 @@ def search_artists(query: str) -> list[dict]:
     """
     def _fetch() -> list[dict]:
         q = urllib.parse.quote(query)
-        data = _get(f"{_api_base()}/api/artists?name={q}&per_page=20")
+        data = _get(f"{require_mirror_configured()}/api/artists?name={q}&per_page=20")
         results = [
             {
                 "id": str(r["id"]),
@@ -260,7 +262,7 @@ def search_artists(query: str) -> list[dict]:
         if exact is None:
             return results
         try:
-            detail = _get(f"{_api_base()}/api/artists/{exact['id']}")
+            detail = _get(f"{require_mirror_configured()}/api/artists/{exact['id']}")
         except (urllib.error.HTTPError, urllib.error.URLError):
             return results
         related = [
@@ -387,7 +389,7 @@ def get_artist_releases(artist_id: int) -> list[dict]:
         entries: dict[tuple[str, str], dict] = {}
 
         masters = msgspec.convert(
-            _get(f"{_api_base()}/api/artists/{artist_id}/masters/all"),
+            _get(f"{require_mirror_configured()}/api/artists/{artist_id}/masters/all"),
             type=_DiscogsArtistMastersResponse,
         )
         _require_complete_artist_catalogue(masters, endpoint="masters/all")
@@ -399,7 +401,7 @@ def get_artist_releases(artist_id: int) -> list[dict]:
             entries.setdefault((namespace, entry["id"]), entry)
 
         appearances = msgspec.convert(
-            _get(f"{_api_base()}/api/artists/{artist_id}/appearances"),
+            _get(f"{require_mirror_configured()}/api/artists/{artist_id}/appearances"),
             type=_DiscogsArtistMastersResponse,
         )
         _require_complete_artist_catalogue(appearances, endpoint="appearances")
@@ -421,7 +423,7 @@ def get_artist_releases(artist_id: int) -> list[dict]:
 def get_master_releases(master_id: int) -> dict:
     """Get all releases (pressings) for a master. Mirrors mb.get_release_group_releases()."""
     def _fetch() -> dict:
-        data = _get(f"{_api_base()}/api/masters/{master_id}")
+        data = _get(f"{require_mirror_configured()}/api/masters/{master_id}")
         releases = []
         for r in data.get("releases", []):
             formats = r.get("formats", [])
@@ -458,7 +460,7 @@ def get_release(release_id: int, *, fresh: bool = False) -> dict:
     artist/title/track data into `album_requests` / `request_tracks`.
     """
     def _fetch() -> dict:
-        data = _get(f"{_api_base()}/api/releases/{release_id}")
+        data = _get(f"{require_mirror_configured()}/api/releases/{release_id}")
         artists = data.get("artists", [])
         artist_name = _primary_artist_name(artists)
         artist_id = _primary_artist_id(artists)
@@ -497,7 +499,7 @@ def get_release(release_id: int, *, fresh: bool = False) -> dict:
 def get_artist_name(artist_id: int) -> str:
     """Look up an artist's name by Discogs ID."""
     def _fetch() -> str:
-        data = _get(f"{_api_base()}/api/artists/{artist_id}")
+        data = _get(f"{require_mirror_configured()}/api/artists/{artist_id}")
         return data.get("name", "")
 
     return _cache.memoize_meta(f"discogs:artist:{artist_id}:name", _fetch)
@@ -698,7 +700,7 @@ def search_labels(query: str, *, page: int = 1, per_page: int = 25) -> list[Labe
     def _fetch() -> list[dict]:
         q = urllib.parse.quote(query)
         raw = _get(
-            f"{_api_base()}/api/labels"
+            f"{require_mirror_configured()}/api/labels"
             f"?name={q}&page={page}&per_page={per_page}"
         )
         decoded = msgspec.convert(raw, type=_DiscogsLabelSearchResponse)
@@ -721,7 +723,7 @@ def get_label(label_id: int | str) -> LabelEntity:
     label_id_str = _assert_discogs_label_id(label_id)
 
     def _fetch() -> dict:
-        raw = _get(f"{_api_base()}/api/labels/{label_id_str}")
+        raw = _get(f"{require_mirror_configured()}/api/labels/{label_id_str}")
         decoded = msgspec.convert(raw, type=_DiscogsLabelDetail)
         return msgspec.to_builtins(_label_entity_from_detail(decoded))
 
@@ -749,7 +751,7 @@ def get_label_releases(label_id: int | str, *, include_sublabels: bool = True,
     def _fetch() -> dict:
         sub_flag = "true" if include_sublabels else "false"
         raw = _get(
-            f"{_api_base()}/api/labels/{label_id_str}/releases"
+            f"{require_mirror_configured()}/api/labels/{label_id_str}/releases"
             f"?include_sublabels={sub_flag}&page={page}&per_page={per_page}",
             timeout=(
                 LABEL_RELEASES_INCLUDE_TIMEOUT_SECONDS

--- a/web/mb.py
+++ b/web/mb.py
@@ -20,6 +20,7 @@ import urllib.error
 # Use the `web.` package-qualified path to keep the web metadata cache
 # separate from the pipeline's peer-cache implementation.
 from web import cache as _cache
+from web.api_bases import PUBLIC_MB_WS2_BASE
 from web.artist_search import merge_exact_artist_identities
 
 # Default: public MusicBrainz (functional but rate-limited ~1 req/s).
@@ -30,8 +31,7 @@ from web.artist_search import merge_exact_artist_identities
 # --mb-api flag in favor of config.ini as the one production source — the
 # flag itself survives as a dev-only override). The value includes the
 # /ws/2 prefix.
-DEFAULT_MB_API_BASE = "https://musicbrainz.org/ws/2"
-MB_API_BASE = DEFAULT_MB_API_BASE
+MB_API_BASE = PUBLIC_MB_WS2_BASE
 USER_AGENT = "cratedigger-web/1.0"
 
 # Canonical Various Artists MBID. Used by the resolver and the browse-tab

--- a/web/mb.py
+++ b/web/mb.py
@@ -30,7 +30,8 @@ from web.artist_search import merge_exact_artist_identities
 # --mb-api flag in favor of config.ini as the one production source — the
 # flag itself survives as a dev-only override). The value includes the
 # /ws/2 prefix.
-MB_API_BASE = "https://musicbrainz.org/ws/2"
+DEFAULT_MB_API_BASE = "https://musicbrainz.org/ws/2"
+MB_API_BASE = DEFAULT_MB_API_BASE
 USER_AGENT = "cratedigger-web/1.0"
 
 # Canonical Various Artists MBID. Used by the resolver and the browse-tab

--- a/web/routes/browse.py
+++ b/web/routes/browse.py
@@ -702,6 +702,8 @@ def get_browse_resolve(h: BaseHTTPRequestHandler, params: dict[str, list[str]]) 
     if source == "discogs" and not raw_id.isdigit():
         h._error("Invalid Discogs ID (must be numeric)")  # type: ignore[attr-defined]
         return
+    if source == "discogs":
+        discogs_api.require_mirror_configured()
 
     cache_key = f"browse-resolve:{source}:{kind}:{raw_id}"
 

--- a/web/routes/browse.py
+++ b/web/routes/browse.py
@@ -568,6 +568,7 @@ def get_artist_compare(h: BaseHTTPRequestHandler, params: dict[str, list[str]]) 
     if not name:
         h._error("Missing parameter 'name'")  # type: ignore[attr-defined]
         return
+    discogs_api.require_mirror_configured()
     mbid = params.get("mbid", [""])[0].strip()
     discogs_id = params.get("discogs_id", [""])[0].strip()
 


### PR DESCRIPTION
## Summary

- add explicit `--mb-api` and `--discogs-api` inputs to the live-db frontend dev server, with startup output that makes the public-MB fallback and fail-closed Discogs posture visible
- replace both metadata adapter origins for every live-db configuration so a prior configured session cannot leak into a missing configuration
- exercise the real `/api/artist/compare` route through local HTTP mirror stubs and the read-only PostgreSQL dev-server path, proving the configured MB release-group request, official-release request, and Discogs bulk request all reach their selected origins
- reject missing Discogs configuration before Redis dispatch in every public cached Discogs adapter: release and artist searches, artist catalogues and names, masters, releases, label search/detail, and label releases
- retain explicit route-boundary guards for the outer `/api/artist/compare` and Discogs `/api/browse/resolve` caches, which can otherwise bypass every inner adapter
- generate real-HTTP warm-cache resolver worlds across arbitrary numeric IDs and release/master/unknown kinds, with an independent call-graph inventory that pins every Discogs-dependent route-level metadata cache
- use one canonical public MusicBrainz WS/2 declaration for the metadata module and dev-server reset path
- pin the Discogs API's exact nullable `primary_artist_id` fixture while retaining strict `primary_types` validation
- make the canonical screenshot workflow pass the doc2 mirror origins directly and require an HTTP 200 compare precondition before accepting pixels

## Verification

- initial deterministic RED: `DevConfig` rejected the new mirror inputs and the metadata wiring helper was absent
- first-review RED: a configured request warmed compare caches, then a missing-Discogs session incorrectly returned 200; the generated route property found the same bypass; the canonical MB WS/2 declaration was absent
- second-review RED: all nine public cached Discogs adapters returned warm entries with configuration missing, and warm Discogs `/api/browse/resolve` returned 200 while compare correctly returned 503
- third-review mutant RED: removing the resolver guard made the generated real-HTTP property return 200 instead of 503 and shrink to `id=1`, `kind='release'`, `marker='a'`; both the exact inventory and known-bad inventory checker also failed
- complete adapter inventory audit: the deterministic matrix exactly matches every public `search_*`/`get_*` function in `web.discogs` that dispatches `memoize_meta`
- complete route-cache inventory audit: transitive Discogs call analysis finds exactly `get_artist_compare` and `get_browse_resolve`, and requires each guard to precede `memoize_meta`
- configured adapter behavior, strict wire validation, PR #684 bulk catalogue behavior, and both outer HTTP routes: green
- generated adapter and route warm-cache properties: default, fuzz, and pre-push profiles green
- full-repo pyright: 0 errors
- dead-code sweep: clean
- integrated current main `caa516dea3be610593128df193f727f70ca42019`
- exact clean full suite: 5,834 tests green at `1998fa1274f78a024b8909d31d19cc015ea4fb0a`; verified artifact `/tmp/issue-681-live-db-a90d29941d-1998fa1274f7.365w9ofz`
- pre-push generated fuzz burst: every shard green, including `tests.test_web_dev_server_generated`
- `nix flake check`: passed

Screenshot acceptance remains an orchestrator live gate after this PR.

Refs #681
