### PR TITLE
feat(web): surface verified/provisional quality identity on release badges

### DIFF
--- a/docs/webui-primer.md
+++ b/docs/webui-primer.md
@@ -148,6 +148,13 @@ Browser → https://music.ablz.au
     and all of its musical type buckets stay collapsed even when a row is
     exactly owned or requested.
   - Releases already in pipeline DB or beets library are badged
+  - Tracked installs carry a quality-identity chip next to the library
+    badge (`web/js/badges.js`): green `verified` when the request's
+    current evidence holds a verified-lossless proof (search complete),
+    pale-green `provisional` when the install is an unverified
+    lossless-source conversion still hunting a verified copy. Derived
+    by `PipelineDB.get_pipeline_overlay` from the linked evidence row —
+    requests without current evidence show no chip.
   - Click release metadata to open MB release page in new tab
 - **Add button** — adds release to pipeline DB (same logic as `pipeline-cli add`)
 - **Pipeline tab** — operational Dashboard + Long Tail views. The old global

--- a/lib/pipeline_db/requests.py
+++ b/lib/pipeline_db/requests.py
@@ -90,14 +90,27 @@ class _RequestsMixin(_PipelineDBBase):
     ) -> dict[str, dict[str, Any]]:
         """Map mb_release_id → badge-overlay info for the browse /
         library views (#445 item 2 — formerly inline SQL in
-        ``web/overlay.py::check_pipeline``)."""
+        ``web/overlay.py::check_pipeline``).
+
+        ``verified_lossless`` / ``provisional_lossless`` derive from the
+        linked current evidence row only — a request without current
+        evidence makes no identity claim. Provisional = an unverified
+        install holding a lossless-source V0 anchor (the quality identity
+        the badge layer renders)."""
         if not mbids:
             return {}
         placeholders = ",".join(["%s"] * len(mbids))
         cur = self._execute(
-            f"SELECT id, mb_release_id, status, search_filetype_override, "
-            f"target_format, min_bitrate "
-            f"FROM album_requests WHERE mb_release_id IN ({placeholders})",
+            f"SELECT r.id, r.mb_release_id, r.status, "
+            f"r.search_filetype_override, r.target_format, r.min_bitrate, "
+            f"COALESCE(e.verified_lossless, FALSE) AS verified_lossless, "
+            f"(COALESCE(e.v0_subject, '') = 'source' "
+            f" AND NOT COALESCE(e.verified_lossless, FALSE)) "
+            f"AS provisional_lossless "
+            f"FROM album_requests r "
+            f"LEFT JOIN album_quality_evidence e "
+            f"ON e.id = r.current_evidence_id "
+            f"WHERE r.mb_release_id IN ({placeholders})",
             tuple(mbids),
         )
         return {
@@ -107,6 +120,8 @@ class _RequestsMixin(_PipelineDBBase):
                 "search_filetype_override": r["search_filetype_override"],
                 "target_format": r["target_format"],
                 "min_bitrate": r["min_bitrate"],
+                "verified_lossless": r["verified_lossless"],
+                "provisional_lossless": r["provisional_lossless"],
             }
             for r in cur.fetchall()
         }

--- a/tests/fakes/pipeline_db.py
+++ b/tests/fakes/pipeline_db.py
@@ -3473,6 +3473,21 @@ class FakePipelineDB:
                 continue
             mbid = str(raw)
             if mbid in wanted:
+                evidence = None
+                evidence_id = r.get("current_evidence_id")
+                if evidence_id is not None:
+                    evidence = self.load_album_quality_evidence_by_id(
+                        evidence_id)
+                verified = bool(
+                    evidence is not None
+                    and evidence.verified_lossless_proof is not None
+                )
+                provisional = bool(
+                    evidence is not None
+                    and not verified
+                    and evidence.v0_metric is not None
+                    and evidence.v0_metric.subject == "source"
+                )
                 out[mbid] = {
                     "id": r["id"],
                     "status": r.get("status"),
@@ -3480,6 +3495,8 @@ class FakePipelineDB:
                         r.get("search_filetype_override"),
                     "target_format": r.get("target_format"),
                     "min_bitrate": r.get("min_bitrate"),
+                    "verified_lossless": verified,
+                    "provisional_lossless": provisional,
                 }
         return out
 

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -6102,6 +6102,8 @@ class TestFakeGetPipelineOverlay(unittest.TestCase):
             "id": 7, "status": "wanted",
             "search_filetype_override": "lossless",
             "target_format": None, "min_bitrate": 900,
+            "verified_lossless": False,
+            "provisional_lossless": False,
         })
 
     def test_empty_mbids_short_circuits(self):

--- a/tests/test_js_badges.mjs
+++ b/tests/test_js_badges.mjs
@@ -36,5 +36,53 @@ console.log('renderStatusBadges() uses average while retaining the min floor');
   assertExcludes(html, 'M V2', 'min 194 does not drive badge label');
 }
 
+console.log('renderStatusBadges() marks a provisional lossless-source install');
+{
+  const html = renderStatusBadges({
+    id: 'request-3652',
+    in_library: true,
+    library_format: 'Opus',
+    library_avg_bitrate: 102,
+    library_rank: 'transparent',
+    pipeline_status: 'wanted',
+    pipeline_provisional: true,
+    pipeline_verified_lossless: false,
+  });
+  assertContains(html, 'badge-provisional', 'provisional install renders chip');
+  assertContains(html, '>provisional<', 'chip label reads provisional');
+  assertExcludes(html, 'badge-verified', 'provisional never claims verified');
+}
+
+console.log('renderStatusBadges() marks a verified lossless install');
+{
+  const html = renderStatusBadges({
+    id: 'request-8877',
+    in_library: true,
+    library_format: 'Opus',
+    library_avg_bitrate: 131,
+    library_rank: 'transparent',
+    pipeline_status: 'imported',
+    pipeline_verified_lossless: true,
+    pipeline_provisional: false,
+  });
+  assertContains(html, 'badge-verified', 'verified install renders chip');
+  assertContains(html, '>verified<', 'chip label reads verified');
+  assertExcludes(html, 'badge-provisional', 'verified never doubles as provisional');
+}
+
+console.log('renderStatusBadges() renders no identity chip without pipeline identity');
+{
+  const html = renderStatusBadges({
+    id: 'request-1',
+    in_library: true,
+    library_format: 'MP3',
+    library_avg_bitrate: 288,
+    library_rank: 'transparent',
+    pipeline_status: 'wanted',
+  });
+  assertExcludes(html, 'badge-verified', 'plain install has no verified chip');
+  assertExcludes(html, 'badge-provisional', 'plain install has no provisional chip');
+}
+
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/tests/test_overlay.py
+++ b/tests/test_overlay.py
@@ -38,8 +38,12 @@ class TestOverlayReleaseRowsInPlace(unittest.TestCase):
                    return_value={"held", "both", "bad-quality"}), \
                 patch("web.server.check_pipeline",
                       return_value={
-                          "queued": {"id": 21, "status": "wanted"},
-                          "both": {"id": 22, "status": "queued"},
+                          "queued": {"id": 21, "status": "wanted",
+                                     "verified_lossless": False,
+                                     "provisional_lossless": True},
+                          "both": {"id": 22, "status": "queued",
+                                   "verified_lossless": True,
+                                   "provisional_lossless": False},
                       }), \
                 patch("web.server._beets_db", return_value=mock_beets):
             overlay_release_rows_in_place(rows, [r["id"] for r in rows])
@@ -59,6 +63,10 @@ class TestOverlayReleaseRowsInPlace(unittest.TestCase):
         self.assertIsNone(by_id["queued"]["beets_album_id"])
         self.assertEqual(by_id["queued"]["pipeline_status"], "wanted")
         self.assertEqual(by_id["queued"]["pipeline_id"], 21)
+        self.assertFalse(by_id["queued"]["pipeline_verified_lossless"])
+        self.assertTrue(by_id["queued"]["pipeline_provisional"])
+        self.assertFalse(by_id["held"]["pipeline_verified_lossless"])
+        self.assertFalse(by_id["held"]["pipeline_provisional"])
 
         self.assertTrue(by_id["both"]["in_library"])
         self.assertEqual(by_id["both"]["beets_album_id"], 11)
@@ -67,6 +75,8 @@ class TestOverlayReleaseRowsInPlace(unittest.TestCase):
         self.assertEqual(by_id["both"]["library_rank"], "transparent")
         self.assertEqual(by_id["both"]["pipeline_status"], "queued")
         self.assertEqual(by_id["both"]["pipeline_id"], 22)
+        self.assertTrue(by_id["both"]["pipeline_verified_lossless"])
+        self.assertFalse(by_id["both"]["pipeline_provisional"])
 
         self.assertFalse(by_id["neither"]["in_library"])
         self.assertIsNone(by_id["neither"]["beets_album_id"])

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -10076,6 +10076,81 @@ class TestGetPipelineOverlay(unittest.TestCase):
         self.assertIsNone(row["target_format"])
         self.assertEqual(row["min_bitrate"], 900)
 
+    def _seed_identity_state(self, db) -> None:
+        """Seed one verified, one provisional, one plain request."""
+        from lib.quality import AlbumQualityV0Metric, VerifiedLosslessProof
+        from tests.helpers import make_album_quality_evidence
+
+        def link_evidence(mbid: str, proof) -> None:
+            rid = db.add_request(
+                mb_release_id=mbid, artist_name="A",
+                album_title="B", source="request")
+            evidence = make_album_quality_evidence(
+                mb_release_id=mbid,
+                source_path=f"/library/{mbid}",
+                v0_metric=AlbumQualityV0Metric(
+                    subject="source", provenance="carried",
+                    avg_bitrate_kbps=251, min_bitrate_kbps=228,
+                ),
+                verified_lossless_proof=proof,
+            )
+            db.upsert_album_quality_evidence(evidence)
+            stored = db.find_album_quality_evidence(
+                mb_release_id=mbid,
+                snapshot_fingerprint=evidence.snapshot_fingerprint,
+            )
+            assert stored is not None and stored.id is not None
+            db.set_request_current_evidence(rid, stored.id)
+
+        link_evidence(
+            "overlay-idn-verified",
+            VerifiedLosslessProof(
+                provenance="carried", source="flac",
+                classifier="spectral_verified_lossless",
+            ),
+        )
+        link_evidence("overlay-idn-provisional", None)
+        db.add_request(
+            mb_release_id="overlay-idn-plain", artist_name="E",
+            album_title="F", source="request")
+
+    def test_overlay_carries_quality_identity(self):
+        """The badge overlay derives verified/provisional from the linked
+        current evidence — the persistent UI identity the provisional
+        engineering lost (2026-07-18)."""
+        self._seed_identity_state(self.db)
+
+        info = self.db.get_pipeline_overlay([
+            "overlay-idn-verified", "overlay-idn-provisional",
+            "overlay-idn-plain",
+        ])
+
+        self.assertTrue(info["overlay-idn-verified"]["verified_lossless"])
+        self.assertFalse(info["overlay-idn-verified"]["provisional_lossless"])
+        self.assertFalse(info["overlay-idn-provisional"]["verified_lossless"])
+        self.assertTrue(info["overlay-idn-provisional"]["provisional_lossless"])
+        self.assertFalse(info["overlay-idn-plain"]["verified_lossless"])
+        self.assertFalse(info["overlay-idn-plain"]["provisional_lossless"])
+
+    def test_identity_fake_parity(self):
+        from tests.fakes import FakePipelineDB
+
+        fake = FakePipelineDB()
+        self._seed_identity_state(self.db)
+        self._seed_identity_state(fake)
+        mbids = [
+            "overlay-idn-verified", "overlay-idn-provisional",
+            "overlay-idn-plain",
+        ]
+        strip = lambda o: {m: {k: v for k, v in row.items() if k != "id"}
+                           for m, row in o.items()}
+        self.assertEqual(
+            strip(self.db.get_pipeline_overlay(mbids)),
+            strip(fake.get_pipeline_overlay(mbids)),
+            "FakePipelineDB's overlay identity mirror drifted from the "
+            "real SQL — fix the fake, never the production SQL, unless "
+            "the SQL change is the point of your PR.")
+
     def test_fake_parity_on_identical_state(self):
         from tests.fakes import FakePipelineDB
 

--- a/tests/test_replaced_write_audit.py
+++ b/tests/test_replaced_write_audit.py
@@ -114,27 +114,28 @@ _REVIEWED_DYNAMIC_SQL_CALLS: dict[tuple[str, int, str], str] = {
     ("lib/pipeline_db/requests.py", 69, "092ac19c7715cd88"): (
         "INSERT columns derive from the fixed AddRequestInput schema"
     ),
-    ("lib/pipeline_db/requests.py", 97, "6a0115f1555f11bd"): (
-        "request batch IN list contains only psycopg value placeholders"
+    ("lib/pipeline_db/requests.py", 103, "723856dd7a3eba80"): (
+        "badge-overlay batch IN list contains only psycopg value placeholders; "
+        "the evidence JOIN and identity derivations are static SQL"
     ),
-    ("lib/pipeline_db/requests.py", 234, "dffc52ed3fcd380d"): (
+    ("lib/pipeline_db/requests.py", 249, "dffc52ed3fcd380d"): (
         "release-id lookup selects one of two fixed identity predicates"
     ),
-    ("lib/pipeline_db/requests.py", 448, "b73bda10a331e1c3"): (
+    ("lib/pipeline_db/requests.py", 463, "b73bda10a331e1c3"): (
         "metadata keys are validated identifiers, lifecycle fields are reserved, "
         "and values use one typed JSONB record parameter"
     ),
-    ("lib/pipeline_db/requests.py", 466, "86eaf6b403f76820"): (
+    ("lib/pipeline_db/requests.py", 481, "86eaf6b403f76820"): (
         "metadata keys are validated identifiers, lifecycle fields are reserved, "
         "and values use one typed JSONB record parameter"
     ),
-    ("lib/pipeline_db/requests.py", 1310, "0e292421052b4282"): (
+    ("lib/pipeline_db/requests.py", 1325, "0e292421052b4282"): (
         "optional LIMIT is normalized through int before interpolation"
     ),
-    ("lib/pipeline_db/requests.py", 1325, "f027e891f4828e53"): (
+    ("lib/pipeline_db/requests.py", 1340, "f027e891f4828e53"): (
         "ORDER is selected from two literals and LIMIT remains a value placeholder"
     ),
-    ("lib/pipeline_db/requests.py", 1510, "714da98640ff84f0"): (
+    ("lib/pipeline_db/requests.py", 1525, "714da98640ff84f0"): (
         "attempt kind is validated against the fixed retry-counter vocabulary"
     ),
     ("lib/pipeline_db/search_plan.py", 949, "3df0db818cab2f3c"): (
@@ -164,25 +165,25 @@ _REVIEWED_STATUS_SQL_CALLS: dict[tuple[str, int, str], str] = {
     ("lib/pipeline_db/download_log.py", 403, "b04c5ae9eb3423c1"): (
         "atomic abandoned-import recovery performs downloading-to-wanted CAS"
     ),
-    ("lib/pipeline_db/requests.py", 273, "558917722283199d"): (
+    ("lib/pipeline_db/requests.py", 288, "558917722283199d"): (
         "Replace holds the row lock and CASes the captured active source status"
     ),
-    ("lib/pipeline_db/requests.py", 773, "cb4bc190bb194188"): (
+    ("lib/pipeline_db/requests.py", 788, "cb4bc190bb194188"): (
         "ordinary typed transitions CAS the source status selected by the DAG"
     ),
-    ("lib/pipeline_db/requests.py", 871, "c99b75cd27718b63"): (
+    ("lib/pipeline_db/requests.py", 886, "c99b75cd27718b63"): (
         "typed imported transition CASes status with rescue audit atomically"
     ),
-    ("lib/pipeline_db/requests.py", 1011, "624291485d30cd9b"): (
+    ("lib/pipeline_db/requests.py", 1026, "624291485d30cd9b"): (
         "typed reset-to-wanted transition CASes its captured source status"
     ),
-    ("lib/pipeline_db/requests.py", 1080, "96c221e77f54ca60"): (
+    ("lib/pipeline_db/requests.py", 1095, "96c221e77f54ca60"): (
         "automatic recovery accepts only downloading as its exact source"
     ),
-    ("lib/pipeline_db/requests.py", 1125, "2b2c27302b2ab78e"): (
+    ("lib/pipeline_db/requests.py", 1140, "2b2c27302b2ab78e"): (
         "typed download claim accepts only the explicit wanted source status"
     ),
-    ("lib/pipeline_db/requests.py", 1161, "186e1c3ba3188478"): (
+    ("lib/pipeline_db/requests.py", 1176, "186e1c3ba3188478"): (
         "plan-aware download claim uses an exact wanted source predicate"
     ),
 }

--- a/tests/test_search_override_generated.py
+++ b/tests/test_search_override_generated.py
@@ -159,3 +159,120 @@ class TestGeneratedTransparentHaveSearchOverride(unittest.TestCase):
             actual,
             cfg,
         )
+
+
+# ---------------------------------------------------------------------------
+# No-widening invariant (issue #711 provisional surfacing, 2026-07-18): no
+# override-resolution path may ADD a lossy search tier. Redirecting scope to
+# "lossless" is legal narrowing (toward the terminal goal); everything else
+# in the result must already have been allowed by the input. This is the
+# structural guarantee that a provisional install's lossless-only scope can
+# never silently re-widen into MP3 tiers.
+# ---------------------------------------------------------------------------
+
+
+def _tiers(override):
+    return {t.strip() for t in override.split(",") if t.strip()}
+
+
+def assert_no_lossy_tier_added(input_override, result_override) -> None:
+    """Checker: result tiers ⊆ input tiers ∪ {"lossless"}."""
+    if result_override is None:
+        return
+    out = _tiers(result_override)
+    allowed = {"lossless"} if input_override is None else (
+        _tiers(input_override) | {"lossless"}
+    )
+    added = out - allowed
+    if added:
+        raise AssertionError(
+            f"override resolution widened with lossy tiers {sorted(added)}: "
+            f"{input_override!r} -> {result_override!r}"
+        )
+
+
+_override_csv = st.one_of(
+    st.none(),
+    st.sampled_from([
+        "lossless",
+        "lossless,mp3 v0,mp3 320",
+        "lossless,mp3 v0,mp3 320,aac,opus,ogg",
+        "mp3 v0,mp3 320",
+        "mp3 320",
+    ]),
+    st.lists(
+        st.sampled_from(
+            ["lossless", "mp3 v0", "mp3 320", "mp3 256", "aac", "opus", "ogg"]
+        ),
+        min_size=1, max_size=5, unique=True,
+    ).map(",".join),
+)
+
+
+@st.composite
+def rejection_worlds(draw):
+    from tests.helpers import make_download_info
+
+    override = draw(_override_csv)
+    dl_info = make_download_info(
+        filetype=draw(st.one_of(
+            st.none(),
+            st.sampled_from(["flac", "mp3", "mp3 320", "aac", "opus"]),
+        )),
+        bitrate=draw(st.one_of(
+            st.none(), st.integers(min_value=0, max_value=1200))),
+        is_vbr=draw(st.booleans()),
+        was_converted=draw(st.booleans()),
+        slskd_filetype=draw(st.one_of(
+            st.none(),
+            st.sampled_from(["flac", "mp3", "mp3 vbr", "aac"]),
+        )),
+    )
+    decision = draw(st.sampled_from([
+        "downgrade", "transcode_downgrade", "reject", "import", None,
+    ]))
+    measurement, audit, cfg = draw(have_worlds())
+    source = draw(st.sampled_from(
+        ["attempt_have_audit", "linked_current_evidence"]))
+    return override, dl_info, decision, measurement, audit, source, cfg
+
+
+class TestGeneratedNoOverrideWidening(unittest.TestCase):
+    @given(world=rejection_worlds())
+    def test_resolution_chain_never_adds_a_lossy_tier(self, world):
+        from lib.quality import (
+            narrow_override_on_downgrade,
+            resolve_rejection_search_override,
+        )
+
+        override, dl_info, decision, measurement, audit, source, cfg = world
+
+        narrowed = narrow_override_on_downgrade(override, dl_info)
+        assert_no_lossy_tier_added(override, narrowed)
+
+        resolution = resolve_rejection_search_override(
+            decision=decision,
+            current_override=override,
+            dl_info=dl_info,
+            current_measurement=measurement,
+            spectral_evidence_source=source,
+            have_spectral_audit=audit,
+            cfg=cfg,
+        )
+        assert_no_lossy_tier_added(override, resolution.override)
+
+
+class TestNoWideningCheckerTripsOnViolations(unittest.TestCase):
+    def test_trips_when_a_lossy_tier_is_added(self):
+        with self.assertRaisesRegex(AssertionError, "widened"):
+            assert_no_lossy_tier_added("lossless", "lossless,mp3 320")
+
+    def test_trips_when_unrestricted_result_invents_lossy_scope(self):
+        with self.assertRaisesRegex(AssertionError, "widened"):
+            assert_no_lossy_tier_added(None, "mp3 v0")
+
+    def test_accepts_redirect_to_lossless(self):
+        assert_no_lossy_tier_added("mp3 v0,mp3 320", "lossless")
+
+    def test_accepts_pure_narrowing(self):
+        assert_no_lossy_tier_added("lossless,mp3 v0,mp3 320", "lossless,mp3 v0")

--- a/tests/web/test_routes_browse.py
+++ b/tests/web/test_routes_browse.py
@@ -48,6 +48,7 @@ class TestBrowseRouteContracts(_FakeDbWebServerCase):
     RELEASE_GROUP_REQUIRED_FIELDS = {
         "id", "title", "country", "date", "format", "track_count", "status",
         "in_library", "beets_album_id", "pipeline_status", "pipeline_id",
+        "pipeline_verified_lossless", "pipeline_provisional",
     }
     RELEASE_DETAIL_REQUIRED_FIELDS = {
         "id", "title", "tracks", "in_library", "beets_album_id",
@@ -876,7 +877,7 @@ class TestBrowseRouteContracts(_FakeDbWebServerCase):
                 patch("web.server.check_beets_library", return_value={self.RELEASE_ID}), \
                 patch("web.server._beets_db", return_value=beets_db), \
                 patch("web.server.check_pipeline",
-                      return_value={self.RELEASE_ID: {"id": 42, "status": "wanted"}}):
+                      return_value={self.RELEASE_ID: {"id": 42, "status": "wanted", "verified_lossless": False, "provisional_lossless": False}}):
             mock_mb.get_release_group_releases.return_value = {"releases": [release]}
             status, data = self._get(f"/api/release-group/{self.RG_ID}")
 
@@ -1024,7 +1025,7 @@ class TestBrowseRouteContracts(_FakeDbWebServerCase):
                 patch("web.server.check_beets_library", return_value={"21491"}), \
                 patch("web.server._beets_db", return_value=beets_db), \
                 patch("web.server.check_pipeline",
-                      return_value={"21491": {"id": 42, "status": "wanted"}}):
+                      return_value={"21491": {"id": 42, "status": "wanted", "verified_lossless": False, "provisional_lossless": False}}):
             status, data = self._get("/api/release-group/0021491")
 
         self.assertEqual(status, 200)

--- a/tests/web/test_routes_labels.py
+++ b/tests/web/test_routes_labels.py
@@ -40,6 +40,7 @@ class TestLabelRouteContracts(_WebServerCase):
         "id", "title", "artist_name", "date", "format", "primary_type",
         "sub_label_name", "in_library", "beets_album_id",
         "pipeline_status", "pipeline_id",
+        "pipeline_verified_lossless", "pipeline_provisional",
     }
     LABEL_DETAIL_RESPONSE_REQUIRED_FIELDS = {
         "label", "releases", "sub_labels", "pagination", "include_sublabels",
@@ -178,7 +179,7 @@ class TestLabelRouteContracts(_WebServerCase):
                 patch("web.server.check_beets_library",
                       return_value={held_id}), \
                 patch("web.server.check_pipeline",
-                      return_value={in_pipeline_id: {"id": 99, "status": "wanted"}}), \
+                      return_value={in_pipeline_id: {"id": 99, "status": "wanted", "verified_lossless": False, "provisional_lossless": False}}), \
                 patch("web.server._beets_db", return_value=beets_db), \
                 patch("web.server.compute_library_rank",
                       side_effect=_compute_rank):

--- a/web/index.html
+++ b/web/index.html
@@ -76,6 +76,7 @@
   .badge-rejected { background: #4a1a1a; color: #d66; }
   .badge-transcode { background: #3a3a1a; color: #da6; }
   .badge-provisional { background: #1f3a24; color: #9d8; }
+  .badge-verified { background: #1a4a2a; color: #6d6; }
   .badge-force { background: #1a2a4a; color: #6af; }
   .badge-failed { background: #4a1a1a; color: #d66; }
   .badge-warn { background: #3a3a1a; color: #ec6; }

--- a/web/js/badges.js
+++ b/web/js/badges.js
@@ -34,6 +34,11 @@ import { qualityLabelShort } from './util.js';
  *   different rank).
  * @property {string|null|undefined} [pipeline_status]
  *   'wanted' | 'downloading' | 'imported' | 'manual' | null
+ * @property {boolean} [pipeline_verified_lossless] - The tracked install
+ *   carries a verified-lossless proof (terminal quality identity).
+ * @property {boolean} [pipeline_provisional] - The tracked install is an
+ *   unverified lossless-source conversion (provisional import — the
+ *   pipeline is still hunting a verified lossless copy).
  */
 
 /**
@@ -59,6 +64,14 @@ export function renderStatusBadges(item) {
     const rank = (item.library_rank || '').toLowerCase();
     const cls = rank ? `badge-rank-${rank}` : 'badge-library';
     html += `<span class="badge ${cls}">in library${suffix}</span>`;
+  }
+  // Quality identity of the tracked install (issue #711 provisional
+  // surfacing): verified is terminal; provisional means an unverified
+  // lossless-source conversion the pipeline is still trying to verify.
+  if (item.pipeline_verified_lossless) {
+    html += '<span class="badge badge-verified" title="verified lossless source — search complete">verified</span>';
+  } else if (item.pipeline_provisional) {
+    html += '<span class="badge badge-provisional" title="unverified lossless-source conversion — still hunting a verified lossless copy">provisional</span>';
   }
   if (pStatus === 'wanted') html += '<span class="badge badge-wanted">wanted</span>';
   if (pStatus === 'downloading') html += '<span class="badge badge-downloading">downloading</span>';

--- a/web/routes/_overlay.py
+++ b/web/routes/_overlay.py
@@ -103,9 +103,12 @@ def overlay_release_rows_in_place(rows: list[dict], release_ids: Iterable[str]) 
         After overlay each row carries:
         `in_library`, `beets_album_id`, `library_format`,
         `library_min_bitrate`, `library_avg_bitrate`, `library_rank`,
-        `pipeline_status`, `pipeline_id`. Library quality fields are only set when the
+        `pipeline_status`, `pipeline_id`, `pipeline_verified_lossless`,
+        `pipeline_provisional`. Library quality fields are only set when the
         release is in the beets library AND the beets DB returned
-        details for it.
+        details for it. The identity pair derives from the request's
+        linked current evidence (verified proof / unverified
+        lossless-source anchor) — see `PipelineDB.get_pipeline_overlay`.
     release_ids
         Iterable of release ids to batch-query against beets / pipeline.
         Typically `[r["id"] for r in rows]`; passed in so callers that
@@ -146,3 +149,9 @@ def overlay_release_rows_in_place(rows: list[dict], release_ids: Iterable[str]) 
         pi = in_pipeline.get(rid)
         r["pipeline_status"] = pi["status"] if pi else None
         r["pipeline_id"] = pi["id"] if pi else None
+        r["pipeline_verified_lossless"] = (
+            bool(pi["verified_lossless"]) if pi else False
+        )
+        r["pipeline_provisional"] = (
+            bool(pi["provisional_lossless"]) if pi else False
+        )


### PR DESCRIPTION
Follow-through on the #711 provisional-engineering decay (operator-reported 2026-07-18): the decision core still narrows new provisional imports to lossless-only, but no persistent UI surface marked an install as provisional, and the legacy cohort (54 of 70 provisional requests) still carries pre-#711 tiered overrides that keep downloading MP3s that can never verify.

## Changes

- **`PipelineDB.get_pipeline_overlay`** now derives `verified_lossless` / `provisional_lossless` from the linked current-evidence row (evidence-only: no evidence → no identity claim). Real-PG test + fake parity + fake self-test.
- **Overlay contract** (`overlay_release_rows_in_place`) stamps `pipeline_verified_lossless` / `pipeline_provisional` on every overlayed release row; browse + label contract `REQUIRED_FIELDS` extended; synthetic `check_pipeline` stubs production-shaped.
- **`badges.js`** renders the identity chip beside the library badge: green `verified` (proof present — search complete) or pale-green `provisional` (unverified lossless-source conversion — still hunting). New `.badge-verified` CSS; JS unit tests.
- **Invariant pair**: generated no-widening property drives the REAL `narrow_override_on_downgrade` + `resolve_rejection_search_override` over generated worlds — no resolution path may ADD a lossy tier (redirect-to-lossless is legal narrowing) — with known-bad self-tests. The provisional→lossless-only action pin already exists in the independent post-import table.
- Replaced-write ratchet re-keyed for the `requests.py` line shifts (one genuinely new fingerprint: the overlay SELECT's evidence JOIN, rationale added).
- Docs: `webui-primer.md` badge section.

## Verification

Screenshot loop on the live-db dev server (both motivating albums): Guapo – Five Suns renders `provisional` + `wanted`; Lisa Hannigan – Passenger renders `verified` + `imported`. Whole-repo Pyright 0 errors; full suite 6210 tests OK.

## Not in this PR

The legacy-cohort override narrowing (54 requests → `lossless`) and `was_converted_from` ancestry stamps are the deploy-window one-shot (operator data, not product code, per scope.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)