### PR TITLE
Complete Recents HAVE evidence snapshots

### DIFF
--- a/lib/import_preview.py
+++ b/lib/import_preview.py
@@ -109,6 +109,16 @@ class ImportPreviewDB(QualityEvidenceDB, Protocol):
 
     def get_download_log_entry(self, log_id: int) -> dict[str, Any] | None: ...
 
+    def persist_current_spectral_measurement(
+        self,
+        *,
+        request_id: int,
+        expected_evidence_id: int,
+        expected_snapshot_fingerprint: str,
+        grade: str,
+        bitrate_kbps: int | None,
+    ) -> bool: ...
+
     def claim_current_v0_research_attempt(
         self,
         *,
@@ -132,6 +142,113 @@ class ImportPreviewDB(QualityEvidenceDB, Protocol):
         expected_evidence_id: int,
         expected_snapshot_fingerprint: str,
     ) -> bool: ...
+
+
+def persist_exact_current_spectral_from_attempt(
+    db: ImportPreviewDB,
+    *,
+    request_id: int,
+    current_evidence: AlbumQualityEvidence | None,
+    measured_existing: SpectralAnalysisDetail | None,
+    measured_existing_path: str | None,
+) -> EvidenceBuildResult:
+    """Fill missing HAVE spectral fields from its exact attempt-time scan.
+
+    ``measure_preimport_state`` independently scans the exact installed
+    release before an import decision. This helper makes that successful scan
+    durable on the already-linked, content-addressed current evidence row. It
+    never rescans, never overwrites spectral provenance, and refuses a Beets
+    path that is not the path snapshotted by the evidence row.
+    """
+    if current_evidence is None or current_evidence.id is None:
+        return EvidenceBuildResult(None, "missing", "current evidence is missing")
+    measurement = current_evidence.measurement
+    if (
+        measurement.spectral_grade is not None
+        or measurement.spectral_bitrate_kbps is not None
+    ):
+        return EvidenceBuildResult(current_evidence, "ready")
+    if (
+        measured_existing is None
+        or not measured_existing.attempted
+        or measured_existing.error is not None
+        or measured_existing.grade is None
+    ):
+        return EvidenceBuildResult(
+            current_evidence,
+            "incomplete",
+            "attempt did not produce a successful HAVE spectral grade",
+        )
+    if (
+        not measured_existing_path
+        or os.path.realpath(measured_existing_path)
+        != os.path.realpath(current_evidence.source_path)
+    ):
+        return EvidenceBuildResult(
+            current_evidence,
+            "stale",
+            "attempt HAVE path does not match current evidence path",
+        )
+    try:
+        current_id = db.get_request_current_evidence_id(request_id)
+        refreshed = db.load_album_quality_evidence_by_id(current_evidence.id)
+    except Exception as exc:
+        return EvidenceBuildResult(None, "failed", f"{type(exc).__name__}: {exc}")
+    if (
+        current_id != current_evidence.id
+        or refreshed is None
+        or refreshed.id != current_evidence.id
+        or refreshed.mb_release_id != current_evidence.mb_release_id
+        or refreshed.snapshot_fingerprint != current_evidence.snapshot_fingerprint
+        or os.path.realpath(refreshed.source_path)
+            != os.path.realpath(measured_existing_path)
+        or not audio_snapshot_matches(refreshed.source_path, refreshed.files)
+    ):
+        return EvidenceBuildResult(
+            current_evidence,
+            "stale",
+            "current evidence changed before HAVE spectral persistence",
+        )
+    refreshed_measurement = refreshed.measurement
+    if (
+        refreshed_measurement.spectral_grade is not None
+        or refreshed_measurement.spectral_bitrate_kbps is not None
+    ):
+        return EvidenceBuildResult(refreshed, "ready")
+    try:
+        persisted = db.persist_current_spectral_measurement(
+            request_id=request_id,
+            expected_evidence_id=current_evidence.id,
+            expected_snapshot_fingerprint=current_evidence.snapshot_fingerprint,
+            grade=measured_existing.grade,
+            bitrate_kbps=measured_existing.bitrate_kbps,
+        )
+        loaded = db.load_album_quality_evidence_by_id(current_evidence.id)
+        linked_id = db.get_request_current_evidence_id(request_id)
+    except Exception as exc:
+        return EvidenceBuildResult(None, "failed", f"{type(exc).__name__}: {exc}")
+    if (
+        linked_id != current_evidence.id
+        or loaded is None
+        or loaded.id != current_evidence.id
+        or loaded.snapshot_fingerprint != current_evidence.snapshot_fingerprint
+    ):
+        return EvidenceBuildResult(
+            current_evidence,
+            "stale",
+            "current evidence changed during HAVE spectral persistence",
+        )
+    loaded_measurement = loaded.measurement
+    if not persisted and (
+        loaded_measurement.spectral_grade is None
+        and loaded_measurement.spectral_bitrate_kbps is None
+    ):
+        return EvidenceBuildResult(
+            loaded,
+            "stale",
+            "exact current evidence rejected HAVE spectral persistence",
+        )
+    return EvidenceBuildResult(loaded, "ready")
 
 
 def load_persisted_existing_spectral(
@@ -1069,6 +1186,15 @@ def measure_and_persist_candidate_evidence(
                 propagate_download_to_existing=False,
                 precomputed_inspection=inspection,
             )
+            spectral_result = persist_exact_current_spectral_from_attempt(
+                db,
+                request_id=request_id,
+                current_evidence=current_evidence,
+                measured_existing=measurement.spectral_audit.existing,
+                measured_existing_path=measurement.existing_spectral_path,
+            )
+            if spectral_result.evidence is not None:
+                current_evidence = spectral_result.evidence
         except Exception as exc:
             return _measurement_failed_result(
                 mode="path",
@@ -1504,6 +1630,15 @@ def preview_import_from_path(
             propagate_download_to_existing=False,
             precomputed_inspection=inspection,
         )
+        spectral_result = persist_exact_current_spectral_from_attempt(
+            db,
+            request_id=request_id,
+            current_evidence=current_evidence,
+            measured_existing=measurement.spectral_audit.existing,
+            measured_existing_path=measurement.existing_spectral_path,
+        )
+        if spectral_result.evidence is not None:
+            current_evidence = spectral_result.evidence
 
         # Four-fact reject (mirror worker-mode lines 517-522). ``nested_layout``
         # is already handled by the ``inspection.has_nested_audio`` branch

--- a/lib/measurement.py
+++ b/lib/measurement.py
@@ -269,6 +269,7 @@ class PreimportMeasurement(msgspec.Struct, frozen=True):
     download_spectral: SpectralMeasurement | None = None
     existing_spectral: SpectralMeasurement | None = None
     existing_min_bitrate: int | None = None
+    existing_spectral_path: str | None = None
     folder_layout: Literal["flat", "nested"] = "flat"
     audio_file_count: int = 0
     filetype_band: str = ""
@@ -610,6 +611,7 @@ def measure_preimport_state(
         candidate=SpectralAnalysisDetail(attempted=False),
         existing=persisted_existing,
     )
+    existing_spectral_path: str | None = None
 
     # --- Audio integrity gate ---
     corrupt_files: list[str] = []
@@ -622,7 +624,7 @@ def measure_preimport_state(
             logger.warning(
                 f"AUDIO CORRUPT: {label} "
                 f"({len(corrupt_files)} files failed ffmpeg decode)")
-            spectral_audit = collect_release_attempt_spectral_audit(
+            spectral_audit, existing_lookup = collect_release_attempt_spectral_audit(
                 path,
                 mb_release_id,
                 existing_spectral_evidence=persisted_existing,
@@ -631,7 +633,8 @@ def measure_preimport_state(
                 ),
                 analyzer=audit_analyzer,
                 existing_resolver=audit_resolver,
-            )[0]
+            )
+            existing_spectral_path = existing_lookup.path
             return PreimportMeasurement(
                 corrupt_files=corrupt_files,
                 audio_corrupt=audio_corrupt,
@@ -645,6 +648,7 @@ def measure_preimport_state(
                     download_min_bitrate_bps
                 ),
                 is_vbr=download_is_vbr,
+                existing_spectral_path=existing_spectral_path,
                 spectral_audit=spectral_audit,
             )
 
@@ -672,7 +676,7 @@ def measure_preimport_state(
                 logger.warning(
                     f"BAD HASH MATCH: {label} "
                     f"hash_id={match.bad_hash_id} track={match.track_path}")
-                spectral_audit = collect_release_attempt_spectral_audit(
+                spectral_audit, existing_lookup = collect_release_attempt_spectral_audit(
                     path,
                     mb_release_id,
                     existing_spectral_evidence=persisted_existing,
@@ -681,7 +685,8 @@ def measure_preimport_state(
                     ),
                     analyzer=audit_analyzer,
                     existing_resolver=audit_resolver,
-                )[0]
+                )
+                existing_spectral_path = existing_lookup.path
                 return PreimportMeasurement(
                     corrupt_files=[],
                     audio_corrupt=False,
@@ -697,6 +702,7 @@ def measure_preimport_state(
                         download_min_bitrate_bps
                     ),
                     is_vbr=download_is_vbr,
+                    existing_spectral_path=existing_spectral_path,
                     spectral_audit=spectral_audit,
                 )
 
@@ -770,6 +776,7 @@ def measure_preimport_state(
             analyzer=audit_analyzer,
             existing_resolver=audit_resolver,
         )
+        existing_spectral_path = existing_lookup.path
         candidate_audit = spectral_audit.candidate
         assert candidate_audit is not None
         download_spectral = SpectralMeasurement.from_parts(
@@ -827,7 +834,7 @@ def measure_preimport_state(
         # Normal harness-bound codecs collect the candidate inside
         # import_one.py before conversion. Fill only HAVE here so the attempt
         # remains two-sided without paying for a duplicate candidate scan.
-        spectral_audit = collect_release_attempt_spectral_audit(
+        spectral_audit, existing_lookup = collect_release_attempt_spectral_audit(
             path,
             mb_release_id,
             existing_spectral_evidence=persisted_existing,
@@ -837,7 +844,8 @@ def measure_preimport_state(
             analyzer=audit_analyzer,
             existing_resolver=audit_resolver,
             candidate_detail=spectral_audit.candidate,
-        )[0]
+        )
+        existing_spectral_path = existing_lookup.path
 
     # --- Persist spectral state to DB (issue #90 propagation) ---
     # This MUST fire on every measurement where spectral was collected,
@@ -870,6 +878,7 @@ def measure_preimport_state(
         download_spectral=download_spectral,
         existing_spectral=existing_spectral,
         existing_min_bitrate=existing_min_bitrate,
+        existing_spectral_path=existing_spectral_path,
         folder_layout=folder_layout,
         audio_file_count=audio_file_count,
         filetype_band=filetype_band,

--- a/lib/pipeline_db/evidence.py
+++ b/lib/pipeline_db/evidence.py
@@ -102,8 +102,18 @@ class _EvidenceMixin(_PipelineDBBase):
                     median_bitrate_kbps = EXCLUDED.median_bitrate_kbps,
                     format = EXCLUDED.format,
                     is_cbr = EXCLUDED.is_cbr,
-                    spectral_grade = EXCLUDED.spectral_grade,
-                    spectral_bitrate_kbps = EXCLUDED.spectral_bitrate_kbps,
+                    -- Spectral is one atomic fact. A grade makes an incoming
+                    -- pair valid (genuine legitimately has no bitrate); an
+                    -- empty or bitrate-only stale writer preserves the whole
+                    -- stored pair so it cannot erase an attempt-time scan.
+                    spectral_grade = CASE WHEN
+                        EXCLUDED.spectral_grade IS NOT NULL
+                        THEN EXCLUDED.spectral_grade
+                        ELSE album_quality_evidence.spectral_grade END,
+                    spectral_bitrate_kbps = CASE WHEN
+                        EXCLUDED.spectral_grade IS NOT NULL
+                        THEN EXCLUDED.spectral_bitrate_kbps
+                        ELSE album_quality_evidence.spectral_bitrate_kbps END,
                     verified_lossless = EXCLUDED.verified_lossless,
                     was_converted_from = EXCLUDED.was_converted_from,
                     -- V0 is one atomic fact, not six independently mergeable
@@ -350,6 +360,44 @@ class _EvidenceMixin(_PipelineDBBase):
         claimed = cur.fetchone() is not None
         self.conn.commit()
         return claimed
+
+
+    def persist_current_spectral_measurement(
+        self,
+        *,
+        request_id: int,
+        expected_evidence_id: int,
+        expected_snapshot_fingerprint: str,
+        grade: str,
+        bitrate_kbps: int | None,
+    ) -> bool:
+        """Fill spectral fields on one exact, still-current empty snapshot."""
+        cur = self._execute(
+            """
+            UPDATE album_quality_evidence AS evidence
+            SET spectral_grade = %s,
+                spectral_bitrate_kbps = %s,
+                updated_at = NOW()
+            FROM album_requests AS request
+            WHERE request.id = %s
+              AND request.current_evidence_id = evidence.id
+              AND evidence.id = %s
+              AND evidence.snapshot_fingerprint = %s
+              AND evidence.spectral_grade IS NULL
+              AND evidence.spectral_bitrate_kbps IS NULL
+            RETURNING evidence.id
+            """,
+            (
+                grade,
+                bitrate_kbps,
+                int(request_id),
+                int(expected_evidence_id),
+                expected_snapshot_fingerprint,
+            ),
+        )
+        persisted = cur.fetchone() is not None
+        self.conn.commit()
+        return persisted
 
 
     def persist_current_v0_research_metric(

--- a/tests/fakes/pipeline_db.py
+++ b/tests/fakes/pipeline_db.py
@@ -2516,6 +2516,23 @@ class FakePipelineDB:
             raise ValueError("; ".join(errors))
         key = (evidence.mb_release_id, evidence.snapshot_fingerprint)
         existing = self.album_quality_evidence.get(key)
+        # Spectral is an atomic pair. A stale writer without a grade cannot
+        # erase a successful attempt-time scan on the same audio snapshot.
+        if (
+            existing is not None
+            and existing.measurement.spectral_grade is not None
+            and evidence.measurement.spectral_grade is None
+        ):
+            evidence = msgspec.structs.replace(
+                evidence,
+                measurement=msgspec.structs.replace(
+                    evidence.measurement,
+                    spectral_grade=existing.measurement.spectral_grade,
+                    spectral_bitrate_kbps=(
+                        existing.measurement.spectral_bitrate_kbps
+                    ),
+                ),
+            )
         # V0 is an atomic tuple. A stale writer with no metric preserves the
         # whole stored fact; a valid incoming metric replaces it wholesale.
         if (
@@ -2590,6 +2607,40 @@ class FakePipelineDB:
         key = (claimed.mb_release_id, claimed.snapshot_fingerprint)
         self.album_quality_evidence[key] = claimed
         self._evidence_by_id[int(expected_evidence_id)] = claimed
+        return True
+
+    def persist_current_spectral_measurement(
+        self,
+        *,
+        request_id: int,
+        expected_evidence_id: int,
+        expected_snapshot_fingerprint: str,
+        grade: str,
+        bitrate_kbps: int | None,
+    ) -> bool:
+        request = self._requests.get(int(request_id))
+        evidence = self._evidence_by_id.get(int(expected_evidence_id))
+        if (
+            request is None
+            or request.get("current_evidence_id") != int(expected_evidence_id)
+            or evidence is None
+            or evidence.snapshot_fingerprint != expected_snapshot_fingerprint
+            or evidence.measurement.spectral_grade is not None
+            or evidence.measurement.spectral_bitrate_kbps is not None
+        ):
+            return False
+        measurement = msgspec.structs.replace(
+            evidence.measurement,
+            spectral_grade=grade,
+            spectral_bitrate_kbps=bitrate_kbps,
+        )
+        completed = copy.deepcopy(msgspec.structs.replace(
+            evidence,
+            measurement=measurement,
+        ))
+        key = (completed.mb_release_id, completed.snapshot_fingerprint)
+        self.album_quality_evidence[key] = completed
+        self._evidence_by_id[int(expected_evidence_id)] = completed
         return True
 
     def persist_current_v0_research_metric(

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -20,7 +20,11 @@ from lib.pipeline_db import (
     TransferLedgerRow,
 )
 from lib.pipeline_db._shared import REQUEST_METADATA_RESERVED_FIELDS
-from lib.quality import SpectralMeasurement, ValidationResult
+from lib.quality import (
+    AudioQualityMeasurement,
+    SpectralMeasurement,
+    ValidationResult,
+)
 from tests.fakes import (
     FakeBeetsDB,
     FakeCursor,
@@ -235,6 +239,59 @@ class TestFakePipelineDB(unittest.TestCase):
         claimed = db.load_album_quality_evidence_by_id(persisted.id)
         assert claimed is not None
         self.assertTrue(claimed.on_disk_v0_research_attempted)
+
+    def test_album_quality_evidence_current_spectral_write_is_exact(self):
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=42, mb_release_id="mb-spectral-1"))
+        evidence = make_album_quality_evidence(
+            mb_release_id="mb-spectral-1",
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=320,
+                avg_bitrate_kbps=320,
+                median_bitrate_kbps=320,
+                format="MP3",
+                spectral_grade=None,
+                spectral_bitrate_kbps=None,
+            ),
+        )
+        db.upsert_album_quality_evidence(evidence)
+        persisted = db.find_album_quality_evidence(
+            mb_release_id=evidence.mb_release_id,
+            snapshot_fingerprint=evidence.snapshot_fingerprint,
+        )
+        assert persisted is not None and persisted.id is not None
+        db.set_request_current_evidence(42, persisted.id)
+
+        wrong_fingerprint = db.persist_current_spectral_measurement(
+            request_id=42,
+            expected_evidence_id=persisted.id,
+            expected_snapshot_fingerprint="wrong",
+            grade="genuine",
+            bitrate_kbps=96,
+        )
+        exact = db.persist_current_spectral_measurement(
+            request_id=42,
+            expected_evidence_id=persisted.id,
+            expected_snapshot_fingerprint=persisted.snapshot_fingerprint,
+            grade="genuine",
+            bitrate_kbps=96,
+        )
+        overwrite = db.persist_current_spectral_measurement(
+            request_id=42,
+            expected_evidence_id=persisted.id,
+            expected_snapshot_fingerprint=persisted.snapshot_fingerprint,
+            grade="likely_transcode",
+            bitrate_kbps=160,
+        )
+        db.upsert_album_quality_evidence(evidence)
+
+        self.assertFalse(wrong_fingerprint)
+        self.assertTrue(exact)
+        self.assertFalse(overwrite)
+        stored = db.load_album_quality_evidence_by_id(persisted.id)
+        assert stored is not None
+        self.assertEqual(stored.measurement.spectral_grade, "genuine")
+        self.assertEqual(stored.measurement.spectral_bitrate_kbps, 96)
 
     def test_album_quality_evidence_attempt_marker_is_monotonic(self):
         db = FakePipelineDB()

--- a/tests/test_import_preview.py
+++ b/tests/test_import_preview.py
@@ -13,6 +13,7 @@ from lib.import_preview import (
     _prefer_successful_spectral_detail,
     compose_attempt_spectral_audit,
     enrich_current_v0_research_for_preview,
+    persist_exact_current_spectral_from_attempt,
     load_persisted_existing_spectral,
     measure_and_persist_candidate_evidence,
     preview_import_from_path,
@@ -403,6 +404,189 @@ class TestImportPreviewPath(unittest.TestCase):
         assert stored is not None and stored.id is not None
         db.set_request_current_evidence(42, stored.id)
         return stored
+
+    def test_attempt_scan_persists_qigong_current_spectral_snapshot(self):
+        """Qigong: the exact installed HAVE scan becomes durable evidence."""
+        db = self._db()
+        source = self._source_dir()
+        try:
+            evidence = make_album_quality_evidence(
+                mb_release_id="mbid-42",
+                source_path=source,
+                files=snapshot_audio_files(source),
+                measurement=AudioQualityMeasurement(
+                    min_bitrate_kbps=320,
+                    avg_bitrate_kbps=320,
+                    median_bitrate_kbps=320,
+                    format="MP3",
+                    spectral_grade=None,
+                    spectral_bitrate_kbps=None,
+                ),
+                lineage_version=1,
+            )
+            db.upsert_album_quality_evidence(evidence)
+            stored = db.find_album_quality_evidence(
+                mb_release_id=evidence.mb_release_id,
+                snapshot_fingerprint=evidence.snapshot_fingerprint,
+            )
+            assert stored is not None and stored.id is not None
+            db.set_request_current_evidence(42, stored.id)
+
+            result = persist_exact_current_spectral_from_attempt(
+                db,
+                request_id=42,
+                current_evidence=stored,
+                measured_existing=SpectralAnalysisDetail(
+                    attempted=True,
+                    grade="genuine",
+                    bitrate_kbps=96,
+                    suspect_pct=52.17,
+                ),
+                measured_existing_path=source,
+            )
+
+            self.assertEqual(result.status, "ready")
+            assert result.evidence is not None
+            self.assertEqual(result.evidence.measurement.spectral_grade, "genuine")
+            self.assertEqual(
+                result.evidence.measurement.spectral_bitrate_kbps,
+                96,
+            )
+            self.assertEqual(result.evidence.id, stored.id)
+            self.assertEqual(
+                result.evidence.snapshot_fingerprint,
+                stored.snapshot_fingerprint,
+            )
+        finally:
+            import shutil
+            shutil.rmtree(source, ignore_errors=True)
+
+    def test_attempt_scan_cannot_persist_for_a_different_installed_path(self):
+        db = self._db()
+        source = self._source_dir()
+        other = self._source_dir()
+        try:
+            evidence = make_album_quality_evidence(
+                mb_release_id="mbid-42",
+                source_path=source,
+                files=snapshot_audio_files(source),
+                measurement=AudioQualityMeasurement(
+                    min_bitrate_kbps=320,
+                    avg_bitrate_kbps=320,
+                    median_bitrate_kbps=320,
+                    format="MP3",
+                    spectral_grade=None,
+                    spectral_bitrate_kbps=None,
+                ),
+            )
+            db.upsert_album_quality_evidence(evidence)
+            current = db.find_album_quality_evidence(
+                mb_release_id=evidence.mb_release_id,
+                snapshot_fingerprint=evidence.snapshot_fingerprint,
+            )
+            assert current is not None and current.id is not None
+            db.set_request_current_evidence(42, current.id)
+            result = persist_exact_current_spectral_from_attempt(
+                db,
+                request_id=42,
+                current_evidence=current,
+                measured_existing=SpectralAnalysisDetail(
+                    attempted=True,
+                    grade="genuine",
+                    bitrate_kbps=96,
+                ),
+                measured_existing_path=other,
+            )
+
+            self.assertEqual(result.status, "stale")
+            persisted = db.load_album_quality_evidence_by_id(current.id)
+            assert persisted is not None
+            self.assertIsNone(persisted.measurement.spectral_grade)
+            self.assertIsNone(persisted.measurement.spectral_bitrate_kbps)
+        finally:
+            import shutil
+            shutil.rmtree(source, ignore_errors=True)
+            shutil.rmtree(other, ignore_errors=True)
+
+    def test_measurement_worker_wires_have_scan_into_current_evidence(self):
+        db = self._db()
+        source = self._source_dir()
+        try:
+            evidence = make_album_quality_evidence(
+                mb_release_id="mbid-42",
+                source_path=source,
+                files=snapshot_audio_files(source),
+                measurement=AudioQualityMeasurement(
+                    min_bitrate_kbps=320,
+                    avg_bitrate_kbps=320,
+                    median_bitrate_kbps=320,
+                    format="MP3",
+                    spectral_grade=None,
+                    spectral_bitrate_kbps=None,
+                ),
+            )
+            db.upsert_album_quality_evidence(evidence)
+            current = db.find_album_quality_evidence(
+                mb_release_id=evidence.mb_release_id,
+                snapshot_fingerprint=evidence.snapshot_fingerprint,
+            )
+            assert current is not None and current.id is not None
+            db.set_request_current_evidence(42, current.id)
+            measurement = PreimportMeasurement(
+                audio_corrupt=True,
+                corrupt_files=["01.mp3"],
+                folder_layout="flat",
+                audio_file_count=1,
+                existing_spectral_path=source,
+                spectral_audit=SpectralDetail(
+                    candidate=SpectralAnalysisDetail(
+                        attempted=True,
+                        grade="likely_transcode",
+                        bitrate_kbps=96,
+                    ),
+                    existing=SpectralAnalysisDetail(
+                        attempted=True,
+                        grade="genuine",
+                        bitrate_kbps=96,
+                    ),
+                ),
+            )
+            candidate = make_album_quality_evidence(
+                mb_release_id="mbid-42-candidate"
+            )
+            with patch(
+                "lib.config.read_runtime_config",
+                return_value=CratediggerConfig(
+                    beets_harness_path="/fake/harness/run_beets_harness.sh",
+                    pipeline_db_enabled=True,
+                ),
+            ), patch(
+                "lib.import_preview.inspect_local_files",
+                return_value=LocalFileInspection(filetype="mp3"),
+            ), patch(
+                "lib.import_preview.measure_preimport_state",
+                return_value=measurement,
+            ):
+                result = measure_and_persist_candidate_evidence(
+                    db,
+                    request_id=42,
+                    path=source,
+                    persist_measurement_fn=(
+                        lambda *args, **kwargs: EvidenceBuildResult(
+                            candidate,
+                            "ready",
+                        )
+                    ),
+                )
+
+            self.assertEqual(result.verdict, "evidence_ready")
+            persisted = db.load_album_quality_evidence_by_id(current.id)
+            assert persisted is not None
+            self.assertEqual(persisted.measurement.spectral_grade, "genuine")
+            self.assertEqual(persisted.measurement.spectral_bitrate_kbps, 96)
+        finally:
+            import shutil
+            shutil.rmtree(source, ignore_errors=True)
 
     def test_preview_v0_research_attempt_is_persisted_once_after_failure(self):
         db = self._db()

--- a/tests/test_js_history.mjs
+++ b/tests/test_js_history.mjs
@@ -597,6 +597,63 @@ console.log('renderEvidenceStrip() requires a number — a codec label alone is 
   }
 }
 
+console.log('Download failures blank IN and keep the complete pre-attempt HAVE row');
+{
+  const strip = renderEvidenceFixture({
+    outcome: 'timeout',
+    source_format: 'FLAC',
+    source_min_bitrate: 455,
+    source_avg_bitrate: 725,
+    spectral_grade: 'likely_transcode',
+    spectral_bitrate: 96,
+    v0_probe_min_bitrate: 178,
+    v0_probe_avg_bitrate: 248,
+    existing_format: 'Opus',
+    existing_min_bitrate: 93,
+    existing_avg_bitrate: 129,
+    existing_median_bitrate: 128,
+    existing_spectral_grade: 'suspect',
+    existing_spectral_bitrate: 96,
+    existing_v0_probe_min_bitrate: 193,
+    existing_v0_probe_avg_bitrate: 256,
+  });
+  assertContains(
+    strip,
+    '<strong class="r-ev-tag">IN</strong><span class="r-ev-cell r-ev-source">',
+    'timeout renders the IN row',
+  );
+  assertContains(strip, '>—</span>', 'timeout leaves IN blank');
+  assertExcludes(strip, '725k avg', 'timeout hides incoming bitrate');
+  assertExcludes(strip, 'V0 248k avg', 'timeout hides incoming V0');
+  assertContains(strip, 'Opus', 'timeout keeps HAVE codec');
+  assertContains(strip, '129k avg (min 93k)', 'timeout keeps HAVE average and minimum');
+  assertContains(strip, '~96k suspect', 'timeout keeps HAVE spectral');
+  assertContains(strip, 'V0 256k avg (min 193k)', 'timeout keeps HAVE V0');
+}
+
+console.log('Import failures retain the grabbed candidate in IN');
+{
+  const strip = renderEvidenceFixture({
+    outcome: 'failed',
+    source_format: 'FLAC',
+    source_min_bitrate: 455,
+    source_avg_bitrate: 725,
+    spectral_grade: 'likely_transcode',
+    spectral_bitrate: 96,
+    v0_probe_min_bitrate: 178,
+    v0_probe_avg_bitrate: 248,
+    existing_format: 'Opus',
+    existing_min_bitrate: 93,
+    existing_avg_bitrate: 129,
+  });
+  assertContains(strip, '725k avg (min 455k)', 'failed import keeps incoming bitrate');
+  assertContains(strip, '~96k likely transcode', 'failed import keeps incoming spectral');
+  assertContains(strip, 'V0 248k avg (min 178k)', 'failed import keeps incoming V0');
+  assertContains(strip, '725/455k a/m', 'mobile metric keeps average and minimum');
+  assertContains(strip, '~96k transcode', 'mobile spectral keeps its floor and grade');
+  assertContains(strip, 'V0 248/178k a/m', 'mobile V0 keeps average and minimum');
+}
+
 console.log('renderEvidenceStrip() shows the on-disk format on the HAVE side');
 {
   // The Mothertongue case (#575): AAC 256 replacing unverified MP3 256.
@@ -1200,24 +1257,22 @@ console.log('evidence strip CSS preserves shared desktop/mobile alignment withou
   assertContains(css, 'grid-template-columns: 3.6em minmax(4.5em, 0.8fr) minmax(12em, 1.7fr) minmax(4.5em, 0.75fr) minmax(7.5em, 1fr) minmax(9em, 1.35fr)',
     'desktop reserves a full avg/min metric column before rank/spectral/V0');
   assertContains(css, '@media (max-width: 720px)', 'shared grid has a narrow-screen layout');
-  assertContains(css, 'grid-template-columns: 4.3em minmax(5em, 0.8fr) minmax(0, 1.8fr)',
-    'mobile uses a readable tag/source/detail three-column grid');
-  assertContains(css, 'row-gap: 4px; font-size: 1em;',
-    'mobile evidence stays at the card text size');
-  assertContains(css, 'grid-template-rows: auto auto auto;',
-    'each evidence side receives three compact rows');
-  assertContains(css, '.r-evidence .r-ev-tag { grid-column: 1; grid-row: 1 / 4;',
-    'IN/HAVE spans every row without touching source text');
-  assertContains(css, '.r-ev-source { grid-column: 2; grid-row: 1; }',
-    'source owns the first aligned field slot');
-  assertContains(css, '.r-ev-metric { grid-column: 3; grid-row: 1; white-space: normal; }',
-    'mobile metric owns the first detail slot and can wrap at spaces');
-  assertContains(css, '.r-ev-rank { grid-column: 2; grid-row: 2; }',
-    'rank owns the second aligned field slot');
-  assertContains(css, '.r-ev-spectral { grid-column: 3; grid-row: 2; white-space: normal; }',
-    'spectral provenance wraps only at word boundaries in its own slot');
-  assertContains(css, '.r-ev-v0 { grid-column: 2 / -1; grid-row: 3; white-space: normal;',
-    'mobile V0 provenance uses a full-width third row');
+  assertContains(css, 'grid-template-columns: max-content max-content max-content max-content max-content max-content;',
+    'mobile packs every evidence field into the same six aligned columns');
+  assertContains(css, 'column-gap: 1px; row-gap: 2px; font-size: clamp(9px, 2.55vw, 10px);',
+    'mobile removes inter-sample whitespace while keeping the two sides distinct');
+  assertContains(css, '.r-ev-compact { display: none; }',
+    'desktop keeps the full evidence wording');
+  assertContains(css, '.r-ev-full { display: none; } .r-ev-compact { display: inline; }',
+    'mobile swaps in bounded avg/min evidence wording');
+  assertContains(css, '.r-ev-row { display: contents; padding: 0; }',
+    'IN and HAVE each occupy exactly one parent-grid row');
+  assertContains(css, '.r-evidence .r-ev-tag { grid-column: auto; grid-row: auto;',
+    'IN/HAVE is the first cell on each packed row');
+  assertContains(css, '.r-ev-source, .r-ev-metric, .r-ev-rank, .r-ev-spectral, .r-ev-v0 { grid-column: auto; grid-row: auto; white-space: nowrap; padding: 0; }',
+    'all mobile samples stay on one line per side without wrapping');
+  assertExcludes(css, 'grid-template-rows: auto auto auto;',
+    'mobile no longer spends three physical rows on each evidence side');
   assertContains(css, '.r-evidence .r-ev-tag { color: #d3deea; font-weight: 900; font-size: 1.08em;',
     'IN/HAVE labels are visibly prominent');
   assertContains(css, '@media (min-width: 721px) { .r-ev-v0 { padding-left: 1em; } }',

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -36,6 +36,7 @@ from lib.pipeline_db import (  # noqa: E402
     TransferLedgerRow,
 )
 from lib.pipeline_db._shared import REQUEST_METADATA_RESERVED_FIELDS  # noqa: E402
+from lib.quality import AudioQualityMeasurement  # noqa: E402
 
 
 TEST_DSN = os.environ.get("TEST_DB_DSN")
@@ -4300,6 +4301,55 @@ class TestAlbumQualityEvidenceStorage(unittest.TestCase):
         assert claimed is not None
         self.assertTrue(claimed.on_disk_v0_research_attempted)
         self.assertIsNone(claimed.v0_metric)
+
+    def test_current_spectral_write_requires_exact_empty_current_snapshot(self):
+        evidence = self._seed(
+            mb_release_id="evidence-uuid",
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=320,
+                avg_bitrate_kbps=320,
+                median_bitrate_kbps=320,
+                format="MP3",
+                spectral_grade=None,
+                spectral_bitrate_kbps=None,
+            ),
+        )
+        self.db.upsert_album_quality_evidence(evidence)
+        stored = self.db.find_album_quality_evidence(
+            mb_release_id=evidence.mb_release_id,
+            snapshot_fingerprint=evidence.snapshot_fingerprint,
+        )
+        assert stored is not None and stored.id is not None
+        self.assertTrue(self.db.set_request_current_evidence(
+            self.req_id, stored.id))
+
+        self.assertFalse(self.db.persist_current_spectral_measurement(
+            request_id=self.req_id,
+            expected_evidence_id=stored.id,
+            expected_snapshot_fingerprint="wrong",
+            grade="genuine",
+            bitrate_kbps=96,
+        ))
+        self.assertTrue(self.db.persist_current_spectral_measurement(
+            request_id=self.req_id,
+            expected_evidence_id=stored.id,
+            expected_snapshot_fingerprint=stored.snapshot_fingerprint,
+            grade="genuine",
+            bitrate_kbps=96,
+        ))
+        self.assertFalse(self.db.persist_current_spectral_measurement(
+            request_id=self.req_id,
+            expected_evidence_id=stored.id,
+            expected_snapshot_fingerprint=stored.snapshot_fingerprint,
+            grade="likely_transcode",
+            bitrate_kbps=160,
+        ))
+        self.db.upsert_album_quality_evidence(evidence)
+
+        loaded = self.db.load_album_quality_evidence_by_id(stored.id)
+        assert loaded is not None
+        self.assertEqual(loaded.measurement.spectral_grade, "genuine")
+        self.assertEqual(loaded.measurement.spectral_bitrate_kbps, 96)
 
     def test_v0_research_attempt_marker_is_monotonic_on_upsert(self):
         evidence = self._seed(

--- a/tests/test_quality_lineage_generated.py
+++ b/tests/test_quality_lineage_generated.py
@@ -11,7 +11,10 @@ import msgspec
 
 from harness.import_one import projected_is_cbr_from_bitrates
 from lib.measurement import PreimportMeasurement
-from lib.import_preview import enrich_current_v0_research_for_preview
+from lib.import_preview import (
+    enrich_current_v0_research_for_preview,
+    persist_exact_current_spectral_from_attempt,
+)
 from lib.pipeline_db.download_log import _DownloadLogMixin
 from lib.quality import (
     AlbumQualityV0Metric,
@@ -20,6 +23,7 @@ from lib.quality import (
     ImportResult,
     MeasuredImportDecisionInput,
     QualityRankConfig,
+    SpectralAnalysisDetail,
     TargetQualityContract,
     V0ProbeEvidence,
     full_pipeline_decision,
@@ -80,6 +84,17 @@ def assert_research_attempted_once_per_snapshot(
         raise AssertionError(
             "unchanged evidence snapshot must record exactly one V0 research attempt"
         )
+
+
+def assert_exact_current_spectral_persisted(
+    *,
+    expected_grade: str,
+    expected_bitrate: int | None,
+    actual_grade: str | None,
+    actual_bitrate: int | None,
+) -> None:
+    if (actual_grade, actual_bitrate) != (expected_grade, expected_bitrate):
+        raise AssertionError("attempt scan did not populate exact current evidence")
 
 
 class TestQualityLineagePins(unittest.TestCase):
@@ -720,6 +735,66 @@ class TestQualityLineagePins(unittest.TestCase):
 
 class TestQualityLineageGenerated(unittest.TestCase):
     @given(
+        grade=st.sampled_from(("genuine", "suspect", "likely_transcode")),
+        bitrate=st.one_of(st.none(), st.integers(min_value=32, max_value=500)),
+        payload_size=st.integers(min_value=1, max_value=128),
+    )
+    @example(grade="genuine", bitrate=96, payload_size=27)
+    def test_attempt_scan_populates_only_the_exact_current_snapshot(
+        self,
+        grade: str,
+        bitrate: int | None,
+        payload_size: int,
+    ) -> None:
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=42, mb_release_id="generated-have"))
+        with tempfile.TemporaryDirectory() as source:
+            with open(os.path.join(source, "01.mp3"), "wb") as handle:
+                handle.write(b"x" * payload_size)
+            evidence = make_album_quality_evidence(
+                mb_release_id="generated-have",
+                source_path=source,
+                files=snapshot_audio_files(source),
+                measurement=AudioQualityMeasurement(
+                    min_bitrate_kbps=320,
+                    avg_bitrate_kbps=320,
+                    median_bitrate_kbps=320,
+                    format="MP3",
+                    spectral_grade=None,
+                    spectral_bitrate_kbps=None,
+                ),
+            )
+            db.upsert_album_quality_evidence(evidence)
+            stored = db.find_album_quality_evidence(
+                mb_release_id=evidence.mb_release_id,
+                snapshot_fingerprint=evidence.snapshot_fingerprint,
+            )
+            assert stored is not None and stored.id is not None
+            db.set_request_current_evidence(42, stored.id)
+
+            result = persist_exact_current_spectral_from_attempt(
+                db,
+                request_id=42,
+                current_evidence=stored,
+                measured_existing=SpectralAnalysisDetail(
+                    attempted=True,
+                    grade=grade,
+                    bitrate_kbps=bitrate,
+                ),
+                measured_existing_path=source,
+            )
+
+            assert result.evidence is not None
+            assert_exact_current_spectral_persisted(
+                expected_grade=grade,
+                expected_bitrate=bitrate,
+                actual_grade=result.evidence.measurement.spectral_grade,
+                actual_bitrate=(
+                    result.evidence.measurement.spectral_bitrate_kbps
+                ),
+            )
+
+    @given(
         label=st.sampled_from(("mp3 v0", "MP3 V0", "mp3 320", " MP3 320 ")),
         supplied_mode=st.booleans(),
     )
@@ -1247,6 +1322,15 @@ class TestQualityLineageGenerated(unittest.TestCase):
 
 
 class TestInvariantCheckersTripOnViolations(unittest.TestCase):
+    def test_exact_current_spectral_checker_rejects_a_blank_have(self):
+        with self.assertRaisesRegex(AssertionError, "exact current evidence"):
+            assert_exact_current_spectral_persisted(
+                expected_grade="genuine",
+                expected_bitrate=96,
+                actual_grade=None,
+                actual_bitrate=None,
+            )
+
     def test_source_target_checker_rejects_target_labelled_proxy(self):
         planted_bad = ImportResult(
             source_measurement=AudioQualityMeasurement(

--- a/tests/test_web_recents_generated.py
+++ b/tests/test_web_recents_generated.py
@@ -78,6 +78,34 @@ def assert_current_library_have_is_projected(
         raise AssertionError("current library median did not populate compact HAVE")
 
 
+def assert_complete_have_snapshot_is_selected(
+    item: dict[str, object],
+    *,
+    expected_format: str,
+    expected_min: int,
+    expected_avg: int,
+    expected_median: int,
+    expected_spectral: str | None,
+    expected_v0: int | None,
+) -> None:
+    """Require one canonical HAVE snapshot, never a partial-field blend."""
+    assert_current_library_have_is_projected(
+        item,
+        expected_format=expected_format,
+        expected_min=expected_min,
+        expected_avg=expected_avg,
+        expected_median=expected_median,
+    )
+    if item.get("existing_spectral_grade") != expected_spectral:
+        raise AssertionError("partial attempt spectral leaked into canonical HAVE")
+    if item.get("existing_v0_probe_avg_bitrate") != expected_v0:
+        raise AssertionError("partial attempt V0 leaked into canonical HAVE")
+    if item.get("existing_spectral_attempted") is True:
+        raise AssertionError("partial attempt failure leaked into canonical HAVE")
+    if item.get("existing_spectral_error") is not None:
+        raise AssertionError("partial attempt error leaked into canonical HAVE")
+
+
 def assert_mutating_attempt_has_no_projected_have(item: dict[str, object]) -> None:
     if any(item.get(field) is not None for field in (
         "existing_format",
@@ -369,6 +397,150 @@ class TestGeneratedRejectVerdictGrammar(unittest.TestCase):
         )
         self.assertEqual(item["existing_spectral_grade"], current_spectral)
         self.assertEqual(item["existing_v0_probe_avg_bitrate"], current_v0)
+
+    @given(
+        card_kind=st.sampled_from(("deleted", "failed", "timeout")),
+        partial_kind=st.sampled_from((
+            "v0_only",
+            "spectral_only",
+            "format_only",
+            "minimum_only",
+            "spectral_failure_only",
+        )),
+        current_format=st.sampled_from(("MP3", "Opus", "FLAC")),
+        current_min=st.integers(min_value=1, max_value=2_000),
+        current_avg=st.integers(min_value=1, max_value=2_000),
+        current_median=st.integers(min_value=1, max_value=2_000),
+        current_spectral=st.one_of(
+            st.none(), st.sampled_from(("genuine", "likely_transcode", "suspect"))
+        ),
+        current_v0=st.one_of(
+            st.none(), st.integers(min_value=1, max_value=2_000)
+        ),
+    )
+    @example(
+        card_kind="deleted",
+        partial_kind="v0_only",
+        current_format="MP3",
+        current_min=320,
+        current_avg=320,
+        current_median=320,
+        current_spectral="genuine",
+        current_v0=268,
+    )
+    @example(
+        card_kind="failed",
+        partial_kind="minimum_only",
+        current_format="Opus",
+        current_min=93,
+        current_avg=129,
+        current_median=128,
+        current_spectral="suspect",
+        current_v0=256,
+    )
+    def test_partial_have_selects_one_complete_snapshot(
+        self,
+        card_kind: str,
+        partial_kind: str,
+        current_format: str,
+        current_min: int,
+        current_avg: int,
+        current_median: int,
+        current_spectral: str | None,
+        current_v0: int | None,
+    ) -> None:
+        item: dict[str, object] = {
+            "outcome": (
+                "rejected" if card_kind == "deleted" else card_kind
+            ),
+            "wrong_match_triage_action": (
+                "deleted_reject" if card_kind == "deleted" else None
+            ),
+            "existing_format": None,
+            "existing_min_bitrate": None,
+            "existing_avg_bitrate": None,
+            "existing_median_bitrate": None,
+            "existing_spectral_grade": None,
+            "existing_spectral_bitrate": None,
+            "existing_spectral_attempted": False,
+            "existing_spectral_error": None,
+            "existing_v0_probe_kind": None,
+            "existing_v0_probe_min_bitrate": None,
+            "existing_v0_probe_avg_bitrate": None,
+            "existing_v0_probe_median_bitrate": None,
+            "comparison_basis": None,
+        }
+        if partial_kind == "v0_only":
+            item.update({
+                "existing_v0_probe_kind": "on_disk_research_v0",
+                "existing_v0_probe_min_bitrate": 245,
+                "existing_v0_probe_avg_bitrate": 268,
+                "existing_v0_probe_median_bitrate": 268,
+            })
+        elif partial_kind == "spectral_only":
+            item.update({
+                "existing_spectral_grade": "likely_transcode",
+                "existing_spectral_bitrate": 96,
+            })
+        elif partial_kind == "format_only":
+            item["existing_format"] = "Legacy"
+        elif partial_kind == "minimum_only":
+            item["existing_min_bitrate"] = 7
+        else:
+            item.update({
+                "existing_spectral_attempted": True,
+                "existing_spectral_error": "legacy decode failure",
+            })
+
+        row: dict[str, object] = {
+            "_current_evidence_id": 42,
+            "_current_evidence_is_pre_attempt": True,
+            "_current_evidence_format": current_format,
+            "_current_evidence_min_bitrate": current_min,
+            "_current_evidence_avg_bitrate": current_avg,
+            "_current_evidence_median_bitrate": current_median,
+            "_current_evidence_spectral_grade": current_spectral,
+            "_current_evidence_spectral_bitrate": (
+                96 if current_spectral is not None else None
+            ),
+            "_current_evidence_v0_probe_kind": (
+                "on_disk_research_v0" if current_v0 is not None else None
+            ),
+            "_current_evidence_v0_probe_min_bitrate": (
+                current_v0 - 1 if current_v0 is not None else None
+            ),
+            "_current_evidence_v0_probe_avg_bitrate": current_v0,
+            "_current_evidence_v0_probe_median_bitrate": current_v0,
+        }
+        _project_current_library_have(item, row, {})
+
+        assert_complete_have_snapshot_is_selected(
+            item,
+            expected_format=current_format,
+            expected_min=current_min,
+            expected_avg=current_avg,
+            expected_median=current_median,
+            expected_spectral=current_spectral,
+            expected_v0=current_v0,
+        )
+
+    def test_complete_snapshot_checker_rejects_partial_field_blends(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "current library format"):
+            assert_complete_have_snapshot_is_selected(
+                {
+                    "existing_format": None,
+                    "existing_min_bitrate": None,
+                    "existing_avg_bitrate": None,
+                    "existing_median_bitrate": None,
+                    "existing_v0_probe_avg_bitrate": 268,
+                },
+                expected_format="MP3",
+                expected_min=320,
+                expected_avg=320,
+                expected_median=320,
+                expected_spectral=None,
+                expected_v0=268,
+            )
 
     @given(
         is_pre_attempt=st.booleans(),

--- a/tests/web/test_routes_pipeline.py
+++ b/tests/web/test_routes_pipeline.py
@@ -490,6 +490,95 @@ class TestPipelineRouteContracts(_FakeDbWebServerCase):
         self.assertEqual(item["existing_v0_probe_min_bitrate"], 193)
         self.assertEqual(item["existing_v0_probe_avg_bitrate"], 256)
 
+    def test_deleted_triage_partial_v0_does_not_suppress_current_have(self):
+        """Music for Qigong Dancing: a lone audit V0 is not a HAVE row."""
+        import web.server as srv
+        from lib.quality import AlbumQualityV0Metric, AudioQualityMeasurement
+        from tests.helpers import make_album_quality_evidence
+
+        self.db.log_download(
+            100,
+            outcome="rejected",
+            validation_result={
+                "scenario": "high_distance",
+                "distance": 0.179,
+                "wrong_match_triage": {
+                    "action": "deleted_reject",
+                    "outcome": "deleted",
+                    "reason": "downgrade",
+                    "preview_verdict": "confident_reject",
+                    "preview_decision": "downgrade",
+                    "stage_chain": ["stage2_import:downgrade"],
+                    "current_measurement": {
+                        "format": None,
+                        "min_bitrate_kbps": None,
+                        "avg_bitrate_kbps": None,
+                        "median_bitrate_kbps": None,
+                        "spectral_grade": None,
+                        "spectral_bitrate_kbps": None,
+                    },
+                    "current_v0_probe": {
+                        "kind": "on_disk_research_v0",
+                        "min_bitrate_kbps": 245,
+                        "avg_bitrate_kbps": 268,
+                        "median_bitrate_kbps": 268,
+                    },
+                },
+            },
+        )
+        evidence = make_album_quality_evidence(
+            mb_release_id="test-mbid-0100",
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=320,
+                avg_bitrate_kbps=320,
+                median_bitrate_kbps=320,
+                format="MP3",
+                spectral_grade="genuine",
+                spectral_bitrate_kbps=96,
+            ),
+            v0_metric=AlbumQualityV0Metric(
+                min_bitrate_kbps=245,
+                avg_bitrate_kbps=268,
+                median_bitrate_kbps=268,
+                source_lineage="on_disk_research",
+            ),
+            lineage_version=1,
+        )
+        self.db.upsert_album_quality_evidence(evidence)
+        stored = self.db.find_album_quality_evidence(
+            mb_release_id=evidence.mb_release_id,
+            snapshot_fingerprint=evidence.snapshot_fingerprint,
+        )
+        assert stored is not None and stored.id is not None
+        self.assertTrue(self.db.set_request_current_evidence(100, stored.id))
+
+        beets = FakeBeetsDB()
+        beets.set_mbid_detail(
+            "test-mbid-0100",
+            {
+                "beets_format": "MP3",
+                "beets_bitrate": 320,
+                "beets_avg_bitrate": 320,
+            },
+        )
+        with patch.object(srv, "_beets_db", return_value=beets):
+            status, data = self._get("/api/pipeline/log")
+
+        self.assertEqual(status, 200)
+        item = data["log"][0]
+        self.assertEqual(item["badge"], "Triaged · deleted")
+        self.assertEqual(item["existing_format"], "MP3")
+        self.assertEqual(item["existing_min_bitrate"], 320)
+        self.assertEqual(item["existing_avg_bitrate"], 320)
+        self.assertEqual(item["existing_median_bitrate"], 320)
+        self.assertEqual(item["existing_spectral_grade"], "genuine")
+        self.assertEqual(item["existing_spectral_bitrate"], 96)
+        self.assertEqual(
+            item["existing_v0_probe_kind"], "on_disk_research"
+        )
+        self.assertEqual(item["existing_v0_probe_min_bitrate"], 245)
+        self.assertEqual(item["existing_v0_probe_avg_bitrate"], 268)
+
     def test_kept_would_import_completes_have_from_explicit_successor(self):
         import web.server as srv
         from lib.quality import AudioQualityMeasurement, ImportResult

--- a/web/index.html
+++ b/web/index.html
@@ -360,16 +360,14 @@
   .r-ev-row { display: contents; }
   .r-evidence .r-ev-tag { color: #d3deea; font-weight: 900; font-size: 1.08em; line-height: 1; letter-spacing: 0.9px; text-shadow: 0 0 8px rgba(170, 205, 235, 0.24); }
   .r-ev-cell { min-width: 0; overflow-wrap: normal; word-break: normal; white-space: nowrap; }
+  .r-ev-compact { display: none; }
   @media (min-width: 721px) { .r-ev-v0 { padding-left: 1em; } }
   @media (max-width: 720px) {
-    .r-evidence { grid-template-columns: 4.3em minmax(5em, 0.8fr) minmax(0, 1.8fr); column-gap: 0.65em; row-gap: 4px; font-size: 1em; }
-    .r-ev-row { display: grid; grid-column: 1 / -1; grid-template-columns: subgrid; grid-template-rows: auto auto auto; row-gap: 1px; padding: 2px 0; }
-    .r-evidence .r-ev-tag { grid-column: 1; grid-row: 1 / 4; align-self: start; padding-top: 1px; font-size: 1.15em; }
-    .r-ev-source { grid-column: 2; grid-row: 1; }
-    .r-ev-metric { grid-column: 3; grid-row: 1; white-space: normal; }
-    .r-ev-rank { grid-column: 2; grid-row: 2; }
-    .r-ev-spectral { grid-column: 3; grid-row: 2; white-space: normal; }
-    .r-ev-v0 { grid-column: 2 / -1; grid-row: 3; white-space: normal; padding-bottom: 2px; }
+    .r-evidence { grid-template-columns: max-content max-content max-content max-content max-content max-content; column-gap: 1px; row-gap: 2px; font-size: clamp(9px, 2.55vw, 10px); font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing: -0.2px; color: #92a2b1; }
+    .r-ev-row { display: contents; padding: 0; }
+    .r-evidence .r-ev-tag { grid-column: auto; grid-row: auto; align-self: baseline; padding: 0; font-size: 1em; letter-spacing: 0; }
+    .r-ev-source, .r-ev-metric, .r-ev-rank, .r-ev-spectral, .r-ev-v0 { grid-column: auto; grid-row: auto; white-space: nowrap; padding: 0; }
+    .r-ev-full { display: none; } .r-ev-compact { display: inline; }
   }
   /* Failure prose can carry raw paths + quoted transport errors — clamp
      it to two lines; the full text stays in the hover title. */

--- a/web/js/history.js
+++ b/web/js/history.js
@@ -202,6 +202,7 @@ function sourceStorageLabel(sourceFormat, storageFormat) {
 function buildEvidenceCardModel(h) {
   const basis = h.comparison_basis || null;
   const inCells = emptyEvidenceCells();
+  const failedDownload = h.outcome === 'timeout';
   const sourceFormat = h.source_format || h.slskd_filetype || h.original_filetype;
   const losslessSource = isLosslessSource(sourceFormat);
   const hasMaterializedMeasurement = Boolean(
@@ -270,6 +271,9 @@ function buildEvidenceCardModel(h) {
   if (h.v0_probe_avg_bitrate) {
     inCells.v0 = stripV0Phrase(h.v0_probe_avg_bitrate, h.v0_probe_min_bitrate);
   }
+  if (failedDownload) {
+    Object.assign(inCells, emptyEvidenceCells(), { source: '—' });
+  }
 
   const haveCells = emptyEvidenceCells();
   if (basis) {
@@ -318,14 +322,33 @@ function buildEvidenceCardModel(h) {
   return { inCells, haveCells };
 }
 
+function compactEvidenceValue(kind, value) {
+  let compact = value
+    .replace(/(\d+)k avg \(min (\d+)k\)/g, '$1/$2k a/m')
+    .replace(/(\d+)k median \(min (\d+)k\)/g, '$1/$2k md/m')
+    .replace(/likely transcode/g, 'transcode');
+  if (kind === 'v0') {
+    compact = compact.replace(/V0 (\d+)k avg \(min (\d+)k\)/g, 'V0 $1/$2k a/m');
+  }
+  return compact;
+}
+
+function renderEvidenceCell(kind, value) {
+  const compact = compactEvidenceValue(kind, value);
+  return `<span class="r-ev-cell r-ev-${kind}">`
+    + `<span class="r-ev-full">${value}</span>`
+    + `<span class="r-ev-compact">${compact}</span>`
+    + `</span>`;
+}
+
 function renderEvidenceRow(side, label, cells) {
   return `<span class="r-ev-row r-ev-${side}">`
     + `<strong class="r-ev-tag">${label}</strong>`
-    + `<span class="r-ev-cell r-ev-source">${cells.source}</span>`
-    + `<span class="r-ev-cell r-ev-metric">${cells.metric}</span>`
-    + `<span class="r-ev-cell r-ev-rank">${cells.rank}</span>`
-    + `<span class="r-ev-cell r-ev-spectral">${cells.spectral}</span>`
-    + `<span class="r-ev-cell r-ev-v0">${cells.v0}</span>`
+    + renderEvidenceCell('source', cells.source)
+    + renderEvidenceCell('metric', cells.metric)
+    + renderEvidenceCell('rank', cells.rank)
+    + renderEvidenceCell('spectral', cells.spectral)
+    + renderEvidenceCell('v0', cells.v0)
     + `</span>`;
 }
 

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -43,14 +43,15 @@ def _project_current_library_have(
     row: Mapping[str, object],
     _beets: Mapping[str, object],
 ) -> None:
-    """Fill legacy HAVE only from a provably pre-attempt exact snapshot.
+    """Select one complete, provably pre-attempt HAVE snapshot.
 
     HAVE is historical: what was on disk before this attempt. Successful and
     explicit import rows may have updated the request's current evidence, so
-    they never receive an overlay. Non-mutating legacy rows may use the
-    request's canonical evidence only when its measurement predates the
-    attempt. Live Beets data has no historical timestamp and is never evidence
-    for HAVE.
+    they never receive an overlay. A deleted-triage or failed row may carry a
+    partial embedded snapshot (for example Qigong's V0 probe with no codec or
+    bitrate); when canonical evidence predates the attempt, replace that
+    partial snapshot wholesale instead of mixing fields. Live Beets data has
+    no historical timestamp and is never evidence for HAVE.
     """
     attempt_measurement_fields = (
         "existing_format",
@@ -66,11 +67,34 @@ def _project_current_library_have(
         "existing_v0_probe_median_bitrate",
         "comparison_basis",
     )
-    if item.get("existing_spectral_attempted") is True or any(
-        item.get(field) is not None for field in attempt_measurement_fields
-    ):
-        return
     if item.get("outcome") in ("success", "force_import", "manual_import"):
+        return
+
+    attempt_has_any = (
+        item.get("existing_spectral_attempted") is True
+        or any(
+            item.get(field) is not None
+            for field in attempt_measurement_fields
+        )
+    )
+    attempt_has_complete_core = (
+        item.get("existing_format") is not None
+        and item.get("existing_min_bitrate") is not None
+        and item.get("existing_avg_bitrate") is not None
+    )
+    partial_snapshot_can_be_replaced = (
+        item.get("comparison_basis") is None
+        and (
+            item.get("outcome") in ("failed", "timeout")
+            or item.get("wrong_match_triage_action") in (
+                "deleted_reject",
+                "deleted_verified_lossless_parent",
+            )
+        )
+    )
+    if attempt_has_any and (
+        attempt_has_complete_core or not partial_snapshot_can_be_replaced
+    ):
         return
 
     current_projection = {
@@ -99,10 +123,19 @@ def _project_current_library_have(
             "_current_evidence_v0_probe_median_bitrate"
         ),
     }
+    current_has_complete_core = (
+        current_projection["existing_format"] is not None
+        and current_projection["existing_min_bitrate"] is not None
+        and current_projection["existing_avg_bitrate"] is not None
+    )
     if (
         row.get("_current_evidence_id") is not None
         and row.get("_current_evidence_is_pre_attempt") is True
+        and (not attempt_has_any or current_has_complete_core)
     ):
+        if attempt_has_any:
+            item["existing_spectral_attempted"] = False
+            item["existing_spectral_error"] = None
         item.update(current_projection)
 
 


### PR DESCRIPTION
## Summary

- select one complete pre-attempt `HAVE` snapshot for triage-deleted and failed-download Recents cards
- keep failed downloads blank on `IN` while preserving candidate evidence for import-phase failures
- persist successful exact-installed spectral scans onto the still-current content-addressed evidence row
- compact phone evidence into one `IN` row over one `HAVE` row without clipping

## Verification

- deterministic and generated regressions for whole-snapshot selection and exact spectral persistence
- fake and real-Postgres atomic-write coverage
- JS evidence-card tests
- Playwright checks at 360px and 390px: no evidence strip overflow

Refs #709
