### PR TITLE
feat: complete HAVE evidence at the download-failure point

### DIFF
--- a/docs/quality-verification.md
+++ b/docs/quality-verification.md
@@ -359,6 +359,24 @@ describe the upstream source audio at import time, not the on-disk
 file. Wrong-match cleanup triage compares future candidates against
 this evidence to reject same-source duplicates.
 
+**Incomplete current evidence self-heals at the failure point.** A
+current-evidence row's spectral scan and on-disk V0 research normally
+complete during import preview — but a request whose downloads always
+fail never reaches preview, so its HAVE snapshot (and therefore the
+Recents IN/HAVE strip) stays partial forever. Download-phase failure
+finalizers (`_timeout_album` and the materialize-grace reset in
+`lib/download.py`) therefore call
+`enrich_incomplete_current_evidence_for_request`
+(`lib/import_preview.py`): it plans exactly the missing pieces
+(`plan_current_evidence_enrichment`, pure), measures the on-disk copy
+directly, and persists through the same preview-owned once-only helpers
+— never overwriting present evidence, never re-probing an attempted
+snapshot, and refusing stale on-disk state. Bounded by
+`CratediggerContext.evidence_enrichment_budget` per cycle so failure
+bursts never balloon the loop; complete rows cost nothing. Over time
+the failed-download cohort's evidence converges without any download
+succeeding.
+
 **Search narrowing companion.** When `lossless_source_locked` fires —
 in the importer (`lib/dispatch/core.py`) or wrong-match cleanup
 triage (`lib/wrong_match_cleanup_service.py`) — the request's

--- a/lib/context.py
+++ b/lib/context.py
@@ -108,6 +108,13 @@ class CratediggerContext:
     # per cycle; >3 sustained warrants investigation.
     cycle_searches_watchdog_killed: int = 0
 
+    # --- Per-cycle HAVE evidence enrichment budget. ---
+    # Download-phase failures opportunistically measure the request's
+    # on-disk copy (missing spectral / V0 research); this bounds how many
+    # such measurements one cycle may run so failure bursts never balloon
+    # the loop. Skip-if-complete costs nothing and is not budgeted.
+    evidence_enrichment_budget: int = 2
+
     # --- Per-cycle find_download pipeline counters (issue #217). ---
     find_download_queued: int = 0
     find_download_completed: int = 0

--- a/lib/download.py
+++ b/lib/download.py
@@ -319,11 +319,54 @@ def _enrich_timeout_reason(reason: str, files: list[DownloadFile]) -> str:
     return reason
 
 
+def _enrich_have_evidence_after_failure(
+    request_id: int,
+    ctx: CratediggerContext,
+    *,
+    enrich_fn: Callable[..., str] | None = None,
+) -> None:
+    """Fill missing HAVE evidence at a download-failure point.
+
+    A failed download never reaches preview — the only other place HAVE
+    spectral/V0 evidence gets completed — but the request's on-disk copy is
+    right there to measure. Budgeted per cycle so failure bursts never
+    balloon the loop; a complete row costs nothing and is not budgeted.
+    Never lets an enrichment error disturb failure bookkeeping.
+    """
+    if ctx.evidence_enrichment_budget <= 0:
+        return
+    try:
+        if enrich_fn is None:
+            from lib.import_preview import (
+                enrich_incomplete_current_evidence_for_request,
+            )
+            enrich_fn = enrich_incomplete_current_evidence_for_request
+        db = ctx.pipeline_db_source._get_db()
+        outcome = enrich_fn(db, request_id=request_id)
+    except Exception:
+        ctx.evidence_enrichment_budget -= 1
+        logger.warning(
+            "HAVE evidence enrichment failed for request %s",
+            request_id,
+            exc_info=True,
+        )
+        return
+    if outcome not in ("complete", "no_current_evidence", "stale"):
+        ctx.evidence_enrichment_budget -= 1
+        logger.info(
+            "HAVE evidence enrichment for request %s: %s",
+            request_id,
+            outcome,
+        )
+
+
 def _timeout_album(
     entry: GrabListEntry,
     request_id: int,
     reason: str,
     ctx: CratediggerContext,
+    *,
+    enrich_fn: Callable[..., str] | None = None,
 ) -> None:
     """Handle download timeout: cancel, log, reset to wanted."""
     cancel_and_delete(entry.files, ctx)
@@ -359,6 +402,7 @@ def _timeout_album(
             attempt_type="download",
         ),
     ))
