### PR TITLE
Refresh legacy current evidence at the right boundary

### DIFF
--- a/docs/quality-verification.md
+++ b/docs/quality-verification.md
@@ -295,7 +295,14 @@ target contract. Source measurements cannot carry `was_converted_from`; that
 field describes materialized output lineage. These rules are enforced at the
 v3 wire decoder/encoder and again before evidence persistence. Active evidence
 rows carry `lineage_version=3`; migration 050 marks older ambiguous rows as
-version 1 instead of guessing their meaning from values.
+version 1 instead of guessing their meaning from values. Current-evidence
+loaders treat those v1 rows as rebuild-required. Actual import/action attempts
+remeasure the exact installed Beets album before deciding. Download failures
+first retain a policy-complete v1 row for the audit log, return the request to
+`wanted`, then upgrade that exact content-addressed row to v3 in the bounded
+post-failure enrichment phase. A same-snapshot repair preserves its original
+`measured_at` and neutral research so historical Recents cards remain
+pre-attempt evidence.
 
 **Motivation (request 6039 / download_log 36608):** a genuine avg 196→288
 rank upgrade (GOOD → TRANSPARENT) rendered as "Upgrade: MP3 V2 to MP3 V2"

--- a/lib/download.py
+++ b/lib/download.py
@@ -364,6 +364,7 @@ def _prepare_have_evidence_before_failure_log(
 
 def _enrich_have_evidence_after_failure(
     request_id: int,
+    mb_release_id: str,
     ctx: CratediggerContext,
     *,
     prepared_outcome: str,
@@ -389,6 +390,9 @@ def _enrich_have_evidence_after_failure(
         outcome = enrich_fn(
             db,
             request_id=request_id,
+            mb_release_id=mb_release_id,
+            quality_ranks=ctx.cfg.quality_ranks,
+            beets_library_root=ctx.cfg.beets_directory,
         )
     except Exception:
         ctx.evidence_enrichment_budget -= 1
@@ -462,6 +466,7 @@ def _timeout_album(
     ))
     _enrich_have_evidence_after_failure(
         request_id,
+        entry.mb_release_id,
         ctx,
         prepared_outcome=prepared_outcome,
         enrich_fn=enrich_fn,
@@ -858,6 +863,7 @@ def _enqueue_completed_processing(
             ))
             _enrich_have_evidence_after_failure(
                 request_id,
+                entry.mb_release_id,
                 ctx,
                 prepared_outcome=prepared_outcome,
             )

--- a/lib/import_evidence.py
+++ b/lib/import_evidence.py
@@ -24,6 +24,7 @@ from lib.quality_evidence import (
     QualityEvidenceDB,
     audio_snapshot_matches,
     backfill_current_evidence_from_album_info,
+    current_evidence_rebuild_reasons,
     load_candidate_evidence_for_source,
     load_or_backfill_current_evidence,
 )
@@ -182,8 +183,8 @@ def ensure_current_evidence_for_action(
             else "current album files changed since evidence capture"
         )
         if (
-            errors
-            and existing_requires_lossless_source_v0
+            existing_requires_lossless_source_v0
+            and not _has_lossless_source_v0_metric(existing)
             and not existing_snapshot_stale
             and not _request_has_current_lossless_source_v0(request_row)
         ):
@@ -292,7 +293,7 @@ def _current_action_incomplete_reasons(
     *,
     require_lossless_source_v0: bool = False,
 ) -> list[str]:
-    reasons = evidence.policy_incomplete_reasons()
+    reasons = current_evidence_rebuild_reasons(evidence)
     if (
         (require_lossless_source_v0 or _requires_lossless_source_v0_metric(
             evidence,

--- a/lib/import_preview.py
+++ b/lib/import_preview.py
@@ -31,6 +31,7 @@ from lib.quality_evidence import (
     EvidenceBuildResult,
     QualityEvidenceDB,
     audio_snapshot_matches,
+    current_evidence_rebuild_reasons,
     legacy_current_lossless_v0_probe_from_request,
     load_or_backfill_current_evidence,
     audit_v0_probe_from_metric,
@@ -589,13 +590,37 @@ def prepare_current_evidence_for_failure(
     beets_library_root: str,
     load_fn: Callable[..., EvidenceBuildResult] = load_or_backfill_current_evidence,
 ) -> str:
-    """Load or backfill the canonical HAVE snapshot before failure logging.
+    """Link usable HAVE before failure logging without refreshing complete v1.
 
     Returns ``ready`` only when the request FK resolves to the surviving
     evidence row, ``no_current_evidence`` only when Beets authoritatively says
     the exact release is absent, and ``failed`` for adapter, snapshot, or
-    persistence failures.
+    persistence failures. A policy-complete v1 row is already historical
+    evidence for the failure card, so this latency-sensitive phase preserves
+    it. The bounded post-failure phase rebuilds that exact snapshot as v3 after
+    the request has converged to ``wanted``.
     """
+    try:
+        current_id = db.get_request_current_evidence_id(request_id)
+        current = (
+            db.load_album_quality_evidence_by_id(current_id)
+            if current_id is not None
+            else None
+        )
+    except Exception:
+        logger.warning(
+            "Could not resolve current evidence for request %s",
+            request_id,
+            exc_info=True,
+        )
+        return "failed"
+    if (
+        current is not None
+        and current.id is not None
+        and not current.policy_incomplete_reasons()
+    ):
+        return "ready"
+
     try:
         result = load_fn(
             db,
@@ -648,6 +673,9 @@ def enrich_incomplete_current_evidence_for_request(
     db: ImportPreviewDB,
     *,
     request_id: int,
+    mb_release_id: str,
+    quality_ranks: QualityRankConfig,
+    beets_library_root: str,
     spectral_analyzer: SpectralDetailAnalyzer = analyze_spectral_audit_path,
     probe_fn: Callable[[str], V0ProbeEvidence | None] = (
         probe_installed_album_as_v0
@@ -656,13 +684,15 @@ def enrich_incomplete_current_evidence_for_request(
     """Opportunistically complete a request's HAVE evidence in place.
 
     Driven from the download-failure path after its canonical HAVE snapshot
-    has been prepared and failure bookkeeping has completed. Both writes go
-    through the preview-owned helpers, so the once-only, exact-snapshot, and
-    never-overwrite guards hold unchanged.
+    has been prepared and failure bookkeeping has completed. Legacy v1 is
+    rebuilt here, after the request is already ``wanted``; normal import
+    attempts rebuild v1 synchronously in their preview loader instead. All
+    writes go through the preview-owned helpers, so the once-only,
+    exact-snapshot, and never-overwrite guards hold unchanged.
 
     Returns "no_current_evidence" (nothing linked), "stale" (files changed
     since capture), "complete" (nothing missing — zero cost), "enriched"
-    (every missing piece resolved), or "partial" (measurement ran but
+    (a rebuild or every missing piece resolved), or "partial" (work ran but
     something is still unresolved).
     """
     try:
@@ -681,9 +711,53 @@ def enrich_incomplete_current_evidence_for_request(
         return "no_current_evidence"
     if evidence is None or evidence.id is None:
         return "no_current_evidence"
+    rebuilt = False
+    if current_evidence_rebuild_reasons(evidence):
+        try:
+            result = load_or_backfill_current_evidence(
+                db,
+                request_id=request_id,
+                mb_release_id=mb_release_id,
+                quality_ranks=quality_ranks,
+                preloaded_evidence=evidence,
+                preloaded=True,
+                beets_library_root=beets_library_root,
+            )
+        except Exception:
+            logger.warning(
+                "Could not rebuild current evidence for request %s",
+                request_id,
+                exc_info=True,
+            )
+            return "partial"
+        if result.status != "ready" or result.evidence is None:
+            logger.warning(
+                "Could not rebuild current evidence for request %s: %s%s",
+                request_id,
+                result.status,
+                f" ({result.reason})" if result.reason else "",
+            )
+            return "partial"
+        try:
+            current_id = db.get_request_current_evidence_id(request_id)
+            evidence = (
+                db.load_album_quality_evidence_by_id(current_id)
+                if current_id is not None
+                else None
+            )
+        except Exception:
+            logger.warning(
+                "Could not resolve rebuilt current evidence for request %s",
+                request_id,
+                exc_info=True,
+            )
+            return "partial"
+        if evidence is None or evidence.id is None:
+            return "partial"
+        rebuilt = True
     plan = plan_current_evidence_enrichment(evidence)
     if not plan.any:
-        return "complete"
+        return "enriched" if rebuilt else "complete"
     # Cheap freshness pre-check before any expensive measurement; the
     # persist/claim helpers each re-verify under their own authority.
     if not audio_snapshot_matches(evidence.source_path, evidence.files):
@@ -730,7 +804,7 @@ def load_current_evidence_for_preview(
     # in place — rebuild it from beets so this same preview's enrichment can
     # complete it before the importer decides.
     should_rebuild = (
-        current is not None and bool(current.policy_incomplete_reasons())
+        current is not None and bool(current_evidence_rebuild_reasons(current))
     )
     if should_load or should_rebuild:
         try:

--- a/lib/quality_evidence.py
+++ b/lib/quality_evidence.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 
+import msgspec
+
 from lib.quality import (
     LOSSLESS_CODECS,
     V0_PROBE_LOSSLESS_SOURCE,
@@ -125,6 +127,18 @@ class EvidenceBuildResult:
     @property
     def available(self) -> bool:
         return self.evidence is not None
+
+
+def current_evidence_rebuild_reasons(
+    evidence: AlbumQualityEvidence,
+) -> list[str]:
+    """Return reasons a current-library snapshot must be measured again."""
+    reasons = evidence.policy_incomplete_reasons()
+    if evidence.lineage_version != 3:
+        reasons.append(
+            f"lineage_version {evidence.lineage_version} must be rebuilt as 3"
+        )
+    return reasons
 
 
 _LOSSLESS_CONTAINERS = {"flac", "alac", "wav", "aiff", "ape"}
@@ -1060,13 +1074,13 @@ def backfill_current_evidence_from_album_info(
     downstream readers can fetch via FK rather than scanning by mbid.
     """
     request_row = db.get_request(request_id)
+    existing_id = db.get_request_current_evidence_id(request_id)
+    existing = (
+        db.load_album_quality_evidence_by_id(existing_id)
+        if existing_id is not None
+        else None
+    )
     if verified_lossless_proof is None and preserve_existing_verified_lossless_proof:
-        existing_id = db.get_request_current_evidence_id(request_id)
-        existing = (
-            db.load_album_quality_evidence_by_id(existing_id)
-            if existing_id is not None
-            else None
-        )
         if (
             existing is not None
             and existing.measurement.verified_lossless
@@ -1079,6 +1093,44 @@ def backfill_current_evidence_from_album_info(
         request_row=request_row,
         verified_lossless_proof=verified_lossless_proof,
     )
+    if (
+        result.evidence is not None
+        and existing is not None
+        and existing.snapshot_fingerprint == result.evidence.snapshot_fingerprint
+    ):
+        # A lineage repair remeasures the same immutable content address. Keep
+        # its original capture time so historical failure cards remain
+        # provably pre-attempt, and retain exact-snapshot neutral research that
+        # does not need to be repeated merely because the row became v3.
+        measurement = result.evidence.measurement
+        existing_measurement = existing.measurement
+        if existing_measurement.spectral_grade is not None:
+            # Spectral grade owns the whole atomic fact, including an
+            # explicitly absent bitrate. Never combine request-row scalars
+            # with the exact-snapshot measurement.
+            measurement = msgspec.structs.replace(
+                measurement,
+                spectral_grade=existing_measurement.spectral_grade,
+                spectral_bitrate_kbps=(
+                    existing_measurement.spectral_bitrate_kbps
+                ),
+            )
+        result = EvidenceBuildResult(
+            msgspec.structs.replace(
+                result.evidence,
+                measurement=measurement,
+                measured_at=existing.measured_at,
+                # V0 is likewise one atomic neutral fact. The persisted
+                # content-addressed metric outranks legacy request scalars.
+                v0_metric=existing.v0_metric or result.evidence.v0_metric,
+                on_disk_v0_research_attempted=(
+                    result.evidence.on_disk_v0_research_attempted
+                    or existing.on_disk_v0_research_attempted
+                ),
+            ),
+            result.status,
+            result.reason,
+        )
     if result.evidence is not None:
         db.upsert_album_quality_evidence(result.evidence)
         persisted = db.find_album_quality_evidence(
@@ -1182,7 +1234,7 @@ def load_or_backfill_current_evidence(
             else None
         )
     if existing is not None:
-        errors = existing.policy_incomplete_reasons()
+        errors = current_evidence_rebuild_reasons(existing)
         if not errors:
             return EvidenceBuildResult(existing, "ready")
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -3589,6 +3589,111 @@ class TestPollActiveDownloads(unittest.TestCase):
         self.assertEqual(fake_db.download_logs[0].outcome, "failed")
         self.assertIn("EVENT-PATH MISSING", "\n".join(logs.output))
 
+    def test_materialize_failure_defers_v1_refresh_until_after_wanted(self):
+        from lib.beets_db import AlbumInfo
+        from lib.download import poll_active_downloads
+        from lib.quality import AlbumQualityV0Metric, AudioQualityMeasurement
+        from lib.quality_evidence import snapshot_audio_files
+        from tests.fakes import FakeBeetsDB
+
+        old = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
+        row = self._make_downloading_row(state_dict={
+            "filetype": "flac",
+            "enqueued_at": old,
+            "last_progress_at": _utc_now_iso(),
+            "processing_started_at": old,
+            "files": [{
+                "username": "user1",
+                "filename": "user1\\Music\\01.flac",
+                "file_dir": "user1\\Music",
+                "size": 30000000,
+                "local_path": None,
+                "last_state": "Completed, Succeeded",
+                "bytes_transferred": 30000000,
+            }],
+        })
+        ctx, fake_db = self._make_poll_ctx(
+            downloading_rows=[row],
+            slskd_downloads=[{
+                "username": "user1",
+                "directories": [{"directory": "user1\\Music", "files": [{
+                    "filename": "user1\\Music\\01.flac",
+                    "id": "tid-1",
+                    "state": "Completed, Succeeded",
+                    "bytesTransferred": 30000000,
+                }]}],
+            }],
+        )
+        source = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, source, ignore_errors=True)
+        with open(os.path.join(source, "01.m4a"), "wb") as handle:
+            handle.write(b"materialize-failure current bytes")
+        cast(Any, ctx.cfg).beets_directory = source
+        legacy = make_album_quality_evidence(
+            mb_release_id="test-mbid-1",
+            source_path=source,
+            files=snapshot_audio_files(source),
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=256,
+                avg_bitrate_kbps=256,
+                median_bitrate_kbps=256,
+                format="AAC",
+                is_cbr=True,
+                spectral_grade="genuine",
+                spectral_bitrate_kbps=96,
+            ),
+            lineage_version=1,
+            v0_metric=AlbumQualityV0Metric(
+                min_bitrate_kbps=259,
+                avg_bitrate_kbps=267,
+                median_bitrate_kbps=269,
+                source_lineage="native_lossy_research",
+            ),
+        )
+        fake_db.upsert_album_quality_evidence(legacy)
+        stored = fake_db.find_album_quality_evidence(
+            mb_release_id=legacy.mb_release_id,
+            snapshot_fingerprint=legacy.snapshot_fingerprint,
+        )
+        assert stored is not None and stored.id is not None
+        fake_db.set_request_current_evidence(1, stored.id)
+        fake_beets = FakeBeetsDB()
+        fake_beets.set_album_info("test-mbid-1", AlbumInfo(
+            album_id=1,
+            track_count=1,
+            min_bitrate_kbps=256,
+            avg_bitrate_kbps=256,
+            median_bitrate_kbps=256,
+            is_cbr=True,
+            album_path=source,
+            format="AAC",
+        ))
+        original_get_album_info = fake_beets.get_album_info
+        beets_statuses: list[str] = []
+
+        def get_album_info(*args: Any, **kwargs: Any):
+            beets_statuses.append(str(fake_db.request(1)["status"]))
+            return original_get_album_info(*args, **kwargs)
+
+        with patch(
+            "lib.beets_db.BeetsDB", lambda **_kwargs: fake_beets,
+        ), patch.object(
+            fake_beets,
+            "get_album_info",
+            side_effect=get_album_info,
+        ):
+            poll_active_downloads(ctx)
+
+        self.assertEqual(beets_statuses, ["wanted"])
+        self.assertEqual(fake_db.request(1)["status"], "wanted")
+        current = fake_db.load_album_quality_evidence_by_id(stored.id)
+        assert current is not None
+        self.assertEqual(current.lineage_version, 3)
+        self.assertEqual(current.measured_at, stored.measured_at)
+        log_row = fake_db.get_log(limit=1)[0]
+        self.assertTrue(log_row["_current_evidence_is_pre_attempt"])
+        self.assertEqual(log_row["_current_evidence_format"], "AAC")
+
     def test_poll_active_all_complete_uses_async_preview_gate(self):
         """Completed automation downloads are materialized before preview."""
         from lib.download import poll_active_downloads
@@ -6445,6 +6550,7 @@ class TestFailureEvidenceEnrichmentHook(unittest.TestCase):
 
         _enrich_have_evidence_after_failure(
             42,
+            "mb-uuid",
             ctx,
             prepared_outcome="ready",
             enrich_fn=enrich,
@@ -6478,6 +6584,31 @@ class TestFailureEvidenceEnrichmentHook(unittest.TestCase):
         self.assertIs(received["quality_ranks"], cfg.quality_ranks)
         self.assertEqual(received["beets_library_root"], "/library")
 
+    def test_post_failure_hook_wires_release_identity_and_beets_config(self):
+        from lib.config import CratediggerConfig
+        from lib.download import _enrich_have_evidence_after_failure
+
+        cfg = CratediggerConfig(beets_directory="/library")
+        ctx = make_ctx_with_fake_db(FakePipelineDB(), cfg=cfg)
+        received: dict[str, Any] = {}
+
+        def enrich(db: Any, **kwargs: Any) -> str:
+            received.update(kwargs)
+            return "enriched"
+
+        _enrich_have_evidence_after_failure(
+            42,
+            "mb-exact-release",
+            ctx,
+            prepared_outcome="ready",
+            enrich_fn=enrich,
+        )
+
+        self.assertEqual(received["request_id"], 42)
+        self.assertEqual(received["mb_release_id"], "mb-exact-release")
+        self.assertIs(received["quality_ranks"], cfg.quality_ranks)
+        self.assertEqual(received["beets_library_root"], "/library")
+
     def test_free_outcomes_do_not_consume_budget(self):
         from lib.download import _enrich_have_evidence_after_failure
         for outcome in ("complete", "no_current_evidence", "stale"):
@@ -6487,6 +6618,7 @@ class TestFailureEvidenceEnrichmentHook(unittest.TestCase):
 
                 _enrich_have_evidence_after_failure(
                     42,
+                    "mb-uuid",
                     ctx,
                     prepared_outcome="ready",
                     enrich_fn=enrich,
@@ -6503,6 +6635,7 @@ class TestFailureEvidenceEnrichmentHook(unittest.TestCase):
 
         _enrich_have_evidence_after_failure(
             42,
+            "mb-uuid",
             ctx,
             prepared_outcome="ready",
             enrich_fn=enrich,
@@ -6517,6 +6650,7 @@ class TestFailureEvidenceEnrichmentHook(unittest.TestCase):
 
         _enrich_have_evidence_after_failure(
             42,
+            "mb-uuid",
             ctx,
             prepared_outcome="ready",
             enrich_fn=enrich,
@@ -6537,7 +6671,7 @@ class TestFailureEvidenceEnrichmentHook(unittest.TestCase):
             self.assertEqual(db.request(42)["status"], "downloading")
             return "ready"
 
-        def enrich(db: Any, *, request_id: int) -> str:
+        def enrich(db: Any, *, request_id: int, **_kwargs: Any) -> str:
             db.assert_log(self, 0, outcome="timeout")
             self.assertEqual(db.request(request_id)["status"], "wanted")
             calls.append(request_id)
@@ -6681,6 +6815,98 @@ class TestFailureEvidenceEnrichmentHook(unittest.TestCase):
         self.assertTrue(log_row["_current_evidence_is_pre_attempt"])
         self.assertEqual(log_row["_current_evidence_format"], "MP3")
         self.assertEqual(log_row["_current_evidence_avg_bitrate"], 190)
+
+    def test_timeout_v1_refresh_runs_after_wanted_and_preserves_history(self):
+        """Timeout bookkeeping stays fast while its v3 repair stays historical."""
+        from lib.beets_db import AlbumInfo
+        from lib.config import CratediggerConfig
+        from lib.download import _timeout_album
+        from lib.quality import AlbumQualityV0Metric, AudioQualityMeasurement
+        from lib.quality_evidence import snapshot_audio_files
+        from tests.fakes import FakeBeetsDB
+
+        source = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, source, ignore_errors=True)
+        with open(os.path.join(source, "01.m4a"), "wb") as handle:
+            handle.write(b"legacy current-library bytes")
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42,
+            mb_release_id="mb-uuid",
+            status="downloading",
+        ))
+        legacy = make_album_quality_evidence(
+            mb_release_id="mb-uuid",
+            source_path=source,
+            files=snapshot_audio_files(source),
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=256,
+                avg_bitrate_kbps=256,
+                median_bitrate_kbps=256,
+                format="AAC",
+                is_cbr=True,
+                spectral_grade="genuine",
+                spectral_bitrate_kbps=96,
+            ),
+            lineage_version=1,
+            v0_metric=AlbumQualityV0Metric(
+                min_bitrate_kbps=259,
+                avg_bitrate_kbps=267,
+                median_bitrate_kbps=269,
+                source_lineage="native_lossy_research",
+            ),
+        )
+        db.upsert_album_quality_evidence(legacy)
+        stored = db.find_album_quality_evidence(
+            mb_release_id=legacy.mb_release_id,
+            snapshot_fingerprint=legacy.snapshot_fingerprint,
+        )
+        assert stored is not None and stored.id is not None
+        db.set_request_current_evidence(42, stored.id)
+
+        fake_beets = FakeBeetsDB()
+        fake_beets.set_album_info("mb-uuid", AlbumInfo(
+            album_id=1,
+            track_count=1,
+            min_bitrate_kbps=256,
+            avg_bitrate_kbps=256,
+            median_bitrate_kbps=256,
+            is_cbr=True,
+            album_path=source,
+            format="AAC",
+        ))
+        original_get_album_info = fake_beets.get_album_info
+        beets_statuses: list[str] = []
+
+        def get_album_info(*args: Any, **kwargs: Any):
+            beets_statuses.append(str(db.request(42)["status"]))
+            return original_get_album_info(*args, **kwargs)
+
+        ctx = make_ctx_with_fake_db(
+            db,
+            cfg=CratediggerConfig(beets_directory=source),
+        )
+        with patch("lib.download.cancel_and_delete"), patch(
+            "lib.beets_db.BeetsDB", lambda **_kwargs: fake_beets,
+        ), patch.object(
+            fake_beets,
+            "get_album_info",
+            side_effect=get_album_info,
+        ):
+            _timeout_album(self._entry(), 42, "stalled", ctx)
+
+        self.assertEqual(beets_statuses, ["wanted"])
+        self.assertEqual(db.request(42)["status"], "wanted")
+        current = db.load_album_quality_evidence_by_id(stored.id)
+        assert current is not None
+        self.assertEqual(current.lineage_version, 3)
+        self.assertEqual(current.measured_at, stored.measured_at)
+        self.assertEqual(ctx.evidence_enrichment_budget, 1)
+        log_row = db.get_log(limit=1)[0]
+        self.assertTrue(log_row["_current_evidence_is_pre_attempt"])
+        self.assertEqual(log_row["_current_evidence_format"], "AAC")
+        self.assertEqual(log_row["_current_evidence_avg_bitrate"], 256)
 
 
 if __name__ == "__main__":

--- a/tests/test_import_evidence.py
+++ b/tests/test_import_evidence.py
@@ -18,6 +18,7 @@ from lib.import_evidence import (
 )
 from lib.quality import (
     AlbumQualityEvidence,
+    AlbumQualityV0Metric,
     AudioQualityMeasurement,
     QualityRankConfig,
 )
@@ -167,6 +168,119 @@ class TestImportEvidenceAcquisition(unittest.TestCase):
         self.assertTrue(result.available)
         self.assertEqual(result.provenance.current_status, "loaded")
         self.assertEqual(result.provenance.snapshot_guard, "matched")
+
+    def test_matching_v1_current_evidence_rebuilds_as_v3(self):
+        evidence = make_album_quality_evidence(
+            mb_release_id="release-1",
+            files=snapshot_audio_files(self.root),
+            lineage_version=1,
+        )
+        self.db.upsert_album_quality_evidence(evidence)
+        persisted = self.db.find_album_quality_evidence(
+            mb_release_id=evidence.mb_release_id,
+            snapshot_fingerprint=evidence.snapshot_fingerprint,
+        )
+        assert persisted is not None and persisted.id is not None
+        self.db.set_request_current_evidence(42, persisted.id)
+
+        result = ensure_current_evidence_for_action(
+            self.db,
+            request_id=42,
+            mb_release_id="release-1",
+            current_album_path=self.root,
+            album_info=AlbumInfo(
+                album_id=1,
+                track_count=1,
+                min_bitrate_kbps=256,
+                avg_bitrate_kbps=256,
+                median_bitrate_kbps=256,
+                is_cbr=True,
+                album_path=self.root,
+                format="AAC",
+            ),
+        )
+
+        self.assertTrue(result.available)
+        self.assertEqual(result.provenance.current_status, "backfilled")
+        self.assertIn("lineage_version", result.provenance.fallback_reason or "")
+        assert result.evidence is not None
+        self.assertEqual(result.evidence.lineage_version, 3)
+        self.assertEqual(result.evidence.measurement.format, "AAC")
+        self.assertEqual(result.evidence.measurement.avg_bitrate_kbps, 256)
+        self.assertEqual(
+            self.db.get_request_current_evidence_id(42),
+            persisted.id,
+        )
+
+    def test_v1_lossless_transcode_rebuild_preserves_source_v0_metric(self):
+        self.db.update_request_fields(
+            42,
+            current_spectral_grade="genuine",
+            current_spectral_bitrate=None,
+            current_lossless_source_v0_probe_min_bitrate=211,
+            current_lossless_source_v0_probe_avg_bitrate=222,
+            current_lossless_source_v0_probe_median_bitrate=220,
+        )
+        evidence = make_album_quality_evidence(
+            mb_release_id="release-1",
+            files=snapshot_audio_files(self.root),
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=108,
+                avg_bitrate_kbps=114,
+                median_bitrate_kbps=114,
+                format="Opus",
+                is_cbr=False,
+                spectral_grade="likely_transcode",
+                spectral_bitrate_kbps=96,
+                was_converted_from="flac",
+            ),
+            lineage_version=1,
+            v0_metric=AlbumQualityV0Metric(
+                min_bitrate_kbps=189,
+                avg_bitrate_kbps=195,
+                median_bitrate_kbps=195,
+                source_lineage="lossless_source",
+            ),
+        )
+        self.db.upsert_album_quality_evidence(evidence)
+        persisted = self.db.find_album_quality_evidence(
+            mb_release_id=evidence.mb_release_id,
+            snapshot_fingerprint=evidence.snapshot_fingerprint,
+        )
+        assert persisted is not None and persisted.id is not None
+        self.db.set_request_current_evidence(42, persisted.id)
+
+        result = ensure_current_evidence_for_action(
+            self.db,
+            request_id=42,
+            mb_release_id="release-1",
+            current_album_path=self.root,
+            album_info=AlbumInfo(
+                album_id=1,
+                track_count=1,
+                min_bitrate_kbps=108,
+                avg_bitrate_kbps=114,
+                median_bitrate_kbps=114,
+                is_cbr=False,
+                album_path=self.root,
+                format="Opus",
+            ),
+        )
+
+        self.assertTrue(result.available)
+        assert result.evidence is not None
+        self.assertEqual(result.evidence.lineage_version, 3)
+        self.assertEqual(
+            result.evidence.measurement.spectral_grade,
+            "likely_transcode",
+        )
+        self.assertEqual(result.evidence.measurement.spectral_bitrate_kbps, 96)
+        assert result.evidence.v0_metric is not None
+        self.assertEqual(
+            result.evidence.v0_metric.source_lineage,
+            "lossless_source",
+        )
+        self.assertEqual(result.evidence.v0_metric.avg_bitrate_kbps, 195)
 
     def test_missing_current_evidence_backfills_from_album_info(self):
         result = ensure_current_evidence_for_action(

--- a/tests/test_import_preview.py
+++ b/tests/test_import_preview.py
@@ -479,6 +479,68 @@ class TestImportPreviewPath(unittest.TestCase):
             import shutil
             shutil.rmtree(source, ignore_errors=True)
 
+    def test_preview_loader_rebuilds_v1_current_evidence_for_import_attempt(self):
+        """An actual import attempt must decide from a fresh v3 HAVE row."""
+        from lib.beets_db import AlbumInfo
+        from lib.import_preview import load_current_evidence_for_preview
+        from tests.fakes import FakeBeetsDB
+
+        db = self._db()
+        source = self._source_dir()
+        try:
+            evidence = make_album_quality_evidence(
+                mb_release_id="mbid-42",
+                source_path=source,
+                files=snapshot_audio_files(source),
+                measurement=AudioQualityMeasurement(
+                    min_bitrate_kbps=256,
+                    avg_bitrate_kbps=256,
+                    median_bitrate_kbps=256,
+                    format="AAC",
+                    is_cbr=True,
+                ),
+                lineage_version=1,
+                on_disk_v0_research_attempted=True,
+            )
+            db.upsert_album_quality_evidence(evidence)
+            stored = db.find_album_quality_evidence(
+                mb_release_id=evidence.mb_release_id,
+                snapshot_fingerprint=evidence.snapshot_fingerprint,
+            )
+            assert stored is not None and stored.id is not None
+            db.set_request_current_evidence(42, stored.id)
+
+            fake_beets = FakeBeetsDB()
+            fake_beets.set_album_info("mbid-42", AlbumInfo(
+                album_id=1,
+                track_count=1,
+                min_bitrate_kbps=256,
+                avg_bitrate_kbps=256,
+                median_bitrate_kbps=256,
+                is_cbr=True,
+                album_path=source,
+                format="AAC",
+            ))
+            with patch("lib.beets_db.BeetsDB", lambda **_kwargs: fake_beets):
+                current = load_current_evidence_for_preview(
+                    db,
+                    request_id=42,
+                    mb_release_id="mbid-42",
+                    quality_ranks=QualityRankConfig.defaults(),
+                    beets_library_root=source,
+                    preloaded_evidence=stored,
+                    preloaded_authoritative=True,
+                )
+
+            assert current is not None
+            self.assertEqual(current.id, stored.id)
+            self.assertEqual(current.lineage_version, 3)
+            self.assertEqual(current.measurement.format, "AAC")
+            self.assertEqual(current.measurement.avg_bitrate_kbps, 256)
+        finally:
+            import shutil
+            shutil.rmtree(source, ignore_errors=True)
+
     def test_attempt_scan_persists_qigong_current_spectral_snapshot(self):
         """Qigong: the exact installed HAVE scan becomes durable evidence."""
         db = self._db()
@@ -1688,6 +1750,9 @@ class TestEnrichIncompleteCurrentEvidence(unittest.TestCase):
         return enrich_incomplete_current_evidence_for_request(
             db,
             request_id=42,
+            mb_release_id="mbid-42",
+            quality_ranks=QualityRankConfig.defaults(),
+            beets_library_root="",
             spectral_analyzer=analyzer,
             probe_fn=probe,
         )
@@ -1734,6 +1799,87 @@ class TestEnrichIncompleteCurrentEvidence(unittest.TestCase):
             db.load_album_quality_evidence_by_id(current_id),
             before,
         )
+
+    def test_failure_defers_complete_v1_rebuild_until_after_wanted(self):
+        from lib.beets_db import AlbumInfo
+        from tests.fakes import FakeBeetsDB
+
+        db = self._db()
+        source = self._source_dir()
+        evidence = make_album_quality_evidence(
+            mb_release_id="mbid-42",
+            source_path=source,
+            files=snapshot_audio_files(source),
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=256,
+                avg_bitrate_kbps=256,
+                median_bitrate_kbps=256,
+                format="AAC",
+                is_cbr=True,
+                spectral_grade="genuine",
+            ),
+            lineage_version=1,
+            on_disk_v0_research_attempted=True,
+        )
+        db.upsert_album_quality_evidence(evidence)
+        before = db.find_album_quality_evidence(
+            mb_release_id=evidence.mb_release_id,
+            snapshot_fingerprint=evidence.snapshot_fingerprint,
+        )
+        assert before is not None and before.id is not None
+        db.set_request_current_evidence(42, before.id)
+        fake_beets = FakeBeetsDB()
+        fake_beets.set_album_info("mbid-42", AlbumInfo(
+            album_id=1,
+            track_count=1,
+            min_bitrate_kbps=256,
+            avg_bitrate_kbps=256,
+            median_bitrate_kbps=256,
+            is_cbr=True,
+            album_path=source,
+            format="AAC",
+        ))
+
+        db.update_status(42, "downloading", expected_status="wanted")
+        with patch(
+            "lib.beets_db.BeetsDB",
+            side_effect=AssertionError("pre-log failure phase must not open Beets"),
+        ):
+            prepared = prepare_current_evidence_for_failure(
+                db,
+                request_id=42,
+                mb_release_id="mbid-42",
+                quality_ranks=QualityRankConfig.defaults(),
+                beets_library_root=source,
+            )
+
+        self.assertEqual(prepared, "ready")
+        current_id = db.get_request_current_evidence_id(42)
+        self.assertEqual(current_id, before.id)
+        current = db.load_album_quality_evidence_by_id(current_id)
+        assert current is not None
+        self.assertEqual(current.lineage_version, 1)
+        self.assertEqual(db.request(42)["status"], "downloading")
+
+        db.update_status(42, "wanted", expected_status="downloading")
+        with patch("lib.beets_db.BeetsDB", lambda **_kwargs: fake_beets):
+            enriched = enrich_incomplete_current_evidence_for_request(
+                db,
+                request_id=42,
+                mb_release_id="mbid-42",
+                quality_ranks=QualityRankConfig.defaults(),
+                beets_library_root=source,
+                spectral_analyzer=lambda _path: self._good_scan(),
+                probe_fn=lambda _path: None,
+            )
+
+        self.assertEqual(enriched, "enriched")
+        self.assertEqual(db.request(42)["status"], "wanted")
+        current = db.load_album_quality_evidence_by_id(current_id)
+        assert current is not None
+        self.assertEqual(current.lineage_version, 3)
+        self.assertEqual(current.measurement.format, "AAC")
+        self.assertEqual(current.measurement.avg_bitrate_kbps, 256)
 
     def test_fills_both_missing_pieces(self):
         db = self._db()
@@ -1877,6 +2023,9 @@ class TestEnrichIncompleteCurrentEvidence(unittest.TestCase):
             outcome = enrich_incomplete_current_evidence_for_request(
                 db,
                 request_id=42,
+                mb_release_id="mbid-42",
+                quality_ranks=QualityRankConfig.defaults(),
+                beets_library_root=source,
                 spectral_analyzer=analyzer,
                 probe_fn=probe,
             )

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -4498,13 +4498,24 @@ class TestAlbumQualityEvidenceStorage(unittest.TestCase):
                 container="mp3",
             ),
         ]
-        first = self._seed(mb_release_id="mbid-replace", files=files_v1)
+        first = msgspec.structs.replace(
+            self._seed(mb_release_id="mbid-replace", files=files_v1),
+            lineage_version=1,
+        )
         self.db.upsert_album_quality_evidence(first)
+        original = self.db.find_album_quality_evidence(
+            mb_release_id=first.mb_release_id,
+            snapshot_fingerprint=first.snapshot_fingerprint,
+        )
+        assert original is not None and original.id is not None
 
-        # Same content address, but mutate a non-keyed field (storage_format)
-        # — the upsert should replace.
-        import msgspec
-        replaced = msgspec.structs.replace(first, storage_format="mp3")
+        # Same content address, but mutate non-keyed fields. Failure-time
+        # current-evidence repair relies on this exact v1 -> v3 in-place path.
+        replaced = msgspec.structs.replace(
+            first,
+            storage_format="mp3",
+            lineage_version=3,
+        )
         self.db.upsert_album_quality_evidence(replaced)
 
         loaded = self.db.find_album_quality_evidence(
@@ -4512,7 +4523,9 @@ class TestAlbumQualityEvidenceStorage(unittest.TestCase):
             snapshot_fingerprint=first.snapshot_fingerprint,
         )
         assert loaded is not None
+        self.assertEqual(loaded.id, original.id)
         self.assertEqual(loaded.storage_format, "mp3")
+        self.assertEqual(loaded.lineage_version, 3)
 
         # Only one row exists for this content address.
         cur = self.db._execute(

--- a/tests/test_quality_lineage_generated.py
+++ b/tests/test_quality_lineage_generated.py
@@ -11,11 +11,13 @@ from hypothesis import example, given, strategies as st
 import msgspec
 
 from harness.import_one import projected_is_cbr_from_bitrates
+from lib.import_evidence import ensure_current_evidence_for_action
 from lib.measurement import PreimportMeasurement
 from lib.import_preview import (
     EnrichmentPlan,
     enrich_current_v0_research_for_preview,
     enrich_incomplete_current_evidence_for_request,
+    load_current_evidence_for_preview,
     prepare_current_evidence_for_failure,
     persist_exact_current_spectral_from_attempt,
     plan_current_evidence_enrichment,
@@ -139,6 +141,54 @@ def assert_failure_enrichment_matches_library_membership(
         raise AssertionError("absent release did not retain no-HAVE outcome")
 
 
+def assert_failure_v1_refresh_phases(
+    *,
+    outcome: str,
+    initial_lineage: int,
+    prepared_lineage: int | None,
+    refresh_status: str,
+    final_lineage: int | None,
+) -> None:
+    """A failed attempt defers v1 rebuilding until the request is wanted."""
+    if outcome != "ready":
+        raise AssertionError("installed current evidence was not prepared")
+    if initial_lineage == 1 and prepared_lineage != 1:
+        raise AssertionError("failure preparation rebuilt v1 before wanted")
+    if refresh_status != "wanted":
+        raise AssertionError("failure refresh ran before request became wanted")
+    if final_lineage != 3:
+        raise AssertionError("post-failure refresh retained ambiguous lineage")
+
+
+def assert_import_attempt_uses_v3_current_evidence(
+    *,
+    initial_lineage: int,
+    decision_lineage: int | None,
+) -> None:
+    """An actual import attempt may not decide from ambiguous v1 evidence."""
+    if initial_lineage == 1 and decision_lineage != 3:
+        raise AssertionError("import attempt retained ambiguous current lineage")
+
+
+def assert_action_refresh_preserves_lossless_source_v0(
+    *,
+    decision_lineage: int | None,
+    v0_source_lineage: str | None,
+    v0_average: int | None,
+    spectral_grade: str | None,
+    spectral_bitrate: int | None,
+) -> None:
+    """Lineage repair must retain exact-snapshot neutral facts atomically."""
+    if decision_lineage != 3:
+        raise AssertionError("action did not rebuild current evidence as v3")
+    if v0_source_lineage != "lossless_source":
+        raise AssertionError("action discarded lossless-source V0 evidence")
+    if v0_average != 195:
+        raise AssertionError("action replaced exact-snapshot V0 evidence")
+    if (spectral_grade, spectral_bitrate) != ("likely_transcode", 96):
+        raise AssertionError("action mixed exact-snapshot spectral evidence")
+
+
 class TestQualityLineagePins(unittest.TestCase):
     def test_research_once_checker_rejects_repeated_unmarked_probe(self):
         with self.assertRaisesRegex(AssertionError, "exactly one"):
@@ -167,6 +217,33 @@ class TestQualityLineagePins(unittest.TestCase):
                 album_present=True,
                 current_evidence_id=None,
                 outcome="no_current_evidence",
+            )
+
+    def test_failure_lineage_checker_rejects_eager_v1_rebuild(self):
+        with self.assertRaisesRegex(AssertionError, "before wanted"):
+            assert_failure_v1_refresh_phases(
+                outcome="ready",
+                initial_lineage=1,
+                prepared_lineage=3,
+                refresh_status="wanted",
+                final_lineage=3,
+            )
+
+    def test_import_attempt_checker_rejects_v1_decision_evidence(self):
+        with self.assertRaisesRegex(AssertionError, "ambiguous current lineage"):
+            assert_import_attempt_uses_v3_current_evidence(
+                initial_lineage=1,
+                decision_lineage=1,
+            )
+
+    def test_action_refresh_checker_rejects_lost_lossless_source_v0(self):
+        with self.assertRaisesRegex(AssertionError, "discarded"):
+            assert_action_refresh_preserves_lossless_source_v0(
+                decision_lineage=3,
+                v0_source_lineage=None,
+                v0_average=None,
+                spectral_grade="likely_transcode",
+                spectral_bitrate=96,
             )
 
     def test_enrichment_plan_pin_complete_row_plans_nothing(self):
@@ -275,6 +352,9 @@ class TestQualityLineagePins(unittest.TestCase):
                     outcome = enrich_incomplete_current_evidence_for_request(
                         db,
                         request_id=42,
+                        mb_release_id="mbid-42",
+                        quality_ranks=QualityRankConfig.defaults(),
+                        beets_library_root=source,
                         spectral_analyzer=lambda _path: SpectralAnalysisDetail(
                             attempted=True,
                             grade="genuine",
@@ -287,6 +367,277 @@ class TestQualityLineagePins(unittest.TestCase):
             album_present=album_present,
             current_evidence_id=db.get_request_current_evidence_id(42),
             outcome=outcome,
+        )
+
+    @given(
+        minimum=st.integers(min_value=32, max_value=320),
+        average=st.integers(min_value=32, max_value=320),
+        median=st.integers(min_value=32, max_value=320),
+    )
+    @example(minimum=256, average=256, median=256)
+    def test_generated_failed_download_rebuilds_v1_current_evidence(
+        self,
+        minimum: int,
+        average: int,
+        median: int,
+    ) -> None:
+        from lib.beets_db import AlbumInfo
+        from tests.fakes import FakeBeetsDB
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42,
+            mb_release_id="mbid-42",
+            status="downloading",
+        ))
+        with tempfile.TemporaryDirectory() as source:
+            with open(os.path.join(source, "01.m4a"), "wb") as handle:
+                handle.write(b"generated legacy current-library bytes")
+            legacy = make_album_quality_evidence(
+                mb_release_id="mbid-42",
+                source_path=source,
+                files=snapshot_audio_files(source),
+                measurement=AudioQualityMeasurement(
+                    min_bitrate_kbps=minimum,
+                    avg_bitrate_kbps=average,
+                    median_bitrate_kbps=median,
+                    format="AAC",
+                    is_cbr=False,
+                    spectral_grade="genuine",
+                ),
+                lineage_version=1,
+                v0_metric=AlbumQualityV0Metric(
+                    min_bitrate_kbps=259,
+                    avg_bitrate_kbps=267,
+                    median_bitrate_kbps=269,
+                    source_lineage="native_lossy_research",
+                ),
+            )
+            db.upsert_album_quality_evidence(legacy)
+            stored = db.find_album_quality_evidence(
+                mb_release_id=legacy.mb_release_id,
+                snapshot_fingerprint=legacy.snapshot_fingerprint,
+            )
+            assert stored is not None and stored.id is not None
+            db.set_request_current_evidence(42, stored.id)
+            fake_beets = FakeBeetsDB()
+            fake_beets.set_album_info("mbid-42", AlbumInfo(
+                album_id=1,
+                track_count=1,
+                min_bitrate_kbps=minimum,
+                avg_bitrate_kbps=average,
+                median_bitrate_kbps=median,
+                is_cbr=False,
+                album_path=source,
+                format="AAC",
+            ))
+
+            with patch(
+                "lib.beets_db.BeetsDB",
+                side_effect=AssertionError(
+                    "pre-log failure phase must not open Beets"
+                ),
+            ):
+                prepared = prepare_current_evidence_for_failure(
+                    db,
+                    request_id=42,
+                    mb_release_id="mbid-42",
+                    quality_ranks=QualityRankConfig.defaults(),
+                    beets_library_root=source,
+                )
+
+            current_id = db.get_request_current_evidence_id(42)
+            prepared_current = db.load_album_quality_evidence_by_id(current_id)
+            db.update_status(42, "wanted", expected_status="downloading")
+            refresh_status = str(db.request(42)["status"])
+            with patch("lib.beets_db.BeetsDB", lambda **_kwargs: fake_beets):
+                enriched = enrich_incomplete_current_evidence_for_request(
+                    db,
+                    request_id=42,
+                    mb_release_id="mbid-42",
+                    quality_ranks=QualityRankConfig.defaults(),
+                    beets_library_root=source,
+                    spectral_analyzer=lambda _path: SpectralAnalysisDetail(
+                        attempted=True,
+                        grade="genuine",
+                        bitrate_kbps=96,
+                    ),
+                    probe_fn=lambda _path: None,
+                )
+
+        current = db.load_album_quality_evidence_by_id(current_id)
+        self.assertEqual(enriched, "enriched")
+        assert_failure_v1_refresh_phases(
+            outcome=prepared,
+            initial_lineage=1,
+            prepared_lineage=(
+                prepared_current.lineage_version
+                if prepared_current is not None
+                else None
+            ),
+            refresh_status=refresh_status,
+            final_lineage=(current.lineage_version if current is not None else None),
+        )
+        assert current is not None
+        self.assertEqual(current.measurement.min_bitrate_kbps, minimum)
+        self.assertEqual(current.measurement.avg_bitrate_kbps, average)
+        self.assertEqual(current.measurement.median_bitrate_kbps, median)
+
+    @given(
+        minimum=st.integers(min_value=32, max_value=320),
+        average=st.integers(min_value=32, max_value=320),
+        median=st.integers(min_value=32, max_value=320),
+    )
+    @example(minimum=256, average=256, median=256)
+    def test_generated_import_attempt_rebuilds_v1_current_evidence(
+        self,
+        minimum: int,
+        average: int,
+        median: int,
+    ) -> None:
+        from lib.beets_db import AlbumInfo
+        from tests.fakes import FakeBeetsDB
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42,
+            mb_release_id="mbid-42",
+            status="downloading",
+            current_spectral_grade="genuine",
+            current_spectral_bitrate=None,
+            current_lossless_source_v0_probe_min_bitrate=211,
+            current_lossless_source_v0_probe_avg_bitrate=222,
+            current_lossless_source_v0_probe_median_bitrate=220,
+        ))
+        with tempfile.TemporaryDirectory() as source:
+            with open(os.path.join(source, "01.m4a"), "wb") as handle:
+                handle.write(b"generated import-attempt library bytes")
+            legacy = make_album_quality_evidence(
+                mb_release_id="mbid-42",
+                source_path=source,
+                files=snapshot_audio_files(source),
+                measurement=AudioQualityMeasurement(
+                    min_bitrate_kbps=minimum,
+                    avg_bitrate_kbps=average,
+                    median_bitrate_kbps=median,
+                    format="AAC",
+                    is_cbr=False,
+                    spectral_grade="likely_transcode",
+                    spectral_bitrate_kbps=96,
+                    was_converted_from="flac",
+                ),
+                lineage_version=1,
+                v0_metric=AlbumQualityV0Metric(
+                    min_bitrate_kbps=189,
+                    avg_bitrate_kbps=195,
+                    median_bitrate_kbps=195,
+                    source_lineage="lossless_source",
+                ),
+            )
+            db.upsert_album_quality_evidence(legacy)
+            stored = db.find_album_quality_evidence(
+                mb_release_id=legacy.mb_release_id,
+                snapshot_fingerprint=legacy.snapshot_fingerprint,
+            )
+            assert stored is not None and stored.id is not None
+            db.set_request_current_evidence(42, stored.id)
+            fake_beets = FakeBeetsDB()
+            fake_beets.set_album_info("mbid-42", AlbumInfo(
+                album_id=1,
+                track_count=1,
+                min_bitrate_kbps=minimum,
+                avg_bitrate_kbps=average,
+                median_bitrate_kbps=median,
+                is_cbr=False,
+                album_path=source,
+                format="AAC",
+            ))
+
+            with patch(
+                "lib.beets_db.BeetsDB", lambda **_kwargs: fake_beets,
+            ):
+                current = load_current_evidence_for_preview(
+                    db,
+                    request_id=42,
+                    mb_release_id="mbid-42",
+                    quality_ranks=QualityRankConfig.defaults(),
+                    beets_library_root=source,
+                    preloaded_evidence=stored,
+                    preloaded_authoritative=True,
+                )
+
+            action_db = FakePipelineDB()
+            action_db.seed_request(make_request_row(
+                id=42,
+                mb_release_id="mbid-42",
+                status="downloading",
+                current_spectral_grade="genuine",
+                current_spectral_bitrate=None,
+                current_lossless_source_v0_probe_min_bitrate=211,
+                current_lossless_source_v0_probe_avg_bitrate=222,
+                current_lossless_source_v0_probe_median_bitrate=220,
+            ))
+            action_db.upsert_album_quality_evidence(legacy)
+            action_stored = action_db.find_album_quality_evidence(
+                mb_release_id=legacy.mb_release_id,
+                snapshot_fingerprint=legacy.snapshot_fingerprint,
+            )
+            assert action_stored is not None and action_stored.id is not None
+            action_db.set_request_current_evidence(42, action_stored.id)
+            action = ensure_current_evidence_for_action(
+                action_db,
+                request_id=42,
+                mb_release_id="mbid-42",
+                current_album_path=source,
+                album_info=AlbumInfo(
+                    album_id=1,
+                    track_count=1,
+                    min_bitrate_kbps=minimum,
+                    avg_bitrate_kbps=average,
+                    median_bitrate_kbps=median,
+                    is_cbr=False,
+                    album_path=source,
+                    format="AAC",
+                ),
+            )
+
+        assert_import_attempt_uses_v3_current_evidence(
+            initial_lineage=1,
+            decision_lineage=(current.lineage_version if current is not None else None),
+        )
+        assert current is not None
+        self.assertEqual(current.measurement.min_bitrate_kbps, minimum)
+        self.assertEqual(current.measurement.avg_bitrate_kbps, average)
+        self.assertEqual(current.measurement.median_bitrate_kbps, median)
+        action_evidence = action.evidence
+        assert_action_refresh_preserves_lossless_source_v0(
+            decision_lineage=(
+                action_evidence.lineage_version
+                if action_evidence is not None
+                else None
+            ),
+            v0_source_lineage=(
+                action_evidence.v0_metric.source_lineage
+                if action_evidence is not None
+                and action_evidence.v0_metric is not None
+                else None
+            ),
+            v0_average=(
+                action_evidence.v0_metric.avg_bitrate_kbps
+                if action_evidence is not None
+                and action_evidence.v0_metric is not None
+                else None
+            ),
+            spectral_grade=(
+                action_evidence.measurement.spectral_grade
+                if action_evidence is not None
+                else None
+            ),
+            spectral_bitrate=(
+                action_evidence.measurement.spectral_bitrate_kbps
+                if action_evidence is not None
+                else None
+            ),
         )
 
     @given(


### PR DESCRIPTION
## Summary

- treat policy-complete v1 current evidence as sufficient for the cheap failure audit, then refresh it to v3 after the request has returned to wanted under the existing enrichment budget
- require fresh v3 evidence synchronously for real import and operator-action decisions
- preserve historical measurement time and merge neutral spectral/V0 facts atomically when rebuilding same-content evidence

## Verification

- independent sub-agent review: clean after three review rounds
- nix-shell --run "pyright --threads 4"
- nix-shell --run "bash scripts/run_tests.sh" (6,096 tests, no skips)