### PR TITLE
fix(beets): never-empty aunique disambiguator — same-key siblings cannot collide

### DIFF
--- a/docs/beets-primer.md
+++ b/docs/beets-primer.md
@@ -53,10 +53,17 @@ import:
 
 # Path templates
 paths:
-  default: $albumartist/$year - $album%aunique{albumartist album,albumtype year label catalognum albumdisambig releasegroupdisambig short_mbid}/$track $title
-  comp: Compilations/$album%aunique{albumartist album,albumtype year label catalognum albumdisambig releasegroupdisambig short_mbid}/$track $title
+  default: $albumartist/$year - $album%aunique{albumartist album,path_disambig}/$track $title
+  comp: Compilations/$album%aunique{albumartist album,path_disambig}/$track $title
   singleton: Non-Album/$artist/$title
-# (short_mbid comes from the inline plugin's item_fields/album_fields)
+# path_disambig is an inline-plugin album field: the first non-empty of
+# albumdisambig / releasegroupdisambig / catalognum / label / str(year).
+# It is never empty by construction — beets' %aunique renders an album's
+# OWN value for the chosen disambiguator, and an empty value renders NO
+# bracket (plain path → collides into the sibling pressing's folder; the
+# Passenger incident, 2026-07-18). Ties fall back to beets' album-id
+# bracket, which is also never empty. Contract-tested against real beets
+# in tests/test_harness_beets2_contract.py.
 
 # MusicBrainz — local mirror on doc2
 musicbrainz:
@@ -95,7 +102,7 @@ plugins: musicbrainz discogs fetchart embedart lyrics lastgenre scrub info missi
 | `fromfilename` | Guesses metadata from filenames when tags are missing | — |
 | `ftintitle` | Moves "feat." from artist to title field | — |
 | `the` | Handles "The" prefix in artist names | — |
-| `inline` | Lets config.yaml define computed item/album fields in Python — powers `short_mbid` (used in the path templates below) | — |
+| `inline` | Lets config.yaml define computed item/album fields in Python — powers `path_disambig` (the never-empty %aunique disambiguator in the path templates below) | — |
 | `permissions` | Sets imported file/art mode to 0664 and dir mode to 02775 (setgid) | Yes |
 
 `permissions` exists so media servers (Jellyfin) can read album art: beets'

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -88,13 +88,25 @@
         item = ["artist" "title"];
       };
     };
+    # %aunique disambiguates same-key (albumartist+album) sibling pressings
+    # into distinct folders. It picks the first disambiguator field whose
+    # values are all-distinct across the set, then renders each album's OWN
+    # value — an album whose value is EMPTY renders NO bracket and lands on
+    # the plain path, straight inside the sibling's sticky folder (the
+    # Passenger collision, 2026-07-18: old pressing label='ATO Records',
+    # new pressing label='' → label "won", new bracket empty). The fix is a
+    # single computed disambiguator that is never empty by construction
+    # (falling through pretty fields to $year); when siblings tie on it,
+    # beets' built-in album-id fallback still yields a non-empty bracket.
+    # Contract: tests/test_harness_beets2_contract.py
+    # (TestAuniqueCollisionContract) sweeps this exact shipped config
+    # against real beets.
     paths = {
-      default = "$albumartist/$year - $album%aunique{albumartist album,albumtype year label catalognum albumdisambig releasegroupdisambig short_mbid}/$track $title";
+      default = "$albumartist/$year - $album%aunique{albumartist album,path_disambig}/$track $title";
       singleton = "Non-Album/$artist/$title";
-      comp = "Compilations/$album%aunique{albumartist album,albumtype year label catalognum albumdisambig releasegroupdisambig short_mbid}/$track $title";
+      comp = "Compilations/$album%aunique{albumartist album,path_disambig}/$track $title";
     };