+    _enrich_have_evidence_after_failure(request_id, ctx, enrich_fn=enrich_fn)
 
 
 def _persist_updated_download_state(
@@ -744,6 +788,7 @@ def _enqueue_completed_processing(
                     attempt_type="download",
                 ),
             ))
+            _enrich_have_evidence_after_failure(request_id, ctx)
             return None
         logger.warning(
             "Completed download for request %s could not be materialized "

--- a/lib/import_preview.py
+++ b/lib/import_preview.py
@@ -13,6 +13,7 @@ import os
 import shutil
 import tempfile
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any, Protocol, runtime_checkable
 
 import msgspec
@@ -20,6 +21,8 @@ import msgspec
 from lib.dispatch import run_import_one
 from lib.dispatch.types import ImportOneRun
 from lib.measurement import (
+    SpectralDetailAnalyzer,
+    analyze_spectral_audit_path,
     inspect_local_files,
     measure_preimport_state,
     spectral_detail_from_persisted_source,
@@ -540,6 +543,109 @@ def enrich_current_v0_research_for_preview(
             "claimed current evidence did not preserve the expected identity",
         )
     return EvidenceBuildResult(persisted, "ready")
+
+
+@dataclass(frozen=True)
+class EnrichmentPlan:
+    """Which measurements a current-evidence row is missing."""
+
+    spectral: bool
+    v0: bool
+
+    @property
+    def any(self) -> bool:
+        return self.spectral or self.v0
+
+
+def plan_current_evidence_enrichment(
+    evidence: AlbumQualityEvidence,
+) -> EnrichmentPlan:
+    """Pure decision: measure exactly the missing HAVE pieces.
+
+    Mirrors the once-only guards of the persist/claim helpers: any spectral
+    field present means the scan already happened; a V0 metric or the
+    attempted marker means the research probe already ran. Complete rows
+    therefore cost nothing to re-plan.
+    """
+    measurement = evidence.measurement
+    return EnrichmentPlan(
+        spectral=(
+            measurement.spectral_grade is None
+            and measurement.spectral_bitrate_kbps is None
+        ),
+        v0=(
+            evidence.v0_metric is None
+            and not evidence.on_disk_v0_research_attempted
+        ),
+    )
+
+
+def enrich_incomplete_current_evidence_for_request(
+    db: ImportPreviewDB,
+    *,
+    request_id: int,
+    spectral_analyzer: SpectralDetailAnalyzer = analyze_spectral_audit_path,
+    probe_fn: Callable[[str], V0ProbeEvidence | None] = (
+        probe_installed_album_as_v0
+    ),
+) -> str:
+    """Opportunistically complete a request's HAVE evidence in place.
+
+    Driven from the download-failure path: a failed download never reaches
+    preview, but the on-disk copy is right there — measure it now instead of
+    waiting for a download that may never succeed. Both writes go through
+    the preview-owned helpers, so the once-only, exact-snapshot, and
+    never-overwrite guards hold unchanged.
+
+    Returns "no_current_evidence" (nothing linked), "stale" (files changed
+    since capture), "complete" (nothing missing — zero cost), "enriched"
+    (every missing piece resolved), or "partial" (measurement ran but
+    something is still unresolved).
+    """
+    try:
+        current_id = db.get_request_current_evidence_id(request_id)
+        evidence = (
+            db.load_album_quality_evidence_by_id(current_id)
+            if current_id is not None
+            else None
+        )
+    except Exception:
+        logger.warning(
+            "Could not load current evidence for request %s",
+            request_id,
+            exc_info=True,
+        )
+        return "no_current_evidence"
+    if evidence is None or evidence.id is None:
+        return "no_current_evidence"
+    plan = plan_current_evidence_enrichment(evidence)
+    if not plan.any:
+        return "complete"
+    # Cheap freshness pre-check before any expensive measurement; the
+    # persist/claim helpers each re-verify under their own authority.
+    if not audio_snapshot_matches(evidence.source_path, evidence.files):
+        return "stale"
+    all_ok = True
+    if plan.spectral:
+        detail = spectral_analyzer(evidence.source_path)
+        spectral_result = persist_exact_current_spectral_from_attempt(
+            db,
+            request_id=request_id,
+            current_evidence=evidence,
+            measured_existing=detail,
+            measured_existing_path=evidence.source_path,
+        )
+        all_ok = all_ok and spectral_result.status == "ready"
+    if plan.v0:
+        v0_result = enrich_current_v0_research_for_preview(
+            db,
+            request_id=request_id,
+            expected_evidence_id=evidence.id,
+            expected_snapshot_fingerprint=evidence.snapshot_fingerprint,
+            probe_fn=probe_fn,
+        )
+        all_ok = all_ok and v0_result.status == "ready"
+    return "enriched" if all_ok else "partial"
 
 
 def load_current_evidence_for_preview(

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -6405,5 +6405,143 @@ class TestPurgeCompletedTransfers(unittest.TestCase):
         self.assertEqual(slskd.transfers.cancel_download_calls, [])
 
 
+class TestFailureEvidenceEnrichmentHook(unittest.TestCase):
+    """Download-phase failures opportunistically complete HAVE evidence.
+
+    The request's on-disk copy is already in the library, so a failed
+    download is a measurement opportunity, not a dead end: the hook fills
+    missing HAVE spectral/V0 evidence through the once-only preview-owned
+    helpers, bounded per cycle so failure bursts never balloon the loop.
+    """
+
+    def _recorder(self, outcome: str = "enriched", error: Exception | None = None):
+        calls: list[int] = []
+
+        def enrich(db: Any, *, request_id: int) -> str:
+            calls.append(request_id)
+            if error is not None:
+                raise error
+            return outcome
+
+        return enrich, calls
+
+    def _entry(self):
+        return make_grab_list_entry(
+            files=[make_download_file(filename="01.flac", id="xfer-1",
+                                      file_dir="Music\\Album",
+                                      username="peer", size=1000)],
+            filetype="flac", title="Album", artist="Artist",
+            mb_release_id="mb-uuid", db_request_id=42,
+        )
+
+    def test_fresh_context_has_default_budget(self):
+        ctx = make_ctx_with_fake_db(FakePipelineDB())
+        self.assertEqual(ctx.evidence_enrichment_budget, 2)
+
+    def test_work_outcome_consumes_budget(self):
+        from lib.download import _enrich_have_evidence_after_failure
+        ctx = make_ctx_with_fake_db(FakePipelineDB())
+        enrich, calls = self._recorder("enriched")
+
+        _enrich_have_evidence_after_failure(42, ctx, enrich_fn=enrich)
+
+        self.assertEqual(calls, [42])
+        self.assertEqual(ctx.evidence_enrichment_budget, 1)
+
+    def test_free_outcomes_do_not_consume_budget(self):
+        from lib.download import _enrich_have_evidence_after_failure
+        for outcome in ("complete", "no_current_evidence", "stale"):
+            with self.subTest(outcome=outcome):
+                ctx = make_ctx_with_fake_db(FakePipelineDB())
+                enrich, calls = self._recorder(outcome)
+
+                _enrich_have_evidence_after_failure(42, ctx, enrich_fn=enrich)
+
+                self.assertEqual(calls, [42])
+                self.assertEqual(ctx.evidence_enrichment_budget, 2)
+
+    def test_exhausted_budget_skips_enrichment(self):
+        from lib.download import _enrich_have_evidence_after_failure
+        ctx = make_ctx_with_fake_db(FakePipelineDB())
+        ctx.evidence_enrichment_budget = 0
+        enrich, calls = self._recorder("enriched")
+
+        _enrich_have_evidence_after_failure(42, ctx, enrich_fn=enrich)
+
+        self.assertEqual(calls, [])
+
+    def test_enrichment_error_is_contained_and_budgeted(self):
+        from lib.download import _enrich_have_evidence_after_failure
+        ctx = make_ctx_with_fake_db(FakePipelineDB())
+        enrich, calls = self._recorder(error=RuntimeError("scan exploded"))
+
+        _enrich_have_evidence_after_failure(42, ctx, enrich_fn=enrich)
+
+        self.assertEqual(calls, [42])
+        self.assertEqual(ctx.evidence_enrichment_budget, 1)
+
+    def test_timeout_album_runs_enrichment_after_failure_bookkeeping(self):
+        from lib.download import _timeout_album
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=42, status="downloading"))
+        ctx = make_ctx_with_fake_db(db)
+        enrich, calls = self._recorder("enriched")
+
+        with patch("lib.download.cancel_and_delete"):
+            _timeout_album(self._entry(), 42, "stalled", ctx, enrich_fn=enrich)
+
+        db.assert_log(self, 0, outcome="timeout")
+        self.assertEqual(db.request(42)["status"], "wanted")
+        self.assertEqual(calls, [42])
+        self.assertEqual(ctx.evidence_enrichment_budget, 1)
+
+    def test_timeout_album_default_enrichment_marks_v0_attempted(self):
+        """Default wiring, no injection: a real (failing) probe still lands
+        the once-only attempted marker on the exact current snapshot."""
+        from lib.download import _timeout_album
+        from lib.quality import AudioQualityMeasurement
+        from lib.quality_evidence import snapshot_audio_files
+
+        source = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, source, ignore_errors=True)
+        with open(os.path.join(source, "01.mp3"), "wb") as handle:
+            handle.write(b"garbage bytes: ffmpeg will fail fast on these")
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=42, status="downloading"))
+        evidence = make_album_quality_evidence(
+            mb_release_id="mb-uuid",
+            source_path=source,
+            files=snapshot_audio_files(source),
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=320,
+                avg_bitrate_kbps=320,
+                median_bitrate_kbps=320,
+                format="MP3",
+                spectral_grade="genuine",
+                spectral_bitrate_kbps=96,
+            ),
+            v0_metric=None,
+        )
+        db.upsert_album_quality_evidence(evidence)
+        stored = db.find_album_quality_evidence(
+            mb_release_id=evidence.mb_release_id,
+            snapshot_fingerprint=evidence.snapshot_fingerprint,
+        )
+        assert stored is not None and stored.id is not None
+        db.set_request_current_evidence(42, stored.id)
+        ctx = make_ctx_with_fake_db(db)
+
+        with patch("lib.download.cancel_and_delete"):
+            _timeout_album(self._entry(), 42, "stalled", ctx)
+
+        persisted = db.load_album_quality_evidence_by_id(stored.id)
+        assert persisted is not None
+        self.assertTrue(persisted.on_disk_v0_research_attempted)
+        self.assertEqual(ctx.evidence_enrichment_budget, 1)
+        db.assert_log(self, 0, outcome="timeout")
+        self.assertEqual(db.request(42)["status"], "wanted")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_import_preview.py
+++ b/tests/test_import_preview.py
@@ -1,6 +1,7 @@
 """Tests for unified import preview service."""
 
 import os
