### PR TITLE
Fix malformed embedded artwork breaking audio measurement

### DIFF
--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -875,6 +875,7 @@ def convert_lossless(album_path: str, spec: ConversionSpec,
         # that already auto-downmix (libmp3lame, aac) ignore the
         # redundant flag.
         cmd = ["ffmpeg", "-i", src_path,
+               "-map", "0:a",
                "-ac", "2",
                "-c:a", spec.codec, *spec.codec_args,
                *spec.metadata_args,

--- a/lib/spectral_check.py
+++ b/lib/spectral_check.py
@@ -260,7 +260,7 @@ def _ffmpeg_to_wav(src, dst, trim_seconds=30):
     cmd = [
         "ffmpeg", "-nostdin", "-loglevel", "error", "-y",
         "-analyzeduration", "5M", "-probesize", "5M",
-        "-i", _safe_path(src),
+        "-i", _safe_path(src), "-map", "0:a",
     ]
     if trim_seconds:
         cmd.extend(["-t", str(trim_seconds)])

--- a/lib/v0_probe.py
+++ b/lib/v0_probe.py
@@ -140,7 +140,8 @@ def probe_files_as_v0(
             try:
                 result = subprocess.run(
                     [
-                        "ffmpeg", "-i", src_path, "-ac", "2", "-c:a",
+                        "ffmpeg", "-i", src_path, "-map", "0:a",
+                        "-ac", "2", "-c:a",
                         V0_CODEC, *V0_CODEC_ARGS, *V0_METADATA_ARGS,
                         "-y", out_path,
                     ],


### PR DESCRIPTION
## Summary

- explicitly map audio streams in lossless conversion
- apply the same audio-only mapping to V0 probing and spectral decoding
- preserve source metadata while excluding malformed attached-picture streams

## Verification

- independent structural review of all production ffmpeg call sites: clean
- Pyright: 0 errors
- full unchanged suite: 6,084 tests passed
- real Iron & Wine malformed-art fixture succeeds through conversion, V0 probe, and spectral decode

No tests were modified.