### PR TITLE
fix(quality): same-snapshot repairs preserve installed facts

### DIFF
--- a/lib/quality_evidence.py
+++ b/lib/quality_evidence.py
@@ -973,6 +973,9 @@ def backfill_current_evidence_from_album_info(
     )
     if result.evidence is not None and existing is not None:
         existing_measurement = existing.measurement
+        same_snapshot = (
+            existing.snapshot_fingerprint == result.evidence.snapshot_fingerprint
+        )
         carry_spectral = (
             existing_measurement.spectral_grade is not None
             and existing_measurement.spectral_subject == EVIDENCE_SUBJECT_SOURCE
@@ -986,42 +989,72 @@ def backfill_current_evidence_from_album_info(
                 spectral_subject=EVIDENCE_SUBJECT_SOURCE,
                 spectral_provenance=EVIDENCE_PROVENANCE_CARRIED,
             )
+        elif (
+            same_snapshot
+            and existing_measurement.spectral_grade is not None
+            and existing_measurement.spectral_subject == EVIDENCE_SUBJECT_INSTALLED
+            and existing_measurement.spectral_provenance
+            == EVIDENCE_PROVENANCE_MEASURED
+        ):
+            # Same-address repair: identical bytes, so the installed
+            # measurement is still a true statement about them — preserve it
+            # verbatim (installed keeps provenance 'measured' per the
+            # cross-product rule; facts are invalidated by byte change, not
+            # by row repair). Ambiguous/off-vocabulary facts still drop —
+            # they cannot legally exist on a v4 row.
+            measurement = msgspec.structs.replace(
+                measurement,
+                spectral_grade=existing_measurement.spectral_grade,
+                spectral_bitrate_kbps=existing_measurement.spectral_bitrate_kbps,
+                spectral_subject=EVIDENCE_SUBJECT_INSTALLED,
+                spectral_provenance=EVIDENCE_PROVENANCE_MEASURED,
+            )
         existing_v0 = existing.v0_metric
-        carry_v0 = (
-            existing_v0 is not None
-            and existing_v0.subject == EVIDENCE_SUBJECT_SOURCE
-            and any(
-                value is not None
-                for value in (
-                    existing_v0.min_bitrate_kbps,
-                    existing_v0.avg_bitrate_kbps,
-                    existing_v0.median_bitrate_kbps,
-                )
+        has_v0_values = existing_v0 is not None and any(
+            value is not None
+            for value in (
+                existing_v0.min_bitrate_kbps,
+                existing_v0.avg_bitrate_kbps,
+                existing_v0.median_bitrate_kbps,
             )
         )
         carried_v0 = None
-        if carry_v0:
-            assert existing_v0 is not None
+        if (
+            existing_v0 is not None
+            and has_v0_values
+            and existing_v0.subject == EVIDENCE_SUBJECT_SOURCE
+        ):
             carried_v0 = msgspec.structs.replace(
                 existing_v0,
                 provenance=EVIDENCE_PROVENANCE_CARRIED,
             )
-        same_snapshot = (
-            existing.snapshot_fingerprint == result.evidence.snapshot_fingerprint
-        )
+        elif (
+            same_snapshot
+            and existing_v0 is not None
+            and has_v0_values
+            and existing_v0.subject == EVIDENCE_SUBJECT_INSTALLED
+            and existing_v0.provenance == EVIDENCE_PROVENANCE_MEASURED
+        ):
+            # Same-address repair preserves the installed research anchor —
+            # dropping it while `on_disk_v0_research_attempted` stays True
+            # would blind the async researcher forever (the deploy-night
+            # Seabear regression).
+            carried_v0 = existing_v0
         result = EvidenceBuildResult(
             msgspec.structs.replace(
                 result.evidence,
                 measurement=measurement,
-                # A same-address v4 repair keeps the historical capture time;
-                # the rebuilt facts still follow the source-only carry rule.
+                # A same-address v4 repair keeps the historical capture time.
                 measured_at=(
                     existing.measured_at
                     if same_snapshot
                     else result.evidence.measured_at
                 ),
-                # Only source-subject acquisition facts survive a rebuild;
-                # installed and ambiguous facts must be measured again.
+                # Source-subject acquisition facts survive every rebuild;
+                # valid installed facts survive a same-address repair (the
+                # bytes are unchanged); a fingerprint change drops installed
+                # facts for re-measurement — and resets the research marker
+                # (fresh build) so the async researcher re-fills the anchor.
                 v0_metric=carried_v0,
                 on_disk_v0_research_attempted=(
                     existing.on_disk_v0_research_attempted

--- a/tests/test_quality_evidence.py
+++ b/tests/test_quality_evidence.py
@@ -575,10 +575,13 @@ class TestQualityEvidenceConstruction(unittest.TestCase):
             "carried",
         )
 
-    def test_v3_touch_drops_ambiguous_and_installed_facts(self):
+    def test_v3_touch_drops_ambiguous_facts(self):
+        # Off-vocabulary facts cannot legally exist on a v4 row — they drop
+        # on conversion whatever the snapshot did. Valid INSTALLED facts on
+        # a same-snapshot repair are preserved (see the pin below): facts
+        # are invalidated by byte change, not by row repair.
         for suffix, subject, provenance in (
             ("ambiguous", "unknown-live-subject", "unknown-live-provenance"),
-            ("installed", "installed", "measured"),
         ):
             with self.subTest(subject=subject):
                 db = FakePipelineDB()
@@ -635,6 +638,75 @@ class TestQualityEvidenceConstruction(unittest.TestCase):
                 self.assertIsNone(result.evidence.measurement.spectral_subject)
                 self.assertIsNone(result.evidence.measurement.spectral_provenance)
                 self.assertIsNone(result.evidence.v0_metric)
+
+    def test_same_snapshot_repair_preserves_installed_facts(self):
+        """Identical bytes keep their installed measurements AND research
+        anchor. The pre-fix drop left `on_disk_v0_research_attempted=True`
+        with no anchor — blinding the async researcher forever (the
+        deploy-night Seabear regression, request 2748).
+        """
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=42, verified_lossless=False))
+        legacy = make_album_quality_evidence(
+            mb_release_id="mb-v3-installed-keep",
+            source_path=self.root,
+            files=snapshot_audio_files(self.root),
+            lineage_version=3,
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=121,
+                avg_bitrate_kbps=128,
+                median_bitrate_kbps=127,
+                format="Opus",
+                spectral_grade="likely_transcode",
+                spectral_subject="installed",
+                spectral_provenance="measured",
+            ),
+            v0_metric=AlbumQualityV0Metric(
+                subject="installed",
+                provenance="measured",
+                avg_bitrate_kbps=213,
+                min_bitrate_kbps=158,
+            ),
+            on_disk_v0_research_attempted=True,
+            storage_format="Opus",
+        )
+        db.upsert_album_quality_evidence(legacy)
+        persisted = db.find_album_quality_evidence(
+            mb_release_id=legacy.mb_release_id,
+            snapshot_fingerprint=legacy.snapshot_fingerprint,
+        )
+        assert persisted is not None and persisted.id is not None
+        db.set_request_current_evidence(42, persisted.id)
+
+        result = backfill_current_evidence_from_album_info(
+            db,
+            request_id=42,
+            mb_release_id=legacy.mb_release_id,
+            album_info=AlbumInfo(
+                album_id=1,
+                track_count=2,
+                min_bitrate_kbps=121,
+                avg_bitrate_kbps=128,
+                median_bitrate_kbps=127,
+                is_cbr=False,
+                album_path=self.root,
+                format="Opus",
+            ),
+        )
+
+        self.assertTrue(result.available)
+        assert result.evidence is not None
+        self.assertEqual(result.evidence.lineage_version, 4)
+        m = result.evidence.measurement
+        self.assertEqual(m.spectral_grade, "likely_transcode")
+        self.assertEqual(m.spectral_subject, "installed")
+        self.assertEqual(m.spectral_provenance, "measured")
+        v0 = result.evidence.v0_metric
+        assert v0 is not None
+        self.assertEqual(v0.subject, "installed")
+        self.assertEqual(v0.provenance, "measured")
+        self.assertEqual(v0.avg_bitrate_kbps, 213)
+        self.assertTrue(result.evidence.on_disk_v0_research_attempted)
 
     def test_fingerprint_flip_carries_only_source_facts(self):
         db = FakePipelineDB()


### PR DESCRIPTION
Facts are invalidated by byte change, not by row repair. The v3→v4 same-snapshot repair dropped installed-subject spectral and V0 research anchors while preserving on_disk_v0_research_attempted=True — blinding the async researcher forever on every touched row and unwinding the fill-every-HAVE evidence campaign (live sighting: Seabear req 2748 after tonight's rebuild wave).

Same-snapshot repairs now preserve valid installed facts verbatim; ambiguous off-vocabulary facts still drop (illegal on v4); fingerprint changes still drop installed facts for re-measurement with the research marker reset so the researcher re-fills. Pin split accordingly; post-deploy repair resets the already-blinded markers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)