### PR TITLE
Fix Recents evidence comparisons

### DIFF
--- a/lib/pipeline_db/download_log.py
+++ b/lib/pipeline_db/download_log.py
@@ -119,6 +119,19 @@ class _DownloadLogMixin(_PipelineDBBase):
                        e.v0_min_bitrate_kbps AS _evidence_v0_probe_min_bitrate,
                        e.v0_avg_bitrate_kbps AS _evidence_v0_probe_avg_bitrate,
                        e.v0_median_bitrate_kbps AS _evidence_v0_probe_median_bitrate,
+                       current_evidence.id AS _current_evidence_id,
+                       (current_evidence.measured_at <= dl.created_at)
+                           AS _current_evidence_is_pre_attempt,
+                       current_evidence.format AS _current_evidence_format,
+                       current_evidence.min_bitrate_kbps AS _current_evidence_min_bitrate,
+                       current_evidence.avg_bitrate_kbps AS _current_evidence_avg_bitrate,
+                       current_evidence.median_bitrate_kbps AS _current_evidence_median_bitrate,
+                       current_evidence.spectral_grade AS _current_evidence_spectral_grade,
+                       current_evidence.spectral_bitrate_kbps AS _current_evidence_spectral_bitrate,
+                       current_evidence.v0_source_lineage AS _current_evidence_v0_probe_kind,
+                       current_evidence.v0_min_bitrate_kbps AS _current_evidence_v0_probe_min_bitrate,
+                       current_evidence.v0_avg_bitrate_kbps AS _current_evidence_v0_probe_avg_bitrate,
+                       current_evidence.v0_median_bitrate_kbps AS _current_evidence_v0_probe_median_bitrate,
                        origin.beets_distance AS original_beets_distance,
                        ar.album_title, ar.artist_name, ar.mb_release_id,
                        ar.year, ar.country, ar.status AS request_status,
@@ -131,6 +144,8 @@ class _DownloadLogMixin(_PipelineDBBase):
                 LEFT JOIN download_log origin
                     ON origin.id = dl.source_download_log_id
                 JOIN album_requests ar ON dl.request_id = ar.id
+                LEFT JOIN album_quality_evidence current_evidence
+                    ON current_evidence.id = ar.current_evidence_id
                 WHERE dl.outcome IN ('success', 'force_import')
                 ORDER BY dl.created_at DESC LIMIT %s
             """
@@ -148,6 +163,19 @@ class _DownloadLogMixin(_PipelineDBBase):
                        e.v0_min_bitrate_kbps AS _evidence_v0_probe_min_bitrate,
                        e.v0_avg_bitrate_kbps AS _evidence_v0_probe_avg_bitrate,
                        e.v0_median_bitrate_kbps AS _evidence_v0_probe_median_bitrate,
+                       current_evidence.id AS _current_evidence_id,
+                       (current_evidence.measured_at <= dl.created_at)
+                           AS _current_evidence_is_pre_attempt,
+                       current_evidence.format AS _current_evidence_format,
+                       current_evidence.min_bitrate_kbps AS _current_evidence_min_bitrate,
+                       current_evidence.avg_bitrate_kbps AS _current_evidence_avg_bitrate,
+                       current_evidence.median_bitrate_kbps AS _current_evidence_median_bitrate,
+                       current_evidence.spectral_grade AS _current_evidence_spectral_grade,
+                       current_evidence.spectral_bitrate_kbps AS _current_evidence_spectral_bitrate,
+                       current_evidence.v0_source_lineage AS _current_evidence_v0_probe_kind,
+                       current_evidence.v0_min_bitrate_kbps AS _current_evidence_v0_probe_min_bitrate,
+                       current_evidence.v0_avg_bitrate_kbps AS _current_evidence_v0_probe_avg_bitrate,
+                       current_evidence.v0_median_bitrate_kbps AS _current_evidence_v0_probe_median_bitrate,
                        origin.beets_distance AS original_beets_distance,
                        ar.album_title, ar.artist_name, ar.mb_release_id,
                        ar.year, ar.country, ar.status AS request_status,
@@ -160,6 +188,8 @@ class _DownloadLogMixin(_PipelineDBBase):
                 LEFT JOIN download_log origin
                     ON origin.id = dl.source_download_log_id
                 JOIN album_requests ar ON dl.request_id = ar.id
+                LEFT JOIN album_quality_evidence current_evidence
+                    ON current_evidence.id = ar.current_evidence_id
                 WHERE dl.outcome IN ('rejected', 'failed', 'timeout')
                 ORDER BY dl.created_at DESC LIMIT %s
             """
@@ -177,6 +207,19 @@ class _DownloadLogMixin(_PipelineDBBase):
                        e.v0_min_bitrate_kbps AS _evidence_v0_probe_min_bitrate,
                        e.v0_avg_bitrate_kbps AS _evidence_v0_probe_avg_bitrate,
                        e.v0_median_bitrate_kbps AS _evidence_v0_probe_median_bitrate,
+                       current_evidence.id AS _current_evidence_id,
+                       (current_evidence.measured_at <= dl.created_at)
+                           AS _current_evidence_is_pre_attempt,
+                       current_evidence.format AS _current_evidence_format,
+                       current_evidence.min_bitrate_kbps AS _current_evidence_min_bitrate,
+                       current_evidence.avg_bitrate_kbps AS _current_evidence_avg_bitrate,
+                       current_evidence.median_bitrate_kbps AS _current_evidence_median_bitrate,
+                       current_evidence.spectral_grade AS _current_evidence_spectral_grade,
+                       current_evidence.spectral_bitrate_kbps AS _current_evidence_spectral_bitrate,
+                       current_evidence.v0_source_lineage AS _current_evidence_v0_probe_kind,
+                       current_evidence.v0_min_bitrate_kbps AS _current_evidence_v0_probe_min_bitrate,
+                       current_evidence.v0_avg_bitrate_kbps AS _current_evidence_v0_probe_avg_bitrate,
+                       current_evidence.v0_median_bitrate_kbps AS _current_evidence_v0_probe_median_bitrate,
                        origin.beets_distance AS original_beets_distance,
                        ar.album_title, ar.artist_name, ar.mb_release_id,
                        ar.year, ar.country, ar.status AS request_status,
@@ -189,6 +232,8 @@ class _DownloadLogMixin(_PipelineDBBase):
                 LEFT JOIN download_log origin
                     ON origin.id = dl.source_download_log_id
                 JOIN album_requests ar ON dl.request_id = ar.id
