### PR TITLE
fix: populate HAVE evidence on failed downloads

### DIFF
--- a/docs/quality-verification.md
+++ b/docs/quality-verification.md
@@ -359,23 +359,26 @@ describe the upstream source audio at import time, not the on-disk
 file. Wrong-match cleanup triage compares future candidates against
 this evidence to reject same-source duplicates.
 
-**Incomplete current evidence self-heals at the failure point.** A
+**Missing or incomplete current evidence self-heals at the failure point.** A
 current-evidence row's spectral scan and on-disk V0 research normally
 complete during import preview — but a request whose downloads always
 fail never reaches preview, so its HAVE snapshot (and therefore the
-Recents IN/HAVE strip) stays partial forever. Download-phase failure
-finalizers (`_timeout_album` and the materialize-grace reset in
-`lib/download.py`) therefore call
-`enrich_incomplete_current_evidence_for_request`
-(`lib/import_preview.py`): it plans exactly the missing pieces
-(`plan_current_evidence_enrichment`, pure), measures the on-disk copy
-directly, and persists through the same preview-owned once-only helpers
-— never overwriting present evidence, never re-probing an attempted
-snapshot, and refusing stale on-disk state. Bounded by
-`CratediggerContext.evidence_enrichment_budget` per cycle so failure
-bursts never balloon the loop; complete rows cost nothing. Over time
-the failed-download cohort's evidence converges without any download
-succeeding.
+Recents IN/HAVE strip) stays absent or partial forever. Download-phase
+failure finalizers (`_timeout_album` and the materialize-grace reset in
+`lib/download.py`) therefore perform two fail-soft steps. Before recording
+the failed attempt, `prepare_current_evidence_for_failure`
+(`lib/import_preview.py`) loads or backfills only the exact release's
+canonical current snapshot; an already-linked complete row returns without
+opening Beets or rewriting evidence. After the download log and request-state
+reset are safely persisted, `enrich_incomplete_current_evidence_for_request`
+plans exactly the missing pieces (`plan_current_evidence_enrichment`, pure),
+measures the on-disk copy directly, and persists through the same
+preview-owned once-only helpers — never overwriting present evidence, never
+re-probing an attempted snapshot, and refusing stale on-disk state. Adapter
+or backfill failures and actual measurement work consume the per-cycle
+`CratediggerContext.evidence_enrichment_budget`; complete or authoritatively
+absent library copies cost nothing. Over time the failed-download cohort's
+evidence converges without delaying or bypassing download cleanup.
 
 **A blank `source_path` is policy-incomplete.** Every enrichment
 helper verifies the scanned path against the row's recorded

--- a/lib/download.py
+++ b/lib/download.py
@@ -319,13 +319,57 @@ def _enrich_timeout_reason(reason: str, files: list[DownloadFile]) -> str:
     return reason
 
 
+def _prepare_have_evidence_before_failure_log(
+    request_id: int,
+    mb_release_id: str,
+    ctx: CratediggerContext,
+    *,
+    prepare_fn: Callable[..., str] | None = None,
+) -> str:
+    """Prepare canonical HAVE before the failure row establishes history."""
+    if ctx.evidence_enrichment_budget <= 0:
+        return "budget_exhausted"
+    try:
+        if prepare_fn is None:
+            from lib.import_preview import prepare_current_evidence_for_failure
+            prepare_fn = prepare_current_evidence_for_failure
+        db = ctx.pipeline_db_source._get_db()
+        outcome = prepare_fn(
+            db,
+            request_id=request_id,
+            mb_release_id=mb_release_id,
+            quality_ranks=ctx.cfg.quality_ranks,
+            beets_library_root=ctx.cfg.beets_directory,
+        )
+    except Exception:
+        outcome = "failed"
+        logger.warning(
+            "HAVE evidence preparation crashed for request %s",
+            request_id,
+            exc_info=True,
+        )
+    if outcome == "failed":
+        ctx.evidence_enrichment_budget -= 1
+        logger.warning("HAVE evidence preparation failed for request %s", request_id)
+    elif outcome not in ("ready", "no_current_evidence"):
+        ctx.evidence_enrichment_budget -= 1
+        logger.warning(
+            "HAVE evidence preparation returned %r for request %s",
+            outcome,
+            request_id,
+        )
+        return "failed"
+    return outcome
+
+
 def _enrich_have_evidence_after_failure(
     request_id: int,
     ctx: CratediggerContext,
     *,
+    prepared_outcome: str,
     enrich_fn: Callable[..., str] | None = None,
 ) -> None:
