### PR TITLE
fix(replace): displace the old install whatever the request status

### DIFF
--- a/lib/mbid_replace_service.py
+++ b/lib/mbid_replace_service.py
@@ -258,15 +258,15 @@ class MbidReplaceService:
            imported_path for Plex partial scan, old release id, status).
            The fresh re-read closes the race window where the importer
            worker finished between Phase 0 and Phase 1 — stale
-           ``old_status`` would skip beets cleanup; stale
            ``old_imported_path`` would mis-route the Plex rescan.
         3. DB transaction: ``supersede_request_mbid`` atomically flips
            the old row's status, clears ``imported_path``, inserts the
            new row, inserts tracks.
         4. Filesystem cleanup (non-fatal warnings collected):
-           - beets removal if old was imported
-             (``clear_pipeline_state=False`` so characteristic fields
-             stay frozen on the audit row)
+           - beets removal of the old release whenever its id resolves —
+             request status is irrelevant (backfill rows are wanted with
+             an install on disk; ``clear_pipeline_state=False`` so
+             characteristic fields stay frozen on the audit row)
            - wrong-matches group delete
            - staging folder rmtree (skipped when old was downloading)
         5. Post-cleanup (advisory lock RELEASED first): regenerate
@@ -861,8 +861,15 @@ class MbidReplaceService:
                     ),
                 )
 