+                LEFT JOIN album_quality_evidence current_evidence
+                    ON current_evidence.id = ar.current_evidence_id
                 ORDER BY dl.created_at DESC LIMIT %s
             """
         cur = self._execute(query, (limit,))
@@ -196,6 +241,35 @@ class _DownloadLogMixin(_PipelineDBBase):
             self._overlay_evidence_onto_download_log_row(dict(r))
             for r in cur.fetchall()
         ]
+
+
+    def get_linked_import_logs(
+        self,
+        source_log_ids: list[int],
+    ) -> list[dict[str, object]]:
+        """Fetch mutating successors for an explicit set of audit rows.
+
+        Recents filters select the rows which are displayed, but a kept
+        wrong-match row still needs the force/manual import which explicitly
+        links back to it. Fetch those companions independently so changing a
+        filter cannot change the displayed evidence.
+        """
+        if not source_log_ids:
+            return []
+        cur = self._execute(
+            """
+            SELECT dl.*,
+                   origin.beets_distance AS original_beets_distance
+            FROM download_log dl
+            LEFT JOIN download_log origin
+                ON origin.id = dl.source_download_log_id
+            WHERE dl.source_download_log_id = ANY(%s)
+              AND dl.outcome IN ('success', 'force_import', 'manual_import')
+            ORDER BY dl.id DESC
+            """,
+            ([int(log_id) for log_id in source_log_ids],),
+        )
+        return [dict(row) for row in cur.fetchall()]
 
 
     # --- Download logging ---

--- a/tests/fakes/pipeline_db.py
+++ b/tests/fakes/pipeline_db.py
@@ -3421,10 +3421,80 @@ class FakePipelineDB:
                     "search_filetype_override"),
                 "request_source": req.get("source"),
             })
+            current_evidence_id = req.get("current_evidence_id")
+            current_evidence = (
+                self._evidence_by_id.get(int(current_evidence_id))
+                if current_evidence_id is not None else None
+            )
+            current_measurement = (
+                current_evidence.measurement
+                if current_evidence is not None else None
+            )
+            current_v0 = (
+                current_evidence.v0_metric
+                if current_evidence is not None else None
+            )
+            joined.update({
+                "_current_evidence_id": (
+                    current_evidence.id if current_evidence is not None else None
+                ),
+                "_current_evidence_is_pre_attempt": (
+                    current_evidence.measured_at <= entry.created_at
+                    if current_evidence is not None else None
+                ),
+                "_current_evidence_format": (
+                    current_measurement.format
+                    if current_measurement is not None else None
+                ),
+                "_current_evidence_min_bitrate": (
+                    current_measurement.min_bitrate_kbps
+                    if current_measurement is not None else None
+                ),
+                "_current_evidence_avg_bitrate": (
+                    current_measurement.avg_bitrate_kbps
+                    if current_measurement is not None else None
+                ),
+                "_current_evidence_median_bitrate": (
+                    current_measurement.median_bitrate_kbps
+                    if current_measurement is not None else None
+                ),
+                "_current_evidence_spectral_grade": (
+                    current_measurement.spectral_grade
+                    if current_measurement is not None else None
+                ),
+                "_current_evidence_spectral_bitrate": (
+                    current_measurement.spectral_bitrate_kbps
+                    if current_measurement is not None else None
+                ),
+                "_current_evidence_v0_probe_kind": (
+                    current_v0.source_lineage if current_v0 is not None else None
+                ),
+                "_current_evidence_v0_probe_min_bitrate": (
+                    current_v0.min_bitrate_kbps if current_v0 is not None else None
+                ),
+                "_current_evidence_v0_probe_avg_bitrate": (
+                    current_v0.avg_bitrate_kbps if current_v0 is not None else None
+                ),
+                "_current_evidence_v0_probe_median_bitrate": (
+                    current_v0.median_bitrate_kbps if current_v0 is not None else None
+                ),
+            })
             rows.append(joined)
             if len(rows) >= limit:
                 break
         return rows
+
+    def get_linked_import_logs(
+        self,
+        source_log_ids: list[int],
+    ) -> list[dict[str, object]]:
+        wanted = {int(log_id) for log_id in source_log_ids}
+        return [
+            self._download_log_to_dict(entry)
+            for entry in reversed(self.download_logs)
+            if entry.source_download_log_id in wanted
+            and entry.outcome in ("success", "force_import", "manual_import")
+        ]
 
     def get_by_status(
         self,

--- a/tests/read_projection_registry.py
+++ b/tests/read_projection_registry.py
@@ -269,6 +269,19 @@ def _seed_get_log(db: Any) -> "list[dict[str, Any]]":
     return list(db.get_log())
 
 
+def _seed_get_linked_import_logs(db: Any) -> "list[dict[str, Any]]":
+    rid = db.add_request(
+        "Parity Artist", "Parity Album", "request",
+        mb_release_id="linked-import-log-parity")
+    source_id = db.log_download(rid, outcome="rejected")
+    db.log_download(
+        rid,
+        outcome="force_import",
+        source_download_log_id=source_id,
+    )
+    return list(db.get_linked_import_logs([source_id]))
+
+
 # --- search_log projections -----------------------------------------------
 
 def _seed_get_search_history(db: Any) -> "list[dict[str, Any]]":
@@ -450,6 +463,7 @@ PARITY_REGISTRY: "dict[str, Seeder]" = {
     "get_download_history_batch": _seed_get_download_history_batch,
     "get_latest_download_summaries": _seed_get_latest_download_summaries,
     "get_log": _seed_get_log,
+    "get_linked_import_logs": _seed_get_linked_import_logs,
     # search_log projections.
     "get_search_history": _seed_get_search_history,
     "get_search_history_page": _seed_get_search_history_page,

--- a/tests/test_js_history.mjs
+++ b/tests/test_js_history.mjs
@@ -565,8 +565,9 @@ console.log('renderEvidenceStrip() renders canonical candidate evidence as ordin
     source_median_bitrate: 255,
   });
   assertContains(strip, '>IN</strong>', 'historical triage evidence keeps the normal IN row');
-  assertContains(strip, '>MP3 V2</span>', 'candidate evidence supplies the source label');
-  assertContains(strip, '>min 201k</span>', 'candidate evidence supplies the source minimum');
+  assertContains(strip, '>MP3</span>', 'candidate evidence supplies the source codec');
+  assertContains(strip, '>259k avg (min 201k)</span>',
+    'candidate evidence supplies its average and minimum');
 }
 
 console.log('renderEvidenceStrip() returns empty string when no evidence exists');
@@ -610,6 +611,21 @@ console.log('renderEvidenceStrip() shows the on-disk format on the HAVE side');
   });
   assertContains(strip, '>MP3</span>', 'HAVE side leads with the on-disk format');
   assertContains(strip, '>min 256k</span>', 'HAVE bitrate stays min-labelled in its shared slot');
+}
+
+console.log('renderEvidenceStrip() renders a supplied pre-attempt HAVE snapshot');
+{
+  // Historical renderers receive only the evidence that belonged to the
+  // attempt; a later current-library snapshot must never be projected here.
+  const strip = renderEvidenceFixture({
+    source_format: 'FLAC',
+    source_min_bitrate: 455,
+    source_avg_bitrate: 725,
+    existing_format: 'Opus',
+    existing_min_bitrate: 93,
+  });
+  assertContains(strip, '>Opus</span>', 'pre-attempt format populates HAVE');
+  assertContains(strip, '>min 93k</span>', 'pre-attempt minimum populates HAVE');
 }
 
 console.log('renderDownloadHistoryItem() does not infer output from legacy min fields');
@@ -720,10 +736,14 @@ console.log('renderEvidenceStrip() renders the persisted comparison basis when p
       verified_lossless_bypass: false,
     },
   });
-  assertContains(strip, 'avg 288k', 'IN side shows the deciding avg');
-  assertContains(strip, 'transparent', 'IN side shows the rank');
-  assertContains(strip, 'avg 196k', 'HAVE side shows the deciding avg');
-  assertContains(strip, 'good', 'HAVE side shows the rank');
+  assertContains(strip, '288k avg (min 194k)',
+    'IN side shows the deciding average and actual minimum');
+  assertExcludes(strip, '>transparent</span>',
+    'compact IN leaves decision ranks to the expanded detail');
+  assertContains(strip, '196k avg (min 194k)',
+    'HAVE side shows the deciding average and actual minimum');
+  assertExcludes(strip, '>good</span>',
+    'compact HAVE leaves decision ranks to the expanded detail');
   assertContains(strip, 'genuine', 'spectral grade chip survives');
   assertContains(strip, '~160k genuine',
     'ordinary avg basis does not suppress a distinct spectral floor');
@@ -746,6 +766,7 @@ console.log('renderEvidenceStrip() renders the persisted comparison basis when p
 console.log('Gas: contract, V0 proof, and materialized Opus output stay distinct');
 {
   const strip = renderEvidenceFixture({
+    outcome: 'force_import',
     downloaded_label: 'FLAC → OPUS 128',
     source_format: 'FLAC',
     source_min_bitrate: 742,
@@ -781,12 +802,26 @@ console.log('Gas: contract, V0 proof, and materialized Opus output stay distinct
       verified_lossless_bypass: false,
     },
   });
-  assertContains(strip, '>FLAC</span>', 'collapsed strip names only the measured source codec');
-  assertExcludes(strip, 'FLAC →', 'collapsed source does not imply a source-to-target measurement');
+  assertContains(strip, '>FLAC - Opus</span>',
+    'IN suffixes the source codec with the selected storage codec');
+  assertContains(strip, '>132k avg (min 102k)</span>',
+    'IN metric stays numeric so it aligns with HAVE');
+  assertExcludes(strip, 'FLAC →', 'collapsed source uses the compact suffix grammar');
   assertExcludes(strip, 'OPUS 128 contract',
     'target contract remains in expanded details instead of the source strip');
-  assertExcludes(strip, 'actual OPUS avg 132k (min 102k)',
-    'materialized output remains in expanded details instead of the source strip');
+  assertContains(strip, '>MP3</span>',
+    'HAVE names the pre-import codec');
+  assertContains(strip, '>128k avg (min 128k)</span>',
+    'HAVE uses the pre-import measurement');
+  const outputCount = strip.split('132k avg (min 102k)').length - 1;
+  if (outputCount === 1) { passed++; } else {
+    failed++;
+    console.error(`  FAIL: materialized output belongs only to IN; rendered ${outputCount} times`);
+  }
+  assertExcludes(strip, '>transparent</span>',
+    'compact HAVE never substitutes a decision rank for measured spectral data');
+  assertContains(strip, '~128k suspect',
+    'HAVE keeps the existing spectral measurement after conversion');
   assertContains(strip, 'V0 224k avg', 'source V0 proof remains explicit');
   assertExcludes(strip, 'OPUS 128 min 191k', 'V0 minimum never wears an Opus label');
 
@@ -843,6 +878,273 @@ console.log('Gas: contract, V0 proof, and materialized Opus output stay distinct
   assertExcludes(detail, '>Min bitrate<', 'ambiguous unqualified row is gone');
 }
 
+console.log('Amaterasu Shiroi: force import HAVE stays pre-import');
+{
+  const strip = renderEvidenceFixture({
+    outcome: 'force_import',
+    source_format: 'FLAC',
+    source_min_bitrate: 529,
+    source_avg_bitrate: 648,
+    source_median_bitrate: 642,
+    target_contract_format: 'opus 128',
+    was_converted: true,
+    spectral_grade: 'likely_transcode',
+    spectral_bitrate: 96,
+    v0_probe_kind: 'lossless_source_v0',
+    v0_probe_min_bitrate: 246,
+    v0_probe_avg_bitrate: 258,
+    materialized_format: 'Opus',
+    materialized_min_bitrate: 118,
+    materialized_avg_bitrate: 124,
+    materialized_median_bitrate: 122,
+    existing_format: 'Opus',
+    existing_min_bitrate: 90,
+    existing_avg_bitrate: 101,
+    existing_median_bitrate: 99,
+    existing_spectral_grade: 'suspect',
+    existing_spectral_bitrate: 80,
+    existing_v0_probe_kind: 'lossless_source_v0',
+    existing_v0_probe_min_bitrate: 201,
+    existing_v0_probe_avg_bitrate: 220,
+    comparison_basis: {
+      verdict: 'better', branch: 'rank',
+      new_rank: 'transparent', existing_rank: 'excellent',
+      new_metric: 'contract', existing_metric: 'avg',
+      new_value_kbps: 128, existing_value_kbps: 96,
+      new_format: 'opus 128', existing_format: 'opus',
+      spectral_clamped: true, tolerance_kbps: null,
+      verified_lossless_bypass: false,
+    },
+  });
+  assertContains(strip, '>FLAC - Opus</span>',
+    'IN keeps the downloaded source and suffixes its storage codec');
+  assertContains(strip, '>124k avg (min 118k)</span>',
+    'IN metric contains only measured output bytes');
+  assertContains(strip, '~96k likely transcode', 'IN keeps source spectral evidence');
+  assertContains(strip, 'V0 258k avg (min 246k)', 'IN keeps its source V0 probe');
+  assertContains(strip, '>OPUS</span>', 'HAVE names the pre-import copy');
+  assertContains(strip, '>101k avg (min 90k)</span>',
+    'HAVE is populated from pre-import bytes');
+  assertExcludes(strip, '>transparent</span>',
+    'HAVE does not substitute the decision rank for spectral data');
+  assertExcludes(strip, '>excellent</span>', 'decision rank stays out of compact HAVE');
+  const spectralCount = strip.split('~96k likely transcode').length - 1;
+  if (spectralCount === 1) { passed++; } else {
+    failed++;
+    console.error(`  FAIL: candidate spectral belongs only to IN; rendered ${spectralCount} times`);
+  }
+  const v0Count = strip.split('V0 258k avg (min 246k)').length - 1;
+  if (v0Count === 1) { passed++; } else {
+    failed++;
+    console.error(`  FAIL: candidate V0 belongs only to IN; rendered ${v0Count} times`);
+  }
+  assertContains(strip, '~80k suspect', 'HAVE keeps its own spectral snapshot');
+  assertContains(strip, 'V0 220k avg (min 201k)', 'HAVE keeps its own V0 snapshot');
+}
+
+console.log('Absentee Schmotime: an upgrade keeps the pre-import copy in HAVE');
+{
+  // Live issue #709 regression: the converted output belongs to IN, while
+  // HAVE remains the MP3 snapshot which the upgrade decision replaced.
+  const strip = renderEvidenceFixture({
+    outcome: 'success',
+    badge: 'Upgraded',
+    source_format: 'FLAC',
+    source_min_bitrate: 863,
+    source_avg_bitrate: 967,
+    source_median_bitrate: 950,
+    target_contract_format: 'opus 128',
+    was_converted: true,
+    spectral_grade: 'genuine',
+    v0_probe_kind: 'lossless_source_v0',
+    v0_probe_min_bitrate: 258,
+    v0_probe_avg_bitrate: 268,
+    materialized_format: 'Opus',
+    materialized_min_bitrate: 127,
+    materialized_avg_bitrate: 136,
+    materialized_median_bitrate: 134,
+    existing_format: 'MP3',
+    existing_min_bitrate: 320,
+    existing_avg_bitrate: 320,
+    existing_median_bitrate: 320,
+    existing_spectral_grade: 'genuine',
+    existing_v0_probe_kind: 'native_lossy_research_v0',
+    existing_v0_probe_min_bitrate: 258,
+    existing_v0_probe_avg_bitrate: 268,
+    comparison_basis: {
+      verdict: 'equivalent', branch: 'cross_family_same_rank',
+      new_rank: 'transparent', existing_rank: 'transparent',
+      new_metric: 'contract', existing_metric: 'avg',
+      new_value_kbps: 128, existing_value_kbps: 320,
+      new_format: 'opus 128', existing_format: 'mp3',
+      spectral_clamped: false, tolerance_kbps: null,
+      verified_lossless_bypass: true,
+    },
+  });
+  assertContains(strip, '>FLAC - Opus</span>', 'IN names the converted source');
+  assertContains(strip, '>136k avg (min 127k)</span>', 'IN uses measured Opus output');
+  assertContains(strip, '>MP3</span>', 'HAVE keeps the pre-import codec');
+  assertContains(strip, '>320k avg (min 320k)</span>',
+    'HAVE keeps the pre-import bitrate snapshot');
+  assertExcludes(strip, '>transparent</span>',
+    'compact upgrade leaves the internal rank in expanded detail');
+  const incomingMetricCount = strip.split('136k avg (min 127k)').length - 1;
+  if (incomingMetricCount === 1) { passed++; } else {
+    failed++;
+    console.error(`  FAIL: incoming output must appear once; rendered ${incomingMetricCount} times`);
+  }
+}
+
+console.log('every attempted import keeps materialized IN separate from historical HAVE');
+{
+  for (const [outcome, badge] of [
+    ['success', 'Upgraded'],
+    ['success', 'Provisional'],
+    ['force_import', 'Force imported'],
+    ['manual_import', 'Imported'],
+  ]) {
+    for (const storage of ['Opus', 'MP3']) {
+      for (const existing of ['MP3', 'AAC', 'Opus']) {
+        for (const offset of [0, 37, 149]) {
+        const incomingAvg = 121 + offset;
+        const incomingMin = 101 + offset;
+        const existingAvg = 211 + offset;
+        const existingMin = 191 + offset;
+        const strip = renderEvidenceFixture({
+          outcome, badge, was_converted: true,
+          source_format: 'FLAC', target_contract_format: storage === 'Opus'
+            ? 'opus 128' : 'mp3 v0',
+          materialized_format: storage,
+          materialized_avg_bitrate: incomingAvg,
+          materialized_min_bitrate: incomingMin,
+          existing_format: existing,
+          existing_avg_bitrate: existingAvg,
+          existing_min_bitrate: existingMin,
+        });
+        assertContains(strip, `>${existing}</span>`,
+          'generated upgrade HAVE keeps its pre-import codec');
+        assertContains(strip, `>${existingAvg}k avg (min ${existingMin}k)</span>`,
+          'generated upgrade HAVE keeps its pre-import measurements');
+        const incomingCount = strip.split(`${incomingAvg}k avg (min ${incomingMin}k)`).length - 1;
+        if (incomingCount === 1) { passed++; } else {
+          failed++;
+          console.error(`  FAIL: attempted output bled into HAVE (${outcome}/${storage}/${existing}/${offset})`);
+        }
+        }
+      }
+    }
+  }
+}
+
+console.log('Forty Days: provisional HAVE stays the comparable on-disk copy');
+{
+  // Live issue #709 regression: a provisional candidate has a materialized
+  // output measurement, but HAVE must remain the pre-attempt library snapshot
+  // used by the decision so every IN field compares top-to-bottom.
+  const strip = renderEvidenceFixture({
+    outcome: 'success',
+    badge: 'Provisional',
+    source_format: 'FLAC',
+    source_min_bitrate: 485,
+    source_avg_bitrate: 600,
+    source_median_bitrate: 618,
+    target_contract_format: 'opus 128',
+    was_converted: true,
+    spectral_grade: 'likely_transcode',
+    spectral_bitrate: 96,
+    v0_probe_kind: 'lossless_source_v0',
+    v0_probe_min_bitrate: 200,
+    v0_probe_avg_bitrate: 223,
+    existing_format: 'Opus',
+    existing_min_bitrate: 103,
+    existing_avg_bitrate: 113,
+    existing_median_bitrate: 114,
+    existing_spectral_grade: 'likely_transcode',
+    existing_spectral_bitrate: 96,
+    existing_v0_probe_kind: 'lossless_source_v0',
+    existing_v0_probe_min_bitrate: 173,
+    existing_v0_probe_avg_bitrate: 207,
+    materialized_format: 'Opus',
+    materialized_min_bitrate: 106,
+    materialized_avg_bitrate: 122,
+  });
+  assertContains(strip, '>FLAC - Opus</span>',
+    'IN names the provisional source and selected storage codec');
+  assertContains(strip, '>122k avg (min 106k)</span>',
+    'IN metric contains only the measured provisional result');
+  assertContains(strip, 'V0 223k avg (min 200k)', 'IN keeps source V0 evidence');
+  assertContains(strip, '>Opus</span>', 'HAVE names the comparable library copy');
+  assertContains(strip, '>113k avg (min 103k)</span>',
+    'HAVE reports average and minimum for the pre-attempt copy');
+  assertContains(strip, '~96k likely transcode', 'HAVE keeps spectral evidence');
+  assertContains(strip, 'V0 207k avg (min 173k)', 'HAVE keeps its V0 probe');
+  assertExcludes(strip, 'avg 122k (min 106k)',
+    'candidate output does not replace provisional comparison evidence');
+}
+
+console.log('Actual Life 3: current canonical evidence fully populates triage HAVE');
+{
+  const strip = renderEvidenceFixture({
+    outcome: 'rejected',
+    badge: 'Triaged · deleted',
+    source_format: 'FLAC',
+    source_min_bitrate: 455,
+    source_avg_bitrate: 725,
+    spectral_grade: 'likely_transcode',
+    spectral_bitrate: 96,
+    v0_probe_kind: 'lossless_source_v0',
+    v0_probe_min_bitrate: 178,
+    v0_probe_avg_bitrate: 248,
+    existing_format: 'Opus',
+    existing_min_bitrate: 93,
+    existing_avg_bitrate: 129,
+    existing_spectral_grade: 'suspect',
+    existing_spectral_bitrate: 96,
+    existing_v0_probe_kind: 'lossless_source_v0',
+    existing_v0_probe_min_bitrate: 193,
+    existing_v0_probe_avg_bitrate: 256,
+  });
+  assertContains(strip, '>FLAC</span>', 'retained lossless keeps the bare source label');
+  assertContains(strip, '>725k avg (min 455k)</span>',
+    'retained lossless metric reports average plus minimum');
+  assertContains(strip, '>Opus</span>', 'triage HAVE names the current copy');
+  assertContains(strip, '>129k avg (min 93k)</span>',
+    'triage HAVE reports average plus minimum');
+  assertContains(strip, '~96k suspect', 'triage HAVE keeps current spectral evidence');
+  assertContains(strip, 'V0 256k avg (min 193k)',
+    'triage HAVE keeps the canonical current V0 probe');
+}
+
+console.log('lossless storage labels distinguish V0 from retained FLAC');
+{
+  const v0 = renderEvidenceFixture({
+    outcome: 'success', badge: 'Imported', was_converted: true,
+    source_format: 'FLAC', source_min_bitrate: 600, source_avg_bitrate: 800,
+    target_contract_format: 'mp3 v0',
+    materialized_format: 'MP3', materialized_min_bitrate: 220,
+    materialized_avg_bitrate: 245,
+  });
+  assertContains(v0, '>FLAC - V0</span>',
+    'V0 target is suffixed to the lossless source label');
+  assertContains(v0, '>245k avg (min 220k)</span>',
+    'V0 target leaves the metric column numeric');
+  const newImportMetricCount = v0.split('245k avg (min 220k)').length - 1;
+  if (newImportMetricCount === 1) { passed++; } else {
+    failed++;
+    console.error(`  FAIL: first import must leave HAVE empty; output rendered ${newImportMetricCount} times`);
+  }
+  assertContains(v0, '>—</span>',
+    'first import makes the absent pre-import HAVE explicit');
+
+  const flac = renderEvidenceFixture({
+    outcome: 'success', badge: 'New', was_converted: false,
+    source_format: 'FLAC', source_min_bitrate: 455, source_avg_bitrate: 725,
+  });
+  assertContains(flac, '>FLAC</span>', 'retained FLAC target keeps the bare codec label');
+  assertContains(flac, '>725k avg (min 455k)</span>',
+    'retained FLAC metric contains only its actual bytes');
+}
+
 console.log('Iron & Wine: the temporary V0 minimum never wears the FLAC label');
 {
   const strip = renderEvidenceFixture({
@@ -868,8 +1170,8 @@ console.log('Iron & Wine: the temporary V0 minimum never wears the FLAC label');
   assertContains(strip, '>FLAC</span>', 'source remains labelled FLAC');
   assertExcludes(strip, '>min 165k</span>', 'V0 minimum is not a FLAC measurement');
   assertContains(strip, 'V0 171k avg (min 165k)', 'candidate V0 owns its minimum');
-  assertContains(strip, '>Opus</span>', 'materialized existing Opus keeps its codec slot');
-  assertContains(strip, '>min 114k</span>', 'materialized existing Opus keeps its real floor');
+  assertContains(strip, '>Opus</span>', 'pre-attempt existing Opus keeps its codec slot');
+  assertContains(strip, '>min 114k</span>', 'pre-attempt existing Opus keeps its real floor');
   assertContains(strip, 'V0 232k avg (min 223k)', 'existing source V0 owns its minimum');
 
   const detail = renderDownloadHistoryFixture({
@@ -895,8 +1197,8 @@ console.log('evidence strip CSS preserves shared desktop/mobile alignment withou
   const css = readFileSync(new URL('../web/index.html', import.meta.url), 'utf8');
   assertContains(css, '.r-ev-row { display: contents; }',
     'row wrappers participate in the parent grid instead of defining independent columns');
-  assertContains(css, 'grid-template-columns: 3.6em minmax(4.5em, 1.05fr) minmax(5.5em, 1fr) minmax(4.5em, 0.85fr) minmax(6.5em, 1fr) minmax(8em, 1.35fr)',
-    'label/source/metric/rank/spectral/V0 use six shared columns');
+  assertContains(css, 'grid-template-columns: 3.6em minmax(4.5em, 0.8fr) minmax(12em, 1.7fr) minmax(4.5em, 0.75fr) minmax(7.5em, 1fr) minmax(9em, 1.35fr)',
+    'desktop reserves a full avg/min metric column before rank/spectral/V0');
   assertContains(css, '@media (max-width: 720px)', 'shared grid has a narrow-screen layout');
   assertContains(css, 'grid-template-columns: 4.3em minmax(5em, 0.8fr) minmax(0, 1.8fr)',
     'mobile uses a readable tag/source/detail three-column grid');
@@ -908,8 +1210,8 @@ console.log('evidence strip CSS preserves shared desktop/mobile alignment withou
     'IN/HAVE spans every row without touching source text');
   assertContains(css, '.r-ev-source { grid-column: 2; grid-row: 1; }',
     'source owns the first aligned field slot');
-  assertContains(css, '.r-ev-metric { grid-column: 3; grid-row: 1; }',
-    'metric owns the first aligned detail slot');
+  assertContains(css, '.r-ev-metric { grid-column: 3; grid-row: 1; white-space: normal; }',
+    'mobile metric owns the first detail slot and can wrap at spaces');
   assertContains(css, '.r-ev-rank { grid-column: 2; grid-row: 2; }',
     'rank owns the second aligned field slot');
   assertContains(css, '.r-ev-spectral { grid-column: 3; grid-row: 2; white-space: normal; }',
@@ -918,6 +1220,10 @@ console.log('evidence strip CSS preserves shared desktop/mobile alignment withou
     'mobile V0 provenance uses a full-width third row');
   assertContains(css, '.r-evidence .r-ev-tag { color: #d3deea; font-weight: 900; font-size: 1.08em;',
     'IN/HAVE labels are visibly prominent');
+  assertContains(css, '@media (min-width: 721px) { .r-ev-v0 { padding-left: 1em; } }',
+    'desktop V0 keeps a visible gutter after long spectral labels');
+  assertContains(css, '.recents-triage-label { color: #d66; font-weight: 600; }',
+    'secondary triage annotations stay rejection-coloured');
   assertExcludes(css, '.r-ev-cell { min-width: 0; overflow-wrap: anywhere;',
     'evidence tokens never use arbitrary mid-word wrapping');
   assertExcludes(css, 'repeat(5, minmax(0, 1fr))',

--- a/tests/test_js_recents.mjs
+++ b/tests/test_js_recents.mjs
@@ -346,7 +346,7 @@ console.log('renderRecentsItems() uses the main badge for deleted triage');
     album_title: 'For Screening Purposes Only',
     artist_name: 'Test Icicles',
     badge: 'Triaged · deleted',
-    badge_class: 'badge-library',
+    badge_class: 'badge-rejected',
     border_color: '#a33',
     summary: 'Wrong match (dist 0.190) · moundsofass',
     wrong_match_triage_summary: 'deleted: spectral reject',
@@ -356,10 +356,33 @@ console.log('renderRecentsItems() uses the main badge for deleted triage');
     'original wrong-match summary remains visible');
   assertContains(html, 'Triaged · deleted',
     'deleted triage is the primary row badge');
+  assertContains(html, 'badge badge-rejected',
+    'deleted triage remains visually rejected');
   assertExcludes(html, 'recents-triage-label',
     'deleted triage does not render a second competing status label');
   assertContains(html, 'mp3_spectral:reject',
     'triage detail appears in hover text');
+}
+
+console.log('renderRecentsItems() uses an amber main badge for kept triage');
+{
+  const html = renderRecentsFixture([{
+    id: 726,
+    request_id: 802,
+    created_at: '2026-07-14T18:36:33+00:00',
+    album_title: 'Amaterasu Shiroi',
+    artist_name: 'Eldar',
+    badge: 'Triaged · kept',
+    badge_class: 'badge-warn',
+    border_color: '#a33',
+    summary: 'Wrong match (dist 0.233) · R@v@scholl',
+    wrong_match_triage_summary: 'kept: would import',
+    wrong_match_triage_detail: 'action: kept would import',
+  }]);
+  assertContains(html, 'Triaged · kept', 'kept triage is the primary row badge');
+  assertContains(html, 'badge badge-warn', 'kept triage uses the amber badge class');
+  assertExcludes(html, 'recents-triage-label',
+    'kept triage does not render a second competing status label');
 }
 
 console.log('renderRecentsItems() escapes wrong-match triage chip fields');

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -2231,6 +2231,42 @@ class TestDownloadLog(unittest.TestCase):
         self.assertAlmostEqual(
             cast(float, recent[force_id]["original_beets_distance"]), 0.2328)
 
+    def test_linked_import_logs_ignore_recents_outcome_filter(self):
+        source_id = self.db.log_download(
+            self.req_id,
+            "source-peer",
+            "flac",
+            "/failed/source",
+            outcome="rejected",
+            validation_result=json.dumps({
+                "scenario": "high_distance",
+                "distance": 0.2328,
+            }),
+        )
+        linked_id = self.db.log_download(
+            self.req_id,
+            "source-peer",
+            "flac",
+            "/failed/source",
+            outcome="force_import",
+            source_download_log_id=source_id,
+        )
+        self.db.log_download(
+            self.req_id,
+            "unrelated-peer",
+            "mp3",
+            "/Incoming/A/B",
+            outcome="success",
+        )
+
+        linked = self.db.get_linked_import_logs([source_id])
+
+        self.assertEqual([row["id"] for row in linked], [linked_id])
+        self.assertEqual(linked[0]["source_download_log_id"], source_id)
+        self.assertAlmostEqual(
+            cast(float, linked[0]["original_beets_distance"]), 0.2328
+        )
+
     def test_candidate_evidence_source_overlay_is_consistent_across_reads(self):
         from lib.quality import AudioQualityMeasurement
 

--- a/tests/test_replaced_write_audit.py
+++ b/tests/test_replaced_write_audit.py
@@ -84,16 +84,16 @@ _REVIEWED_DYNAMIC_SQL_CALLS: dict[tuple[str, int, str], str] = {
     ("lib/pipeline_db/dashboard.py", 481, "5e3b8177198ccbed"): (
         "dashboard WHERE and ORDER fragments come from closed enum branches"
     ),
-    ("lib/pipeline_db/download_log.py", 660, "a4d9b82e27a004bb"): (
+    ("lib/pipeline_db/download_log.py", 734, "a4d9b82e27a004bb"): (
         "validation key is selected from a closed server-owned vocabulary"
     ),
-    ("lib/pipeline_db/download_log.py", 712, "e0154e89026dc8ef"): (
+    ("lib/pipeline_db/download_log.py", 786, "e0154e89026dc8ef"): (
         "validation key is selected from a closed server-owned vocabulary"
     ),
-    ("lib/pipeline_db/download_log.py", 730, "1ca75e0c21fa6d7e"): (
+    ("lib/pipeline_db/download_log.py", 804, "1ca75e0c21fa6d7e"): (
         "validation key is closed vocabulary and IN list is value placeholders"
     ),
-    ("lib/pipeline_db/download_log.py", 747, "d87a36ba1d1768e7"): (
+    ("lib/pipeline_db/download_log.py", 821, "d87a36ba1d1768e7"): (
         "JSON path key is selected from a closed server-owned vocabulary"
     ),
     ("lib/pipeline_db/import_jobs.py", 105, "ecf3d1844c67f653"): (
@@ -161,7 +161,7 @@ _REVIEWED_STATUS_SQL_CALLS: dict[tuple[str, int, str], str] = {
     ("lib/pipeline_db/terminal_outcomes.py", 299, "0a9c4396d1185b94"): (
         "atomic terminal typed transition CASes the source status selected by the DAG"
     ),
-    ("lib/pipeline_db/download_log.py", 329, "b04c5ae9eb3423c1"): (
+    ("lib/pipeline_db/download_log.py", 403, "b04c5ae9eb3423c1"): (
         "atomic abandoned-import recovery performs downloading-to-wanted CAS"
     ),
     ("lib/pipeline_db/requests.py", 245, "558917722283199d"): (

--- a/tests/test_web_recents.py
+++ b/tests/test_web_recents.py
@@ -344,7 +344,8 @@ class TestClassifyWrongMatchTriageAudit(unittest.TestCase):
         }))
 
         self.assertEqual(result.badge, "Triaged · deleted")
-        self.assertEqual(result.badge_class, "badge-library")
+        self.assertEqual(result.badge_class, "badge-rejected")
+        self.assertEqual(result.border_color, "#a33")
         self.assertEqual(result.verdict, "Wrong match (dist 0.190)")
         self.assertEqual(result.summary,
                          "Wrong match (dist 0.190) · moundsofass")
@@ -425,6 +426,7 @@ class TestClassifyWrongMatchTriageAudit(unittest.TestCase):
         self.assertEqual(result.source_avg_bitrate, 320)
         self.assertEqual(result.existing_format, "MP3")
         self.assertEqual(result.existing_min_bitrate, 320)
+        self.assertEqual(result.existing_avg_bitrate, 320)
         self.assertEqual(result.spectral_grade, "likely_transcode")
         self.assertEqual(result.v0_probe_avg_bitrate, 259)
         self.assertEqual(result.existing_v0_probe_kind,
@@ -441,7 +443,9 @@ class TestClassifyWrongMatchTriageAudit(unittest.TestCase):
             "stage_chain": ["stage2_import:import"],
         }))
 
-        self.assertEqual(result.badge, "Rejected")
+        self.assertEqual(result.badge, "Triaged · kept")
+        self.assertEqual(result.badge_class, "badge-warn")
+        self.assertEqual(result.border_color, "#a33")
         self.assertEqual(result.wrong_match_triage_action, "kept_would_import")
         self.assertIn("kept", result.wrong_match_triage_summary or "")
         self.assertIn("import", result.wrong_match_triage_summary or "")
@@ -2077,8 +2081,45 @@ class TestClassifyComparisonBasis(unittest.TestCase):
         c = classify_log_entry(entry)
         self.assertEqual(
             c.verdict,
-            "Equivalent: MP3 avg 250k vs avg 248k (within 5k)"
-            " — imported: verified lossless")
+            "Upgrade: MP3 V0 to MP3 V0, verified lossless")
+
+    def test_schmotime_verified_lossless_upgrade_restores_concise_copy(self):
+        entry = _entry(
+            outcome="success",
+            was_converted=True,
+            original_filetype="flac",
+            actual_filetype="opus",
+            actual_min_bitrate=127,
+            existing_min_bitrate=320,
+            spectral_grade="genuine",
+            soulseek_username="trelospatrinos",
+            import_result={
+                "version": 2,
+                "decision": "import",
+                "comparison_basis": {
+                    "verdict": "equivalent",
+                    "branch": "cross_family_same_rank",
+                    "new_rank": "transparent",
+                    "existing_rank": "transparent",
+                    "new_metric": "contract",
+                    "existing_metric": "avg",
+                    "new_value_kbps": 128,
+                    "existing_value_kbps": 320,
+                    "new_format": "opus 128",
+                    "existing_format": "mp3",
+                    "spectral_clamped": False,
+                    "tolerance_kbps": None,
+                    "verified_lossless_bypass": True,
+                },
+            },
+        )
+        result = classify_log_entry(entry)
+        self.assertEqual(result.badge, "Upgraded")
+        self.assertEqual(
+            result.summary,
+            "Upgrade: MP3 320 to OPUS 127k, from FLAC, verified lossless"
+            " · trelospatrinos",
+        )
 
     def test_flac_conversion_suffixes_survive_basis_path(self):
         basis = self._basis_dict(self._SAY_HELLO_NEW, self._SAY_HELLO_EXISTING)

--- a/tests/test_web_recents_generated.py
+++ b/tests/test_web_recents_generated.py
@@ -9,6 +9,10 @@ from hypothesis import example, given, strategies as st
 import tests._hypothesis_profiles  # noqa: F401
 from tests.test_web_recents import _entry
 from web.classify import classify_log_entry
+from web.routes.pipeline import (
+    _project_current_library_have,
+    _project_linked_import_evidence,
+)
 
 
 REJECT_SCENARIOS = (
@@ -36,6 +40,75 @@ def assert_triage_summary_uses_persisted_reject(
         raise AssertionError("triage summary lost persisted reject reason")
     if "spectral reject" in summary:
         raise AssertionError("non-reject spectral stage became a spectral reject")
+
+
+def assert_triaged_rejection_style(
+    action: str,
+    badge: str,
+    badge_class: str,
+    border_color: str,
+) -> None:
+    if border_color != "#a33":
+        raise AssertionError("triaged rejection lost its rejected row border")
+    if action.startswith("deleted_"):
+        if badge != "Triaged · deleted" or badge_class != "badge-rejected":
+            raise AssertionError("triaged deletion was styled as a successful library outcome")
+    elif action.startswith("kept_"):
+        if badge != "Triaged · kept" or badge_class != "badge-warn":
+            raise AssertionError("kept triage lost its primary amber badge")
+    elif badge_class != "badge-rejected":
+        raise AssertionError("triaged rejection lost its rejected badge")
+
+
+def assert_current_library_have_is_projected(
+    item: dict[str, object],
+    *,
+    expected_format: str | None,
+    expected_min: int | None,
+    expected_avg: int | None,
+    expected_median: int | None,
+) -> None:
+    if item.get("existing_format") != expected_format:
+        raise AssertionError("current library format did not populate compact HAVE")
+    if item.get("existing_min_bitrate") != expected_min:
+        raise AssertionError("current library minimum did not populate compact HAVE")
+    if item.get("existing_avg_bitrate") != expected_avg:
+        raise AssertionError("current library average did not populate compact HAVE")
+    if item.get("existing_median_bitrate") != expected_median:
+        raise AssertionError("current library median did not populate compact HAVE")
+
+
+def assert_mutating_attempt_has_no_projected_have(item: dict[str, object]) -> None:
+    if any(item.get(field) is not None for field in (
+        "existing_format",
+        "existing_min_bitrate",
+        "existing_avg_bitrate",
+        "existing_median_bitrate",
+    )):
+        raise AssertionError("post-import current state leaked into attempt HAVE")
+
+
+def assert_only_explicit_source_receives_materialized_output(
+    items: list[dict[str, object]],
+    *,
+    source_id: int,
+    unrelated_id: int,
+    expected_format: str,
+) -> None:
+    by_id = {item["id"]: item for item in items}
+    if by_id[source_id].get("materialized_format") != expected_format:
+        raise AssertionError("explicit source row missed its linked output")
+    if by_id[unrelated_id].get("materialized_format") is not None:
+        raise AssertionError("unrelated same-release row received inferred output")
+
+
+def assert_verified_lossless_upgrade_copy_is_concise(verdict: str) -> None:
+    if "Equivalent:" in verdict or "both transparent" in verdict:
+        raise AssertionError("internal comparison trace leaked into upgrade copy")
+    if not verdict.startswith("Upgrade: "):
+        raise AssertionError("verified-lossless import lost upgrade grammar")
+    if "verified lossless" not in verdict:
+        raise AssertionError("verified-lossless reason disappeared")
 
 
 class TestGeneratedRejectVerdictGrammar(unittest.TestCase):
@@ -110,6 +183,12 @@ class TestGeneratedRejectVerdictGrammar(unittest.TestCase):
             },
         ))
         self.assertEqual(result.badge, "Triaged · deleted")
+        assert_triaged_rejection_style(
+            "deleted_reject",
+            result.badge,
+            result.badge_class,
+            result.border_color,
+        )
         assert_triage_summary_uses_persisted_reject(
             result.wrong_match_triage_summary or "", reason)
 
@@ -117,6 +196,412 @@ class TestGeneratedRejectVerdictGrammar(unittest.TestCase):
         with self.assertRaisesRegex(AssertionError, "persisted reject reason"):
             assert_triage_summary_uses_persisted_reject(
                 "deleted: spectral reject", "suspect_lossless_downgrade")
+
+    def test_triage_style_checker_rejects_the_old_success_style(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "rejected row border"):
+            assert_triaged_rejection_style(
+                "deleted_reject",
+                "Triaged · deleted",
+                "badge-library",
+                "#6a5",
+            )
+
+    def test_triage_style_checker_rejects_the_old_secondary_kept_label(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "primary amber badge"):
+            assert_triaged_rejection_style(
+                "kept_would_import",
+                "Rejected",
+                "badge-rejected",
+                "#a33",
+            )
+
+    @given(action=st.sampled_from((
+        "deleted_reject",
+        "deleted_verified_lossless_parent",
+        "kept_would_import",
+        "kept_uncertain",
+        "skipped_current_evidence_missing",
+    )))
+    @example(action="kept_would_import")
+    def test_every_triaged_rejection_stays_red(self, action: str) -> None:
+        result = classify_log_entry(_entry(
+            outcome="rejected",
+            beets_scenario="high_distance",
+            validation_result={
+                "wrong_match_triage": {
+                    "action": action,
+                    "outcome": action,
+                    "reason": "import",
+                    "preview_verdict": "would_import",
+                    "preview_decision": "import",
+                    "stage_chain": ["stage2_import:import"],
+                },
+            },
+        ))
+        assert_triaged_rejection_style(
+            action,
+            result.badge,
+            result.badge_class,
+            result.border_color,
+        )
+
+    @given(
+        existing_format=st.one_of(st.none(), st.sampled_from(("MP3", "Opus"))),
+        existing_min=st.one_of(st.none(), st.integers(min_value=1, max_value=2_000)),
+        has_attempt_spectral=st.booleans(),
+        current_format=st.sampled_from(("MP3", "Opus", "FLAC")),
+        current_min=st.integers(min_value=1, max_value=2_000),
+    )
+    @example(
+        existing_format=None,
+        existing_min=None,
+        has_attempt_spectral=False,
+        current_format="Opus",
+        current_min=93,
+    )
+    @example(
+        existing_format=None,
+        existing_min=None,
+        has_attempt_spectral=True,
+        current_format="Opus",
+        current_min=99,
+    )
+    def test_unproven_current_library_never_backfills_attempt_have(
+        self,
+        existing_format: str | None,
+        existing_min: int | None,
+        has_attempt_spectral: bool,
+        current_format: str,
+        current_min: int,
+    ) -> None:
+        item: dict[str, object] = {
+            "existing_format": existing_format,
+            "existing_min_bitrate": existing_min,
+            "existing_spectral_grade": (
+                "likely_transcode" if has_attempt_spectral else None
+            ),
+            "existing_spectral_bitrate": 160 if has_attempt_spectral else None,
+        }
+        _project_current_library_have(item, {}, {
+            "beets_format": current_format,
+            "beets_bitrate": current_min,
+            "beets_avg_bitrate": current_min + 20,
+        })
+
+        assert_current_library_have_is_projected(
+            item,
+            expected_format=existing_format,
+            expected_min=existing_min,
+            expected_avg=None,
+            expected_median=None,
+        )
+
+    @given(
+        current_format=st.sampled_from(("MP3", "Opus", "FLAC")),
+        current_min=st.integers(min_value=1, max_value=2_000),
+        current_avg=st.integers(min_value=1, max_value=2_000),
+        current_median=st.integers(min_value=1, max_value=2_000),
+        current_spectral=st.one_of(
+            st.none(), st.sampled_from(("genuine", "likely_transcode", "suspect"))
+        ),
+        current_v0=st.one_of(
+            st.none(), st.integers(min_value=1, max_value=2_000)
+        ),
+    )
+    @example(
+        current_format="Opus",
+        current_min=93,
+        current_avg=129,
+        current_median=128,
+        current_spectral="suspect",
+        current_v0=256,
+    )
+    def test_canonical_current_evidence_is_one_complete_have_snapshot(
+        self,
+        current_format: str,
+        current_min: int,
+        current_avg: int,
+        current_median: int,
+        current_spectral: str | None,
+        current_v0: int | None,
+    ) -> None:
+        item: dict[str, object] = {
+            "existing_format": None,
+            "existing_min_bitrate": None,
+            "existing_spectral_grade": None,
+            "existing_spectral_bitrate": None,
+            "existing_v0_probe_kind": None,
+            "existing_v0_probe_min_bitrate": None,
+            "existing_v0_probe_avg_bitrate": None,
+            "existing_v0_probe_median_bitrate": None,
+        }
+        row: dict[str, object] = {
+            "_current_evidence_id": 42,
+            "_current_evidence_is_pre_attempt": True,
+            "_current_evidence_format": current_format,
+            "_current_evidence_min_bitrate": current_min,
+            "_current_evidence_avg_bitrate": current_avg,
+            "_current_evidence_median_bitrate": current_median,
+            "_current_evidence_spectral_grade": current_spectral,
+            "_current_evidence_spectral_bitrate": (
+                96 if current_spectral is not None else None
+            ),
+            "_current_evidence_v0_probe_kind": (
+                "lossless_source" if current_v0 is not None else None
+            ),
+            "_current_evidence_v0_probe_min_bitrate": (
+                current_v0 - 1 if current_v0 is not None else None
+            ),
+            "_current_evidence_v0_probe_avg_bitrate": current_v0,
+            "_current_evidence_v0_probe_median_bitrate": current_v0,
+        }
+        _project_current_library_have(item, row, {
+            "beets_format": "conflicting-beets-format",
+            "beets_bitrate": current_min + 100,
+        })
+
+        assert_current_library_have_is_projected(
+            item,
+            expected_format=current_format,
+            expected_min=current_min,
+            expected_avg=current_avg,
+            expected_median=current_median,
+        )
+        self.assertEqual(item["existing_spectral_grade"], current_spectral)
+        self.assertEqual(item["existing_v0_probe_avg_bitrate"], current_v0)
+
+    @given(
+        is_pre_attempt=st.booleans(),
+        current_format=st.sampled_from(("MP3", "Opus", "FLAC")),
+        current_min=st.integers(min_value=1, max_value=2_000),
+    )
+    @example(
+        is_pre_attempt=False,
+        current_format="Opus",
+        current_min=117,
+    )
+    def test_current_overlay_requires_pre_attempt_timestamp(
+        self,
+        is_pre_attempt: bool,
+        current_format: str,
+        current_min: int,
+    ) -> None:
+        item: dict[str, object] = {
+            "outcome": "rejected",
+            "existing_format": None,
+            "existing_min_bitrate": None,
+            "existing_avg_bitrate": None,
+            "existing_median_bitrate": None,
+        }
+        _project_current_library_have(item, {
+            "_current_evidence_id": 42,
+            "_current_evidence_is_pre_attempt": is_pre_attempt,
+            "_current_evidence_format": current_format,
+            "_current_evidence_min_bitrate": current_min,
+            "_current_evidence_avg_bitrate": current_min + 10,
+            "_current_evidence_median_bitrate": current_min + 5,
+        }, {})
+        if is_pre_attempt:
+            self.assertEqual(item["existing_format"], current_format)
+            self.assertEqual(item["existing_min_bitrate"], current_min)
+        else:
+            assert_mutating_attempt_has_no_projected_have(item)
+
+    @given(
+        outcome=st.sampled_from(("success", "force_import", "manual_import")),
+        current_format=st.sampled_from(("MP3", "Opus", "FLAC")),
+        current_min=st.integers(min_value=1, max_value=2_000),
+        current_avg=st.integers(min_value=1, max_value=2_000),
+    )
+    @example(
+        outcome="success",
+        current_format="Opus",
+        current_min=117,
+        current_avg=131,
+    )
+    def test_mutating_attempt_never_projects_current_state_into_have(
+        self,
+        outcome: str,
+        current_format: str,
+        current_min: int,
+        current_avg: int,
+    ) -> None:
+        item: dict[str, object] = {
+            "outcome": outcome,
+            "existing_format": None,
+            "existing_min_bitrate": None,
+            "existing_avg_bitrate": None,
+            "existing_median_bitrate": None,
+        }
+        _project_current_library_have(item, {
+            "_current_evidence_id": 42,
+            "_current_evidence_is_pre_attempt": True,
+            "_current_evidence_format": current_format,
+            "_current_evidence_min_bitrate": current_min,
+            "_current_evidence_avg_bitrate": current_avg,
+            "_current_evidence_median_bitrate": current_avg,
+        }, {
+            "beets_format": current_format,
+            "beets_bitrate": current_min,
+            "beets_avg_bitrate": current_avg,
+        })
+        assert_mutating_attempt_has_no_projected_have(item)
+
+    def test_mutating_have_checker_rejects_post_import_projection(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "post-import current state"):
+            assert_mutating_attempt_has_no_projected_have({
+                "existing_format": "Opus",
+                "existing_min_bitrate": 117,
+                "existing_avg_bitrate": 131,
+            })
+
+    def test_have_projection_checker_rejects_the_old_route_shape(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "current library format"):
+            assert_current_library_have_is_projected(
+                {
+                    "existing_format": None,
+                    "existing_min_bitrate": None,
+                    "beets_format": "Opus",
+                    "beets_bitrate": 93,
+                },
+                expected_format="Opus",
+                expected_min=93,
+                expected_avg=129,
+                expected_median=128,
+            )
+
+    def test_linked_output_checker_rejects_album_inference(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "unrelated same-release"):
+            assert_only_explicit_source_receives_materialized_output(
+                [
+                    {"id": 1, "materialized_format": "Opus"},
+                    {"id": 2, "materialized_format": "Opus"},
+                ],
+                source_id=1,
+                unrelated_id=2,
+                expected_format="Opus",
+            )
+
+    def test_linked_output_checker_rejects_filter_dependent_projection(
+        self,
+    ) -> None:
+        with self.assertRaisesRegex(AssertionError, "explicit source row missed"):
+            assert_only_explicit_source_receives_materialized_output(
+                [
+                    {"id": 1, "materialized_format": None},
+                    {"id": 2, "materialized_format": None},
+                ],
+                source_id=1,
+                unrelated_id=2,
+                expected_format="Opus",
+            )
+
+    def test_verified_lossless_copy_checker_rejects_internal_trace(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "internal comparison trace"):
+            assert_verified_lossless_upgrade_copy_is_concise(
+                "Equivalent: OPUS 128 vs MP3 — both transparent — "
+                "imported: verified lossless",
+            )
+
+    @given(
+        existing_min=st.integers(min_value=1, max_value=2_000),
+        output_min=st.integers(min_value=1, max_value=2_000),
+        existing_avg=st.integers(min_value=1, max_value=2_000),
+        target=st.sampled_from(("opus 128", "mp3 v0")),
+    )
+    @example(
+        existing_min=320,
+        output_min=127,
+        existing_avg=320,
+        target="opus 128",
+    )
+    def test_verified_lossless_bypass_uses_concise_upgrade_copy(
+        self,
+        existing_min: int,
+        output_min: int,
+        existing_avg: int,
+        target: str,
+    ) -> None:
+        actual_format = "opus" if target == "opus 128" else "mp3"
+        result = classify_log_entry(_entry(
+            outcome="success",
+            was_converted=True,
+            original_filetype="flac",
+            actual_filetype=actual_format,
+            actual_min_bitrate=output_min,
+            existing_min_bitrate=existing_min,
+            spectral_grade="genuine",
+            import_result={
+                "version": 2,
+                "decision": "import",
+                "comparison_basis": {
+                    "verdict": "equivalent",
+                    "branch": "cross_family_same_rank",
+                    "new_rank": "transparent",
+                    "existing_rank": "transparent",
+                    "new_metric": "contract",
+                    "existing_metric": "avg",
+                    "new_value_kbps": 128,
+                    "existing_value_kbps": existing_avg,
+                    "new_format": target,
+                    "existing_format": "mp3",
+                    "spectral_clamped": False,
+                    "tolerance_kbps": None,
+                    "verified_lossless_bypass": True,
+                },
+            },
+        ))
+        assert_verified_lossless_upgrade_copy_is_concise(result.verdict)
+
+    @given(
+        source_id=st.integers(min_value=1, max_value=1_000),
+        unrelated_offset=st.integers(min_value=1, max_value=1_000),
+        outcome=st.sampled_from(("success", "force_import", "manual_import")),
+        materialized_format=st.sampled_from(("Opus", "MP3", "FLAC")),
+        materialized_min=st.integers(min_value=1, max_value=2_000),
+        materialized_avg=st.integers(min_value=1, max_value=2_000),
+    )
+    @example(
+        source_id=37120,
+        unrelated_offset=8,
+        outcome="force_import",
+        materialized_format="Opus",
+        materialized_min=118,
+        materialized_avg=124,
+    )
+    def test_linked_materialized_output_follows_only_explicit_source_id(
+        self,
+        source_id: int,
+        unrelated_offset: int,
+        outcome: str,
+        materialized_format: str,
+        materialized_min: int,
+        materialized_avg: int,
+    ) -> None:
+        unrelated_id = source_id + unrelated_offset
+        successor_id = unrelated_id + 1
+        items: list[dict[str, object]] = [
+            {"id": source_id, "request_id": 42, "materialized_format": None},
+            {"id": unrelated_id, "request_id": 42, "materialized_format": None},
+        ]
+        linked_successor = {
+            "id": successor_id,
+            "request_id": 42,
+            "outcome": outcome,
+            "source_download_log_id": source_id,
+            "materialized_format": materialized_format,
+            "materialized_min_bitrate": materialized_min,
+            "materialized_avg_bitrate": materialized_avg,
+        }
+        _project_linked_import_evidence(items, [linked_successor])
+        assert_only_explicit_source_receives_materialized_output(
+            items,
+            source_id=source_id,
+            unrelated_id=unrelated_id,
+            expected_format=materialized_format,
+        )
+        self.assertEqual(items[0]["materialized_min_bitrate"], materialized_min)
+        self.assertEqual(items[0]["materialized_avg_bitrate"], materialized_avg)
 
 
 if __name__ == "__main__":

--- a/tests/web/test_routes_pipeline.py
+++ b/tests/web/test_routes_pipeline.py
@@ -172,7 +172,7 @@ class TestPipelineRouteContracts(_FakeDbWebServerCase):
             "pipeline log counts",
         )
 
-    def test_pipeline_log_current_beets_projection_keeps_min_and_average(self):
+    def test_pipeline_log_beets_never_backfills_attempt_have(self):
         import web.server as srv
 
         beets = FakeBeetsDB()
@@ -190,6 +190,417 @@ class TestPipelineRouteContracts(_FakeDbWebServerCase):
         self.assertEqual(status, 200)
         self.assertEqual(data["log"][0]["beets_bitrate"], 194)
         self.assertEqual(data["log"][0]["beets_avg_bitrate"], 288)
+        self.assertIsNone(data["log"][0]["existing_format"])
+        self.assertIsNone(data["log"][0]["existing_min_bitrate"])
+
+    def test_new_import_never_projects_post_import_current_evidence(self):
+        from lib.quality import AudioQualityMeasurement
+        from tests.helpers import make_album_quality_evidence
+
+        evidence = make_album_quality_evidence(
+            mb_release_id="test-mbid-0100",
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=117,
+                avg_bitrate_kbps=131,
+                median_bitrate_kbps=132,
+                format="Opus",
+            ),
+            codec="opus",
+            container="opus",
+            storage_format="Opus",
+        )
+        self.db.upsert_album_quality_evidence(evidence)
+        stored = self.db.find_album_quality_evidence(
+            mb_release_id=evidence.mb_release_id,
+            snapshot_fingerprint=evidence.snapshot_fingerprint,
+        )
+        assert stored is not None and stored.id is not None
+        self.assertTrue(self.db.set_request_current_evidence(100, stored.id))
+
+        status, data = self._get("/api/pipeline/log")
+
+        self.assertEqual(status, 200)
+        self.assertEqual(data["log"][0]["badge"], "Imported")
+        self.assertIsNone(data["log"][0]["existing_format"])
+        self.assertIsNone(data["log"][0]["existing_min_bitrate"])
+
+    def test_later_current_evidence_never_rewrites_rejected_attempt_have(self):
+        from datetime import timedelta
+
+        from lib.quality import AudioQualityMeasurement
+        from tests.helpers import make_album_quality_evidence
+
+        log_id = self.db.log_download(
+            100,
+            outcome="rejected",
+            beets_scenario="high_distance",
+        )
+        attempt = next(row for row in self.db.download_logs if row.id == log_id)
+        evidence = make_album_quality_evidence(
+            mb_release_id="test-mbid-0100",
+            measured_at=attempt.created_at + timedelta(seconds=1),
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=117,
+                avg_bitrate_kbps=131,
+                median_bitrate_kbps=132,
+                format="Opus",
+            ),
+            codec="opus",
+            container="opus",
+            storage_format="Opus",
+        )
+        self.db.upsert_album_quality_evidence(evidence)
+        stored = self.db.find_album_quality_evidence(
+            mb_release_id=evidence.mb_release_id,
+            snapshot_fingerprint=evidence.snapshot_fingerprint,
+        )
+        assert stored is not None and stored.id is not None
+        self.assertTrue(self.db.set_request_current_evidence(100, stored.id))
+
+        status, data = self._get("/api/pipeline/log")
+
+        self.assertEqual(status, 200)
+        item = next(row for row in data["log"] if row["id"] == log_id)
+        self.assertIsNone(item["existing_format"])
+        self.assertIsNone(item["existing_min_bitrate"])
+
+    def test_pipeline_log_attempt_have_evidence_wins_over_current_beets(self):
+        import web.server as srv
+
+        self.db.log_download(
+            100,
+            outcome="rejected",
+            validation_result={
+                "scenario": "high_distance",
+                "distance": 0.22,
+                "wrong_match_triage": {
+                    "action": "deleted_reject",
+                    "outcome": "deleted",
+                    "reason": "suspect_lossless_downgrade",
+                    "preview_verdict": "confident_reject",
+                    "preview_decision": "downgrade",
+                    "stage_chain": ["stage2_import:downgrade"],
+                    "current_measurement": {
+                        "format": "AAC",
+                        "min_bitrate_kbps": 256,
+                        "avg_bitrate_kbps": 288,
+                    },
+                },
+            },
+        )
+        # Canonical request evidence is independently authoritative; the
+        # route must not require Beets' lookup to return the album first.
+        beets = FakeBeetsDB()
+        with patch.object(srv, "_beets_db", return_value=beets):
+            status, data = self._get("/api/pipeline/log")
+
+        self.assertEqual(status, 200)
+        self.assertEqual(data["log"][0]["existing_format"], "AAC")
+        self.assertEqual(data["log"][0]["existing_min_bitrate"], 256)
+
+    def test_kept_would_import_uses_complete_canonical_current_have(self):
+        import web.server as srv
+        from lib.quality import (
+            AlbumQualityV0Metric,
+            AudioQualityMeasurement,
+            ImportResult,
+            TargetQualityContract,
+        )
+        from tests.helpers import make_album_quality_evidence
+
+        source_log_id = self.db.log_download(
+            100,
+            outcome="rejected",
+            validation_result={
+                "scenario": "high_distance",
+                "distance": 0.2328,
+                "wrong_match_triage": {
+                    "action": "kept_would_import",
+                    "outcome": "kept_would_import",
+                    "reason": "import",
+                    "preview_verdict": "would_import",
+                    "preview_decision": "import",
+                    "stage_chain": ["stage2_import:import"],
+                },
+            },
+        )
+        evidence = make_album_quality_evidence(
+            mb_release_id="test-mbid-0100",
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=118,
+                avg_bitrate_kbps=124,
+                median_bitrate_kbps=122,
+                format="Opus",
+                spectral_grade="likely_transcode",
+                spectral_bitrate_kbps=96,
+            ),
+            v0_metric=AlbumQualityV0Metric(
+                min_bitrate_kbps=246,
+                avg_bitrate_kbps=258,
+                median_bitrate_kbps=257,
+                source_lineage="lossless_source",
+            ),
+            codec="opus",
+            container="opus",
+            storage_format="Opus",
+        )
+        self.db.upsert_album_quality_evidence(evidence)
+        stored = self.db.find_album_quality_evidence(
+            mb_release_id=evidence.mb_release_id,
+            snapshot_fingerprint=evidence.snapshot_fingerprint,
+        )
+        assert stored is not None and stored.id is not None
+        self.assertTrue(self.db.set_request_current_evidence(100, stored.id))
+        self.db.log_download(
+            100,
+            outcome="force_import",
+            source_download_log_id=source_log_id,
+            was_converted=True,
+            import_result=ImportResult(
+                decision="import",
+                source_measurement=AudioQualityMeasurement(
+                    min_bitrate_kbps=529,
+                    avg_bitrate_kbps=648,
+                    median_bitrate_kbps=642,
+                    format="FLAC",
+                ),
+                current_measurement=AudioQualityMeasurement(
+                    min_bitrate_kbps=118,
+                    avg_bitrate_kbps=124,
+                    median_bitrate_kbps=122,
+                    format="Opus",
+                ),
+                target_quality_contract=(
+                    TargetQualityContract.from_explicit_label("opus 128")
+                ),
+                materialized_measurement=AudioQualityMeasurement(
+                    min_bitrate_kbps=118,
+                    avg_bitrate_kbps=124,
+                    median_bitrate_kbps=122,
+                    format="Opus",
+                ),
+            ).to_json(),
+        )
+        beets = FakeBeetsDB()
+        beets.set_mbid_detail(
+            "test-mbid-0100",
+            {
+                "beets_format": "Opus",
+                "beets_bitrate": 118,
+                "beets_avg_bitrate": 124,
+            },
+        )
+        with patch.object(srv, "_beets_db", return_value=beets):
+            status, data = self._get("/api/pipeline/log")
+
+        self.assertEqual(status, 200)
+        item = next(
+            row for row in data["log"]
+            if row["wrong_match_triage_action"] == "kept_would_import"
+        )
+        self.assertEqual(item["wrong_match_triage_action"], "kept_would_import")
+        self.assertEqual(item["badge"], "Triaged · kept")
+        self.assertEqual(item["badge_class"], "badge-warn")
+        self.assertEqual(item["border_color"], "#a33")
+        self.assertEqual(item["existing_format"], "Opus")
+        self.assertEqual(item["existing_min_bitrate"], 118)
+        self.assertEqual(item["existing_avg_bitrate"], 124)
+        self.assertEqual(item["existing_median_bitrate"], 122)
+        self.assertEqual(item["existing_spectral_grade"], "likely_transcode")
+        self.assertEqual(item["existing_spectral_bitrate"], 96)
+        self.assertEqual(item["existing_v0_probe_kind"], "lossless_source")
+        self.assertEqual(item["existing_v0_probe_min_bitrate"], 246)
+        self.assertEqual(item["existing_v0_probe_avg_bitrate"], 258)
+        self.assertEqual(item["materialized_format"], "Opus")
+        self.assertEqual(item["materialized_min_bitrate"], 118)
+        self.assertEqual(item["materialized_avg_bitrate"], 124)
+        self.assertEqual(item["target_contract_format"], "opus 128")
+
+    def test_deleted_triage_uses_complete_canonical_current_have(self):
+        import web.server as srv
+        from lib.quality import AlbumQualityV0Metric, AudioQualityMeasurement
+        from tests.helpers import make_album_quality_evidence
+
+        self.db.log_download(
+            100,
+            outcome="rejected",
+            validation_result={
+                "scenario": "high_distance",
+                "distance": 0.221,
+                "wrong_match_triage": {
+                    "action": "deleted_reject",
+                    "outcome": "deleted",
+                    "reason": "suspect_lossless_downgrade",
+                    "preview_verdict": "confident_reject",
+                    "preview_decision": "suspect_lossless_downgrade",
+                    "stage_chain": ["stage2_import:suspect_lossless_downgrade"],
+                },
+            },
+        )
+        evidence = make_album_quality_evidence(
+            mb_release_id="test-mbid-0100",
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=93,
+                avg_bitrate_kbps=129,
+                median_bitrate_kbps=128,
+                format="Opus",
+                spectral_grade="suspect",
+                spectral_bitrate_kbps=96,
+            ),
+            v0_metric=AlbumQualityV0Metric(
+                min_bitrate_kbps=193,
+                avg_bitrate_kbps=256,
+                median_bitrate_kbps=258,
+                source_lineage="lossless_source",
+            ),
+            codec="opus",
+            container="opus",
+            storage_format="Opus",
+        )
+        self.db.upsert_album_quality_evidence(evidence)
+        stored = self.db.find_album_quality_evidence(
+            mb_release_id=evidence.mb_release_id,
+            snapshot_fingerprint=evidence.snapshot_fingerprint,
+        )
+        assert stored is not None and stored.id is not None
+        self.assertTrue(self.db.set_request_current_evidence(100, stored.id))
+
+        beets = FakeBeetsDB()
+        beets.set_mbid_detail(
+            "test-mbid-0100",
+            {
+                "beets_format": "Opus",
+                "beets_bitrate": 93,
+                "beets_avg_bitrate": 129,
+            },
+        )
+        with patch.object(srv, "_beets_db", return_value=beets):
+            status, data = self._get("/api/pipeline/log")
+
+        self.assertEqual(status, 200)
+        item = data["log"][0]
+        self.assertEqual(item["badge"], "Triaged · deleted")
+        self.assertEqual(item["existing_format"], "Opus")
+        self.assertEqual(item["existing_min_bitrate"], 93)
+        self.assertEqual(item["existing_avg_bitrate"], 129)
+        self.assertEqual(item["existing_median_bitrate"], 128)
+        self.assertEqual(item["existing_spectral_grade"], "suspect")
+        self.assertEqual(item["existing_spectral_bitrate"], 96)
+        self.assertEqual(item["existing_v0_probe_kind"], "lossless_source")
+        self.assertEqual(item["existing_v0_probe_min_bitrate"], 193)
+        self.assertEqual(item["existing_v0_probe_avg_bitrate"], 256)
+
+    def test_kept_would_import_completes_have_from_explicit_successor(self):
+        import web.server as srv
+        from lib.quality import AudioQualityMeasurement, ImportResult
+
+        source_log_id = self.db.log_download(
+            100,
+            outcome="rejected",
+            validation_result={
+                "scenario": "high_distance",
+                "distance": 0.172,
+                "wrong_match_triage": {
+                    "action": "kept_would_import",
+                    "outcome": "kept_would_import",
+                    "reason": "import",
+                    "preview_verdict": "would_import",
+                    "preview_decision": "import",
+                    "stage_chain": ["stage2_import:import"],
+                    "current_measurement": {
+                        "format": None,
+                        "min_bitrate_kbps": None,
+                        "avg_bitrate_kbps": None,
+                        "median_bitrate_kbps": None,
+                        "spectral_grade": "likely_transcode",
+                        "spectral_bitrate_kbps": 160,
+                    },
+                    "current_v0_probe": {
+                        "kind": "on_disk_research_v0",
+                        "min_bitrate_kbps": 160,
+                        "avg_bitrate_kbps": 241,
+                        "median_bitrate_kbps": 251,
+                    },
+                },
+            },
+        )
+        self.db.log_download(
+            100,
+            outcome="force_import",
+            source_download_log_id=source_log_id,
+            was_converted=True,
+            import_result=ImportResult(
+                decision="import",
+                source_measurement=AudioQualityMeasurement(
+                    min_bitrate_kbps=732,
+                    avg_bitrate_kbps=944,
+                    median_bitrate_kbps=961,
+                    format="FLAC",
+                ),
+                current_measurement=AudioQualityMeasurement(
+                    min_bitrate_kbps=153,
+                    avg_bitrate_kbps=228,
+                    median_bitrate_kbps=236,
+                    format="MP3",
+                    spectral_grade="likely_transcode",
+                    spectral_bitrate_kbps=160,
+                ),
+                materialized_measurement=AudioQualityMeasurement(
+                    min_bitrate_kbps=99,
+                    avg_bitrate_kbps=128,
+                    median_bitrate_kbps=127,
+                    format="Opus",
+                ),
+            ).to_json(),
+        )
+        beets = FakeBeetsDB()
+        beets.set_mbid_detail(
+            "test-mbid-0100",
+            {
+                "beets_format": "Opus",
+                "beets_bitrate": 99,
+                "beets_avg_bitrate": 128,
+            },
+        )
+        with patch.object(srv, "_beets_db", return_value=beets):
+            status, data = self._get("/api/pipeline/log")
+
+        self.assertEqual(status, 200)
+        item = next(
+            row for row in data["log"]
+            if row["wrong_match_triage_action"] == "kept_would_import"
+        )
+        self.assertEqual(item["existing_format"], "MP3")
+        self.assertEqual(item["existing_min_bitrate"], 153)
+        self.assertEqual(item["existing_avg_bitrate"], 228)
+        self.assertEqual(item["existing_median_bitrate"], 236)
+        self.assertEqual(item["existing_spectral_grade"], "likely_transcode")
+        self.assertEqual(item["existing_v0_probe_avg_bitrate"], 241)
+        self.assertEqual(item["materialized_format"], "Opus")
+        self.assertEqual(item["materialized_min_bitrate"], 99)
+        self.assertEqual(item["materialized_avg_bitrate"], 128)
+
+        with patch.object(srv, "_beets_db", return_value=beets):
+            filtered_status, filtered_data = self._get(
+                "/api/pipeline/log?outcome=rejected"
+            )
+
+        self.assertEqual(filtered_status, 200)
+        filtered_item = next(
+            row for row in filtered_data["log"]
+            if row["wrong_match_triage_action"] == "kept_would_import"
+        )
+        self.assertEqual(filtered_item["existing_format"], "MP3")
+        self.assertEqual(filtered_item["existing_min_bitrate"], 153)
+        self.assertEqual(filtered_item["existing_avg_bitrate"], 228)
+        self.assertEqual(filtered_item["existing_median_bitrate"], 236)
+        self.assertEqual(
+            filtered_item["existing_spectral_grade"], "likely_transcode"
+        )
+        self.assertEqual(filtered_item["existing_v0_probe_avg_bitrate"], 241)
+        self.assertEqual(filtered_item["materialized_format"], "Opus")
+        self.assertEqual(filtered_item["materialized_min_bitrate"], 99)
+        self.assertEqual(filtered_item["materialized_avg_bitrate"], 128)
 
     def test_pipeline_log_projects_complete_canonical_candidate_evidence(self):
         from lib.quality import AlbumQualityV0Metric, AudioQualityMeasurement

--- a/web/classify.py
+++ b/web/classify.py
@@ -174,6 +174,8 @@ class ClassifiedEntry(msgspec.Struct):
     # The classifier owns the final attempt-local projection for both normal
     # import rows and persisted wrong-match triage snapshots.
     existing_min_bitrate: int | None = None
+    existing_avg_bitrate: int | None = None
+    existing_median_bitrate: int | None = None
     v0_probe_kind: str | None = None
     v0_probe_min_bitrate: int | None = None
     v0_probe_avg_bitrate: int | None = None
@@ -315,7 +317,12 @@ def classify_log_entry(entry: LogEntry) -> ClassifiedEntry:
     core = _classify(entry, triage_action=triage["action"])
     summary = _build_summary(entry, core.badge, core.verdict)
     downloaded_label = _build_downloaded_label(entry)
-    existing_format = _extract_existing_format(entry)
+    (
+        existing_format,
+        existing_min_bitrate,
+        existing_avg_bitrate,
+        existing_median_bitrate,
+    ) = _extract_existing_measurement(entry)
     materialized = _extract_materialized_measurement(entry)
     lineage = _extract_quality_lineage(entry)
     disambig_reason, disambig_detail = _extract_disambiguation_failure(entry)
@@ -341,6 +348,9 @@ def classify_log_entry(entry: LogEntry) -> ClassifiedEntry:
         )
     if current_measurement is not None:
         existing_format = current_measurement.format
+        existing_min_bitrate = current_measurement.min_bitrate_kbps
+        existing_avg_bitrate = current_measurement.avg_bitrate_kbps
+        existing_median_bitrate = current_measurement.median_bitrate_kbps
         spectral = (
             spectral[0], spectral[1],
             current_measurement.spectral_grade,
@@ -387,10 +397,9 @@ def classify_log_entry(entry: LogEntry) -> ClassifiedEntry:
         spectral_error=spectral[5],
         existing_spectral_attempted=spectral[6],
         existing_spectral_error=spectral[7],
-        existing_min_bitrate=(
-            current_measurement.min_bitrate_kbps
-            if current_measurement is not None else entry.existing_min_bitrate
-        ),
+        existing_min_bitrate=existing_min_bitrate,
+        existing_avg_bitrate=existing_avg_bitrate,
+        existing_median_bitrate=existing_median_bitrate,
         v0_probe_kind=(
             candidate_v0.kind if candidate_v0 is not None else entry.v0_probe_kind
         ),
@@ -509,14 +518,20 @@ def _extract_attempt_spectral(
     )
 
 
-def _extract_existing_format(entry: LogEntry) -> Optional[str]:
-    """The on-disk codec at download time, from
-    ``import_result.current_measurement.format``. None when the blob is
-    missing/legacy — renderers fall back to the bare bitrate suffix."""
+def _extract_existing_measurement(
+    entry: LogEntry,
+) -> tuple[str | None, int | None, int | None, int | None]:
+    """The complete on-disk bitrate snapshot used by this attempt."""
     ir = _parse_import_result(entry)
     if ir is None or ir.current_measurement is None:
-        return None
-    return ir.current_measurement.format
+        return (None, entry.existing_min_bitrate, None, None)
+    measurement = ir.current_measurement
+    return (
+        measurement.format,
+        measurement.min_bitrate_kbps,
+        measurement.avg_bitrate_kbps,
+        measurement.median_bitrate_kbps,
+    )
 
 
 def _extract_materialized_measurement(
@@ -720,9 +735,13 @@ def _classify(
     # --- Rejected ---
     if entry.outcome == "rejected":
         verdict = _rejection_verdict(entry)
+        if triage_action in ("kept_would_import", "kept_uncertain"):
+            return _Classification(
+                "Triaged · kept", "badge-warn", "#a33", verdict
+            )
         if triage_action in ("deleted_reject", "deleted_verified_lossless_parent"):
             return _Classification(
-                "Triaged · deleted", "badge-library", "#6a5", verdict
+                "Triaged · deleted", "badge-rejected", "#a33", verdict
             )
         return _Classification("Rejected", "badge-rejected", "#a33", verdict)
 
@@ -799,7 +818,20 @@ def _classify(
             if entry.search_filetype_override:
                 return _classify_search_filetype_override(entry, is_verified_lossless)
             basis = _entry_comparison_basis(entry)
-            if basis is not None:
+            if basis is not None and basis.verified_lossless_bypass:
+                # The evidence rows already carry the exact comparison. Keep
+                # the collapsed footer on the older concise upgrade grammar;
+                # the basis trace ("Equivalent ... both transparent") is an
+                # internal decision explanation, not a useful success label.
+                verdict = _upgrade_verdict(
+                    entry.existing_min_bitrate,
+                    _downloaded_min_bitrate_kbps(entry),
+                    entry.was_converted,
+                    entry.original_filetype,
+                    True,
+                    actual_filetype=entry.actual_filetype,
+                )
+            elif basis is not None:
                 verdict = _upgrade_verdict_from_basis(
                     basis, entry.was_converted, entry.original_filetype,
                     is_verified_lossless)

--- a/web/download_history_view.py
+++ b/web/download_history_view.py
@@ -64,6 +64,8 @@ class DownloadHistoryViewRow(msgspec.Struct, frozen=True):
     spectral_grade: str | None
     spectral_bitrate: int | None
     existing_min_bitrate: int | None
+    existing_avg_bitrate: int | None
+    existing_median_bitrate: int | None
     existing_spectral_bitrate: int | None
     existing_spectral_grade: str | None
     spectral_attempted: bool | None

--- a/web/index.html
+++ b/web/index.html
@@ -112,7 +112,7 @@
   .p-title { font-weight: 500; font-size: 0.95em; }
   .p-artist { color: #999; font-size: 0.85em; }
   .p-meta { color: #666; font-size: 0.75em; margin-top: 3px; display: flex; gap: 12px; flex-wrap: wrap; }
-  .recents-triage-label { color: #ec6; font-weight: 600; }
+  .recents-triage-label { color: #d66; font-weight: 600; }
   .p-detail { background: #191919; padding: 10px 12px; margin: 0 0 4px 0; border-radius: 0 0 6px 6px; display: none; border-left: 3px solid #333; }
   .p-detail.open { display: block; }
   .p-detail-row { display: flex; gap: 8px; margin-bottom: 4px; font-size: 0.8em; }
@@ -356,16 +356,17 @@
   .p-hist-forensics summary { cursor: pointer; user-select: none; color: #556; font-size: 0.9em; }
   .p-hist-forensics summary:hover, .p-hist-forensics[open] summary { color: #889; }
   /* Compact IN/HAVE evidence strip on Recents list rows (issue #575). */
-  .r-evidence { display: grid; grid-template-columns: 3.6em minmax(4.5em, 1.05fr) minmax(5.5em, 1fr) minmax(4.5em, 0.85fr) minmax(6.5em, 1fr) minmax(8em, 1.35fr); column-gap: 0.7em; row-gap: 2px; align-items: baseline; width: 100%; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.95em; color: #7a8a99; }
+  .r-evidence { display: grid; grid-template-columns: 3.6em minmax(4.5em, 0.8fr) minmax(12em, 1.7fr) minmax(4.5em, 0.75fr) minmax(7.5em, 1fr) minmax(9em, 1.35fr); column-gap: 0.7em; row-gap: 2px; align-items: baseline; width: 100%; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.95em; color: #7a8a99; }
   .r-ev-row { display: contents; }
   .r-evidence .r-ev-tag { color: #d3deea; font-weight: 900; font-size: 1.08em; line-height: 1; letter-spacing: 0.9px; text-shadow: 0 0 8px rgba(170, 205, 235, 0.24); }
   .r-ev-cell { min-width: 0; overflow-wrap: normal; word-break: normal; white-space: nowrap; }
+  @media (min-width: 721px) { .r-ev-v0 { padding-left: 1em; } }
   @media (max-width: 720px) {
     .r-evidence { grid-template-columns: 4.3em minmax(5em, 0.8fr) minmax(0, 1.8fr); column-gap: 0.65em; row-gap: 4px; font-size: 1em; }
     .r-ev-row { display: grid; grid-column: 1 / -1; grid-template-columns: subgrid; grid-template-rows: auto auto auto; row-gap: 1px; padding: 2px 0; }
     .r-evidence .r-ev-tag { grid-column: 1; grid-row: 1 / 4; align-self: start; padding-top: 1px; font-size: 1.15em; }
     .r-ev-source { grid-column: 2; grid-row: 1; }
-    .r-ev-metric { grid-column: 3; grid-row: 1; }
+    .r-ev-metric { grid-column: 3; grid-row: 1; white-space: normal; }
     .r-ev-rank { grid-column: 2; grid-row: 2; }
     .r-ev-spectral { grid-column: 3; grid-row: 2; white-space: normal; }
     .r-ev-v0 { grid-column: 2 / -1; grid-row: 3; white-space: normal; padding-bottom: 2px; }

--- a/web/js/history.js
+++ b/web/js/history.js
@@ -138,71 +138,116 @@ function basisSidePhrase(basis, side) {
     + ` · ${esc(rank)}`;
 }
 
-/**
- * Compact one-line IN/HAVE evidence comparison for list rows.
- *
- * Same numbers as the detail grid (measured incoming vs on-disk at the
- * time of THIS download), compressed for glance-ability: the Recents
- * list renders it under the title so quality decisions read without
- * expanding the card. Returns '' when neither side has measurements
- * (download-phase failures have nothing to compare).
- * @param {Object} h - Download history entry / recents log item from the API
- * @returns {string} HTML string, or '' when there is no evidence
- */
-export function renderEvidenceStrip(h) {
-  // A strip is a comparison — it needs at least one NUMBER. A codec
-  // label alone (failed downloads carry a filetype but no measurements)
-  // would render a noisy "IN MP3 HAVE —" on every failure row.
-  const hasMeasurement = Boolean(
-    h.actual_min_bitrate || h.spectral_bitrate || h.spectral_grade
-    || h.spectral_error || h.existing_spectral_error
-    || h.source_min_bitrate || h.source_avg_bitrate
-    || h.source_median_bitrate
-    || h.v0_probe_avg_bitrate || h.existing_min_bitrate
-    || h.existing_spectral_bitrate || h.existing_v0_probe_avg_bitrate
-    || h.comparison_basis,
-  );
-  if (!hasMeasurement) return '';
+function emptyEvidenceCells() {
+  return { source: '', metric: '', rank: '', spectral: '', v0: '' };
+}
 
+function avgMinPhrase(avg, median, min) {
+  if (avg != null) {
+    return `${esc(avg)}k avg${min != null ? ` (min ${esc(min)}k)` : ''}`;
+  }
+  if (median != null) {
+    return `${esc(median)}k median${min != null ? ` (min ${esc(min)}k)` : ''}`;
+  }
+  return min != null ? `min ${esc(min)}k` : '';
+}
+
+function comparisonMetricPhrase(avg, median, min, basis, side) {
+  if (avg != null || median != null) return avgMinPhrase(avg, median, min);
+  if (!basis) return avgMinPhrase(null, null, min);
+
+  const metric = side === 'new' ? basis.new_metric : basis.existing_metric;
+  const value = side === 'new' ? basis.new_value_kbps : basis.existing_value_kbps;
+  if (basis.spectral_clamped && basis.branch === 'rank') {
+    return basisValuePhrase(basis, side);
+  }
+  if (metric === 'avg') return avgMinPhrase(value, null, min);
+  if (metric === 'median') return avgMinPhrase(null, value, min);
+  if (min != null) return avgMinPhrase(null, null, min);
+  return basisValuePhrase(basis, side);
+}
+
+function isLosslessSource(format) {
+  return ['FLAC', 'ALAC', 'WAV', 'AIFF'].includes(
+    String(format || '').trim().toUpperCase(),
+  );
+}
+
+function storageFormatLabel(h, fallback) {
+  const contract = String(h.target_contract_format || '').toLowerCase();
+  if (/\bv0\b/.test(contract)) return 'V0';
+  if (contract.includes('opus')) return 'Opus';
+  if (contract.includes('flac')) return 'FLAC';
+  const format = h.materialized_format || fallback || '';
+  const normalized = String(format).trim();
+  return normalized.toUpperCase() === 'OPUS' ? 'Opus' : normalized.toUpperCase();
+}
+
+function sourceStorageLabel(sourceFormat, storageFormat) {
+  const source = String(sourceFormat || '').trim().toUpperCase();
+  const storage = String(storageFormat || '').trim();
+  if (!storage || source === storage.toUpperCase()) return source;
+  return `${source} - ${storage}`;
+}
+
+/**
+ * Normalize every Recents outcome into the same two-sided card model.
+ *
+ * IN always means the downloaded source; a lossless source suffixes the
+ * selected storage codec in its source cell so its metric stays vertically
+ * aligned with HAVE. HAVE always means the on-disk snapshot from before this
+ * attempt. Materialized output is candidate evidence and therefore belongs
+ * only to IN; a first import has an empty HAVE row.
+ */
+function buildEvidenceCardModel(h) {
   const basis = h.comparison_basis || null;
-  const inCells = { source: '', metric: '', rank: '', spectral: '', v0: '' };
+  const inCells = emptyEvidenceCells();
   const sourceFormat = h.source_format || h.slskd_filetype || h.original_filetype;
-  const collapsedConvertedSource = Boolean(h.was_converted && sourceFormat);
-  if (basis) {
-    // The persisted basis IS the comparison the decider performed —
-    // render it instead of re-deriving labels from min bitrate (request
-    // 6039: min-derived labels turned a real avg 196→288 rank upgrade
-    // into "IN MP3 V2 · 194k HAVE MP3 194k").
-    if (collapsedConvertedSource) {
-      // Collapsed evidence names the measured source only. Target/output
-      // lineage belongs in the expanded detail, where it cannot make a
-      // target bitrate look like a property of the source codec.
-      inCells.source = esc(String(sourceFormat).toUpperCase());
-    } else {
-      inCells.source = esc(String(basis.new_format || '?').toUpperCase());
-      inCells.metric = basisValuePhrase(basis, 'new');
-      inCells.rank = esc(basis.new_rank);
-    }
+  const losslessSource = isLosslessSource(sourceFormat);
+  const hasMaterializedMeasurement = Boolean(
+    h.materialized_format
+    && (h.materialized_avg_bitrate != null
+      || h.materialized_median_bitrate != null
+      || h.materialized_min_bitrate != null),
+  );
+  if (sourceFormat) {
+    inCells.source = esc(String(sourceFormat).toUpperCase());
+  } else if (basis?.new_format) {
+    inCells.source = esc(String(basis.new_format).toUpperCase());
+  } else if (h.downloaded_label) {
+    inCells.source = esc(h.downloaded_label);
+  }
+  if (losslessSource && hasMaterializedMeasurement) {
+    const storage = storageFormatLabel(h, h.materialized_format);
+    inCells.source = esc(sourceStorageLabel(sourceFormat, storage));
+    const bytes = avgMinPhrase(
+      h.materialized_avg_bitrate,
+      h.materialized_median_bitrate,
+      h.materialized_min_bitrate,
+    );
+    inCells.metric = bytes;
   } else {
-    if (collapsedConvertedSource) {
-      inCells.source = esc(String(sourceFormat).toUpperCase());
-    } else if (h.downloaded_label) {
-      inCells.source = esc(h.downloaded_label);
-    }
-    // Labelled "min": bare numbers on a card that also shows avg-labelled
-    // basis and V0 values invite exactly the min-vs-avg confusion the
-    // basis exists to kill (request 8781 operator report).
-    const minIsLosslessSourceProbe = (
-      h.legacy_projection_version != null
+    const projectedMinIsV0Probe = (
+      h.source_min_bitrate == null
+      && h.legacy_projection_version != null
       && (h.v0_probe_kind === 'lossless_source_v0'
         || h.v0_probe_kind === 'lossless_source')
-      && h.v0_probe_min_bitrate !== null
-      && h.v0_probe_min_bitrate !== undefined
+      && h.v0_probe_min_bitrate != null
       && Number(h.actual_min_bitrate) === Number(h.v0_probe_min_bitrate)
     );
-    const sourceMin = h.actual_min_bitrate || h.source_min_bitrate;
-    if (sourceMin && !minIsLosslessSourceProbe && !collapsedConvertedSource) {
-      inCells.metric = `min ${esc(sourceMin)}k`;
+    const sourceMin = projectedMinIsV0Probe
+      ? null : (h.source_min_bitrate ?? h.actual_min_bitrate);
+    const bytes = comparisonMetricPhrase(
+      h.source_avg_bitrate,
+      h.source_median_bitrate,
+      sourceMin,
+      basis,
+      'new',
+    );
+    if (losslessSource && bytes) {
+      inCells.metric = bytes;
+    } else if (bytes) {
+      inCells.metric = bytes;
     }
   }
   if (h.spectral_grade) {
@@ -226,22 +271,29 @@ export function renderEvidenceStrip(h) {
     inCells.v0 = stripV0Phrase(h.v0_probe_avg_bitrate, h.v0_probe_min_bitrate);
   }
 
-  const haveCells = { source: '', metric: '', rank: '', spectral: '', v0: '' };
-  // Lead with "MP3 min 256k" as one piece — the codec class is often the
-  // deciding metric (a rank upgrade at equal bitrate is unreadable
-  // without it), and the min label keeps it distinct from the avg-labelled
-  // basis/V0 values on the same card.
+  const haveCells = emptyEvidenceCells();
   if (basis) {
     haveCells.source = esc(String(basis.existing_format || '?').toUpperCase());
-    haveCells.metric = basisValuePhrase(basis, 'existing');
-    haveCells.rank = esc(basis.existing_rank);
-  } else if (h.existing_format && h.existing_min_bitrate) {
-    haveCells.source = esc(h.existing_format);
-    haveCells.metric = `min ${esc(h.existing_min_bitrate)}k`;
+    haveCells.metric = comparisonMetricPhrase(
+      h.existing_avg_bitrate,
+      h.existing_median_bitrate,
+      h.existing_min_bitrate,
+      basis,
+      'existing',
+    );
   } else if (h.existing_format) {
     haveCells.source = esc(h.existing_format);
-  } else if (h.existing_min_bitrate) {
-    haveCells.metric = `min ${esc(h.existing_min_bitrate)}k`;
+    haveCells.metric = avgMinPhrase(
+      h.existing_avg_bitrate,
+      h.existing_median_bitrate,
+      h.existing_min_bitrate,
+    );
+  } else {
+    haveCells.metric = avgMinPhrase(
+      h.existing_avg_bitrate,
+      h.existing_median_bitrate,
+      h.existing_min_bitrate,
+    );
   }
   if (h.existing_spectral_grade) {
     const floor = h.existing_spectral_bitrate ? `~${esc(h.existing_spectral_bitrate)}k ` : '';
@@ -259,10 +311,15 @@ export function renderEvidenceStrip(h) {
       h.existing_v0_probe_avg_bitrate,
       h.existing_v0_probe_min_bitrate);
   }
+  if (!Object.values(haveCells).some(Boolean)) {
+    haveCells.source = '—';
+  }
 
-  const hasCells = (cells) => Object.values(cells).some(Boolean);
-  if (!hasCells(inCells) && !hasCells(haveCells)) return '';
-  const row = (side, label, cells) => `<span class="r-ev-row r-ev-${side}">`
+  return { inCells, haveCells };
+}
+
+function renderEvidenceRow(side, label, cells) {
+  return `<span class="r-ev-row r-ev-${side}">`
     + `<strong class="r-ev-tag">${label}</strong>`
     + `<span class="r-ev-cell r-ev-source">${cells.source}</span>`
     + `<span class="r-ev-cell r-ev-metric">${cells.metric}</span>`
@@ -270,9 +327,37 @@ export function renderEvidenceStrip(h) {
     + `<span class="r-ev-cell r-ev-spectral">${cells.spectral}</span>`
     + `<span class="r-ev-cell r-ev-v0">${cells.v0}</span>`
     + `</span>`;
+}
+
+/**
+ * Compact one-line IN/HAVE evidence comparison for every list-row outcome.
+ * @param {Object} h - Download history entry / recents log item from the API
+ * @returns {string} HTML string, or '' when there is no evidence
+ */
+export function renderEvidenceStrip(h) {
+  // A strip is a comparison — it needs at least one NUMBER. A codec
+  // label alone (failed downloads carry a filetype but no measurements)
+  // would render a noisy "IN MP3 HAVE —" on every failure row.
+  const hasMeasurement = Boolean(
+    h.actual_min_bitrate || h.spectral_bitrate || h.spectral_grade
+    || h.spectral_error || h.existing_spectral_error
+    || h.source_min_bitrate || h.source_avg_bitrate
+    || h.source_median_bitrate
+    || h.v0_probe_avg_bitrate || h.existing_min_bitrate
+    || h.existing_spectral_bitrate || h.existing_v0_probe_avg_bitrate
+    || h.materialized_min_bitrate || h.materialized_avg_bitrate
+    || h.materialized_median_bitrate
+    || h.comparison_basis,
+  );
+  if (!hasMeasurement) return '';
+
+  const { inCells, haveCells } = buildEvidenceCardModel(h);
+
+  const hasCells = (cells) => Object.values(cells).some(Boolean);
+  if (!hasCells(inCells) && !hasCells(haveCells)) return '';
   return `<span class="r-evidence">`
-    + row('in', 'IN', inCells)
-    + row('have', 'HAVE', haveCells)
+    + renderEvidenceRow('in', 'IN', inCells)
+    + renderEvidenceRow('have', 'HAVE', haveCells)
     + `</span>`;
 }
 

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -16,6 +16,7 @@ was split out (#546 W4) into ``web/routes/pipeline_mutations.py``.
 """
 
 import logging