-    """Fill missing HAVE evidence at a download-failure point.
+    """Fill missing HAVE evidence after failure bookkeeping completes.
 
     A failed download never reaches preview — the only other place HAVE
     spectral/V0 evidence gets completed — but the request's on-disk copy is
@@ -333,7 +377,7 @@ def _enrich_have_evidence_after_failure(
     balloon the loop; a complete row costs nothing and is not budgeted.
     Never lets an enrichment error disturb failure bookkeeping.
     """
-    if ctx.evidence_enrichment_budget <= 0:
+    if prepared_outcome != "ready" or ctx.evidence_enrichment_budget <= 0:
         return
     try:
         if enrich_fn is None:
@@ -342,7 +386,10 @@ def _enrich_have_evidence_after_failure(
             )
             enrich_fn = enrich_incomplete_current_evidence_for_request
         db = ctx.pipeline_db_source._get_db()
-        outcome = enrich_fn(db, request_id=request_id)
+        outcome = enrich_fn(
+            db,
+            request_id=request_id,
+        )
     except Exception:
         ctx.evidence_enrichment_budget -= 1
         logger.warning(
@@ -366,6 +413,7 @@ def _timeout_album(
     reason: str,
     ctx: CratediggerContext,
     *,
+    prepare_fn: Callable[..., str] | None = None,
     enrich_fn: Callable[..., str] | None = None,
 ) -> None:
     """Handle download timeout: cancel, log, reset to wanted."""
@@ -383,6 +431,16 @@ def _timeout_album(
                 f"({completed}/{total} files done, reason={reason})")
 
     db = ctx.pipeline_db_source._get_db()
+    # Capture/backfill HAVE before creating the audit row so Recents can
+    # distinguish this unchanged pre-import library snapshot from a later
+    # successful mutation. The helper is fail-soft; failure bookkeeping
+    # still proceeds unchanged.
+    prepared_outcome = _prepare_have_evidence_before_failure_log(
+        request_id,
+        entry.mb_release_id,
+        ctx,
+        prepare_fn=prepare_fn,
+    )
     db.log_download(
         request_id=request_id,
         soulseek_username=dl_info.username,
@@ -402,7 +460,12 @@ def _timeout_album(
             attempt_type="download",
         ),
     ))
-    _enrich_have_evidence_after_failure(request_id, ctx, enrich_fn=enrich_fn)
+    _enrich_have_evidence_after_failure(
+        request_id,
+        ctx,
+        prepared_outcome=prepared_outcome,
+        enrich_fn=enrich_fn,
+    )
 
 
 def _persist_updated_download_state(
@@ -773,6 +836,11 @@ def _enqueue_completed_processing(
                 detail,
             )
             dl_info = _build_download_info(entry)
+            prepared_outcome = _prepare_have_evidence_before_failure_log(
+                request_id,
+                entry.mb_release_id,
+                ctx,
+            )
             db.log_download(
                 request_id=request_id,
                 soulseek_username=dl_info.username,
@@ -788,7 +856,11 @@ def _enqueue_completed_processing(
                     attempt_type="download",
                 ),
             ))
-            _enrich_have_evidence_after_failure(request_id, ctx)
+            _enrich_have_evidence_after_failure(
+                request_id,
+                ctx,
+                prepared_outcome=prepared_outcome,
+            )
             return None
         logger.warning(
             "Completed download for request %s could not be materialized "

--- a/lib/import_preview.py
+++ b/lib/import_preview.py
@@ -580,6 +580,70 @@ def plan_current_evidence_enrichment(
     )
 
 
+def prepare_current_evidence_for_failure(
+    db: ImportPreviewDB,
+    *,
+    request_id: int,
+    mb_release_id: str,
+    quality_ranks: QualityRankConfig,
+    beets_library_root: str,
+    load_fn: Callable[..., EvidenceBuildResult] = load_or_backfill_current_evidence,
+) -> str:
+    """Load or backfill the canonical HAVE snapshot before failure logging.
+
+    Returns ``ready`` only when the request FK resolves to the surviving
+    evidence row, ``no_current_evidence`` only when Beets authoritatively says
+    the exact release is absent, and ``failed`` for adapter, snapshot, or
+    persistence failures.
+    """
+    try:
+        result = load_fn(
+            db,
+            request_id=request_id,
+            mb_release_id=mb_release_id,
+            quality_ranks=quality_ranks,
+            beets_library_root=beets_library_root,
+        )
+    except Exception:
+        logger.warning(
+            "Could not load/backfill current evidence for request %s",
+            request_id,
+            exc_info=True,
+        )
+        return "failed"
+    if result.status == "empty_current":
+        return "no_current_evidence"
+    if result.status != "ready" or result.evidence is None:
+        logger.warning(
+            "Could not prepare current evidence for request %s: %s%s",
+            request_id,
+            result.status,
+            f" ({result.reason})" if result.reason else "",
+        )
+        return "failed"
+    try:
+        current_id = db.get_request_current_evidence_id(request_id)
+        evidence = (
+            db.load_album_quality_evidence_by_id(current_id)
+            if current_id is not None
+            else None
+        )
+    except Exception:
+        logger.warning(
+            "Could not resolve prepared current evidence for request %s",
+            request_id,
+            exc_info=True,
+        )
+        return "failed"
+    if evidence is None or evidence.id is None:
+        logger.warning(
+            "Prepared current evidence was not linked for request %s",
+            request_id,
+        )
+        return "failed"
+    return "ready"
+
+
 def enrich_incomplete_current_evidence_for_request(
     db: ImportPreviewDB,
     *,
@@ -591,10 +655,9 @@ def enrich_incomplete_current_evidence_for_request(
 ) -> str:
     """Opportunistically complete a request's HAVE evidence in place.
 
-    Driven from the download-failure path: a failed download never reaches
-    preview, but the on-disk copy is right there — measure it now instead of
-    waiting for a download that may never succeed. Both writes go through
-    the preview-owned helpers, so the once-only, exact-snapshot, and
+    Driven from the download-failure path after its canonical HAVE snapshot
+    has been prepared and failure bookkeeping has completed. Both writes go
+    through the preview-owned helpers, so the once-only, exact-snapshot, and
     never-overwrite guards hold unchanged.
 
     Returns "no_current_evidence" (nothing linked), "stale" (files changed

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -6417,7 +6417,7 @@ class TestFailureEvidenceEnrichmentHook(unittest.TestCase):
     def _recorder(self, outcome: str = "enriched", error: Exception | None = None):
         calls: list[int] = []
 
-        def enrich(db: Any, *, request_id: int) -> str:
+        def enrich(db: Any, *, request_id: int, **_kwargs: Any) -> str:
             calls.append(request_id)
             if error is not None:
                 raise error
@@ -6443,10 +6443,40 @@ class TestFailureEvidenceEnrichmentHook(unittest.TestCase):
         ctx = make_ctx_with_fake_db(FakePipelineDB())
         enrich, calls = self._recorder("enriched")
 
-        _enrich_have_evidence_after_failure(42, ctx, enrich_fn=enrich)
+        _enrich_have_evidence_after_failure(
+            42,
+            ctx,
+            prepared_outcome="ready",
+            enrich_fn=enrich,
+        )
 
         self.assertEqual(calls, [42])
         self.assertEqual(ctx.evidence_enrichment_budget, 1)
+
+    def test_hook_wires_release_identity_and_beets_config(self):
+        from lib.config import CratediggerConfig
+        from lib.download import _prepare_have_evidence_before_failure_log
+
+        cfg = CratediggerConfig(beets_directory="/library")
+        ctx = make_ctx_with_fake_db(FakePipelineDB(), cfg=cfg)
+        received: dict[str, Any] = {}
+
+        def prepare(db: Any, **kwargs: Any) -> str:
+            received.update(kwargs)
+            return "ready"
+
+        outcome = _prepare_have_evidence_before_failure_log(
+            42,
+            "mb-exact-release",
+            ctx,
+            prepare_fn=prepare,
+        )
+
+        self.assertEqual(outcome, "ready")
+        self.assertEqual(received["request_id"], 42)
+        self.assertEqual(received["mb_release_id"], "mb-exact-release")
+        self.assertIs(received["quality_ranks"], cfg.quality_ranks)
+        self.assertEqual(received["beets_library_root"], "/library")
 
     def test_free_outcomes_do_not_consume_budget(self):
         from lib.download import _enrich_have_evidence_after_failure
@@ -6455,7 +6485,12 @@ class TestFailureEvidenceEnrichmentHook(unittest.TestCase):
                 ctx = make_ctx_with_fake_db(FakePipelineDB())
                 enrich, calls = self._recorder(outcome)
 
-                _enrich_have_evidence_after_failure(42, ctx, enrich_fn=enrich)
+                _enrich_have_evidence_after_failure(
+                    42,
+                    ctx,
+                    prepared_outcome="ready",
+                    enrich_fn=enrich,
+                )
 
                 self.assertEqual(calls, [42])
                 self.assertEqual(ctx.evidence_enrichment_budget, 2)
@@ -6466,7 +6501,12 @@ class TestFailureEvidenceEnrichmentHook(unittest.TestCase):
         ctx.evidence_enrichment_budget = 0
         enrich, calls = self._recorder("enriched")
 
-        _enrich_have_evidence_after_failure(42, ctx, enrich_fn=enrich)
+        _enrich_have_evidence_after_failure(
+            42,
+            ctx,
+            prepared_outcome="ready",
+            enrich_fn=enrich,
+        )
 
         self.assertEqual(calls, [])
 
@@ -6475,25 +6515,78 @@ class TestFailureEvidenceEnrichmentHook(unittest.TestCase):
         ctx = make_ctx_with_fake_db(FakePipelineDB())
         enrich, calls = self._recorder(error=RuntimeError("scan exploded"))
 
-        _enrich_have_evidence_after_failure(42, ctx, enrich_fn=enrich)
+        _enrich_have_evidence_after_failure(
+            42,
+            ctx,
+            prepared_outcome="ready",
+            enrich_fn=enrich,
+        )
 
         self.assertEqual(calls, [42])
         self.assertEqual(ctx.evidence_enrichment_budget, 1)
 
-    def test_timeout_album_runs_enrichment_after_failure_bookkeeping(self):
+    def test_timeout_album_runs_enrichment_and_failure_bookkeeping(self):
         from lib.download import _timeout_album
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=42, status="downloading"))
         ctx = make_ctx_with_fake_db(db)
