### PR TITLE
Ratchet explicit ffmpeg audio stream mapping

### DIFF
--- a/tests/structural_audits/ffmpeg_audio_map.py
+++ b/tests/structural_audits/ffmpeg_audio_map.py
@@ -1,0 +1,84 @@
+"""Bounded AST contract for literal production ffmpeg command sequences."""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class FFmpegCommandSite:
+    """One canonical literal ffmpeg command construction."""
+
+    filename: str
+    lineno: int
+
+
+def _string_literal(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _is_ffmpeg_token(node: ast.AST) -> bool:
+    value = _string_literal(node)
+    return value == "ffmpeg" or bool(value and value.endswith("/ffmpeg"))
+
+
+def _has_literal_audio_map(elements: list[ast.expr]) -> bool:
+    return any(
+        _string_literal(current) == "-map"
+        and _string_literal(following) == "0:a"
+        for current, following in zip(elements, elements[1:])
+    )
+
+
+def assert_ffmpeg_audio_mapping(
+    source: str,
+    *,
+    filename: str = "<unknown>",
+) -> tuple[FFmpegCommandSite, ...]:
+    """Require every literal ffmpeg token to head an audio-mapped sequence.
+
+    The accepted grammar is deliberately small: a list or tuple whose first
+    element is a literal ``ffmpeg`` binary token and which contains the
+    adjacent literal pair ``"-map", "0:a"``. Incremental construction,
+    aliases, and shared argument splats fail closed instead of asking this
+    audit to infer runtime values.
+    """
+
+    tree = ast.parse(source, filename=filename)
+    parents = {
+        id(child): parent
+        for parent in ast.walk(tree)
+        for child in ast.iter_child_nodes(parent)
+    }
+    sites: list[FFmpegCommandSite] = []
+    violations: list[str] = []
+
+    for node in ast.walk(tree):
+        if not _is_ffmpeg_token(node):
+            continue
+        parent = parents.get(id(node))
+        if (
+            not isinstance(parent, (ast.List, ast.Tuple))
+            or not parent.elts
+            or parent.elts[0] is not node
+        ):
+            lineno = getattr(node, "lineno", 0)
+            violations.append(
+                f"{filename}:{lineno}: non-canonical ffmpeg token; "
+                "use one literal command list or tuple"
+            )
+            continue
+
+        sites.append(FFmpegCommandSite(filename=filename, lineno=parent.lineno))
+        if not _has_literal_audio_map(parent.elts):
+            violations.append(
+                f"{filename}:{parent.lineno}: ffmpeg command is missing "
+                "literal -map 0:a"
+            )
+
+    if violations:
+        raise AssertionError("\n".join(violations))
+    return tuple(sorted(sites, key=lambda site: (site.filename, site.lineno)))

--- a/tests/test_ffmpeg_audio_map_audit.py
+++ b/tests/test_ffmpeg_audio_map_audit.py
@@ -1,0 +1,94 @@
+"""Deterministic pins for explicit audio mapping in production ffmpeg commands."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+from tests.structural_audits.ffmpeg_audio_map import (
+    assert_ffmpeg_audio_mapping,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+PRODUCTION_ROOTS = REPO_ROOT / "tools" / "production_python_sources.txt"
+
+
+def _production_python_paths() -> tuple[Path, ...]:
+    roots = (
+        line.strip()
+        for line in PRODUCTION_ROOTS.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    )
+    paths: list[Path] = []
+    for relative_root in roots:
+        root = REPO_ROOT / relative_root
+        if root.is_file():
+            paths.append(root)
+        else:
+            paths.extend(path for path in root.rglob("*.py") if path.is_file())
+    return tuple(sorted(paths))
+
+
+class TestProductionFfmpegAudioMapAudit(unittest.TestCase):
+    def test_every_production_ffmpeg_command_explicitly_maps_audio(self) -> None:
+        sites = []
+        for path in _production_python_paths():
+            relative_path = str(path.relative_to(REPO_ROOT))
+            source = path.read_text(encoding="utf-8")
+            sites.extend(
+                assert_ffmpeg_audio_mapping(source, filename=relative_path)
+            )
+
+        self.assertTrue(sites, "audit must reach real production ffmpeg commands")
+
+    def test_known_bad_real_production_command_without_map_is_rejected(self) -> None:
+        path = REPO_ROOT / "lib" / "v0_probe.py"
+        source = path.read_text(encoding="utf-8")
+        mutant = source.replace('"-map", "0:a",', "", 1)
+        self.assertNotEqual(mutant, source, "fault injection must remove the map")
+        with self.assertRaisesRegex(AssertionError, "missing literal -map 0:a"):
+            assert_ffmpeg_audio_mapping(mutant, filename="lib/v0_probe.py")
+
+    def test_metadata_mapping_does_not_masquerade_as_audio_mapping(self) -> None:
+        source = '''
+cmd = [
+    "ffmpeg", "-i", source_path,
+    "-map_metadata", "0",
+    "-c:a", "libmp3lame", output_path,
+]
+'''
+        with self.assertRaisesRegex(AssertionError, "missing literal -map 0:a"):
+            assert_ffmpeg_audio_mapping(source, filename="metadata_only.py")
+
+    def test_incremental_command_construction_fails_closed(self) -> None:
+        source = '''
+cmd = ["ffmpeg", "-i", source_path]
+cmd.extend(["-map", "0:a", output_path])
+'''
+        with self.assertRaisesRegex(AssertionError, "missing literal -map 0:a"):
+            assert_ffmpeg_audio_mapping(source, filename="incremental.py")
+
+    def test_noncanonical_binary_alias_fails_closed(self) -> None:
+        source = '''
+FFMPEG = "ffmpeg"
+cmd = [FFMPEG, "-i", source_path, "-map", "0:a", output_path]
+'''
+        with self.assertRaisesRegex(AssertionError, "non-canonical ffmpeg token"):
+            assert_ffmpeg_audio_mapping(source, filename="aliased.py")
+
+    def test_audio_mapping_allows_source_metadata_policy_to_remain_explicit(self) -> None:
+        source = '''
+cmd = [
+    "ffmpeg", "-i", source_path,
+    "-map", "0:a",
+    "-map_metadata", "0",
+    "-c:a", "libmp3lame", output_path,
+]
+'''
+        sites = assert_ffmpeg_audio_mapping(source, filename="metadata_kept.py")
+        self.assertEqual(len(sites), 1)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_ffmpeg_audio_map_audit_generated.py
+++ b/tests/test_ffmpeg_audio_map_audit_generated.py
@@ -1,0 +1,73 @@
+"""Generated syntax patrol for the production ffmpeg audio-map contract."""
+
+from __future__ import annotations
+
+import unittest
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+import tests._hypothesis_profiles  # noqa: F401 - registers active profile
+from tests.structural_audits.ffmpeg_audio_map import (
+    assert_ffmpeg_audio_mapping,
+)
+
+
+_EXTRA_ARGS = st.lists(
+    st.sampled_from(("-nostdin", "-y", "-hide_banner", "-loglevel", "error")),
+    max_size=6,
+)
+
+
+def _command_source(args: list[str], *, multiline: bool) -> str:
+    rendered = [repr(arg) for arg in args]
+    separator = ",\n    " if multiline else ", "
+    return f"cmd = [{separator.join(rendered)}]\n"
+
+
+class TestGeneratedFfmpegAudioMapSyntax(unittest.TestCase):
+    @given(prefix=_EXTRA_ARGS, suffix=_EXTRA_ARGS, multiline=st.booleans())
+    def test_formatting_and_list_layout_cannot_hide_a_safe_audio_map(
+        self,
+        prefix: list[str],
+        suffix: list[str],
+        multiline: bool,
+    ) -> None:
+        source = _command_source(
+            ["ffmpeg", *prefix, "-i", "input.flac", "-map", "0:a", *suffix],
+            multiline=multiline,
+        )
+        sites = assert_ffmpeg_audio_mapping(source, filename="generated_safe.py")
+        self.assertEqual(len(sites), 1)
+
+    @given(
+        replacement=st.sampled_from(
+            (
+                (),
+                ("-map",),
+                ("0:a",),
+                ("-map", "0:v"),
+                ("-map", "0", "0:a"),
+            )
+        ),
+        prefix=_EXTRA_ARGS,
+        suffix=_EXTRA_ARGS,
+        multiline=st.booleans(),
+    )
+    def test_generated_non_audio_map_shapes_fail_closed(
+        self,
+        replacement: tuple[str, ...],
+        prefix: list[str],
+        suffix: list[str],
+        multiline: bool,
+    ) -> None:
+        source = _command_source(
+            ["ffmpeg", *prefix, "-i", "input.flac", *replacement, *suffix],
+            multiline=multiline,
+        )
+        with self.assertRaises(AssertionError):
+            assert_ffmpeg_audio_mapping(source, filename="generated_bad.py")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary

- audit every literal production ffmpeg command through the canonical production-source manifest
- require an adjacent literal `-map 0:a` in a deliberately bounded, fail-closed AST grammar
- pin the contract with a real-source mutant plus generated formatting and malformed-map cases

## Why

Malformed attached artwork can break audio processing when ffmpeg implicitly selects non-audio streams. The production call sites already map audio explicitly; this change makes that invariant unshippable without introducing a shared command builder across materially different ffmpeg policies.

## Validation

- `nix-shell --run "pyright --threads 4"`
- `nix-shell --run "bash scripts/run_tests.sh"` — 6,225 tests passed

Closes #729