+from collections.abc import Mapping, Sequence
 from typing import cast
 
 import msgspec
@@ -35,6 +36,135 @@ from lib.quality import CandidateScore, top_candidates
 
 DEFAULT_PIPELINE_LOG_LIMIT = 50
 MAX_PIPELINE_LOG_LIMIT = 500
+
+
+def _project_current_library_have(
+    item: dict[str, object],
+    row: Mapping[str, object],
+    _beets: Mapping[str, object],
+) -> None:
+    """Fill legacy HAVE only from a provably pre-attempt exact snapshot.
+
+    HAVE is historical: what was on disk before this attempt. Successful and
+    explicit import rows may have updated the request's current evidence, so
+    they never receive an overlay. Non-mutating legacy rows may use the
+    request's canonical evidence only when its measurement predates the
+    attempt. Live Beets data has no historical timestamp and is never evidence
+    for HAVE.
+    """
+    attempt_measurement_fields = (
+        "existing_format",
+        "existing_min_bitrate",
+        "existing_avg_bitrate",
+        "existing_median_bitrate",
+        "existing_spectral_grade",
+        "existing_spectral_bitrate",
+        "existing_spectral_error",
+        "existing_v0_probe_kind",
+        "existing_v0_probe_min_bitrate",
+        "existing_v0_probe_avg_bitrate",
+        "existing_v0_probe_median_bitrate",
+        "comparison_basis",
+    )
+    if item.get("existing_spectral_attempted") is True or any(
+        item.get(field) is not None for field in attempt_measurement_fields
+    ):
+        return
+    if item.get("outcome") in ("success", "force_import", "manual_import"):
+        return
+
+    current_projection = {
+        "existing_format": row.get("_current_evidence_format"),
+        "existing_min_bitrate": row.get("_current_evidence_min_bitrate"),
+        "existing_avg_bitrate": row.get("_current_evidence_avg_bitrate"),
+        "existing_median_bitrate": row.get(
+            "_current_evidence_median_bitrate"
+        ),
+        "existing_spectral_grade": row.get(
+            "_current_evidence_spectral_grade"
+        ),
+        "existing_spectral_bitrate": row.get(
+            "_current_evidence_spectral_bitrate"
+        ),
+        "existing_v0_probe_kind": row.get(
+            "_current_evidence_v0_probe_kind"
+        ),
+        "existing_v0_probe_min_bitrate": row.get(
+            "_current_evidence_v0_probe_min_bitrate"
+        ),
+        "existing_v0_probe_avg_bitrate": row.get(
+            "_current_evidence_v0_probe_avg_bitrate"
+        ),
+        "existing_v0_probe_median_bitrate": row.get(
+            "_current_evidence_v0_probe_median_bitrate"
+        ),
+    }
+    if (
+        row.get("_current_evidence_id") is not None
+        and row.get("_current_evidence_is_pre_attempt") is True
+    ):
+        item.update(current_projection)
+
+
+def _project_linked_import_evidence(
+    items: list[dict[str, object]],
+    linked_successors: Sequence[Mapping[str, object]] = (),
+) -> None:
+    """Attach a successor import's measurements to its source audit row.
+
+    Force/manual import rows explicitly point back through
+    ``source_download_log_id``. That is the authoritative bridge from a kept
+    wrong-match card to the conversion which later materialized those bytes;
+    do not infer the relationship from matching albums or measurements.
+    """
+    by_id = {
+        item.get("id"): item
+        for item in items
+        if isinstance(item.get("id"), int)
+    }
+    for successor in (*items, *linked_successors):
+        if successor.get("outcome") not in (
+            "success", "force_import", "manual_import"
+        ):
+            continue
+        source_id = successor.get("source_download_log_id")
+        origin = by_id.get(source_id)
+        if origin is None or successor.get("materialized_format") is None:
+            continue
+        for field in (
+            "existing_format",
+            "existing_min_bitrate",
+            "existing_avg_bitrate",
+            "existing_median_bitrate",
+            "existing_spectral_grade",
+            "existing_spectral_bitrate",
+            "existing_spectral_attempted",
+            "existing_spectral_error",
+            "existing_v0_probe_kind",
+            "existing_v0_probe_min_bitrate",
+            "existing_v0_probe_avg_bitrate",
+            "existing_v0_probe_median_bitrate",
+            "materialized_format",
+            "materialized_min_bitrate",
+            "materialized_avg_bitrate",
+            "materialized_median_bitrate",
+            "target_contract_format",
+        ):
+            if origin.get(field) is None:
+                origin[field] = successor.get(field)
+
+
+def _classify_pipeline_log_item(
+    row: Mapping[str, object],
+) -> dict[str, object]:
+    classified_row = classify_download_log_row(row)
+    return {
+        **classified_row.entry.to_json_dict(),
+        **cast(
+            dict[str, object],
+            msgspec.to_builtins(classified_row.classified),
+        ),
+    }
 
 
 def _pipeline_log_limit(params: dict[str, list[str]]) -> int:
@@ -61,21 +191,26 @@ def get_pipeline_log(h, params: dict[str, list[str]]) -> None:
     beets_info = _server().check_beets_library_detail(mbids) if mbids else {}
     result = []
     for e in entries:
-        classified_row = classify_download_log_row(e)
-        entry = classified_row.entry
-        classified = classified_row.classified
-        item = {
-            **entry.to_json_dict(),
-            **cast(dict[str, object], msgspec.to_builtins(classified)),
-        }
-        mbid = entry.mb_release_id
-        bi = beets_info.get(mbid) if mbid else None
+        item = _classify_pipeline_log_item(e)
+        mbid = item.get("mb_release_id")
+        bi = beets_info.get(mbid) if isinstance(mbid, str) else None
         item["in_beets"] = bi is not None
+        _project_current_library_have(item, e, bi or {})
         if bi:
             item["beets_format"] = bi.get("beets_format")
             item["beets_bitrate"] = bi.get("beets_bitrate")
             item["beets_avg_bitrate"] = bi.get("beets_avg_bitrate")
         result.append(item)
+    source_ids = [
+        int(item["id"])
+        for item in result
+        if isinstance(item.get("id"), int)
+    ]
+    linked_items = [
+        _classify_pipeline_log_item(row)
+        for row in _server()._db().get_linked_import_logs(source_ids)
+    ]
+    _project_linked_import_evidence(result, linked_items)
     # Count recents filters plus found-search enqueue rates (single query).
     counts = _server()._db().get_download_log_counts()
     h._json({


### PR DESCRIPTION
## Summary

- render every Recents outcome through one aligned IN/HAVE evidence model on desktop and mobile
- keep HAVE strictly tied to the on-disk snapshot from before the attempt; first imports render HAVE as an em dash
- preserve complete spectral, V0, and average/minimum evidence across force-import and triage cards without filter-dependent leakage
- restore amber kept-triage and red deleted-triage styling plus concise historical upgrade copy

Refs #709

## Verification

- independent review: CLEAN on signed SHA `43849845c6f6fbf96531400baa7151f0ffb236cf`
- full suite: 6,034 tests passed with verified exact-HEAD artifact
- pre-push generated fuzz burst: passed
- Jellyfin metadata VM and read-projection parity gates: passed
- approved desktop and mobile live-DB screenshots for import, upgrade, force-import, provisional, kept-triage, and deleted-triage cards