-        enrich, calls = self._recorder("enriched")
+        calls: list[int] = []
+
+        def prepare(db: Any, **_kwargs: Any) -> str:
+            self.assertEqual(db.get_log(limit=1), [])
+            self.assertEqual(db.request(42)["status"], "downloading")
+            return "ready"
+
+        def enrich(db: Any, *, request_id: int) -> str:
+            db.assert_log(self, 0, outcome="timeout")
+            self.assertEqual(db.request(request_id)["status"], "wanted")
+            calls.append(request_id)
+            return "enriched"
 
         with patch("lib.download.cancel_and_delete"):
-            _timeout_album(self._entry(), 42, "stalled", ctx, enrich_fn=enrich)
+            _timeout_album(
+                self._entry(),
+                42,
+                "stalled",
+                ctx,
+                prepare_fn=prepare,
+                enrich_fn=enrich,
+            )
 
         db.assert_log(self, 0, outcome="timeout")
         self.assertEqual(db.request(42)["status"], "wanted")
         self.assertEqual(calls, [42])
         self.assertEqual(ctx.evidence_enrichment_budget, 1)
+
+    def test_failed_have_preparation_consumes_budget(self):
+        from lib.download import _prepare_have_evidence_before_failure_log
+
+        ctx = make_ctx_with_fake_db(FakePipelineDB())
+
+        outcome = _prepare_have_evidence_before_failure_log(
+            42,
+            "mb-uuid",
+            ctx,
+            prepare_fn=lambda *_args, **_kwargs: "failed",
+        )
+
+        self.assertEqual(outcome, "failed")
+        self.assertEqual(ctx.evidence_enrichment_budget, 1)
+
+    def test_absent_have_preparation_does_not_consume_budget(self):
+        from lib.download import _prepare_have_evidence_before_failure_log
+
+        ctx = make_ctx_with_fake_db(FakePipelineDB())
+
+        outcome = _prepare_have_evidence_before_failure_log(
+            42,
+            "mb-uuid",
+            ctx,
+            prepare_fn=lambda *_args, **_kwargs: "no_current_evidence",
+        )
+
+        self.assertEqual(outcome, "no_current_evidence")
+        self.assertEqual(ctx.evidence_enrichment_budget, 2)
 
     def test_timeout_album_default_enrichment_marks_v0_attempted(self):
         """Default wiring, no injection: a real (failing) probe still lands
@@ -6541,6 +6634,53 @@ class TestFailureEvidenceEnrichmentHook(unittest.TestCase):
         self.assertEqual(ctx.evidence_enrichment_budget, 1)
         db.assert_log(self, 0, outcome="timeout")
         self.assertEqual(db.request(42)["status"], "wanted")
+
+    def test_timeout_backfill_predates_failure_log_for_recents(self):
+        """A newly linked HAVE remains provably historical for its card."""
+        from lib.beets_db import AlbumInfo
+        from lib.config import CratediggerConfig
+        from lib.download import _timeout_album
+        from tests.fakes import FakeBeetsDB
+
+        source = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, source, ignore_errors=True)
+        with open(os.path.join(source, "01.mp3"), "wb") as handle:
+            handle.write(b"garbage bytes: analyzers fail fast")
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42,
+            mb_release_id="mb-uuid",
+            status="downloading",
+        ))
+        fake_beets = FakeBeetsDB()
+        fake_beets.set_album_info("mb-uuid", AlbumInfo(
+            album_id=1,
+            track_count=1,
+            min_bitrate_kbps=183,
+            avg_bitrate_kbps=190,
+            median_bitrate_kbps=191,
+            is_cbr=False,
+            album_path=source,
+            format="MP3",
+        ))
+        ctx = make_ctx_with_fake_db(
+            db,
+            cfg=CratediggerConfig(beets_directory=source),
+        )
+
+        with patch("lib.download.cancel_and_delete"), patch(
+            "lib.beets_db.BeetsDB", lambda **_kwargs: fake_beets,
+        ):
+            _timeout_album(self._entry(), 42, "stalled", ctx)
+
+        evidence_id = db.get_request_current_evidence_id(42)
+        self.assertIsNotNone(evidence_id)
+        log_row = db.get_log(limit=1)[0]
+        self.assertEqual(log_row["outcome"], "timeout")
+        self.assertTrue(log_row["_current_evidence_is_pre_attempt"])
+        self.assertEqual(log_row["_current_evidence_format"], "MP3")
+        self.assertEqual(log_row["_current_evidence_avg_bitrate"], 190)
 
 
 if __name__ == "__main__":

--- a/tests/test_import_preview.py
+++ b/tests/test_import_preview.py
@@ -15,6 +15,7 @@ from lib.import_preview import (
     compose_attempt_spectral_audit,
     enrich_current_v0_research_for_preview,
     enrich_incomplete_current_evidence_for_request,
+    prepare_current_evidence_for_failure,
     persist_exact_current_spectral_from_attempt,
     load_persisted_existing_spectral,
     measure_and_persist_candidate_evidence,
@@ -1683,6 +1684,14 @@ class TestEnrichIncompleteCurrentEvidence(unittest.TestCase):
             attempted=True, grade="genuine", bitrate_kbps=96,
         )
 
+    def _enrich(self, db, analyzer, probe):
+        return enrich_incomplete_current_evidence_for_request(
+            db,
+            request_id=42,
+            spectral_analyzer=analyzer,
+            probe_fn=probe,
+        )
+
     def test_complete_row_skips_all_measurement(self):
         db = self._db()
         source = self._source_dir()
@@ -1690,13 +1699,41 @@ class TestEnrichIncompleteCurrentEvidence(unittest.TestCase):
         analyzer, spectral_calls = self._spectral_recorder(self._good_scan())
         probe, probe_calls = self._probe_recorder()
 
-        outcome = enrich_incomplete_current_evidence_for_request(
-            db, request_id=42, spectral_analyzer=analyzer, probe_fn=probe,
-        )
+        outcome = self._enrich(db, analyzer, probe)
 
         self.assertEqual(outcome, "complete")
         self.assertEqual(spectral_calls, [])
         self.assertEqual(probe_calls, [])
+
+    def test_preparation_preserves_an_existing_complete_current_row(self):
+        db = self._db()
+        source = self._source_dir()
+        before = self._seed_current(
+            db,
+            source,
+            spectral_present=True,
+            v0_attempted=True,
+        )
+
+        with patch(
+            "lib.beets_db.BeetsDB",
+            side_effect=AssertionError("complete HAVE must not open Beets"),
+        ):
+            outcome = prepare_current_evidence_for_failure(
+                db,
+                request_id=42,
+                mb_release_id="mbid-42",
+                quality_ranks=QualityRankConfig.defaults(),
+                beets_library_root=source,
+            )
+
+        current_id = db.get_request_current_evidence_id(42)
+        self.assertEqual(outcome, "ready")
+        self.assertEqual(current_id, before.id)
+        self.assertEqual(
+            db.load_album_quality_evidence_by_id(current_id),
+            before,
+        )
 
     def test_fills_both_missing_pieces(self):
         db = self._db()
@@ -1706,9 +1743,7 @@ class TestEnrichIncompleteCurrentEvidence(unittest.TestCase):
         analyzer, spectral_calls = self._spectral_recorder(self._good_scan())
         probe, probe_calls = self._probe_recorder()
 
-        outcome = enrich_incomplete_current_evidence_for_request(
-            db, request_id=42, spectral_analyzer=analyzer, probe_fn=probe,
-        )
+        outcome = self._enrich(db, analyzer, probe)
 
         self.assertEqual(outcome, "enriched")
         self.assertEqual(spectral_calls, [source])
@@ -1728,9 +1763,7 @@ class TestEnrichIncompleteCurrentEvidence(unittest.TestCase):
         analyzer, spectral_calls = self._spectral_recorder(self._good_scan())
         probe, probe_calls = self._probe_recorder()
 
-        outcome = enrich_incomplete_current_evidence_for_request(
-            db, request_id=42, spectral_analyzer=analyzer, probe_fn=probe,
-        )
+        outcome = self._enrich(db, analyzer, probe)
 
         self.assertEqual(outcome, "enriched")
         self.assertEqual(spectral_calls, [])
@@ -1745,9 +1778,7 @@ class TestEnrichIncompleteCurrentEvidence(unittest.TestCase):
         analyzer, spectral_calls = self._spectral_recorder(self._good_scan())
         probe, probe_calls = self._probe_recorder()
 
-        outcome = enrich_incomplete_current_evidence_for_request(
-            db, request_id=42, spectral_analyzer=analyzer, probe_fn=probe,
-        )
+        outcome = self._enrich(db, analyzer, probe)
 
         self.assertEqual(outcome, "enriched")
         self.assertEqual(spectral_calls, [source])
@@ -1762,9 +1793,7 @@ class TestEnrichIncompleteCurrentEvidence(unittest.TestCase):
         analyzer, spectral_calls = self._spectral_recorder(self._good_scan())
         probe, probe_calls = self._probe_recorder()
 
-        outcome = enrich_incomplete_current_evidence_for_request(
-            db, request_id=42, spectral_analyzer=analyzer, probe_fn=probe,
-        )
+        outcome = self._enrich(db, analyzer, probe)
 
         self.assertEqual(outcome, "stale")
         self.assertEqual(spectral_calls, [])
@@ -1775,13 +1804,96 @@ class TestEnrichIncompleteCurrentEvidence(unittest.TestCase):
         analyzer, spectral_calls = self._spectral_recorder(self._good_scan())
         probe, probe_calls = self._probe_recorder()
 
-        outcome = enrich_incomplete_current_evidence_for_request(
-            db, request_id=42, spectral_analyzer=analyzer, probe_fn=probe,
-        )
+        outcome = self._enrich(db, analyzer, probe)
 
         self.assertEqual(outcome, "no_current_evidence")
         self.assertEqual(spectral_calls, [])
         self.assertEqual(probe_calls, [])
+
+    def test_failed_backfill_is_not_classified_as_absent_library_copy(self):
+        db = self._db()
+
+        outcome = prepare_current_evidence_for_failure(
+            db,
+            request_id=42,
+            mb_release_id="mbid-42",
+            quality_ranks=QualityRankConfig.defaults(),
+            beets_library_root="",
+            load_fn=lambda *_args, **_kwargs: EvidenceBuildResult(
+                None,
+                "failed",
+                "beets library unreadable",
+            ),
+        )
+
+        self.assertEqual(outcome, "failed")
+
+    def test_backfill_exception_is_not_classified_as_absent_library_copy(self):
+        db = self._db()
+
+        def broken_loader(*_args, **_kwargs):
+            raise RuntimeError("beets adapter crashed")
+
+        outcome = prepare_current_evidence_for_failure(
+            db,
+            request_id=42,
+            mb_release_id="mbid-42",
+            quality_ranks=QualityRankConfig.defaults(),
+            beets_library_root="",
+            load_fn=broken_loader,
+        )
+
+        self.assertEqual(outcome, "failed")
+
+    def test_failed_download_backfills_unlinked_seabear_have(self):
+        """We Built a Fire: an installed album cannot stay HAVE-less."""
+        from lib.beets_db import AlbumInfo
+        from tests.fakes import FakeBeetsDB
+
+        db = self._db()
+        source = self._source_dir()
+        fake_beets = FakeBeetsDB()
+        fake_beets.set_album_info("mbid-42", AlbumInfo(
+            album_id=1,
+            track_count=17,
+            min_bitrate_kbps=183,
+            avg_bitrate_kbps=190,
+            median_bitrate_kbps=191,
+            is_cbr=False,
+            album_path=source,
+            format="MP3",
+        ))
+        analyzer, spectral_calls = self._spectral_recorder(self._good_scan())
+        probe, probe_calls = self._probe_recorder()
+
+        with patch("lib.beets_db.BeetsDB", lambda **_kwargs: fake_beets):
+            prepared = prepare_current_evidence_for_failure(
+                db,
+                request_id=42,
+                mb_release_id="mbid-42",
+                quality_ranks=QualityRankConfig.defaults(),
+                beets_library_root=source,
+            )
+            outcome = enrich_incomplete_current_evidence_for_request(
+                db,
+                request_id=42,
+                spectral_analyzer=analyzer,
+                probe_fn=probe,
+            )
+
+        self.assertEqual(prepared, "ready")
+        self.assertEqual(outcome, "enriched")
+        self.assertEqual(spectral_calls, [source])
+        self.assertEqual(probe_calls, [source])
+        evidence_id = db.get_request_current_evidence_id(42)
+        self.assertIsNotNone(evidence_id)
+        persisted = db.load_album_quality_evidence_by_id(evidence_id)
+        assert persisted is not None
+        self.assertEqual(persisted.measurement.format, "MP3")
+        self.assertEqual(persisted.measurement.avg_bitrate_kbps, 190)
+        self.assertEqual(persisted.measurement.spectral_grade, "genuine")
+        assert persisted.v0_metric is not None
+        self.assertEqual(persisted.v0_metric.avg_bitrate_kbps, 259)
 
     def test_failed_spectral_scan_reports_partial(self):
         db = self._db()
@@ -1795,9 +1907,7 @@ class TestEnrichIncompleteCurrentEvidence(unittest.TestCase):
         )
         probe, probe_calls = self._probe_recorder()
 
-        outcome = enrich_incomplete_current_evidence_for_request(
-            db, request_id=42, spectral_analyzer=analyzer, probe_fn=probe,
-        )
+        outcome = self._enrich(db, analyzer, probe)
 
         self.assertEqual(outcome, "partial")
         self.assertEqual(spectral_calls, [source])

--- a/tests/test_quality_lineage_generated.py
+++ b/tests/test_quality_lineage_generated.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import tempfile
 import unittest
+from unittest.mock import patch
 
 from hypothesis import example, given, strategies as st
 import msgspec
@@ -14,6 +15,8 @@ from lib.measurement import PreimportMeasurement
 from lib.import_preview import (
     EnrichmentPlan,
     enrich_current_v0_research_for_preview,
+    enrich_incomplete_current_evidence_for_request,
+    prepare_current_evidence_for_failure,
     persist_exact_current_spectral_from_attempt,
     plan_current_evidence_enrichment,
 )
@@ -119,6 +122,23 @@ def assert_enrichment_plan_never_remeasures(evidence, plan) -> None:
         )
 
 
+def assert_failure_enrichment_matches_library_membership(
+    *,
+    album_present: bool,
+    current_evidence_id: int | None,
+    outcome: str,
+) -> None:
+    """An installed exact release must acquire a linked HAVE snapshot."""
+    if album_present and current_evidence_id is None:
+        raise AssertionError("installed release remained without linked HAVE")
+    if album_present and outcome == "no_current_evidence":
+        raise AssertionError("installed release was classified as absent HAVE")
+    if not album_present and current_evidence_id is not None:
+        raise AssertionError("absent release fabricated a HAVE snapshot")
+    if not album_present and outcome != "no_current_evidence":
+        raise AssertionError("absent release did not retain no-HAVE outcome")
+
+
 class TestQualityLineagePins(unittest.TestCase):
     def test_research_once_checker_rejects_repeated_unmarked_probe(self):
         with self.assertRaisesRegex(AssertionError, "exactly one"):
@@ -139,6 +159,14 @@ class TestQualityLineagePins(unittest.TestCase):
         with self.assertRaisesRegex(AssertionError, "V0"):
             assert_enrichment_plan_never_remeasures(
                 attempted, EnrichmentPlan(spectral=False, v0=True),
+            )
+
+    def test_failure_enrichment_checker_rejects_unlinked_installed_release(self):
+        with self.assertRaisesRegex(AssertionError, "without linked HAVE"):
+            assert_failure_enrichment_matches_library_membership(
+                album_present=True,
+                current_evidence_id=None,
+                outcome="no_current_evidence",
             )
 
     def test_enrichment_plan_pin_complete_row_plans_nothing(self):
@@ -195,6 +223,71 @@ class TestQualityLineagePins(unittest.TestCase):
             grade is None and spectral_bitrate is None,
         )
         self.assertEqual(plan.v0, not v0_present and not v0_attempted)
+
+    @given(
+        album_present=st.booleans(),
+        minimum=st.integers(min_value=32, max_value=320),
+        average=st.integers(min_value=32, max_value=320),
+        median=st.integers(min_value=32, max_value=320),
+    )
+    @example(album_present=True, minimum=183, average=190, median=191)
+    def test_generated_failed_download_links_have_when_release_is_installed(
+        self,
+        album_present: bool,
+        minimum: int,
+        average: int,
+        median: int,
+    ) -> None:
+        from lib.beets_db import AlbumInfo
+        from tests.fakes import FakeBeetsDB
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42,
+            mb_release_id="mbid-42",
+            status="wanted",
+        ))
+        with tempfile.TemporaryDirectory() as source:
+            with open(os.path.join(source, "01.mp3"), "wb") as handle:
+                handle.write(b"generated current-library bytes")
+            fake_beets = FakeBeetsDB()
+            if album_present:
+                fake_beets.set_album_info("mbid-42", AlbumInfo(
+                    album_id=1,
+                    track_count=1,
+                    min_bitrate_kbps=minimum,
+                    avg_bitrate_kbps=average,
+                    median_bitrate_kbps=median,
+                    is_cbr=False,
+                    album_path=source,
+                    format="MP3",
+                ))
+            with patch("lib.beets_db.BeetsDB", lambda **_kwargs: fake_beets):
+                prepared = prepare_current_evidence_for_failure(
+                    db,
+                    request_id=42,
+                    mb_release_id="mbid-42",
+                    quality_ranks=QualityRankConfig.defaults(),
+                    beets_library_root=source,
+                )
+                outcome = prepared
+                if prepared == "ready":
+                    outcome = enrich_incomplete_current_evidence_for_request(
+                        db,
+                        request_id=42,
+                        spectral_analyzer=lambda _path: SpectralAnalysisDetail(
+                            attempted=True,
+                            grade="genuine",
+                            bitrate_kbps=96,
+                        ),
+                        probe_fn=lambda _path: None,
+                    )
+
+        assert_failure_enrichment_matches_library_membership(
+            album_present=album_present,
+            current_evidence_id=db.get_request_current_evidence_id(42),
+            outcome=outcome,
+        )
 
     @given(
         projected_format=st.sampled_from(("OPUS 128", "MP3 V0", "FLAC")),


### PR DESCRIPTION
## Summary

- backfill the exact Beets release's canonical HAVE snapshot when a failed download has no linked current evidence
- establish the historical snapshot before the failure log, then run spectral/V0 enrichment only after failure bookkeeping and the request reset complete
- preserve already-linked complete HAVE rows without opening Beets or rewriting evidence, and budget adapter/backfill failures separately from authoritative absence

## Regression coverage

- pins the Seabear / We Built a Fire all-files-errored shape so Recents receives MP3 HAVE evidence
- proves existing complete HAVE evidence is unchanged and avoids Beets access
- proves the snapshot predates the failure row while expensive enrichment runs after the request is safely back in wanted
- adds generated library-present/library-absent coverage and a known-bad checker self-test

## Verification

- independent review: CLEAN
- focused download/import/Recents suites: 478 tests passed
- generated fuzz profile: passed
- `pyright --threads 4`: passed
- `bash scripts/run_tests.sh`: 6,057 tests passed