-            # Phase 4 — filesystem cleanup (non-fatal).
-            if old_status == "imported" and old_release_id:
+            # Phase 4 — filesystem cleanup (non-fatal). Keyed on the old
+            # release id ONLY — never on request status. "wanted" does not
+            # mean "nothing on disk": library-backfill rows (2026-06-04)
+            # track pre-existing installs while still wanted, and Replace
+            # REPLACES — the old pressing's install is displaced whenever
+            # it resolves in beets (the Passenger regression, 2026-07-18).
+            # ``remove_and_reset_release`` is a safe no-op when the old
+            # release is not in beets.
+            if old_release_id:
                 try:
                     beets_db = self.beets_db_factory()
                     result = remove_and_reset_release(

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -9966,14 +9966,17 @@ class TestReplaceFullPath(unittest.TestCase):
         # slskd was never touched (R23).
         self.assertEqual(self._svc_slskd_mock.mock_calls, [])
 
-    def test_wanted_variant_no_beets_removal(self):
-        """For source ``status='wanted'`` there is no library entry —
-        the beets-removal primitive must not be called. Staging
+    def test_wanted_variant_displaces_old_install(self):
+        """``status='wanted'`` does NOT mean "nothing on disk" — library-
+        backfill rows track pre-existing installs while still wanted
+        (the Passenger regression, 2026-07-18). Replace displaces the
+        old release whenever its id resolves; the removal primitive is
+        a safe no-op when the release is absent from beets. Staging
         cleanup still runs."""
         from lib.mbid_replace_service import RESULT_REPLACED
         db, result, _, _, mocks = self._run(old_status="wanted")
         self.assertEqual(result.outcome, RESULT_REPLACED)
-        mocks["remove"].assert_not_called()
+        mocks["remove"].assert_called_once()
         if mocks["stage_path"]:
             self.assertFalse(
                 os.path.isdir(mocks["stage_path"]),
@@ -10011,11 +10014,12 @@ class TestReplaceFullPath(unittest.TestCase):
         self.assertIsNone(new["active_download_state"])
 
     def test_manual_variant(self):
-        """``status='manual'`` behaves like ``wanted`` for fs cleanup."""
+        """``status='manual'`` behaves like ``wanted`` for fs cleanup:
+        the old release is displaced whenever its id resolves."""
         from lib.mbid_replace_service import RESULT_REPLACED
         _db, result, _, _, mocks = self._run(old_status="manual")
         self.assertEqual(result.outcome, RESULT_REPLACED)
-        mocks["remove"].assert_not_called()
+        mocks["remove"].assert_called_once()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mbid_replace_service.py
+++ b/tests/test_mbid_replace_service.py
@@ -18,6 +18,9 @@ sys.path.insert(
     0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")),
 )
 
+import tests._hypothesis_profiles  # noqa: F401  (loads the active profile)
+from hypothesis import given, strategies as st
+
 from lib.config import CratediggerConfig
 from lib.mbid_replace_service import (
     MbidReplaceService,
@@ -1169,6 +1172,49 @@ class TestReplaceHappyPath(_ServiceCase):
         self.assertEqual(kwargs.get("clear_pipeline_state"), False)
         self.assertEqual(kwargs.get("request_id"), 42)
         self.assertEqual(kwargs.get("release_id"), OLD_MBID)
+
+    def test_replace_removes_preexisting_install_on_wanted_backfill_row(self):
+        """The Passenger regression (2026-07-18): a library-backfill row is
+        ``wanted`` while its pre-existing install sits in beets. Replace
+        gated cleanup on ``old_status == "imported"`` — an invariant that
+        was true at U4 time and silently broke when the 2026-06-04 full-
+        library backfill created wanted rows tracking on-disk installs.
+        Replace REPLACES: the old release's install is displaced whenever
+        the old release id resolves, whatever the request status."""
+        self._patch_externals()
+        db, _, svc = self._replace(old_status="wanted")
+        from lib import mbid_replace_service as svcmod
+        result = svc.replace_request_mbid(
+            42, target_mb_release_id=NEW_MBID,
+        )
+        self.assertEqual(result.outcome, RESULT_REPLACED)
+        mock_remove = svcmod.remove_and_reset_release
+        assert isinstance(mock_remove, MagicMock)
+        mock_remove.assert_called_once()
+        _, kwargs = mock_remove.call_args
+        self.assertEqual(kwargs.get("release_id"), OLD_MBID)
+        self.assertEqual(kwargs.get("clear_pipeline_state"), False)
+
+    @given(old_status=st.sampled_from(
+        ["wanted", "downloading", "manual", "imported"]))
+    def test_replace_displaces_old_install_for_every_source_status(
+        self, old_status,
+    ):
+        """Generated pair for the pin above: over the complete source-status
+        space, Replace always routes the old release through
+        ``remove_and_reset_release`` (clear_pipeline_state=False). Status
+        is lifecycle; displacement keys on identity."""
+        mocks = self._patch_externals()
+        db, _, svc = self._replace(old_status=old_status)
+        result = svc.replace_request_mbid(
+            42, target_mb_release_id=NEW_MBID,
+        )
+        self.assertEqual(result.outcome, RESULT_REPLACED)
+        mock_remove = mocks[0]
+        mock_remove.assert_called_once()
+        _, kwargs = mock_remove.call_args
+        self.assertEqual(kwargs.get("release_id"), OLD_MBID)
+        self.assertEqual(kwargs.get("clear_pipeline_state"), False)
 
     def test_happy_path_downloading_skips_staging_logs_warning(self):
         self._patch_externals()


### PR DESCRIPTION
The Passenger regression's class fix (#739 item 1, operator-decided 2026-07-18).

Replace gated its beets cleanup on `old_status == "imported"` — an invariant that was **true when U4 shipped** (2026-05-18: only a pipeline import put files on disk) and **silently false since the 2026-06-04 full-library backfill** created ~4,700 `wanted` rows tracking pre-existing installs. Replacing such a row skipped removal; the new pressing later imported into the same folder alongside the old files (the interleaved Passenger directory).

**Replace REPLACES.** Filesystem cleanup now keys on the old release id resolving in beets — never on request lifecycle. `remove_and_reset_release` is already a safe no-op when the release is absent, and `clear_pipeline_state=False` keeps the frozen audit row untouched exactly as before.

Pair: deterministic pin (wanted backfill row → old install displaced — the Passenger scenario) + generated property over the complete source-status space (all four statuses route the old release through the removal primitive). Two integration slices pinning the old behavior flipped to the new contract (their coverage of staging cleanup / outcome / audit-freeze is unchanged; the removal expectation inverts per the operator decision).

Remaining in #739: the same-folder disambiguation defect (item 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)