+import shutil
 import tempfile
 import unittest
 from types import SimpleNamespace
@@ -13,6 +14,7 @@ from lib.import_preview import (
     _prefer_successful_spectral_detail,
     compose_attempt_spectral_audit,
     enrich_current_v0_research_for_preview,
+    enrich_incomplete_current_evidence_for_request,
     persist_exact_current_spectral_from_attempt,
     load_persisted_existing_spectral,
     measure_and_persist_candidate_evidence,
@@ -1533,6 +1535,206 @@ if TYPE_CHECKING:
     # tests/test_wrong_match_cleanup_service.py for the rationale.
     _pipeline_db_satisfies_preview_protocol: _PreviewDB = cast("PipelineDB", None)
     _fake_db_satisfies_preview_protocol: _PreviewDB = cast("FakePipelineDB", None)
+
+
+class TestEnrichIncompleteCurrentEvidence(unittest.TestCase):
+    """Failure-point HAVE enrichment fills only what's missing, once."""
+
+    def _db(self) -> FakePipelineDB:
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=42, status="wanted"))
+        return db
+
+    def _source_dir(self) -> str:
+        source = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, source, ignore_errors=True)
+        with open(os.path.join(source, "01.mp3"), "wb") as handle:
+            handle.write(b"not real audio but never inspected in this test")
+        return source
+
+    def _seed_current(
+        self,
+        db: FakePipelineDB,
+        source: str,
+        *,
+        spectral_present: bool,
+        v0_attempted: bool = False,
+    ):
+        evidence = make_album_quality_evidence(
+            mb_release_id="mbid-42",
+            source_path=source,
+            files=snapshot_audio_files(source),
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=320,
+                avg_bitrate_kbps=320,
+                median_bitrate_kbps=320,
+                format="MP3",
+                spectral_grade="genuine" if spectral_present else None,
+                spectral_bitrate_kbps=96 if spectral_present else None,
+            ),
+            v0_metric=None,
+            on_disk_v0_research_attempted=v0_attempted,
+        )
+        db.upsert_album_quality_evidence(evidence)
+        stored = db.find_album_quality_evidence(
+            mb_release_id=evidence.mb_release_id,
+            snapshot_fingerprint=evidence.snapshot_fingerprint,
+        )
+        assert stored is not None and stored.id is not None
+        db.set_request_current_evidence(42, stored.id)
+        return stored
+
+    def _spectral_recorder(self, detail: SpectralAnalysisDetail):
+        calls: list[str] = []
+
+        def analyzer(path: str) -> SpectralAnalysisDetail:
+            calls.append(path)
+            return detail
+
+        return analyzer, calls
+
+    def _probe_recorder(self):
+        calls: list[str] = []
+
+        def probe(path: str) -> V0ProbeEvidence:
+            calls.append(path)
+            return V0ProbeEvidence(
+                kind="on_disk_research_v0",
+                min_bitrate_kbps=201,
+                avg_bitrate_kbps=259,
+                median_bitrate_kbps=255,
+            )
+
+        return probe, calls
+
+    def _good_scan(self) -> SpectralAnalysisDetail:
+        return SpectralAnalysisDetail(
+            attempted=True, grade="genuine", bitrate_kbps=96,
+        )
+
+    def test_complete_row_skips_all_measurement(self):
+        db = self._db()
+        source = self._source_dir()
+        self._seed_current(db, source, spectral_present=True, v0_attempted=True)
+        analyzer, spectral_calls = self._spectral_recorder(self._good_scan())
+        probe, probe_calls = self._probe_recorder()
+
+        outcome = enrich_incomplete_current_evidence_for_request(
+            db, request_id=42, spectral_analyzer=analyzer, probe_fn=probe,
+        )
+
+        self.assertEqual(outcome, "complete")
+        self.assertEqual(spectral_calls, [])
+        self.assertEqual(probe_calls, [])
+
+    def test_fills_both_missing_pieces(self):
+        db = self._db()
+        source = self._source_dir()
+        stored = self._seed_current(db, source, spectral_present=False)
+        assert stored.id is not None
+        analyzer, spectral_calls = self._spectral_recorder(self._good_scan())
+        probe, probe_calls = self._probe_recorder()
+
+        outcome = enrich_incomplete_current_evidence_for_request(
+            db, request_id=42, spectral_analyzer=analyzer, probe_fn=probe,
+        )
+
+        self.assertEqual(outcome, "enriched")
+        self.assertEqual(spectral_calls, [source])
+        self.assertEqual(probe_calls, [source])
+        persisted = db.load_album_quality_evidence_by_id(stored.id)
+        assert persisted is not None
+        self.assertEqual(persisted.measurement.spectral_grade, "genuine")
+        self.assertEqual(persisted.measurement.spectral_bitrate_kbps, 96)
+        self.assertTrue(persisted.on_disk_v0_research_attempted)
+        assert persisted.v0_metric is not None
+        self.assertEqual(persisted.v0_metric.avg_bitrate_kbps, 259)
+
+    def test_fills_v0_only_when_spectral_present(self):
+        db = self._db()
+        source = self._source_dir()
+        self._seed_current(db, source, spectral_present=True)
+        analyzer, spectral_calls = self._spectral_recorder(self._good_scan())
+        probe, probe_calls = self._probe_recorder()
+
+        outcome = enrich_incomplete_current_evidence_for_request(
+            db, request_id=42, spectral_analyzer=analyzer, probe_fn=probe,
+        )
+
+        self.assertEqual(outcome, "enriched")
+        self.assertEqual(spectral_calls, [])
+        self.assertEqual(probe_calls, [source])
+
+    def test_fills_spectral_only_when_v0_already_attempted(self):
+        db = self._db()
+        source = self._source_dir()
+        self._seed_current(
+            db, source, spectral_present=False, v0_attempted=True,
+        )
+        analyzer, spectral_calls = self._spectral_recorder(self._good_scan())
+        probe, probe_calls = self._probe_recorder()
+
+        outcome = enrich_incomplete_current_evidence_for_request(
+            db, request_id=42, spectral_analyzer=analyzer, probe_fn=probe,
+        )
+
+        self.assertEqual(outcome, "enriched")
+        self.assertEqual(spectral_calls, [source])
+        self.assertEqual(probe_calls, [])
+
+    def test_stale_snapshot_measures_nothing(self):
+        db = self._db()
+        source = self._source_dir()
+        self._seed_current(db, source, spectral_present=False)
+        with open(os.path.join(source, "01.mp3"), "ab") as handle:
+            handle.write(b"changed after snapshot")
+        analyzer, spectral_calls = self._spectral_recorder(self._good_scan())
+        probe, probe_calls = self._probe_recorder()
+
+        outcome = enrich_incomplete_current_evidence_for_request(
+            db, request_id=42, spectral_analyzer=analyzer, probe_fn=probe,
+        )
+
+        self.assertEqual(outcome, "stale")
+        self.assertEqual(spectral_calls, [])
+        self.assertEqual(probe_calls, [])
+
+    def test_without_current_evidence_returns_no_current_evidence(self):
+        db = self._db()
+        analyzer, spectral_calls = self._spectral_recorder(self._good_scan())
+        probe, probe_calls = self._probe_recorder()
+
+        outcome = enrich_incomplete_current_evidence_for_request(
+            db, request_id=42, spectral_analyzer=analyzer, probe_fn=probe,
+        )
+
+        self.assertEqual(outcome, "no_current_evidence")
+        self.assertEqual(spectral_calls, [])
+        self.assertEqual(probe_calls, [])
+
+    def test_failed_spectral_scan_reports_partial(self):
+        db = self._db()
+        source = self._source_dir()
+        stored = self._seed_current(
+            db, source, spectral_present=False, v0_attempted=True,
+        )
+        assert stored.id is not None
+        analyzer, spectral_calls = self._spectral_recorder(
+            SpectralAnalysisDetail(attempted=True, error="sox exploded"),
+        )
+        probe, probe_calls = self._probe_recorder()
+
+        outcome = enrich_incomplete_current_evidence_for_request(
+            db, request_id=42, spectral_analyzer=analyzer, probe_fn=probe,
+        )
+
+        self.assertEqual(outcome, "partial")
+        self.assertEqual(spectral_calls, [source])
+        self.assertEqual(probe_calls, [])
+        persisted = db.load_album_quality_evidence_by_id(stored.id)
+        assert persisted is not None
+        self.assertIsNone(persisted.measurement.spectral_grade)
+        self.assertIsNone(persisted.measurement.spectral_bitrate_kbps)
 
 
 class TestPreviewDBProtocolParity(unittest.TestCase):

