### PR TITLE
fix(quality): lossless-sourced rows keep their source spectral (R19)

### DIFF
--- a/lib/import_preview.py
+++ b/lib/import_preview.py
@@ -273,6 +273,16 @@ def persist_exact_current_spectral_from_attempt(
             "stale",
             "current evidence changed before HAVE spectral persistence",
         )
+    # R19 belt-and-braces: a lossless-sourced row keeps its source spectral
+    # (or stays empty until it is carried in) — an attempt-time scan of the
+    # installed derivative must never be persisted as its grade, whatever
+    # the caller's preserve flag said.
+    if preserve_existing_source_spectral(refreshed):
+        return EvidenceBuildResult(
+            refreshed,
+            "skipped",
+            "lossless-sourced copy keeps its source spectral (R19)",
+        )
     refreshed_measurement = refreshed.measurement
     if (
         refreshed_measurement.spectral_grade is not None
@@ -904,7 +914,17 @@ def load_current_evidence_for_preview(
 def preserve_existing_source_spectral(
     current_evidence: AlbumQualityEvidence | None,
 ) -> bool:
-    """Whether HAVE must retain lossless-source pre-conversion evidence."""
+    """Whether HAVE must retain lossless-source pre-conversion evidence.
+
+    R19: a lossless-sourced installed copy wears its SOURCE's spectral;
+    scanning the installed derivative can rewrite a transcode-like source
+    as apparently genuine (fullband codecs like Opus always scan clean).
+    Any row-local acquisition fact proves lossless lineage: a lossless
+    ``was_converted_from``, verified-lossless proof, or a source-subject
+    V0 anchor (the provisional lane's marker — enrichment-born rows carry
+    no ``was_converted_from``, which is how the #711 deploy-night rows
+    were minted ``genuine/installed``).
+    """
     if current_evidence is None:
         return False
     converted_from = (
@@ -912,10 +932,11 @@ def preserve_existing_source_spectral(
     ).lower()
     if converted_from in LOSSLESS_CODECS:
         return True
+    if current_evidence.verified_lossless_proof is not None:
+        return True
     v0_metric = current_evidence.v0_metric
     return (
-        converted_from == "m4a"
-        and v0_metric is not None
+        v0_metric is not None
         and v0_metric.subject == EVIDENCE_SUBJECT_SOURCE
     )
 

--- a/tests/test_import_preview.py
+++ b/tests/test_import_preview.py
@@ -102,6 +102,75 @@ class TestSpectralAuditMerge(unittest.TestCase):
 
         self.assertTrue(preserve_existing_source_spectral(evidence))
 
+    def test_source_anchor_alone_preserves_source_spectral(self):
+        """R19: an enrichment-born provisional row (no was_converted_from)
+        is still lossless-sourced — its source-subject anchor proves it.
+        The 2026-07-17 deploy-night rows were minted genuine/installed
+        because this predicate could not see anchor-only lineage.
+        """
+        from lib.import_preview import preserve_existing_source_spectral
+        from lib.quality import EVIDENCE_SUBJECT_SOURCE, AlbumQualityV0Metric
+
+        evidence = make_album_quality_evidence(
+            mb_release_id="anchor-only",
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=129,
+                avg_bitrate_kbps=129,
+                median_bitrate_kbps=129,
+                format="Opus",
+            ),
+            v0_metric=AlbumQualityV0Metric(
+                min_bitrate_kbps=187,
+                avg_bitrate_kbps=213,
+                median_bitrate_kbps=210,
+                subject=EVIDENCE_SUBJECT_SOURCE,
+                provenance="carried",
+            ),
+            codec="opus",
+            container="opus",
+            storage_format="Opus",
+        )
+        self.assertTrue(preserve_existing_source_spectral(evidence))
+
+    def test_proof_alone_preserves_source_spectral(self):
+        """R19: verified-lossless proof is lossless lineage by definition."""
+        from lib.import_preview import preserve_existing_source_spectral
+        from lib.quality import VerifiedLosslessProof
+
+        evidence = make_album_quality_evidence(
+            mb_release_id="proof-only",
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=129,
+                avg_bitrate_kbps=129,
+                median_bitrate_kbps=129,
+                format="Opus",
+            ),
+            verified_lossless_proof=VerifiedLosslessProof(
+                provenance="carried",
+                source="flac",
+                classifier="request_seed",
+            ),
+            codec="opus",
+            container="opus",
+            storage_format="Opus",
+        )
+        self.assertTrue(preserve_existing_source_spectral(evidence))
+
+    def test_native_row_without_lineage_is_not_preserved(self):
+        """A native copy with no lossless lineage is scanned normally."""
+        from lib.import_preview import preserve_existing_source_spectral
+
+        evidence = make_album_quality_evidence(
+            mb_release_id="native-mp3",
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=320,
+                avg_bitrate_kbps=320,
+                median_bitrate_kbps=320,
+                format="MP3",
+            ),
+        )
+        self.assertFalse(preserve_existing_source_spectral(evidence))
+
     def test_candidate_measured_error_yields_to_harness_success(self):
         measured = SpectralAnalysisDetail(
             attempted=True, error="RuntimeError: measured failed")
