### PR TITLE
fix: rebuild blank-source_path HAVE evidence; persist reuse-path spectral scans

### DIFF
--- a/docs/quality-verification.md
+++ b/docs/quality-verification.md
@@ -377,6 +377,27 @@ bursts never balloon the loop; complete rows cost nothing. Over time
 the failed-download cohort's evidence converges without any download
 succeeding.
 
+**A blank `source_path` is policy-incomplete.** Every enrichment
+helper verifies the scanned path against the row's recorded
+`source_path`, so a row without one (legacy 2026-05 library backfills
+wrote `source_path=''`) could never be completed — and an incomplete
+HAVE side silently disables all three spectral protections in the
+import comparison (download_log 37206: a ~96k transcode replaced a
+better copy as a "better" avg-bitrate tiebreak). `policy_incomplete_reasons`
+therefore rejects blank paths; the action loader
+(`ensure_current_evidence_for_action`) and the preview loader
+(`load_current_evidence_for_preview`) rebuild such rows from beets.
+When the on-disk files are unchanged (the legacy-backfill case) the
+rebuilt row shares the `(mb_release_id, snapshot_fingerprint)` content
+address, so the upsert repairs `source_path` in place — same row id,
+FK untouched; if the files have changed since capture, backfill writes
+a fresh row and repoints the FK. Either way enrichment can then
+complete the surviving row. The candidate-reuse preview fast path also
+persists its attempt-time HAVE scan through
+`persist_exact_current_spectral_from_attempt` before marking the job
+importable, so a reused-evidence force import decides against the same
+completed HAVE the full measurement path would see.
+
 **Search narrowing companion.** When `lossless_source_locked` fires —
 in the importer (`lib/dispatch/core.py`) or wrong-match cleanup
 triage (`lib/wrong_match_cleanup_service.py`) — the request's

