### PR TITLE
fix: readable aligned mobile evidence strips on Recents

### DIFF
--- a/tests/test_js_history.mjs
+++ b/tests/test_js_history.mjs
@@ -649,9 +649,32 @@ console.log('Import failures retain the grabbed candidate in IN');
   assertContains(strip, '725k avg (min 455k)', 'failed import keeps incoming bitrate');
   assertContains(strip, '~96k likely transcode', 'failed import keeps incoming spectral');
   assertContains(strip, 'V0 248k avg (min 178k)', 'failed import keeps incoming V0');
-  assertContains(strip, '725/455k a/m', 'mobile metric keeps average and minimum');
-  assertContains(strip, '~96k transcode', 'mobile spectral keeps its floor and grade');
-  assertContains(strip, 'V0 248/178k a/m', 'mobile V0 keeps average and minimum');
+  assertContains(strip, '>725k avg/455k min<', 'mobile metric labels each number in place');
+  const spectralCount = strip.split('~96k likely transcode').length - 1;
+  if (spectralCount === 2) { passed++; } else {
+    failed++;
+    console.error(`  FAIL: mobile spectral keeps the full "likely transcode" wording (the column ellipsizes instead); got ${spectralCount} of 2 spans`);
+  }
+  assertContains(strip, 'V0 248/178k<', 'mobile V0 stays the bare pair — its label is the V0 prefix');
+  assertExcludes(strip, 'a/m', 'the cryptic a/m shorthand is dead');
+}
+
+console.log('renderEvidenceStrip() collapses equal avg/min pairs to one number on mobile');
+{
+  const strip = renderEvidenceFixture({
+    source_format: 'MP3',
+    source_min_bitrate: 320,
+    source_avg_bitrate: 320,
+    existing_format: 'MP3',
+    existing_min_bitrate: 192,
+    existing_avg_bitrate: 192,
+    existing_v0_probe_avg_bitrate: 245,
+    existing_v0_probe_min_bitrate: 245,
+  });
+  assertContains(strip, '320k avg (min 320k)', 'desktop wording keeps both numbers');
+  assertContains(strip, '>320k<', 'mobile collapses a CBR pair to one number');
+  assertExcludes(strip, '320k avg/320k min', 'no redundant equal pair on mobile');
+  assertContains(strip, '>V0 245k<', 'an equal V0 pair collapses too');
 }
 
 console.log('renderEvidenceStrip() shows the on-disk format on the HAVE side');
@@ -985,10 +1008,12 @@ console.log('Amaterasu Shiroi: force import HAVE stays pre-import');
   assertExcludes(strip, '>transparent</span>',
     'HAVE does not substitute the decision rank for spectral data');
   assertExcludes(strip, '>excellent</span>', 'decision rank stays out of compact HAVE');
+  // One cell renders the phrase twice (full + compact span); a leak into
+  // HAVE would double that to 4.
   const spectralCount = strip.split('~96k likely transcode').length - 1;
-  if (spectralCount === 1) { passed++; } else {
+  if (spectralCount === 2) { passed++; } else {
     failed++;
-    console.error(`  FAIL: candidate spectral belongs only to IN; rendered ${spectralCount} times`);
+    console.error(`  FAIL: candidate spectral belongs only to IN; rendered ${spectralCount} spans, expected 2`);
   }
   const v0Count = strip.split('V0 258k avg (min 246k)').length - 1;
   if (v0Count === 1) { passed++; } else {
@@ -1249,30 +1274,30 @@ console.log('Iron & Wine: the temporary V0 minimum never wears the FLAC label');
     'detail existing V0 owns its minimum');
 }
 
-console.log('evidence strip CSS preserves shared desktop/mobile alignment without mid-word wraps');
+console.log('evidence strip CSS keeps desktop alignment and gives mobile readable aligned one-line rows');
 {
   const css = readFileSync(new URL('../web/index.html', import.meta.url), 'utf8');
   assertContains(css, '.r-ev-row { display: contents; }',
-    'row wrappers participate in the parent grid instead of defining independent columns');
+    'desktop row wrappers participate in the parent grid instead of defining independent columns');
   assertContains(css, 'grid-template-columns: 3.6em minmax(4.5em, 0.8fr) minmax(12em, 1.7fr) minmax(4.5em, 0.75fr) minmax(7.5em, 1fr) minmax(9em, 1.35fr)',
     'desktop reserves a full avg/min metric column before rank/spectral/V0');
   assertContains(css, '@media (max-width: 720px)', 'shared grid has a narrow-screen layout');