--- a/tests/test_quality_lineage_generated.py
+++ b/tests/test_quality_lineage_generated.py
@@ -12,8 +12,10 @@ import msgspec
 from harness.import_one import projected_is_cbr_from_bitrates
 from lib.measurement import PreimportMeasurement
 from lib.import_preview import (
+    EnrichmentPlan,
     enrich_current_v0_research_for_preview,
     persist_exact_current_spectral_from_attempt,
+    plan_current_evidence_enrichment,
 )
 from lib.pipeline_db.download_log import _DownloadLogMixin
 from lib.quality import (
@@ -97,6 +99,26 @@ def assert_exact_current_spectral_persisted(
         raise AssertionError("attempt scan did not populate exact current evidence")
 
 
+def assert_enrichment_plan_never_remeasures(evidence, plan) -> None:
+    """Independent checker: enrichment only measures what is missing."""
+
+    measurement = evidence.measurement
+    if plan.spectral and (
+        measurement.spectral_grade is not None
+        or measurement.spectral_bitrate_kbps is not None
+    ):
+        raise AssertionError(
+            "enrichment plan re-measures spectral evidence that already exists"
+        )
+    if plan.v0 and (
+        evidence.v0_metric is not None
+        or evidence.on_disk_v0_research_attempted
+    ):
+        raise AssertionError(
+            "enrichment plan re-researches V0 evidence that already exists"
+        )
+
+
 class TestQualityLineagePins(unittest.TestCase):
     def test_research_once_checker_rejects_repeated_unmarked_probe(self):
         with self.assertRaisesRegex(AssertionError, "exactly one"):
@@ -104,6 +126,75 @@ class TestQualityLineagePins(unittest.TestCase):
                 probe_calls=2,
                 evidence_attempted=False,
             )
+
+    def test_enrichment_plan_checker_rejects_planted_remeasure(self):
+        graded = make_album_quality_evidence()  # default: genuine spectral
+        with self.assertRaisesRegex(AssertionError, "spectral"):
+            assert_enrichment_plan_never_remeasures(
+                graded, EnrichmentPlan(spectral=True, v0=False),
+            )
+        attempted = make_album_quality_evidence(
+            on_disk_v0_research_attempted=True,
+        )
+        with self.assertRaisesRegex(AssertionError, "V0"):
+            assert_enrichment_plan_never_remeasures(
+                attempted, EnrichmentPlan(spectral=False, v0=True),
+            )
+
+    def test_enrichment_plan_pin_complete_row_plans_nothing(self):
+        evidence = make_album_quality_evidence(
+            on_disk_v0_research_attempted=True,
+        )
+        plan = plan_current_evidence_enrichment(evidence)
+        self.assertFalse(plan.spectral)
+        self.assertFalse(plan.v0)
+
+    @given(
+        grade=st.one_of(
+            st.none(),
+            st.sampled_from(("genuine", "suspect", "likely_transcode")),
+        ),
+        spectral_bitrate=st.one_of(
+            st.none(), st.integers(min_value=32, max_value=500),
+        ),
+        v0_present=st.booleans(),
+        v0_attempted=st.booleans(),
+    )
+    @example(grade=None, spectral_bitrate=None,
+             v0_present=False, v0_attempted=False)
+    @example(grade="genuine", spectral_bitrate=None,
+             v0_present=False, v0_attempted=True)
+    def test_generated_enrichment_plan_measures_exactly_the_missing_pieces(
+        self, grade, spectral_bitrate, v0_present, v0_attempted,
+    ):
+        evidence = make_album_quality_evidence(
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=320,
+                avg_bitrate_kbps=320,
+                median_bitrate_kbps=320,
+                format="MP3",
+                spectral_grade=grade,
+                spectral_bitrate_kbps=spectral_bitrate,
+            ),
+            v0_metric=(
+                AlbumQualityV0Metric(
+                    min_bitrate_kbps=201,
+                    avg_bitrate_kbps=259,
+                    median_bitrate_kbps=255,
+                    source_lineage="on_disk_research",
+                )
+                if v0_present
+                else None
+            ),
+            on_disk_v0_research_attempted=v0_attempted,
+        )
+        plan = plan_current_evidence_enrichment(evidence)
+        assert_enrichment_plan_never_remeasures(evidence, plan)
+        self.assertEqual(
+            plan.spectral,
+            grade is None and spectral_bitrate is None,
+        )
+        self.assertEqual(plan.v0, not v0_present and not v0_attempted)
 
     @given(
         projected_format=st.sampled_from(("OPUS 128", "MP3 V0", "FLAC")),


### PR DESCRIPTION
## Summary

A request whose downloads always fail never reaches import preview — the only place HAVE spectral / on-disk V0 research evidence gets completed — so its Recents IN/HAVE strip stays partial forever. Live numbers: only 35% of the wanted cohort's current-evidence rows were complete vs 92% for imported. The album is already in the library; measuring it never required a download.

Download-phase failure finalizers (`_timeout_album`, the materialize-grace reset) now opportunistically complete the request's current evidence:

- `plan_current_evidence_enrichment` (pure) decides exactly which pieces are missing — any present spectral field or a prior V0 research attempt means that piece is never re-measured.
- `enrich_incomplete_current_evidence_for_request` measures the on-disk copy directly and persists through the existing preview-owned once-only helpers (`persist_exact_current_spectral_from_attempt`, `enrich_current_v0_research_for_preview`) — all exact-snapshot / never-overwrite / once-only guards hold unchanged.
- Bounded by `CratediggerContext.evidence_enrichment_budget` (2/cycle) so failure bursts never balloon the loop; complete rows cost nothing and are unbudgeted; enrichment errors never disturb failure bookkeeping.

Because the Recents route projects the live current-evidence row onto failed/timeout rows, each enrichment retroactively completes the display of past failure rows for that request too — the failed-download cohort converges over time without any download succeeding.

## Tests

- Pin + generated property pair (house rule): `plan_current_evidence_enrichment` measures exactly the missing pieces; independent checker `assert_enrichment_plan_never_remeasures` with known-bad self-test (`tests/test_quality_lineage_generated.py`).
- Orchestration coverage: skip-if-complete, fill-both, fill-one, stale-snapshot, no-evidence, failed-scan-partial (`tests/test_import_preview.py`).
- Hook coverage: budget default/consumption/exhaustion, free outcomes, error containment, plus a no-injection integration where a real failing ffmpeg probe lands the once-only attempted marker (`tests/test_download.py`).
- Full suite green at HEAD (6,060+ tests, artifact-cited push); pyright clean; docs updated in `docs/quality-verification.md` (evidence policy section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)