-    item_fields.short_mbid = "mb_albumid[:8] if mb_albumid else ''";
-    album_fields.short_mbid = "mb_albumid[:8] if mb_albumid else ''";
+    album_fields.path_disambig = "albumdisambig or releasegroupdisambig or catalognum or label or str(year)";
     musicbrainz = {
       host = bc.musicbrainz.host;
       https = bc.musicbrainz.https;

--- a/nix/tests/module-vm.nix
+++ b/nix/tests/module-vm.nix
@@ -51,9 +51,14 @@ let
     assert cfg["discogs"]["user_token"] == "cratedigger-placeholder-token"
     assert "include" not in cfg, cfg.get("include")
 
-    # Path-affecting keys present and production-shaped.
+    # Path-affecting keys present and production-shaped. path_disambig is
+    # the never-empty aunique disambiguator (Passenger collision fix,
+    # 2026-07-18) — it must appear in the template AND be defined as an
+    # inline album field, or same-key sibling pressings collide into one
+    # folder again.
     assert cfg["asciify_paths"] is True
-    assert "short_mbid" in cfg["paths"]["default"], cfg["paths"]
+    assert "path_disambig" in cfg["paths"]["default"], cfg["paths"]
+    assert "path_disambig" in cfg["album_fields"], cfg.get("album_fields")
 
     print("BEETS_CONFIG_OK")
   '';

--- a/tests/test_harness_beets2_contract.py
+++ b/tests/test_harness_beets2_contract.py
@@ -289,6 +289,13 @@ def _shipped_aunique_config() -> dict:
     m = re.search(r'default = "(\$albumartist[^"]+)";', src)
     assert m, "paths.default template not found in nix/module.nix"
     fields = dict(re.findall(r'album_fields\.(\w+) = "([^"]+)";', src))
+    # Fail loudly if a nix restyle stops the regex from seeing the shipped
+    # disambiguator — a vacuous sweep would keep passing while no longer
+    # exercising the production expression (review nit, PR #742).
+    assert "path_disambig" in fields, (
+        f"album_fields.path_disambig not extracted from nix/module.nix "
+        f"(got {sorted(fields)}); update the extraction regex"
+    )
     return {"template": m.group(1), "album_fields": fields}
 
 

--- a/tests/test_harness_beets2_contract.py
+++ b/tests/test_harness_beets2_contract.py
@@ -173,6 +173,147 @@ print("BAD_RIP_CLEANUP_OK")
 '''
 
 
+# Fresh-interpreter sweep of the SHIPPED aunique config against real beets.
+# The Passenger collision class (2026-07-18): beets' %aunique picks the first
+# disambiguator field whose values are all-distinct across the same-key album
+# set, then renders each album's OWN value — an album whose value for that
+# field is EMPTY renders NO bracket and lands on the plain path, colliding
+# with the sibling's sticky plain path (old album label='ATO Records', new
+# album label='' → label is "all-distinct" → new album's bracket is empty).
+# The invariant: under the shipped template + album_fields, two same-key
+# albums with different release ids ALWAYS render distinct directories.
+_AUNIQUE_CONTRACT = r'''
+import itertools
+import json
+import os
+import sys
+import tempfile
+
+import beets
+from beets import config as bconfig
+from beets import plugins as bplugins
+from beets.library import Album, Library
+from beets.util import functemplate
+
+shipped = json.loads(os.environ["AUNIQUE_SHIPPED_CONFIG"])
+TEMPLATE = shipped["template"]
+ALBUM_FIELDS = shipped["album_fields"]
+
+# The pre-2026-07-18 poisoned template — the planted known-bad the sweep
+# must detect, proving the checker catches the class.
+OLD_TEMPLATE = (
+    "$albumartist/$year - $album%aunique{albumartist album,"
+    "albumtype year label catalognum albumdisambig releasegroupdisambig "
+    "short_mbid}/$track $title"
+)
+
+FIELD_STATES = [("", ""), ("X", ""), ("X", "X"), ("X", "Y")]
+SWEEP_FIELDS = ("albumdisambig", "releasegroupdisambig", "catalognum", "label")
+
+
+def find_collisions(lib, template, worlds):
+    """Return violating pairs under the collision invariant.
+
+    A violation is EITHER two same-key siblings rendering the same
+    directory, OR any sibling rendering its PLAIN stem (the template
+    with the %aunique call stripped) — the live hazard: the other
+    sibling's sticky on-disk path IS the plain stem, so a plain-stem
+    render lands the import inside the existing album's folder
+    (Passenger, 2026-07-18)."""
+    import re as _re
+
+    tmpl = functemplate.template(template)
+    stem_tmpl = functemplate.template(
+        _re.sub(r"%aunique\{[^}]*\}", "", template))
+    bad = []
+    for a, b in worlds:
+        da = a.evaluate_template(tmpl, True).rsplit("/", 1)[0]
+        db = b.evaluate_template(tmpl, True).rsplit("/", 1)[0]
+        stem_a = a.evaluate_template(stem_tmpl, True).rsplit("/", 1)[0]
+        stem_b = b.evaluate_template(stem_tmpl, True).rsplit("/", 1)[0]
+        if da == db or da == stem_a or db == stem_b:
+            bad.append((da, db))
+    return bad
+
+
+with tempfile.TemporaryDirectory() as d:
+    bconfig["directory"] = d
+    for name, expr in ALBUM_FIELDS.items():
+        bconfig["album_fields"][name] = expr
+    bconfig["plugins"] = "inline"
+    bplugins.load_plugins()
+    lib = Library(os.path.join(d, "lib.db"), d)
+
+    worlds = []
+    n = 0
+    for states in itertools.product(FIELD_STATES, repeat=len(SWEEP_FIELDS)):
+        for year_b in (2011, 2012):
+            n += 1
+            fields_a = {f: s[0] for f, s in zip(SWEEP_FIELDS, states)}
+            fields_b = {f: s[1] for f, s in zip(SWEEP_FIELDS, states)}
+            a = Album(albumartist="Lisa Hannigan", album=f"Passenger {n}",
+                      year=2011, albumtype="album",
+                      mb_albumid="dd578a59-ef6d-46fa-9f28-1e19c456dac8",
+                      **fields_a)
+            lib.add(a)
+            b = Album(albumartist="Lisa Hannigan", album=f"Passenger {n}",
+                      year=year_b, albumtype="album",
+                      mb_albumid="5e7a6000-ce08-4e7b-9773-22a26e0a2980",
+                      **fields_b)
+            lib.add(b)
+            worlds.append((a, b))
+
+    collisions = find_collisions(lib, TEMPLATE, worlds)
+    if collisions:
+        print("SHIPPED_TEMPLATE_COLLISIONS=%d" % len(collisions))
+        print("first:", collisions[0])
+        sys.exit(1)
+    print("AUNIQUE_SHIPPED_OK worlds=%d" % len(worlds))
+
+    # Known-bad: the poisoned historical template must trip the checker.
+    old_collisions = find_collisions(lib, OLD_TEMPLATE, worlds)
+    assert old_collisions, (
+        "sweep failed to detect the known-bad empty-disambiguator "
+        "collision in the pre-fix template — the checker is toothless"
+    )
+    print("AUNIQUE_KNOWN_BAD_DETECTED=%d" % len(old_collisions))
+'''
+
+
+def _shipped_aunique_config() -> dict:
+    """Extract the shipped beets path template + inline album_fields from
+    nix/module.nix — the test patrols what production actually renders."""
+    import re
+
+    src = open(os.path.join(_REPO, "nix", "module.nix")).read()
+    m = re.search(r'default = "(\$albumartist[^"]+)";', src)
+    assert m, "paths.default template not found in nix/module.nix"
+    fields = dict(re.findall(r'album_fields\.(\w+) = "([^"]+)";', src))
+    return {"template": m.group(1), "album_fields": fields}
+
+
+class TestAuniqueCollisionContract(unittest.TestCase):
+    def test_shipped_template_never_collides_same_key_siblings(self):
+        import json as _json
+
+        proc = subprocess.run(
+            [sys.executable, "-c", _AUNIQUE_CONTRACT],
+            cwd=_REPO,
+            env={**os.environ,
+                 "PYTHONPATH": _REPO + os.pathsep + os.environ.get("PYTHONPATH", ""),
+                 "AUNIQUE_SHIPPED_CONFIG": _json.dumps(_shipped_aunique_config())},
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            proc.returncode, 0,
+            f"aunique collision contract failed\n"
+            f"STDOUT:\n{proc.stdout}\nSTDERR:\n{proc.stderr}",
+        )
+        self.assertIn("AUNIQUE_SHIPPED_OK", proc.stdout)
+        self.assertIn("AUNIQUE_KNOWN_BAD_DETECTED", proc.stdout)
+
+
 class TestHarnessBeets2Contract(unittest.TestCase):
     def test_real_beets_import_library_and_duplicate_action(self):
         proc = subprocess.run(


### PR DESCRIPTION
Closes #739. The Passenger same-folder collision, root-caused empirically and fixed at the config layer — where the operator correctly insisted it belongs ("beets should handle this").

## RCA (reproduced end-to-end against the real pinned beets)

beets' `%aunique` picks the **first disambiguator field whose values are all-distinct** across the same-key album set, then renders **each album's own value** as its bracket — and an album whose value for that chosen field is **empty renders no bracket at all**. Passenger: old pressing `label='ATO Records'` vs new pressing `label=''` → `label` won the selection → the new album rendered the plain stem → the import landed inside the sibling's sticky folder. Every July pair survived only because its distinguishing field happened to be non-empty on the new side (`[2010]`, `[iTunes bonus track]`, `[D11669]`) or fell through to the id fallback. Scratch-library reproduction with the production config collided identically; the fixed config imports the same world to `2011 - Passenger [2011]`.

## Fix

One computed inline disambiguator, never empty by construction:

```
path_disambig = albumdisambig or releasegroupdisambig or catalognum or label or str(year)
```

- First-differing values keep the pretty brackets; ties fall back to beets' built-in album-id bracket (also never empty).
- `short_mbid` retired: only the old list consumed it, and it is empty for Discogs-sourced albums (`mb_albumid` neutralization, #570) — its own latent instance of the same poison.
- Existing sticky paths untouched — no mass `beet move` (the asciify lesson).

## Tests

`TestAuniqueCollisionContract` (real-beets fresh-interpreter contract, same pattern as the 2.12 drift gate): extracts the **shipped** template + `album_fields` from `nix/module.nix` and sweeps 512 exhaustive sibling worlds asserting no member ever renders its plain stem or a duplicate directory. RED on the old template (120 violating worlds); the old template stays in the test as the permanent known-bad the checker must detect. `moduleVm` asserts `path_disambig` in both the template and `album_fields` (built, passing). Whole-repo Pyright clean; full suite 6,213 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)