### PR TITLE
Tighten issue review-loop cadence

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -163,6 +163,24 @@ Any type that **crosses JSON** — harness stdout, an HTTP response, a JSONB blo
   citation for every peeled target commit.
 - For single modules during dev: `nix-shell --run "python3 -m unittest tests.<module> -v"`
 
+## Prefer canonical contracts over semantic scanners
+
+When an invariant can be enforced by narrowing the production contract, make
+the allowed code shape small and explicit. Prefer one typed owner, one
+canonical call or SQL form, and a fail-closed audit that rejects everything
+outside that grammar.
+
+Do not grow a home-made AST, data-flow, SQL, or control-flow analyzer one
+syntax case at a time in an attempt to reproduce Python or database execution
+semantics. Static audits are appropriate for local structural facts; they are
+not substitutes for a language runtime or SQL parser. If adversarial review
+keeps finding equivalent spellings that bypass an audit, stop extending the
+scanner and simplify the permitted production form instead.
+
+Qualify the narrow contract with known-bad variants and at least one real
+production-path test. Any non-canonical or unresolved construction must fail
+closed unless it is an explicitly reviewed, tightly bounded seam.
+
 ## API Contract Tests
 - Every API endpoint consumed by the frontend must have a contract test in `tests/web/` — one `test_*.py` per `web/routes/*.py` module (e.g. `tests/web/test_routes_pipeline.py` for `web/routes/pipeline.py`)
 - Contract tests use the real `_FakeDbWebServerCase` harness (HTTPServer on a random port + a fresh bare `FakePipelineDB` installed as `web.server.db` per test) — see existing `TestPipelineRouteContracts`, `TestBrowseRouteContracts`, etc. as reference patterns. Seed state (`self.db.seed_request(...)`, `self.db.log_download(...)`) and assert against the fake's real query semantics — never configure mock returns (#430; the `WEB_HARNESS_MOCK_BASELINE` ratchet in `tests/_mock_audit_scanner.py` is permanently empty and bans `mock_db` references in tests/web outright)

--- a/.claude/skills/orchestrate-issue/SKILL.md
+++ b/.claude/skills/orchestrate-issue/SKILL.md
@@ -51,7 +51,8 @@ plan or coverage ledger.
 
 ## 3. Delegate implementation with a hard role boundary
 
-Create one implementation agent for the PR. Give it:
+Create a fresh implementation agent for each PR. Never carry an implementation
+agent into the next PR. Give it:
 
 - the exact worktree and branch it may modify;
 - the issue items assigned to this PR;
@@ -127,13 +128,35 @@ Require one of two outputs:
 - severity-ranked findings with file/line, concrete failure mode, and a
   specific correction.
 
+Require the reviewer to finish one full exploratory pass and return a
+consolidated final report. Treat interim findings as evidence, not as a
+handoff: do not begin corrections while the reviewer is still searching.
+Batching the complete pass prevents one finding from triggering a commit,
+full gate run, and push before an equivalent bypass arrives.
+
 When review is not clean:
 
-1. Send every finding back to the original implementation agent.
-2. Require a signed correction, focused gates, updated PR body, and exact new
-   SHA. Do not let the implementer declare itself clean.
-3. Send the corrected exact SHA to the same reviewer.
-4. Repeat until the reviewer returns `CLEAN`.
+1. Send the complete finding batch back to the implementation agent. Do not
+   let the implementer declare itself clean.
+2. During correction rounds, run focused tests and the smallest relevant fuzz
+   or real-service qualification. Do not run the full suite, Nix gates,
+   guarded push, or other release-grade gates after each finding.
+3. When the batch is fixed and the worktree is quiescent, let the same reviewer
+   make a read-only preflight pass over the uncommitted correction. The
+   implementation agent must not edit concurrently with this pass.
+4. Repeat the focused correction/preflight loop until the reviewer reports no
+   provisional findings.
+5. Only then create the signed correction commit, run the full required gates,
+   update the PR body, push, and report the exact new SHA.
+6. Send that exact pushed SHA to the reviewer for the binding `CLEAN` verdict.
+
+If the PR reaches a third substantial correction round, rotate both roles at
+the round boundary instead of extending already-long agent contexts. Do not
+interrupt active edits. Give the fresh implementation agent and fresh reviewer
+a compact durable handoff containing the worktree, base/head SHAs, coverage
+ledger, consolidated finding history, current diff, and focused evidence.
+They must rebuild understanding from repository and PR artifacts rather than
+from a conversation transcript.
 
 Do not merge on CI, mergeability, or the orchestrator's opinion alone.
 


### PR DESCRIPTION
## Summary

- batch a reviewer’s complete exploratory pass before correction work begins
- use focused correction/preflight loops and defer release-grade gates until the candidate is stable
- rotate implementation and review agents at the third substantial correction round
- prefer narrow canonical production contracts over home-grown semantic analyzers

## Verification

- skill-creator `quick_validate.py`: valid
- pyright: 0 errors
- focused workflow, docs, and AI portability tests: 55 passed
- exact-HEAD full suite: 5,909 passed
- guarded push: generated fuzz burst and `nix flake check` passed

This codifies the review-loop lessons from PR #693.