### PR TITLE
Remove the dead evidence-strip rank slot

### DIFF
--- a/tests/test_js_history.mjs
+++ b/tests/test_js_history.mjs
@@ -518,13 +518,14 @@ console.log('renderEvidenceStrip() builds the compact IN/HAVE comparison');
   assertContains(strip, 'class="r-evidence"', 'strip wrapper class');
   assertContains(strip, 'class="r-ev-row r-ev-in"', 'IN is a semantic grid row');
   assertContains(strip, 'class="r-ev-row r-ev-have"', 'HAVE is a semantic grid row');
-  for (const slot of ['source', 'metric', 'rank', 'spectral', 'v0']) {
+  for (const slot of ['source', 'metric', 'spectral', 'v0']) {
     const count = strip.split(`r-ev-${slot}`).length - 1;
     if (count === 2) { passed++; } else {
       failed++;
       console.error(`  FAIL: ${slot} must occupy the same explicit slot in both rows; got ${count}`);
     }
   }
+  assertExcludes(strip, 'r-ev-rank', 'rows do not render the permanently empty rank slot');
   assertExcludes(strip, 'r-ev-value', 'rows do not collapse back to one freeform value cell');
   assertContains(strip, 'IN', 'IN side labelled');
   assertContains(strip, 'MP3 320', 'incoming label rendered');
@@ -1279,10 +1280,10 @@ console.log('evidence strip CSS keeps desktop alignment and gives mobile readabl
   const css = readFileSync(new URL('../web/index.html', import.meta.url), 'utf8');
   assertContains(css, '.r-ev-row { display: contents; }',
     'desktop row wrappers participate in the parent grid instead of defining independent columns');
-  assertContains(css, 'grid-template-columns: 3.6em minmax(4.5em, 0.8fr) minmax(12em, 1.7fr) minmax(4.5em, 0.75fr) minmax(7.5em, 1fr) minmax(9em, 1.35fr)',
-    'desktop reserves a full avg/min metric column before rank/spectral/V0');
+  assertContains(css, 'grid-template-columns: 3.6em minmax(4.5em, 0.8fr) minmax(12em, 1.7fr) minmax(7.5em, 1fr) minmax(9em, 1.35fr)',
+    'desktop reserves aligned tag/source/metric/spectral/V0 columns');
   assertContains(css, '@media (max-width: 720px)', 'shared grid has a narrow-screen layout');
-  assertContains(css, '.r-evidence { grid-template-columns: 2.9em 3.2em minmax(8.5em, max-content) 0 minmax(3em, 1fr) max-content; column-gap: 0.45em; font-size: 12px;',
+  assertContains(css, '.r-evidence { grid-template-columns: 2.9em 3.2em minmax(8.5em, max-content) minmax(3em, 1fr) max-content; column-gap: 0.45em; font-size: 12px;',
     'mobile fixes tag+source and floors the bitrate column at a labelled-pair width, so a bare CBR value keeps the same column edges as the pair above it');
   assertContains(css, 'font-family: system-ui,',
     'mobile uses the narrow system font so full lines fit without squeezing');
@@ -1310,6 +1311,10 @@ console.log('evidence strip CSS keeps desktop alignment and gives mobile readabl
     'mobile evidence never collapses every field into equal tiny columns');
   assertExcludes(css, 'grid-template-columns: 2.8em minmax(3.4em',
     'the overlapping five-column mobile layout cannot return');
+  assertExcludes(css, 'minmax(4.5em, 0.75fr)',
+    'desktop does not reserve a track for the permanently empty rank slot');
+  assertExcludes(css, 'minmax(8.5em, max-content) 0 minmax(3em, 1fr)',
+    'mobile does not retain a zero-width track for the permanently empty rank slot');
 }
 
 console.log('renderEvidenceStrip() marks spectral-clamped rank values with ~');

--- a/web/index.html
+++ b/web/index.html
@@ -356,7 +356,7 @@
   .p-hist-forensics summary { cursor: pointer; user-select: none; color: #556; font-size: 0.9em; }
   .p-hist-forensics summary:hover, .p-hist-forensics[open] summary { color: #889; }
   /* Compact IN/HAVE evidence strip on Recents list rows (issue #575). */
-  .r-evidence { display: grid; grid-template-columns: 3.6em minmax(4.5em, 0.8fr) minmax(12em, 1.7fr) minmax(4.5em, 0.75fr) minmax(7.5em, 1fr) minmax(9em, 1.35fr); column-gap: 0.7em; row-gap: 2px; align-items: baseline; width: 100%; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.95em; color: #7a8a99; }
+  .r-evidence { display: grid; grid-template-columns: 3.6em minmax(4.5em, 0.8fr) minmax(12em, 1.7fr) minmax(7.5em, 1fr) minmax(9em, 1.35fr); column-gap: 0.7em; row-gap: 2px; align-items: baseline; width: 100%; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 0.95em; color: #7a8a99; }
   .r-ev-row { display: contents; }
   .r-evidence .r-ev-tag { color: #d3deea; font-weight: 900; font-size: 1.08em; line-height: 1; letter-spacing: 0.9px; text-shadow: 0 0 8px rgba(170, 205, 235, 0.24); }
   .r-ev-cell { min-width: 0; overflow-wrap: normal; word-break: normal; white-space: nowrap; }
@@ -369,13 +369,12 @@
        flush right on every card (the flexible spectral column eats the
        slack between them, ellipsizing under pressure — its color still
        tells the grade). Number columns are max-content and never shrink.
-       The rank slot is never populated on strips, so its track is 0.
        The bitrate column is floored at a labelled-pair width so a bare
        CBR value ("320k") keeps the same column edges as a full pair —
        only rare 4-digit pairs grow past it. One line per side,
        guaranteed. Compact wording labels each number in place (avg/min
        beside the values), never "a/m". */
-    .r-evidence { grid-template-columns: 2.9em 3.2em minmax(8.5em, max-content) 0 minmax(3em, 1fr) max-content; column-gap: 0.45em; font-size: 12px; line-height: 1.5; font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #92a2b1; }
+    .r-evidence { grid-template-columns: 2.9em 3.2em minmax(8.5em, max-content) minmax(3em, 1fr) max-content; column-gap: 0.45em; font-size: 12px; line-height: 1.5; font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; color: #92a2b1; }
     .r-ev-cell { overflow: hidden; text-overflow: ellipsis; }
     .r-ev-full { display: none; } .r-ev-compact { display: inline; }
   }

--- a/web/js/history.js
+++ b/web/js/history.js
@@ -139,7 +139,7 @@ function basisSidePhrase(basis, side) {
 }
 
 function emptyEvidenceCells() {
-  return { source: '', metric: '', rank: '', spectral: '', v0: '' };
+  return { source: '', metric: '', spectral: '', v0: '' };
 }
 
 function avgMinPhrase(avg, median, min) {
@@ -356,7 +356,6 @@ function renderEvidenceRow(side, label, cells) {
     + `<strong class="r-ev-tag">${label}</strong>`
     + renderEvidenceCell('source', cells.source)
     + renderEvidenceCell('metric', cells.metric)
-    + renderEvidenceCell('rank', cells.rank)
     + renderEvidenceCell('spectral', cells.spectral)
     + renderEvidenceCell('v0', cells.v0)
     + `</span>`;


### PR DESCRIPTION
## Summary

- remove the permanently empty `rank` cell from the Recents IN/HAVE evidence model and markup
- collapse the desktop and mobile grids from six tracks to the five real tracks: tag, source, metric, spectral, and V0
- update the JavaScript contract pins so the dead slot and its CSS tracks cannot return

This completes the remaining item in #719. The issue stays open until deployment and live verification.

## Validation

- focused JavaScript history suite: 488 passed
- live-db visual QA at 1000x900 and 390x844, followed by operator approval
- `nix-shell --run "pyright --threads 4"`: 0 errors, 0 warnings
- `nix-shell --run "bash scripts/run_tests.sh"`: all JavaScript/dead-code gates and 6,057 Python tests passed, no skips