@@ -740,6 +809,69 @@ class TestImportPreviewPath(unittest.TestCase):
                 result.evidence.snapshot_fingerprint,
                 stored.snapshot_fingerprint,
             )
+        finally:
+            import shutil
+            shutil.rmtree(source, ignore_errors=True)
+
+    def test_attempt_scan_never_persists_onto_lossless_sourced_row(self):
+        """R19 guard: a lossless-sourced row (source anchor, empty spectral)
+        must refuse the installed-derivative scan — the source grade
+        governs; the slot stays empty until it is carried in. Reproduces
+        the 2026-07-17 deploy-night minting exactly.
+        """
+        from lib.quality import EVIDENCE_SUBJECT_SOURCE, AlbumQualityV0Metric
+
+        db = self._db()
+        source = self._source_dir()
+        try:
+            evidence = make_album_quality_evidence(
+                mb_release_id="mbid-6108",
+                source_path=source,
+                files=snapshot_audio_files(source),
+                measurement=AudioQualityMeasurement(
+                    min_bitrate_kbps=129,
+                    avg_bitrate_kbps=129,
+                    median_bitrate_kbps=129,
+                    format="Opus",
+                    spectral_grade=None,
+                    spectral_bitrate_kbps=None,
+                ),
+                v0_metric=AlbumQualityV0Metric(
+                    min_bitrate_kbps=187,
+                    avg_bitrate_kbps=213,
+                    median_bitrate_kbps=210,
+                    subject=EVIDENCE_SUBJECT_SOURCE,
+                    provenance="carried",
+                ),
+                codec="opus",
+                container="opus",
+                storage_format="Opus",
+            )
+            db.upsert_album_quality_evidence(evidence)
+            stored = db.find_album_quality_evidence(
+                mb_release_id=evidence.mb_release_id,
+                snapshot_fingerprint=evidence.snapshot_fingerprint,
+            )
+            assert stored is not None and stored.id is not None
+            db.set_request_current_evidence(42, stored.id)
+
+            result = persist_exact_current_spectral_from_attempt(
+                db,
+                request_id=42,
+                current_evidence=stored,
+                measured_existing=SpectralAnalysisDetail(
+                    attempted=True,
+                    grade="genuine",
+                    bitrate_kbps=128,
+                ),
+                measured_existing_path=source,
+            )
+
+            self.assertEqual(result.status, "skipped")
+            refreshed = db.load_album_quality_evidence_by_id(stored.id)
+            assert refreshed is not None
+            self.assertIsNone(refreshed.measurement.spectral_grade)
+            self.assertIsNone(refreshed.measurement.spectral_subject)
         finally:
             import shutil
             shutil.rmtree(source, ignore_errors=True)

--- a/tests/test_spectral_attempt_audit_generated.py
+++ b/tests/test_spectral_attempt_audit_generated.py
@@ -603,14 +603,14 @@ class TestAttemptAuditGenerated(unittest.TestCase):
             scanned_grade=scanned_grade,
             scanned_bitrate=scanned_bitrate,
         )
+        # R19: a source-subject V0 anchor alone proves lossless lineage —
+        # enrichment-born rows carry no was_converted_from, and their
+        # installed derivative must not be scanned into a fresh grade.
         self.assertEqual(
             preserve_existing_source,
             (
                 (converted_from or "").lower() in LOSSLESS_CODECS
-                or (
-                    (converted_from or "").lower() == "m4a"
-                    and lossless_v0_lineage
-                )
+                or lossless_v0_lineage
             ),
         )
         for calls in (normal_calls, reused_calls):


### PR DESCRIPTION
LOSSLESS sourced files get the spectral of their lossless source — settled in the #711 thread, encoded as R19. The preserve predicate only recognized lineage via was_converted_from, so enrichment-born rows (June-era, plus the deploy-day scalar materializations) were scanned as native copies and their installed Opus derivatives — which always scan clean, Opus is fullband — were persisted genuine/installed/measured. Live sighting: requests 5219/6108 wearing 'genuine' over suspect/likely_transcode sources.

Fix: the predicate accepts any row-local acquisition fact (lossless was_converted_from, proof, or a source-subject anchor); the persist seam refuses installed-derivative scans on lossless-sourced rows regardless of caller flags. Pins + re-pinned generated property included. Post-deploy agent one-shot repairs the mislabeled cohort from the request stamps (the point-in-time source truth).

🤖 Generated with [Claude Code](https://claude.com/claude-code)