### PR TITLE
Preserve historical Jellyfin Recently Added dates

### DIFF
--- a/docs/jellyfin-primer.md
+++ b/docs/jellyfin-primer.md
@@ -85,7 +85,10 @@ deliberate differences:
   its folder path (exact `Path` match after the `path_map` translation) and
   stash the **maximum `DateCreated` across its Audio children** (the value
   Jellyfin actually uses to order grouped music Latest), plus a snapshot of
-  the album and Audio item ids, as a `pending` row.
+  the album and Audio item ids, as a `pending` row. When Plex already knows
+  the album, its preserved pre-upgrade `addedAt` is an older historical floor:
+  the Jellyfin pin uses the earlier value. This prevents a prior Jellyfin
+  rebuild or broken refresh from becoming the new baseline forever.
   A genuinely-new album isn't in Jellyfin yet, so nothing is captured — the
   table self-selects upgrades.
 - **Reconcile** (`reconcile_jellyfin_date_created_pins`, each 5-min

--- a/lib/dispatch/core.py
+++ b/lib/dispatch/core.py
@@ -838,15 +838,20 @@ def dispatch_import_core(
                     # restore it and keep upgrades out of "Recently Added"
                     # (migration 040). No-op for genuinely-new albums (not yet
                     # in Plex) and when Plex is unconfigured; best-effort.
+                    plex_original_added_at: int | None = None
                     try:
                         from lib.plex_pin_service import capture_plex_added_at_pin
-                        capture_plex_added_at_pin(
+                        plex_pin = capture_plex_added_at_pin(
                             cfg, db, ir.postflight.imported_path, request_id)
+                        plex_original_added_at = plex_pin.original_added_at
                     except Exception:
                         logger.exception(
                             "PLEX PIN: capture wiring failed (non-fatal)")
                     _trigger_plex(cfg, ir.postflight.imported_path)
-                    # Same capture-before-refresh dance for Jellyfin
+                    # Same capture-before-refresh dance for Jellyfin. Plex's
+                    # preserved historical value is also the floor for
+                    # Jellyfin: a prior Jellyfin rebuild must not become the
+                    # new definition of when an old album joined the library.
                     # (migration 046, issue #574): snapshot the album's
                     # maximum Audio DateCreated + item ids while the
                     # pre-upgrade items still exist, so the reconciler can
@@ -858,7 +863,12 @@ def dispatch_import_core(
                             capture_jellyfin_date_created_pin,
                         )
                         capture_jellyfin_date_created_pin(
-                            cfg, db, ir.postflight.imported_path, request_id)
+                            cfg,
+                            db,
+                            ir.postflight.imported_path,
+                            request_id,
+                            historical_added_at=plex_original_added_at,
+                        )
                     except Exception:
                         logger.exception(
                             "JELLYFIN PIN: capture wiring failed (non-fatal)")

--- a/lib/jellyfin_pin_service.py
+++ b/lib/jellyfin_pin_service.py
@@ -10,9 +10,10 @@ upgrade wrongly surfaces at the top. This module preserves the original date:
 
   capture   (importer, BEFORE the Jellyfin refresh): read the maximum
             ``DateCreated`` across the album's Audio children (the value that
-            actually orders Jellyfin's music Latest rows) and snapshot the
-            item ids. A genuinely-new album isn't in Jellyfin yet, so nothing
-            is captured — the table self-selects upgrades.
+            actually orders Jellyfin's music Latest rows), clamp it to Plex's
+            older preserved ``addedAt`` when available, and snapshot the item
+            ids. A genuinely-new album isn't in Jellyfin yet, so nothing is
+            captured — the table self-selects upgrades.
   reconcile (5-min cratedigger cycle): for each pending pin past the settle
             window, re-find the album and check whether the rescan has LANDED
             — an item id differs from the snapshot OR an existing Audio item's
@@ -40,7 +41,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, Callable, Protocol
 
 from lib.pipeline_db.pin_status import JellyfinTerminalPinStatus
@@ -133,13 +134,17 @@ def capture_jellyfin_date_created_pin(
     imported_path: str | None,
     request_id: int | None,
     *,
+    historical_added_at: int | None = None,
     find_fn: FindFn = jellyfin_find_album_by_path,
     children_fn: ChildrenFn = jellyfin_get_album_children,
 ) -> CaptureResult:
-    """Stash the album's maximum Audio date and item-id snapshot.
+    """Stash the album's historical Audio date and item-id snapshot.
 
     MUST run before the Jellyfin media update so the children still carry the
     pre-upgrade dates that determine the album's current Latest position.
+    ``historical_added_at`` is Plex's preserved original epoch value. It can
+    only move the Jellyfin baseline backwards, repairing a prior Jellyfin
+    rebuild or refresh that had already polluted the captured child dates.
     Best-effort: never raises.
     """
     if not _jellyfin_pin_enabled(cfg) or not imported_path:
@@ -159,6 +164,18 @@ def capture_jellyfin_date_created_pin(
             (child.date_created for child in children if child.date_created),
             default=ref.date_created,
         )
+        if historical_added_at is not None:
+            historical = datetime.fromtimestamp(
+                historical_added_at, tz=timezone.utc
+            )
+            captured = datetime.fromisoformat(
+                original_date_created.replace("Z", "+00:00")
+            )
+            if historical < captured:
+                original_date_created = (
+                    historical.isoformat(timespec="seconds")
+                    .replace("+00:00", "Z")
+                )
         pin_id = db.add_jellyfin_date_created_pin(
             imported_path=imported_path,
             original_date_created=original_date_created,

--- a/tests/test_jellyfin_pin_service.py
+++ b/tests/test_jellyfin_pin_service.py
@@ -61,6 +61,38 @@ class TestCapture(unittest.TestCase):
         self.assertEqual(pin["request_id"], 8812)
         self.assertEqual(pin["status"], "pending")
 
+    def test_plex_history_clamps_a_polluted_jellyfin_baseline(self):
+        """A Jellyfin rebuild must not redefine an old album as newly added."""
+        db = FakePipelineDB()
+        historical = int(datetime(
+            2010, 6, 10, 10, 10, 38, tzinfo=timezone.utc
+        ).timestamp())
+        res = capture_jellyfin_date_created_pin(
+            _cfg(), db, "Eldar/2010 - Amaterasu Shiroi", 2506,
+            historical_added_at=historical,
+            find_fn=lambda cfg, path: _album(
+                date_created="2026-07-14T02:03:57.0000000Z"),
+            children_fn=lambda cfg, iid: _children(
+                ("tr-1", "2026-07-14T02:03:57.0000000Z")))
+        self.assertEqual(res.outcome, "captured")
+        self.assertEqual(res.original_date_created, "2010-06-10T10:10:38Z")
+        self.assertEqual(
+            db.jellyfin_date_created_pins[0]["original_date_created"],
+            "2010-06-10T10:10:38Z",
+        )
+
+    def test_plex_history_never_moves_a_jellyfin_baseline_forward(self):
+        db = FakePipelineDB()
+        later = int(datetime(
+            2026, 7, 11, tzinfo=timezone.utc
+        ).timestamp())
+        res = capture_jellyfin_date_created_pin(
+            _cfg(), db, "A/B", 1,
+            historical_added_at=later,
+            find_fn=lambda cfg, path: _album(),
+            children_fn=lambda cfg, iid: [])
+        self.assertEqual(res.original_date_created, ORIGINAL)
+
     def test_no_album_writes_no_pin(self):
         # Invariant 1: genuinely-new albums self-select out — no pin.
         db = FakePipelineDB()

--- a/tests/test_jellyfin_pins_generated.py
+++ b/tests/test_jellyfin_pins_generated.py
@@ -18,9 +18,10 @@ entry points over ``FakePipelineDB`` with the Jellyfin client seams injected:
    drifted item (album + audio children) was written, and no write failed;
    skipped ⟺ the album is no longer locatable; a failed write or an
    erroring client always leaves the pin pending.
-4. **P4 (capture snapshot fidelity)** — a capture persists the maximum Audio
-   ``DateCreated`` that actually drives music Latest, plus the item ids,
-   path, and request id; a genuinely new album persists nothing.
+4. **P4 (capture snapshot fidelity)** — a capture persists the earlier of
+   Jellyfin's maximum Audio ``DateCreated`` and Plex's preserved historical
+   ``addedAt``, plus the item ids, path, and request id; a genuinely new album
+   persists nothing.
 
 The deterministic pins for these same invariants live in
 tests/test_jellyfin_pin_service.py.
@@ -252,10 +253,11 @@ class TestCaptureProperty(unittest.TestCase):
             unique_by=lambda pair: pair[0],
             max_size=4,
         ),
+        historical_date=st.one_of(st.none(), st.sampled_from(_DATES)),
     )
     def test_capture_snapshot_mirrors_finder_or_writes_nothing(
             self, found: bool, album_date: str,
-            children: list[tuple[str, str]]):
+            children: list[tuple[str, str]], historical_date: str | None):
         db = FakePipelineDB()
         ref = (
             JellyfinAlbumRef(item_id="alb-1", date_created=album_date)
@@ -263,6 +265,12 @@ class TestCaptureProperty(unittest.TestCase):
         )
         res = capture_jellyfin_date_created_pin(
             _cfg(), db, "Artist/2026 - Album", 42,
+            historical_added_at=(
+                int(datetime.fromisoformat(
+                    historical_date.replace("Z", "+00:00")
+                ).timestamp())
+                if historical_date is not None else None
+            ),
             find_fn=lambda cfg, path: ref,
             children_fn=lambda cfg, iid: [
                 JellyfinItemRef(item_id=item_id, date_created=date)
@@ -275,6 +283,8 @@ class TestCaptureProperty(unittest.TestCase):
         pin = db.jellyfin_date_created_pins[0]
         expected_date = max(
             (date for _, date in children), default=album_date)
+        if historical_date is not None:
+            expected_date = min(expected_date, historical_date)
         self.assertEqual(pin["original_date_created"], expected_date)
         self.assertEqual(pin["album_item_id"], "alb-1")
         self.assertEqual(


### PR DESCRIPTION
## Summary
- use Plex's preserved pre-upgrade `addedAt` as the historical floor for Jellyfin DateCreated pins
- never move a Jellyfin baseline forward when Plex has a newer value
- add deterministic and generated coverage for the previously polluted Eldar-shaped case

## Live evidence
- corrected 28 affected albums / 287 Jellyfin items from existing Plex pin history
- Paul Kelly, Nullsleep, Eldar, and Usher are absent from the first 500 live Latest results
- exact child maxima now match their historical dates

## Verification
- 5,980-test full suite
- randomized generated-test push burst
- nix flake check including both NixOS VMs