--- a/lib/import_preview.py
+++ b/lib/import_preview.py
@@ -661,23 +661,36 @@ def load_current_evidence_for_preview(
     """Load/backfill HAVE and perform preview-owned neutral enrichment."""
 
     current = preloaded_evidence
-    if current is None and not preloaded_authoritative:
+    should_load = current is None and not preloaded_authoritative
+    # An authoritative linked row that is policy-incomplete (canonical case:
+    # a legacy backfill with a blank ``source_path``) can never be enriched
+    # in place — rebuild it from beets so this same preview's enrichment can
+    # complete it before the importer decides.
+    should_rebuild = (
+        current is not None and bool(current.policy_incomplete_reasons())
+    )
+    if should_load or should_rebuild:
         try:
             load_result = load_or_backfill_current_evidence(
                 db,
                 request_id=request_id,
                 mb_release_id=mb_release_id,
                 quality_ranks=quality_ranks,
+                preloaded_evidence=current,
+                preloaded=should_rebuild,
                 beets_library_root=beets_library_root,
             )
-            current = load_result.evidence
         except Exception:
             logger.warning(
                 "Unable to load/backfill preview HAVE evidence for request %s",
                 request_id,
                 exc_info=True,
             )
-            return None
+            if should_load:
+                return None
+            load_result = None
+        if load_result is not None and load_result.evidence is not None:
+            current = load_result.evidence
 
     # Backfill returns its pre-upsert value; reload through the exact request
     # FK so the public enrichment helper always receives the surviving id.

--- a/lib/quality/evidence_types.py
+++ b/lib/quality/evidence_types.py
@@ -390,6 +390,14 @@ class AlbumQualityEvidence(msgspec.Struct, frozen=True):
         """Return reasons this row is not ready for action reducers."""
 
         reasons = self.storage_validation_errors()
+        if not self.source_path.strip():
+            # A row without a recorded path can never be re-verified against
+            # disk nor completed by HAVE enrichment (every persist guard
+            # compares the scanned path against ``source_path``), so it must
+            # be rebuilt rather than used as decision authority
+            # (download_log 37206: a blank-path legacy backfill kept the
+            # French Quarter import spectrally blind forever).
+            reasons.append("source_path is required")
         if self.measurement.format is None:
             reasons.append("measurement.format is required")
         if (

--- a/scripts/import_preview_worker.py
+++ b/scripts/import_preview_worker.py
@@ -30,6 +30,7 @@ from lib.import_preview import (
     load_current_evidence_for_preview,
     load_persisted_existing_spectral,
     measure_and_persist_candidate_evidence,
+    persist_exact_current_spectral_from_attempt,
     preserve_existing_source_spectral,
 )
 from lib.import_evidence import (
@@ -446,6 +447,7 @@ def process_claimed_preview_job(
         persisted_existing = SpectralAnalysisDetail(attempted=False)
         preserve_have_source = False
         mb_release_id = ""
+        current_evidence = None
         if job.request_id is not None:
             try:
                 req = db.get_request(job.request_id) or {}
@@ -497,7 +499,7 @@ def process_claimed_preview_job(
                 audit_resolver = lambda _release_id: failed_lookup
             else:
                 audit_resolver = existing_spectral_resolver_for_config(audit_cfg)
-        audit = collect_release_attempt_spectral_audit(
+        audit, have_lookup = collect_release_attempt_spectral_audit(
             front_gate_source,
             mb_release_id,
             existing_spectral_evidence=persisted_existing,
@@ -506,7 +508,32 @@ def process_claimed_preview_job(
                 spectral_detail_analyzer or analyze_spectral_audit_path
             ),
             existing_resolver=audit_resolver,
-        )[0]
+        )
+        # The reuse fast path skips measurement but must still make its
+        # HAVE scan durable BEFORE the importer decides — an audit-only
+        # scan left the decision spectrally blind (download_log 37206).
+        # The persist helper's own guards keep this once-only, exact-path,
+        # exact-snapshot; failures are fail-soft like the audit itself.
+        if (
+            job.request_id is not None
+            and current_evidence is not None
+            and not preserve_have_source
+            and have_lookup.path is not None
+        ):
+            try:
+                persist_exact_current_spectral_from_attempt(
+                    db,
+                    request_id=job.request_id,
+                    current_evidence=current_evidence,
+                    measured_existing=audit.existing,
+                    measured_existing_path=have_lookup.path,
+                )
+            except Exception:
+                logger.exception(
+                    "Unable to persist reused-path HAVE spectral for "
+                    "request %s",
+                    job.request_id,
+                )
         reused_payload = _reused_evidence_preview_payload(
             job,
             front_gate_result.evidence,

--- a/tests/test_evidence_generated.py
+++ b/tests/test_evidence_generated.py
@@ -207,6 +207,244 @@ class TestGeneratedEvidenceLifecycle(unittest.TestCase):
         )
 
 
+@dataclass(frozen=True)
+class BlankPathWorld:
+    """One current-evidence world varying source_path recordability."""
+    source_path_kind: str      # "blank" | "whitespace" | "real"
+    spectral_grade: str | None
+    min_bitrate: int
+    avg_bitrate: int
+    # Converted-from-lossless rows interact with the lossless-source-V0
+    # fail-closed branch: without a request V0 scalar to resurrect, the
+    # action loader must fail closed rather than rebuild (a disk rebuild
+    # would lose the lossless-source provenance).
+    was_converted_from: str | None = None
+    request_has_v0_scalar: bool = False
+
+
+@st.composite
+def blank_path_worlds(draw) -> BlankPathWorld:
+    min_bitrate = draw(st.integers(min_value=1, max_value=400))
+    return BlankPathWorld(
+        source_path_kind=draw(
+            st.sampled_from(("blank", "whitespace", "real"))
+        ),
+        spectral_grade=draw(
+            st.sampled_from((None, "genuine", "likely_transcode"))
+        ),
+        min_bitrate=min_bitrate,
+        avg_bitrate=min_bitrate + draw(st.integers(min_value=0, max_value=100)),
+        was_converted_from=draw(st.sampled_from((None, "flac"))),
+        request_has_v0_scalar=draw(st.booleans()),
+    )
+
+
+def assert_blank_path_outcome(
+    *,
+    source_path_kind: str,
+    requires_lossless_v0: bool,
+    has_v0_backfill_source: bool,
+    current_status: str | None,
+    available: bool,
+    result_source_path: str | None,
+) -> None:
+    """A blank-source_path row is never authoritative for an action.
+
+    The invariant behind download_log 37206 (French Quarter): a row whose
+    recorded path is blank can never be re-verified against disk nor
+    enriched with HAVE spectral, so the loader must rebuild it — never
+    hand it to the decision as ``loaded``. The one legitimate non-rebuild
+    outcome is the pre-existing lossless-source-V0 guard: a row that
+    requires the lossless-source V0 metric and has no request scalar to
+    resurrect fails closed instead (a disk rebuild would fabricate
+    provenance). That V0 lifecycle is the property above; here it only
+    shapes which blank-path outcome is legal.
+    """
+    if source_path_kind == "real":
+        if not requires_lossless_v0 and current_status != "loaded":
+            raise AssertionError(
+                "complete current evidence with a real source_path must "
+                f"load as authoritative (got {current_status})")
+        return
+    if current_status == "loaded":
+        raise AssertionError(
+            "blank-source_path current evidence was loaded as authoritative")
+    if requires_lossless_v0 and not has_v0_backfill_source:
+        if available:
+            raise AssertionError(
+                "lossless-source row without a V0 backfill source "
+                "must fail closed, not become available")
+        return
+    if not available:
+        raise AssertionError(
+            "blank-source_path row must rebuild from album_info, "
+            "not fail closed")
+    if not (result_source_path or "").strip():
+        raise AssertionError(
+            "rebuilt action evidence still carries a blank source_path")
+
+
+def _run_blank_path_world(
+    world: BlankPathWorld,
+) -> tuple[str | None, bool, str | None]:
+    """Build the world's on-disk + DB state and run the action loader."""
+    root = tempfile.mkdtemp(prefix="cratedigger-blankpath-gen-")
+    try:
+        with open(os.path.join(root, "01 - Track.mp3"), "wb") as handle:
+            handle.write(b"generated-audio")
+
+        request_id = 1
+        mbid = "blank-path-generated-mbid"
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=request_id, mb_release_id=mbid))
+        if world.request_has_v0_scalar:
+            db.update_request_fields(
+                request_id,
+                current_lossless_source_v0_probe_min_bitrate=190,
+                current_lossless_source_v0_probe_avg_bitrate=200,
+                current_lossless_source_v0_probe_median_bitrate=200,
+            )
+
+        source_path = {
+            "blank": "",
+            "whitespace": "   ",
+            "real": root,
+        }[world.source_path_kind]
+        current = make_album_quality_evidence(
+            mb_release_id=mbid,
+            source_path=source_path,
+            files=snapshot_audio_files(root),
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=world.min_bitrate,
+                avg_bitrate_kbps=world.avg_bitrate,
+                median_bitrate_kbps=world.avg_bitrate,
+                format="MP3",
+                is_cbr=False,
+                spectral_grade=world.spectral_grade,
+                spectral_bitrate_kbps=(
+                    96 if world.spectral_grade == "likely_transcode" else None
+                ),
+                was_converted_from=world.was_converted_from,
+            ),
+            v0_metric=None,
+        )
+        db.upsert_album_quality_evidence(current)
+        persisted = db.find_album_quality_evidence(
+            mb_release_id=mbid,
+            snapshot_fingerprint=current.snapshot_fingerprint,
+        )
+        assert persisted is not None and persisted.id is not None
+        db.set_request_current_evidence(request_id, persisted.id)
+
+        result = ensure_current_evidence_for_action(
+            db,
+            request_id=request_id,
+            mb_release_id=mbid,
+            current_album_path=root,
+            album_info=AlbumInfo(
+                album_id=1,
+                track_count=1,
+                min_bitrate_kbps=world.min_bitrate,
+                avg_bitrate_kbps=world.avg_bitrate,
+                median_bitrate_kbps=world.avg_bitrate,
+                is_cbr=False,
+                album_path=root,
+                format="MP3",
+            ),
+        )
+        return (
+            result.provenance.current_status,
+            result.available,
+            result.evidence.source_path if result.evidence is not None else None,
+        )
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+
+
+# The exact French Quarter shape (download_log 37206): a 2026-05-16
+# library-backfill row with min 186 / avg 194 and no spectral, whose blank
+# source_path kept every HAVE enrichment guard refusing forever.
+_FRENCH_QUARTER_WORLD = BlankPathWorld(
+    source_path_kind="blank",
+    spectral_grade=None,
+    min_bitrate=186,
+    avg_bitrate=194,
+)
+
+# The fail-closed seam: a blank-path row that is ALSO converted-from-
+# lossless with no request V0 scalar must fail closed, not rebuild.
+_BLANK_LOSSLESS_NO_SCALAR_WORLD = BlankPathWorld(
+    source_path_kind="blank",
+    spectral_grade=None,
+    min_bitrate=108,
+    avg_bitrate=114,
+    was_converted_from="flac",
+    request_has_v0_scalar=False,
+)
+
+
+class TestGeneratedBlankSourcePath(unittest.TestCase):
+    """Action-loader invariants over generated source_path worlds."""
+
+    @given(world=blank_path_worlds())
+    @example(world=_FRENCH_QUARTER_WORLD)
+    @example(world=_BLANK_LOSSLESS_NO_SCALAR_WORLD)
+    def test_blank_source_path_is_never_authoritative(self, world):
+        current_status, available, result_source_path = (
+            _run_blank_path_world(world)
+        )
+        assert_blank_path_outcome(
+            source_path_kind=world.source_path_kind,
+            requires_lossless_v0=(
+                world.was_converted_from is not None
+                or world.request_has_v0_scalar
+            ),
+            has_v0_backfill_source=world.request_has_v0_scalar,
+            current_status=current_status,
+            available=available,
+            result_source_path=result_source_path,
+        )
+
+
+class TestBlankPathCheckerTripsOnViolations(unittest.TestCase):
+    """Known-bad self-tests for the blank-path invariant checker."""
+
+    def test_trips_on_loaded_blank_path(self):
+        with self.assertRaises(AssertionError):
+            assert_blank_path_outcome(
+                source_path_kind="blank", requires_lossless_v0=False,
+                has_v0_backfill_source=False, current_status="loaded",
+                available=True, result_source_path="")
+
+    def test_trips_on_fail_closed_instead_of_rebuild(self):
+        with self.assertRaises(AssertionError):
+            assert_blank_path_outcome(
+                source_path_kind="blank", requires_lossless_v0=False,
+                has_v0_backfill_source=False, current_status="failed",
+                available=False, result_source_path=None)
+
+    def test_trips_on_rebuilt_row_still_blank(self):
+        with self.assertRaises(AssertionError):
+            assert_blank_path_outcome(
+                source_path_kind="whitespace", requires_lossless_v0=False,
+                has_v0_backfill_source=False, current_status="backfilled",
+                available=True, result_source_path="   ")
+
+    def test_trips_on_real_path_not_loading(self):
+        with self.assertRaises(AssertionError):
+            assert_blank_path_outcome(
+                source_path_kind="real", requires_lossless_v0=False,
+                has_v0_backfill_source=False, current_status="backfilled",
+                available=True, result_source_path="/library/album")
+
+    def test_trips_on_lossless_no_scalar_becoming_available(self):
+        with self.assertRaises(AssertionError):
+            assert_blank_path_outcome(
+                source_path_kind="blank", requires_lossless_v0=True,
+                has_v0_backfill_source=False, current_status="backfilled",
+                available=True, result_source_path="/library/album")
+
+
 class TestLifecycleCheckerTripsOnViolations(unittest.TestCase):
     """Known-bad self-tests for the lifecycle invariant checker."""
 

--- a/tests/test_import_evidence.py
+++ b/tests/test_import_evidence.py
@@ -293,6 +293,87 @@ class TestImportEvidenceAcquisition(unittest.TestCase):
             stale_evidence_id,
         )
 
+    def _persist_blank_path_current(self) -> int:
+        """Legacy backfill shape: matching snapshot, empty source_path.
+
+        The download_log 37206 (French Quarter) row: a 2026-05-16 library
+        backfill wrote current evidence with ``source_path=''``, which no
+        enrichment helper can ever complete (every persist guard compares
+        against the recorded path), so the import decision stayed
+        spectrally blind forever.
+        """
+        evidence = make_album_quality_evidence(
+            mb_release_id="release-1",
+            source_path="",
+            files=snapshot_audio_files(self.root),
+        )
+        self.db.upsert_album_quality_evidence(evidence)
+        persisted = self.db.find_album_quality_evidence(
+            mb_release_id=evidence.mb_release_id,
+            snapshot_fingerprint=evidence.snapshot_fingerprint,
+        )
+        assert persisted is not None and persisted.id is not None
+        self.db.set_request_current_evidence(42, persisted.id)
+        return persisted.id
+
+    def test_blank_source_path_current_evidence_is_never_loaded(self):
+        self._persist_blank_path_current()
+
+        result = ensure_current_evidence_for_action(
+            self.db,
+            request_id=42,
+            mb_release_id="release-1",
+            current_album_path=self.root,
+            album_info=AlbumInfo(
+                album_id=1,
+                track_count=1,
+                min_bitrate_kbps=186,
+                avg_bitrate_kbps=194,
+                median_bitrate_kbps=194,
+                is_cbr=False,
+                album_path=self.root,
+                format="MP3",
+            ),
+        )
+
+        self.assertNotEqual(result.provenance.current_status, "loaded")
+        self.assertTrue(result.available)
+        self.assertEqual(result.provenance.current_status, "backfilled")
+        self.assertIn(
+            "source_path",
+            result.provenance.fallback_reason or "",
+        )
+        assert result.evidence is not None
+        self.assertEqual(result.evidence.source_path, self.root)
+
+    def test_blank_source_path_rebuild_repairs_the_row_in_place(self):
+        """Same files ⇒ same content address ⇒ the upsert must repair
+        ``source_path`` on the linked row so enrichment can complete it."""
+        stale_id = self._persist_blank_path_current()
+
+        ensure_current_evidence_for_action(
+            self.db,
+            request_id=42,
+            mb_release_id="release-1",
+            current_album_path=self.root,
+            album_info=AlbumInfo(
+                album_id=1,
+                track_count=1,
+                min_bitrate_kbps=186,
+                avg_bitrate_kbps=194,
+                median_bitrate_kbps=194,
+                is_cbr=False,
+                album_path=self.root,
+                format="MP3",
+            ),
+        )
+
+        linked_id = self.db.get_request_current_evidence_id(42)
+        self.assertEqual(linked_id, stale_id)
+        linked = self.db.load_album_quality_evidence_by_id(linked_id)
+        assert linked is not None
+        self.assertEqual(linked.source_path, self.root)
+
     def test_stale_current_evidence_is_not_reused_as_preloaded_backfill(self):
         self._persist_current()
         with open(os.path.join(self.root, "01 - Track.mp3"), "ab") as handle:

--- a/tests/test_import_preview.py
+++ b/tests/test_import_preview.py
@@ -25,6 +25,7 @@ from lib.measurement import LocalFileInspection, PreimportMeasurement
 from lib.quality import (
     AudioQualityMeasurement,
     ImportResult,
+    QualityRankConfig,
     SpectralAnalysisDetail,
     SpectralDetail,
     TargetQualityContract,
@@ -406,6 +407,76 @@ class TestImportPreviewPath(unittest.TestCase):
         assert stored is not None and stored.id is not None
         db.set_request_current_evidence(42, stored.id)
         return stored
+
+    def test_preview_loader_rebuilds_blank_source_path_current_evidence(self):
+        """A blank-path HAVE row must be rebuilt, not reused authoritatively.
+
+        download_log 37206 (French Quarter): the linked current evidence was
+        a legacy backfill with ``source_path=''``; every enrichment guard
+        refused it, so preview kept handing the importer a spectrally blind
+        HAVE side. The preview loader must rebuild such rows from beets so
+        the same preview's enrichment can complete them.
+        """
+        from lib.beets_db import AlbumInfo
+        from lib.import_preview import load_current_evidence_for_preview
+        from tests.fakes import FakeBeetsDB
+
+        db = self._db()
+        source = self._source_dir()
+        try:
+            evidence = make_album_quality_evidence(
+                mb_release_id="mbid-42",
+                source_path="",
+                files=snapshot_audio_files(source),
+                measurement=AudioQualityMeasurement(
+                    min_bitrate_kbps=186,
+                    avg_bitrate_kbps=194,
+                    median_bitrate_kbps=194,
+                    format="MP3",
+                    spectral_grade=None,
+                    spectral_bitrate_kbps=None,
+                ),
+            )
+            db.upsert_album_quality_evidence(evidence)
+            stored = db.find_album_quality_evidence(
+                mb_release_id=evidence.mb_release_id,
+                snapshot_fingerprint=evidence.snapshot_fingerprint,
+            )
+            assert stored is not None and stored.id is not None
+            db.set_request_current_evidence(42, stored.id)
+
+            fake_beets = FakeBeetsDB()
+            fake_beets.set_album_info("mbid-42", AlbumInfo(
+                album_id=1,
+                track_count=1,
+                min_bitrate_kbps=186,
+                avg_bitrate_kbps=194,
+                median_bitrate_kbps=194,
+                is_cbr=False,
+                album_path=source,
+                format="MP3",
+            ))
+            with patch("lib.beets_db.BeetsDB", lambda **_kwargs: fake_beets):
+                current = load_current_evidence_for_preview(
+                    db,
+                    request_id=42,
+                    mb_release_id="mbid-42",
+                    quality_ranks=QualityRankConfig.defaults(),
+                    beets_library_root="",
+                    preloaded_evidence=stored,
+                    preloaded_authoritative=True,
+                )
+
+            assert current is not None
+            self.assertEqual(current.source_path, source)
+            linked_id = db.get_request_current_evidence_id(42)
+            self.assertEqual(linked_id, stored.id)
+            linked = db.load_album_quality_evidence_by_id(linked_id)
+            assert linked is not None
+            self.assertEqual(linked.source_path, source)
+        finally:
+            import shutil
+            shutil.rmtree(source, ignore_errors=True)
 
     def test_attempt_scan_persists_qigong_current_spectral_snapshot(self):
         """Qigong: the exact installed HAVE scan becomes durable evidence."""

--- a/tests/test_import_queue.py
+++ b/tests/test_import_queue.py
@@ -2296,6 +2296,161 @@ class TestImportPreviewWorkerFrontGate(unittest.TestCase):
         self.assertEqual(import_result.spectral.existing.grade, "suspect")
         self.assertEqual(import_result.spectral.existing.bitrate_kbps, 128)
 
+    def test_reused_evidence_persists_missing_have_spectral(self):
+        """Front-gate reuse must make its HAVE scan durable pre-decision.
+
+        download_log 37206 (French Quarter): the reuse fast path scanned
+        the installed album for the audit payload but never persisted the
+        result, so the importer's decision ran with a spectrally blind
+        HAVE side and called a ~96k transcode an upgrade.
+        """
+        from scripts import import_preview_worker
+        from lib.measurement import ExistingSpectralAuditLookup
+        from lib.quality import SpectralAnalysisDetail
+
+        with tempfile.TemporaryDirectory() as source, \
+             tempfile.TemporaryDirectory() as existing:
+            for root in (source, existing):
+                with open(os.path.join(root, "01.mp3"), "wb") as handle:
+                    handle.write(b"audio")
+            db = FakePipelineDB()
+            db.seed_request(make_request_row(id=42, mb_release_id="mbid-42"))
+            _seed_current_for_request(
+                db,
+                42,
+                mb_release_id="mbid-42",
+                source_path=existing,
+                files=snapshot_audio_files(existing),
+                measurement=AudioQualityMeasurement(
+                    min_bitrate_kbps=320,
+                    avg_bitrate_kbps=320,
+                    median_bitrate_kbps=320,
+                    format="MP3",
+                    is_cbr=True,
+                ),
+                codec="mp3",
+                container="mp3",
+                storage_format="MP3",
+            )
+            download_log_id = db.log_download(42, outcome="rejected")
+            db.enqueue_import_job(
+                IMPORT_JOB_FORCE,
+                request_id=42,
+                dedupe_key=force_import_dedupe_key(download_log_id),
+                payload=force_import_payload(
+                    download_log_id=download_log_id,
+                    failed_path=source,
+                    source_username="alice",
+                ),
+            )
+            claimed = db.claim_next_import_preview_job(worker_id="preview")
+            assert claimed is not None
+            self._seed_evidence_for_download_log(db, download_log_id, source)
+
+            def analyze(path: str) -> SpectralAnalysisDetail:
+                return SpectralAnalysisDetail(
+                    attempted=True,
+                    grade="suspect" if path == existing else "genuine",
+                    bitrate_kbps=128 if path == existing else None,
+                )
+
+            with patch(
+                "scripts.import_preview_worker.read_runtime_config",
+                return_value=CratediggerConfig(audio_check_mode="off"),
+            ):
+                updated = import_preview_worker.process_claimed_preview_job(
+                    db,
+                    claimed,
+                    spectral_detail_analyzer=analyze,
+                    existing_spectral_resolver=lambda _mbid: (
+                        ExistingSpectralAuditLookup(path=existing)
+                    ),
+                )
+
+            linked_id = db.get_request_current_evidence_id(42)
+            linked = db.load_album_quality_evidence_by_id(linked_id)
+
+        assert updated is not None
+        self.assertEqual(updated.preview_status, "evidence_ready")
+        assert linked is not None
+        self.assertEqual(linked.measurement.spectral_grade, "suspect")
+        self.assertEqual(linked.measurement.spectral_bitrate_kbps, 128)
+
+    def test_reused_evidence_never_overwrites_present_have_spectral(self):
+        """A fresh audit scan must not clobber persisted HAVE provenance."""
+        from scripts import import_preview_worker
+        from lib.measurement import ExistingSpectralAuditLookup
+        from lib.quality import SpectralAnalysisDetail
+
+        with tempfile.TemporaryDirectory() as source, \
+             tempfile.TemporaryDirectory() as existing:
+            for root in (source, existing):
+                with open(os.path.join(root, "01.mp3"), "wb") as handle:
+                    handle.write(b"audio")
+            db = FakePipelineDB()
+            db.seed_request(make_request_row(id=42, mb_release_id="mbid-42"))
+            _seed_current_for_request(
+                db,
+                42,
+                mb_release_id="mbid-42",
+                source_path=existing,
+                files=snapshot_audio_files(existing),
+                measurement=AudioQualityMeasurement(
+                    min_bitrate_kbps=245,
+                    avg_bitrate_kbps=256,
+                    median_bitrate_kbps=252,
+                    format="MP3",
+                    spectral_grade="genuine",
+                    spectral_bitrate_kbps=None,
+                ),
+                codec="mp3",
+                container="mp3",
+                storage_format="MP3",
+            )
+            download_log_id = db.log_download(42, outcome="rejected")
+            db.enqueue_import_job(
+                IMPORT_JOB_FORCE,
+                request_id=42,
+                dedupe_key=force_import_dedupe_key(download_log_id),
+                payload=force_import_payload(
+                    download_log_id=download_log_id,
+                    failed_path=source,
+                    source_username="alice",
+                ),
+            )
+            claimed = db.claim_next_import_preview_job(worker_id="preview")
+            assert claimed is not None
+            self._seed_evidence_for_download_log(db, download_log_id, source)
+
+            def analyze(path: str) -> SpectralAnalysisDetail:
+                return SpectralAnalysisDetail(
+                    attempted=True,
+                    grade="suspect" if path == existing else "genuine",
+                    bitrate_kbps=128 if path == existing else None,
+                )
+
+            with patch(
+                "scripts.import_preview_worker.read_runtime_config",
+                return_value=CratediggerConfig(audio_check_mode="off"),
+            ):
+                updated = import_preview_worker.process_claimed_preview_job(
+                    db,
+                    claimed,
+                    spectral_detail_analyzer=analyze,
+                    existing_spectral_resolver=lambda _mbid: (
+                        ExistingSpectralAuditLookup(path=existing)
+                    ),
+                )
+
+            linked_id = db.get_request_current_evidence_id(42)
+            linked = db.load_album_quality_evidence_by_id(linked_id)
+
+        assert updated is not None
+        self.assertEqual(updated.preview_status, "evidence_ready")
+        assert linked is not None
+        self.assertEqual(linked.measurement.spectral_grade, "genuine")
+        self.assertIsNone(linked.measurement.spectral_bitrate_kbps)
+
     def test_have_lookup_failure_still_analyzes_candidate(self):
         """A DB failure on HAVE provenance must not suppress the WANT scan."""
         from scripts import import_preview_worker

--- a/tests/test_quality_evidence.py
+++ b/tests/test_quality_evidence.py
@@ -22,6 +22,7 @@ from lib.quality import (
     ImportResult,
     V0ProbeEvidence,
     VerifiedLosslessProof,
+    full_pipeline_decision_from_evidence,
 )
 from lib.quality_evidence import (
     audio_snapshot_matches,
@@ -416,6 +417,43 @@ class TestQualityEvidenceConstruction(unittest.TestCase):
         self.assertFalse(result.available)
         self.assertEqual(result.status, "incomplete")
         self.assertIn("duplicate snapshot relative_path", result.reason or "")
+
+
+class TestBlankSourcePathPolicy(unittest.TestCase):
+    """A blank ``source_path`` is action-incomplete (download_log 37206).
+
+    A row without a recorded path can never be re-verified against disk
+    nor enriched with HAVE spectral — every persist guard compares against
+    ``source_path``. Treating it as complete let the French Quarter import
+    decide spectrally blind forever.
+    """
+
+    def test_policy_incomplete_reasons_flags_blank_source_path(self):
+        for desc, path in (("empty", ""), ("whitespace", "   ")):
+            with self.subTest(desc=desc):
+                evidence = make_album_quality_evidence(source_path=path)
+                self.assertTrue(
+                    any(
+                        "source_path" in reason
+                        for reason in evidence.policy_incomplete_reasons()
+                    ),
+                    f"{desc} source_path must be an incomplete reason",
+                )
+
+    def test_policy_incomplete_reasons_accepts_real_source_path(self):
+        evidence = make_album_quality_evidence(source_path="/library/album")
+        self.assertEqual(evidence.policy_incomplete_reasons(), [])
+
+    def test_decider_refuses_blank_source_path_candidate(self):
+        blank = make_album_quality_evidence(source_path="")
+        with self.assertRaises(ValueError):
+            full_pipeline_decision_from_evidence(blank, None)
+
+    def test_decider_refuses_blank_source_path_current(self):
+        complete = make_album_quality_evidence(source_path="/library/album")
+        blank = make_album_quality_evidence(source_path="")
+        with self.assertRaises(ValueError):
+            full_pipeline_decision_from_evidence(complete, blank)
 
 
 class TestAudioSnapshotMatches(unittest.TestCase):


### PR DESCRIPTION
## The bug (download_log 37206 — French Quarter)

A force import replaced a ~160k-true-quality installed copy with a ~96k transcode, with the comparison recording `verdict=better` on a raw avg-bitrate tiebreak (204 vs 194, `spectral_clamped=false`). Force imports DO honor downgrade verdicts — the verdict itself was blind: the request's linked current evidence was a legacy 2026-05 library-backfill row with `source_path=''`, which

- can never be completed by HAVE enrichment (every persist guard compares the scanned path against the recorded `source_path`; blank never matches), and
- with no HAVE spectral, silently disables all three spectral protections (stage-1 spectral reject, shared-spectral clamp, transcode-rank-regression guard).

The same preview had freshly scanned the installed album at `likely_transcode/160k` — but the candidate-reuse fast path only carried the scan as audit payload, never persisting it. Counterfactual through the real decider: with HAVE spectral present, stage 1 rejects outright (import refused, force or not).

## The fix

1. **`policy_incomplete_reasons()` rejects blank/whitespace `source_path`** (`lib/quality/evidence_types.py`). The decider (`_require_evidence_ready`) now refuses such rows, and both loaders treat them as incomplete. The action loader (`ensure_current_evidence_for_action`) and preview loader rebuild them from beets; same files ⇒ same `(mb_release_id, snapshot_fingerprint)` content address ⇒ the upsert repairs `source_path` in place (same row id, FK untouched).
2. **`load_current_evidence_for_preview` rebuilds policy-incomplete linked rows** instead of reusing them authoritatively, so the same preview's enrichment completes them before the importer decides.
3. **The candidate-reuse preview fast path persists its HAVE scan** via `persist_exact_current_spectral_from_attempt` (fail-soft, guarded once-only/exact-path/exact-snapshot) before marking the job importable.

## Tests

- Deterministic pins: action loader never returns a blank-path row as `loaded` + in-place repair; preview loader rebuild; worker reuse-path persist + never-overwrites guard; decider `ValueError` refusal; policy unit rows.
- Generated property `TestGeneratedBlankSourcePath` (blank/whitespace/real × spectral × converted-from-lossless × request-V0-scalar worlds) with the French Quarter shape and the lossless-fail-closed seam as `@example` pins, and five known-bad checker self-tests.
- Full suite 6076 green at HEAD (artifact-verified); fuzz burst on the generated module green.
- Opus adversarial review: no blocking findings; both observations (lossless fail-closed seam coverage, docs FK nuance) addressed in this PR.

## Post-deploy operator one-shot (not committed, per scope.md)

57 `wanted` requests have linked blank-path evidence rows; an agent-driven one-shot on doc2 will rebuild them through the production loader (the 1 `replaced` row stays frozen). Enrichment then completes them organically at preview/failure points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)