-  assertContains(css, 'grid-template-columns: max-content max-content max-content max-content max-content max-content;',
-    'mobile packs every evidence field into the same six aligned columns');
-  assertContains(css, 'column-gap: 1px; row-gap: 2px; font-size: clamp(9px, 2.55vw, 10px);',
-    'mobile removes inter-sample whitespace while keeping the two sides distinct');
+  assertContains(css, '.r-evidence { grid-template-columns: 2.9em 3.2em minmax(8.5em, max-content) 0 minmax(3em, 1fr) max-content; column-gap: 0.45em; font-size: 12px;',
+    'mobile fixes tag+source and floors the bitrate column at a labelled-pair width, so a bare CBR value keeps the same column edges as the pair above it');
+  assertContains(css, 'font-family: system-ui,',
+    'mobile uses the narrow system font so full lines fit without squeezing');
+  assertContains(css, '.r-ev-cell { overflow: hidden; text-overflow: ellipsis; }',
+    'squeezed cells drop end characters instead of wrapping');
+  assertContains(css, '.r-ev-full { display: none; } .r-ev-compact { display: inline; }',
+    'mobile swaps in the spelled-out compact wording');
   assertContains(css, '.r-ev-compact { display: none; }',
     'desktop keeps the full evidence wording');
-  assertContains(css, '.r-ev-full { display: none; } .r-ev-compact { display: inline; }',
-    'mobile swaps in bounded avg/min evidence wording');
-  assertContains(css, '.r-ev-row { display: contents; padding: 0; }',
-    'IN and HAVE each occupy exactly one parent-grid row');
-  assertContains(css, '.r-evidence .r-ev-tag { grid-column: auto; grid-row: auto;',
-    'IN/HAVE is the first cell on each packed row');
-  assertContains(css, '.r-ev-source, .r-ev-metric, .r-ev-rank, .r-ev-spectral, .r-ev-v0 { grid-column: auto; grid-row: auto; white-space: nowrap; padding: 0; }',
-    'all mobile samples stay on one line per side without wrapping');
+  assertExcludes(css, 'clamp(9px', 'mobile never shrinks evidence below readable size');
+  assertExcludes(css, 'grid-template-columns: max-content max-content max-content max-content max-content max-content;',
+    'the six-column mobile crush cannot return');
+  assertExcludes(css, 'column-gap: 1px', 'the 1px column crush cannot return');
   assertExcludes(css, 'grid-template-rows: auto auto auto;',
-    'mobile no longer spends three physical rows on each evidence side');
+    'mobile does not spend three physical rows on each evidence side');
   assertContains(css, '.r-evidence .r-ev-tag { color: #d3deea; font-weight: 900; font-size: 1.08em;',
     'IN/HAVE labels are visibly prominent');
   assertContains(css, '@media (min-width: 721px) { .r-ev-v0 { padding-left: 1em; } }',

--- a/web/index.html
+++ b/web/index.html
@@ -363,10 +363,20 @@
   .r-ev-compact { display: none; }
   @media (min-width: 721px) { .r-ev-v0 { padding-left: 1em; } }
   @media (max-width: 720px) {
-    .r-evidence { grid-template-columns: max-content max-content max-content max-content max-content max-content; column-gap: 1px; row-gap: 2px; font-size: clamp(9px, 2.55vw, 10px); font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing: -0.2px; color: #92a2b1; }
-    .r-ev-row { display: contents; padding: 0; }
-    .r-evidence .r-ev-tag { grid-column: auto; grid-row: auto; align-self: baseline; padding: 0; font-size: 1em; letter-spacing: 0; }
-    .r-ev-source, .r-ev-metric, .r-ev-rank, .r-ev-spectral, .r-ev-v0 { grid-column: auto; grid-row: auto; white-space: nowrap; padding: 0; }
+    /* Mobile: the same shared grid as desktop, sized for cross-card
+       scanning at 12px. Tag and source columns are FIXED so the bitrate
+       column starts at the same x on every card; the V0 column ends
+       flush right on every card (the flexible spectral column eats the
+       slack between them, ellipsizing under pressure — its color still
+       tells the grade). Number columns are max-content and never shrink.
+       The rank slot is never populated on strips, so its track is 0.
+       The bitrate column is floored at a labelled-pair width so a bare
+       CBR value ("320k") keeps the same column edges as a full pair —
+       only rare 4-digit pairs grow past it. One line per side,
+       guaranteed. Compact wording labels each number in place (avg/min
+       beside the values), never "a/m". */
+    .r-evidence { grid-template-columns: 2.9em 3.2em minmax(8.5em, max-content) 0 minmax(3em, 1fr) max-content; column-gap: 0.45em; font-size: 12px; line-height: 1.5; font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #92a2b1; }
+    .r-ev-cell { overflow: hidden; text-overflow: ellipsis; }
     .r-ev-full { display: none; } .r-ev-compact { display: inline; }
   }
   /* Failure prose can carry raw paths + quoted transport errors — clamp

--- a/web/js/history.js
+++ b/web/js/history.js
@@ -322,22 +322,32 @@ function buildEvidenceCardModel(h) {
   return { inCells, haveCells };
 }
 
+/**
+ * Mobile wording: each number carries its own label in place ("725k
+ * avg/455k min") instead of a detached trailing legend. Equal pairs (CBR
+ * albums) collapse to one number, the V0 cell stays the bare pair (the V0
+ * prefix is its label), and a converted source reads "FLAC→Opus". Full
+ * wording stays a tap away in the detail panel.
+ */
 function compactEvidenceValue(kind, value) {
+  const labelled = (label) => (_, a, b) =>
+    (a === b ? `${a}k` : `${a}k ${label}/${b}k min`);
   let compact = value
-    .replace(/(\d+)k avg \(min (\d+)k\)/g, '$1/$2k a/m')
-    .replace(/(\d+)k median \(min (\d+)k\)/g, '$1/$2k md/m')
-    .replace(/likely transcode/g, 'transcode');
+    .replace(/(\d+)k avg \(min (\d+)k\)/g, labelled('avg'))
+    .replace(/(\d+)k median \(min (\d+)k\)/g, labelled('med'));
   if (kind === 'v0') {
-    compact = compact.replace(/V0 (\d+)k avg \(min (\d+)k\)/g, 'V0 $1/$2k a/m');
+    compact = compact.replace(/V0 (\d+)k \w+\/(\d+)k min/g, 'V0 $1/$2k');
+  }
+  if (kind === 'source') {
+    compact = compact.replace(' - ', '→');
   }
   return compact;
 }
 
 function renderEvidenceCell(kind, value) {
-  const compact = compactEvidenceValue(kind, value);
   return `<span class="r-ev-cell r-ev-${kind}">`
     + `<span class="r-ev-full">${value}</span>`
-    + `<span class="r-ev-compact">${compact}</span>`
+    + `<span class="r-ev-compact">${compactEvidenceValue(kind, value)}</span>`
     + `</span>`;
 }
 


### PR DESCRIPTION
## Summary

The mobile (≤720px) IN/HAVE evidence strip on Recents packed six max-content columns at `clamp(9px, 2.55vw, 10px)` with 1px gaps and cryptic shorthand (`725/455k a/m`) — operator-illegible on a phone. This replaces it with the same shared grid as desktop, sized for cross-card scanning at 12px in the system font.

- Tag and source columns are fixed and the bitrate column is floored at a labelled-pair width, so column edges align both between IN/HAVE and across cards; the V0 column ends flush right on every card.
- Number columns are max-content and never shrink; the flexible spectral column absorbs any squeeze and ellipsizes (its color still tells the grade). One guaranteed line per side.
- Compact wording labels each number in place (`725k avg/455k min`, `229k med/128k min`), collapses equal CBR pairs to one number (`320k`), keeps V0 as the bare pair (`V0 248/178k`), renders a converted source as `FLAC→Opus`, and keeps the full `likely transcode` grade wording instead of shortening it.

Desktop rendering is unchanged.

## Verification

- Iterated live against the live-db dev server with per-cell truncation measurements (playwright agent) at 390×844; **final state verified on-device by the operator**.
- Full suite green at HEAD (6,044 tests, artifact-cited push); pyright clean; CSS contract pins in `tests/test_js_history.mjs` updated to pin the new mobile grid and forbid the old crush (`clamp(9px`, six max-content columns, 1px gaps, `a/m`) from returning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)