### PR TITLE
refactor: make unsearchable the explicit search stop

### DIFF
--- a/.claude/rules/pipeline-db.md
+++ b/.claude/rules/pipeline-db.md
@@ -11,9 +11,11 @@ paths:
 
 - Connection: `postgresql://cratedigger@10.20.0.11:5432/cratedigger`
 - **MUST use `autocommit=True`** in `PipelineDB` — prevents idle-in-transaction deadlocks
-- Active statuses: `wanted`, `downloading`, `imported`, `manual`; terminal audit
-  status: `replaced`. `replaced` rows are frozen and have no outgoing ordinary
-  lifecycle transition; only `supersede_request_mbid` may create that status.
+- Active statuses: `wanted`, `downloading`, `imported`, `unsearchable`; terminal
+  audit status: `replaced`. `unsearchable` is the reversible operator-owned
+  search stop, not a source-cleanup state. `replaced` rows are frozen and have
+  no outgoing ordinary lifecycle transition; only `supersede_request_mbid` may
+  create that status.
 - JSONB columns: use for structured audit data (`import_result`, `validation_result`)
 
 ## Schema migrations are versioned files, NOT runtime DDL

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ If a design drifts toward "good enough" matches, "smart" defaults, or auto-throt
 1. **Run `hostname` at the start of every chat.** `proxmox-vm` = doc1, `doc2` = doc2, `framework` = Framework laptop, `DESKTOP-*` = Windows. You are likely already on doc1 — do NOT ssh to doc1 from doc1.
 2. **Windows laptop SSH**: no native key. Extract via WSL: `wsl -d NixOS -- bash -c 'cat /run/secrets/ssh_key_abl030' > ~/.ssh/id_doc2 && chmod 600 ~/.ssh/id_doc2`, then `ssh -i ~/.ssh/id_doc2 abl030@doc2` (works for doc1 too).
 3. **nixosconfig changes MUST be made on doc1** (`~/nixosconfig`; it has the Forgejo token + signing key). Edit, commit (signed), push, then deploy to doc2.
-4. **Pipeline DB is PostgreSQL on doc2** (nspawn `cratedigger-db` at `10.20.0.11:5432`; DSN in `/var/lib/cratedigger/config.ini`). The `10.20.0.0/24` subnet is doc2-local — query via `pipeline-cli` over SSH to doc2, never raw TCP from elsewhere. Request statuses: `wanted`, `downloading`, `imported`, `manual`, `replaced` (terminal, frozen audit). Import queue: `queued`, `running`, `completed`, `failed`.
+4. **Pipeline DB is PostgreSQL on doc2** (nspawn `cratedigger-db` at `10.20.0.11:5432`; DSN in `/var/lib/cratedigger/config.ini`). The `10.20.0.0/24` subnet is doc2-local — query via `pipeline-cli` over SSH to doc2, never raw TCP from elsewhere. Request statuses: `wanted`, `downloading`, `imported`, `unsearchable`, `replaced` (terminal, frozen audit). `unsearchable` is an explicit, reversible operator search stop; it is orthogonal to source cleanup such as Bad Rip / ban-source. Import queue: `queued`, `running`, `completed`, `failed`.
 5. **This is a curated collection.** Multiple editions/pressings of the same album are intentional. NEVER delete or merge duplicate albums — beets disambiguates them into separate folders.
 6. **The pipeline self-heals — the request is the source of truth, everything else is derived.** Operator actions that touch identity supersede the row rather than mutate it (canonical example: Replace, `lib/mbid_replace_service.py` — old row flips to `replaced`, new row points back via `replaces_request_id`, next cycle rebuilds).
 7. **Don't duplicate convergence — reuse the cleanup paths that already exist.** Prefer letting existing convergence (e.g. `lib/slskd_transfers.py::converge_slskd_orphans`) reap orphans over adding bespoke teardown to an action.
@@ -122,7 +122,7 @@ docs/             — subsystem docs; docs/solutions/ = compounding lessons (gre
 ## Pipeline flow
 
 ```
-Web UI / CLI → PostgreSQL (wanted → downloading → imported | manual)
+Web UI / CLI → PostgreSQL (wanted → downloading → imported; wanted ↔ unsearchable)
    Phase 1: poll_active_downloads()   Phase 2: get_wanted() → search + enqueue
    completed download → validate vs exact release ID (dist ≤ 0.15)
    source=request    → stage /Incoming/auto-import  → import_one.py (spectral → convert → quality gate) → /Beets

--- a/docs/code-improvement-ideas.md
+++ b/docs/code-improvement-ideas.md
@@ -31,7 +31,7 @@ Tests get `ctx.cfg.stalled_timeout = 600` → `make_test_config(stalled_timeout=
 
 ```python
 # lib/pipeline_db.py
-VALID_STATUSES = ("wanted", "downloading", "imported", "manual")
+VALID_STATUSES = ("wanted", "downloading", "imported", "unsearchable")
 
 # tests/test_pipeline_db.py
 def test_status_exhaustiveness(self):

--- a/docs/debugging-cli.md
+++ b/docs/debugging-cli.md
@@ -47,7 +47,6 @@ Every top-level `pipeline-cli` subcommand, one line each. Run `pipeline-cli rout
 | `add` | Add a new request by MBID or Discogs ID |
 | `beets-distance` | Real beets-distance between a download_log's audio and an MBID (refuses if MBID is outside the request's release group) |
 | `ban-source` | Mark a request's server-resolved exact release as a bad rip, remove it from beets, and requeue it (requires `--confirm BAN`) |
-| `cancel` | Cancel a request (set to skipped) |
 | `disk-coverage` | Show which active pipeline rows are actually present in beets |
 | `force-import` | Force-import a rejected download by download_log ID |
 | `import-jobs` | List recent import queue jobs |
@@ -73,10 +72,9 @@ the named PostgreSQL row remains after a purge failure.
 | `query` | Run a read-only SQL query for debugging |
 | `repair-spectral` | Fix albums stuck by stale `current_spectral_bitrate` (#18) |
 | `replace` | Supersede a request with a new row at a different release id in the same release group/master (same pathway as the source) |
-| `retry` | Reset a failed request to wanted |
 | `routes` | Self-document the CLI surface — every subcommand, its args, and its description |
 | `search-plan` | Inspect persisted search plans (read-only, U6) |
-| `set` | Change the status of a request |
+| `set` | Set a request to `wanted`, `unsearchable`, or `imported` through the lifecycle transition graph |
 | `set-intent` | Toggle lossless-on-disk for a request |
 | `show` | Show full details of a request |
 | `status` | Show counts by status |

--- a/docs/debugging-cli.md
+++ b/docs/debugging-cli.md
@@ -46,7 +46,7 @@ Every top-level `pipeline-cli` subcommand, one line each. Run `pipeline-cli rout
 |---|---|
 | `add` | Add a new request by MBID or Discogs ID |
 | `beets-distance` | Real beets-distance between a download_log's audio and an MBID (refuses if MBID is outside the request's release group) |
-| `ban-source` | Mark a request's server-resolved exact release as a bad rip, remove it from beets, and requeue it (requires `--confirm BAN`) |
+| `ban-source` | Mark a request's server-resolved exact release as a bad rip and remove it from beets; an `unsearchable` stop is preserved, otherwise the request is requeued as `wanted` (requires `--confirm BAN`) |
 | `disk-coverage` | Show which active pipeline rows are actually present in beets |
 | `force-import` | Force-import a rejected download by download_log ID |
 | `import-jobs` | List recent import queue jobs |

--- a/docs/pipeline-db-schema.md
+++ b/docs/pipeline-db-schema.md
@@ -100,16 +100,19 @@ that audit trail.
 ## `album_requests` — quality-tracking fields
 
 - `status TEXT` — active vocabulary: `wanted`, `downloading`, `imported`,
-  `manual`; terminal audit vocabulary: `replaced`. Ordinary transitions are
-  fail-closed and use SQL compare-and-set against the exact observed/declared
-  source status. `replaced` has no outgoing edge and is created only by the
-  one-way `supersede_request_mbid` transaction.
+  `unsearchable`; terminal audit vocabulary: `replaced`. `unsearchable` is an
+  explicit operator-owned search stop and is independent of source cleanup.
+  Ordinary transitions are fail-closed and use SQL compare-and-set against the
+  exact observed/declared source status. `replaced` has no outgoing edge and is
+  created only by the one-way `supersede_request_mbid` transaction.
 
-  The explicit transition graph has 13 edges: `wanted → downloading/manual/
-  imported`; `downloading → wanted/manual/imported`; `imported → wanted/manual/
-  imported`; `manual → wanted/manual/imported`; and `wanted → wanted`.
-  Status-only self-transitions for `wanted`, `imported`, and `manual` are true
-  no-ops: they do not change `updated_at` or any other byte. There is no
+  The explicit transition graph has 11 edges: `wanted → downloading/
+  unsearchable/imported/wanted`; `downloading → wanted/imported`; `imported →
+  wanted/imported`; and `unsearchable → wanted/imported/unsearchable`.
+  `downloading → unsearchable` cannot abandon an active transfer, and
+  `imported → unsearchable` cannot retroactively stop a completed request.
+  Status-only self-transitions for `wanted`, `imported`, and `unsearchable` are
+  true no-ops: they do not change `updated_at` or any other byte. There is no
   `downloading → downloading` edge because acquiring download ownership must
   remain an explicit compare-and-set operation.
 
@@ -614,10 +617,6 @@ existing `idx_search_log_request_created_at` composite index.
 
 The 14-day window is intentional — triage windows that need older
 data should query `search_log` directly. (R29)
-
-## `album_requests.manual_reason`
-
-A free-form `TEXT` column populated by system flips that move a request to `status='manual'`. Currently unused — the persisted-search-plans cutover replaced the legacy variant ladder's `exhausted` flow with cursor wrap (no manual flip). The column stays for future operator-hold workflows that need a structured reason without overloading the human-authored `reasoning` field. Cleared (`NULL`) on every `reset_to_wanted` so re-queue starts with a clean slate.
 
 ## Wrong Matches and Force-Import
 

--- a/docs/webui-primer.md
+++ b/docs/webui-primer.md
@@ -84,8 +84,9 @@ Browser → https://music.ablz.au
   never establish ownership and a Discogs master never inherits ownership
   from one of its child pressings. Missing = ordinary own-work
   release groups the beets library doesn't hold; In flight =
-  requests currently `downloading` or `manual` (`wanted` is ambient after the
-  full-library backfill and stays a badge). Appearances, promo-only,
+  requests currently `downloading`. `wanted` is ambient after the full-library
+  backfill and stays a badge; `unsearchable` is a stopped request, not active
+  work. Appearances, promo-only,
   unofficial-only, and unknown-provenance rows all remain visible inside Other
   releases; pairing and master topology are internal diagnostic facts, not page
   taxonomy. Two slow feeds decorate the page after the fast render:

--- a/harness/import_one.py
+++ b/harness/import_one.py
@@ -1061,8 +1061,10 @@ def run_import(path, mb_release_id):
 # Pipeline DB updates
 # ---------------------------------------------------------------------------
 
-def update_pipeline_db(request_id, status, imported_path=None, distance=None, scenario=None):
-    """Update pipeline DB via the shared finalization seam.
+def update_pipeline_db(
+    request_id, imported_path=None, distance=None, scenario=None,
+):
+    """Record a successful imported outcome through the finalization seam.
 
     Best-effort — failures are logged but do not block the import harness.
     """
@@ -1078,20 +1080,8 @@ def update_pipeline_db(request_id, status, imported_path=None, distance=None, sc
         if scenario:
             extra["beets_scenario"] = scenario
         try:
-            if status == "imported":
-                transition = transitions.RequestTransition.to_imported_fields(
-                    fields=extra)
-            elif status == "wanted":
-                transition = transitions.RequestTransition.to_wanted_fields(
-                    fields=extra)
-            elif status == "manual":
-                if extra:
-                    names = ", ".join(sorted(extra))
-                    raise ValueError(
-                        f"manual transitions do not accept fields: {names}")
-                transition = transitions.RequestTransition.to_manual()
-            else:
-                transition = transitions.RequestTransition.status_only(status)
+            transition = transitions.RequestTransition.to_imported_fields(
+                fields=extra)
             transitions.require_transition_applied(
                 finalize_request(
                     db,
@@ -1500,7 +1490,7 @@ def _run_quality_evidence_authorized_import(
 
     if request_id:
         stage_start = time.monotonic()
-        update_pipeline_db(request_id, "imported", imported_path=album_path)
+        update_pipeline_db(request_id, imported_path=album_path)
         _log_timing("pipeline_db_update", stage_start)
 
     beets.close()
@@ -1611,7 +1601,7 @@ def main():
                         beets_id=info.album_id,
                         track_count=info.track_count,
                         imported_path=info.album_path)
-                    update_pipeline_db(request_id, "imported",
+                    update_pipeline_db(request_id,
                                        imported_path=info.album_path)
         else:
             _log(f"[ERROR] {r.error}")
@@ -2237,7 +2227,7 @@ def main():
     # --- Pipeline DB: imported ---
     if request_id:
         stage_start = time.monotonic()
-        update_pipeline_db(request_id, "imported", imported_path=album_path)
+        update_pipeline_db(request_id, imported_path=album_path)
         _log_timing("pipeline_db_update", stage_start)
 
     # --- Final exit ---

--- a/lib/destructive_release_service.py
+++ b/lib/destructive_release_service.py
@@ -172,6 +172,7 @@ class BanSourceRequest:
 class BanSourceSuccess:
     request_id: int
     release_id: str
+    request_status: Literal["wanted", "unsearchable"]
     username: str | None
     beets_removed: bool
     hashes_recorded: int
@@ -258,6 +259,9 @@ def _ban_source_locked(
     if current.get("min_bitrate") is not None:
         fields["min_bitrate"] = current["min_bitrate"]
     current_status = str(current["status"])
+    request_status: Literal["wanted", "unsearchable"] = (
+        "unsearchable" if current_status == "unsearchable" else "wanted"
+    )
     transition = (
         transitions.RequestTransition.to_unsearchable_fields(
             from_status=current_status,
@@ -348,6 +352,7 @@ def _ban_source_locked(
     return BanSourceSuccess(
         request_id=request.request_id,
         release_id=release_id,
+        request_status=request_status,
         username=reported_username,
         beets_removed=cleanup.beets_removed,
         hashes_recorded=hashes_recorded,

--- a/lib/destructive_release_service.py
+++ b/lib/destructive_release_service.py
@@ -257,13 +257,22 @@ def _ban_source_locked(
     fields: dict[str, object] = {"search_filetype_override": quality}
     if current.get("min_bitrate") is not None:
         fields["min_bitrate"] = current["min_bitrate"]
+    current_status = str(current["status"])
+    transition = (
+        transitions.RequestTransition.to_unsearchable_fields(
+            from_status=current_status,
+            fields=fields,
+        )
+        if current_status == "unsearchable"
+        else transitions.RequestTransition.to_wanted_fields(
+            from_status=current_status,
+            fields=fields,
+        )
+    )
     transition_result = finalize_request_fn(
         pipeline_db,
         request.request_id,
-        transitions.RequestTransition.to_wanted_fields(
-            from_status=str(current["status"]),
-            fields=fields,
-        ),
+        transition,
     )
     if isinstance(transition_result, transitions.TransitionConflict):
         return BanSourceTransitionConflict(

--- a/lib/dispatch/outcome_actions.py
+++ b/lib/dispatch/outcome_actions.py
@@ -89,7 +89,7 @@ def _reject_import_from_evidence_decision(
 
     Every reject honours ``requeue_on_failure``. Automatic imports pass True
     because a rejected candidate should self-heal to ``wanted``. Force imports
-    pass False because their ``manual`` (next-step ``unsearchable``) request
+    pass False because their ``unsearchable`` request
     status is operator-owned and a candidate fact must not clear it.
     """
 

--- a/lib/pipeline_db/download_log.py
+++ b/lib/pipeline_db/download_log.py
@@ -405,7 +405,6 @@ class _DownloadLogMixin(_PipelineDBBase):
                     UPDATE album_requests
                     SET status = 'wanted',
                         active_download_state = NULL,
-                        manual_reason = NULL,
                         updated_at = %s
                     WHERE id = %s
                       AND status = 'downloading'

--- a/lib/pipeline_db/requests.py
+++ b/lib/pipeline_db/requests.py
@@ -1003,15 +1003,11 @@ class _RequestsMixin(_PipelineDBBase):
         preserved.  Pass ``search_filetype_override=None`` to clear the column;
         omitting it leaves the existing value untouched.
 
-        ``clear_retry_counters`` is for operator/manual requeues that should get
+        ``clear_retry_counters`` is for operator requeues that should get
         a clean slate. Automatic downloading → wanted failure paths preserve the
         counters so backoff can keep growing and the picker does not treat the
         row as brand new.
 
-        Always clears ``manual_reason`` — re-queueing past a manual flip
-        means the operator wants a clean slate. Per U6: every re-queue path
-        funnels through this method, so a single ``manual_reason = NULL``
-        write here covers web UI, CLI, and importer requeue paths.
         """
         unknown = sorted(
             set(fields) - {
@@ -1044,7 +1040,7 @@ class _RequestsMixin(_PipelineDBBase):
         cur = self._execute(
             "UPDATE album_requests "
             "SET status = 'wanted', active_download_state = NULL, "
-            "manual_reason = NULL, updated_at = %s, "
+            "updated_at = %s, "
             "search_attempts = CASE WHEN %s THEN 0 ELSE search_attempts END, "
             "download_attempts = CASE WHEN %s THEN 0 ELSE download_attempts END, "
             "validation_attempts = CASE WHEN %s THEN 0 ELSE validation_attempts END, "
@@ -1113,7 +1109,7 @@ class _RequestsMixin(_PipelineDBBase):
         cur = self._execute(
             "UPDATE album_requests "
             "SET status = 'wanted', active_download_state = NULL, "
-            "manual_reason = NULL, updated_at = %s, "
+            "updated_at = %s, "
             "prev_min_bitrate = CASE WHEN %s THEN %s "
             "WHEN %s THEN COALESCE(min_bitrate, prev_min_bitrate) "
             "ELSE prev_min_bitrate END, "
@@ -1320,7 +1316,7 @@ class _RequestsMixin(_PipelineDBBase):
 
     def get_wanted(self, limit=None):
         now = datetime.now(timezone.utc)
-        # New/manual-requeued albums go first, then random.
+        # New/operator-requeued albums go first, then random.
         # This ensures freshly added or upgrade-requeued albums get picked
         # up on the next cycle instead of waiting for random selection, while
         # automatic failed-download requeues stay in the normal random pool.
@@ -1454,7 +1450,7 @@ class _RequestsMixin(_PipelineDBBase):
 
         One Postgres query regardless of cohort size. Banding happens
         downstream in the service (beets-only, batched). Ordered by id ASC for
-        stable rendering. ``replaced`` / ``imported`` / ``manual`` /
+        stable rendering. ``replaced`` / ``imported`` / ``unsearchable`` /
         ``downloading`` rows are correctly excluded (R2 — worklist is the
         ``wanted`` set only).
         """

--- a/lib/pipeline_db/terminal_outcomes.py
+++ b/lib/pipeline_db/terminal_outcomes.py
@@ -131,7 +131,7 @@ class _TransactionalTransitionsDB:
         cur = self._db._execute(
             "UPDATE album_requests "
             "SET status = 'wanted', active_download_state = NULL, "
-            "manual_reason = NULL, updated_at = %s, "
+            "updated_at = %s, "
             "search_attempts = CASE WHEN %s THEN 0 ELSE search_attempts END, "
             "download_attempts = CASE WHEN %s THEN 0 ELSE download_attempts END, "
             "validation_attempts = CASE WHEN %s THEN 0 ELSE validation_attempts END, "
@@ -190,7 +190,7 @@ class _TransactionalTransitionsDB:
         cur = self._db._execute(
             "UPDATE album_requests "
             "SET status = 'wanted', active_download_state = NULL, "
-            "manual_reason = NULL, updated_at = %s, "
+            "updated_at = %s, "
             "prev_min_bitrate = CASE WHEN %s THEN %s "
             "WHEN %s THEN COALESCE(min_bitrate, prev_min_bitrate) "
             "ELSE prev_min_bitrate END, "
@@ -225,7 +225,7 @@ class _TransactionalTransitionsDB:
         """Apply wanted-policy facts while retaining the locked lifecycle.
 
         This is the terminal operator-stop path. It deliberately preserves
-        status, retry counters, and ``manual_reason`` while retaining the
+        status and retry counters while retaining the
         ordinary wanted transition's field and attempt/backoff effects.
         """
         unknown = sorted(
@@ -274,6 +274,21 @@ class _TransactionalTransitionsDB:
                 expected_status=expected_status,
             )
         return True
+
+    def apply_terminal_metadata_without_transition(
+        self,
+        request_id: int,
+        *,
+        expected_status: str,
+        fields: dict[str, object],
+    ) -> bool:
+        """Persist terminal facts while retaining operator lifecycle state."""
+        return self._update_metadata(
+            request_id,
+            dict(fields),
+            expected_status=expected_status,
+            now=datetime.now(timezone.utc),
+        )
 
     def record_attempt(
         self,
@@ -417,19 +432,19 @@ class _TerminalOutcomesMixin(_PipelineDBBase):
         transition: transitions.RequestTransition,
         *,
         operator_stop_was_current: bool,
+        successful_terminal_acceptance: bool,
     ) -> tuple[transitions.TransitionApplied, ...]:
         """Apply one transition without letting automation clear a stop.
 
-        Every terminal ``wanted`` command passes here, regardless of whether
-        it is the bundle's initial transition or a post-import policy action.
-        When the row carried the operator stop at lock time, retain its wanted
-        policy fields and attempt/backoff accounting in place, then restore the
-        stop if an earlier transition in this same bundle proved an import.
+        Every terminal request command passes here. When the row carried the
+        operator stop at lock time, a non-accepting outcome retains that state
+        while applying wanted-policy accounting or imported metadata in place.
         """
-        if not (
+        preserve_stop = (
             operator_stop_was_current
-            and transition.target_status == "wanted"
-        ):
+            and not successful_terminal_acceptance
+        )
+        if not preserve_stop:
             return (transitions.require_transition_applied(
                 transitions.finalize_request(
                     transition_db,
@@ -449,10 +464,12 @@ class _TerminalOutcomesMixin(_PipelineDBBase):
             ),)
         current_status = str(row["status"])
         applied: list[transitions.TransitionApplied] = []
-        has_policy_effect = bool(transition.fields) or (
-            transition.attempt_type is not None
-        )
-        if has_policy_effect:
+        if transition.target_status == "wanted":
+            has_policy_effect = bool(transition.fields) or (
+                transition.attempt_type is not None
+            )
+            if not has_policy_effect:
+                return ()
             if not transition_db.apply_wanted_policy_without_requeue(
                 request_id,
                 expected_status=current_status,
@@ -467,17 +484,34 @@ class _TerminalOutcomesMixin(_PipelineDBBase):
                 from_status=current_status,
                 target_status=current_status,
             ))
-        if current_status != "manual":
-            applied.append(transitions.require_transition_applied(
-                transitions.finalize_request(
-                    transition_db,
-                    request_id,
-                    transitions.RequestTransition.to_manual(
-                        from_status=current_status,
-                    ),
+            return tuple(applied)
+        if transition.attempt_type is not None:
+            raise ValueError(
+                f"{transition.target_status} transition cannot record an attempt"
+            )
+        if transition.target_status in {"imported", "unsearchable"}:
+            if not transition.fields:
+                return ()
+            if not transition_db.apply_terminal_metadata_without_transition(
+                request_id,
+                expected_status=current_status,
+                fields=dict(transition.fields),
+            ):
+                raise RuntimeError(
+                    "locked operator-stop row changed during terminal metadata"
                 )
-            ))
-        return tuple(applied)
+            return (transitions.TransitionApplied(
+                request_id=request_id,
+                from_status=current_status,
+                target_status=current_status,
+            ),)
+        return (transitions.require_transition_applied(
+            transitions.finalize_request(
+                transition_db,
+                request_id,
+                transition,
+            )
+        ),)
 
     def _insert_terminal_download_audit(
         self,
@@ -659,15 +693,34 @@ class _TerminalOutcomesMixin(_PipelineDBBase):
         cooled: set[str] = set()
         with self._atomic():
             transition_db = _TransactionalTransitionsDB(self, boundary)
+            locked_status = self._lock_terminal_request_status(
+                command.request_id
+            )
             operator_stop_was_current = operator_search_stop_is_current(
-                self._lock_terminal_request_status(command.request_id)
+                locked_status
             )
             if command.initial_transition is not None:
+                if (
+                    operator_stop_was_current
+                    and not command.successful_terminal_acceptance
+                    and command.initial_transition.from_status is not None
+                    and command.initial_transition.from_status != locked_status
+                ):
+                    transitions.require_transition_applied(
+                        transitions.finalize_request(
+                            transition_db,
+                            command.request_id,
+                            command.initial_transition,
+                        )
+                    )
                 applied.extend(self._apply_terminal_request_transition(
                     transition_db,
                     command.request_id,
                     command.initial_transition,
                     operator_stop_was_current=operator_stop_was_current,
+                    successful_terminal_acceptance=(
+                        command.successful_terminal_acceptance
+                    ),
                 ))
             download_log_id = self._insert_terminal_download_audit(
                 command.request_id,
@@ -680,31 +733,14 @@ class _TerminalOutcomesMixin(_PipelineDBBase):
                     command.request_id,
                     transition,
                     operator_stop_was_current=operator_stop_was_current,
+                    successful_terminal_acceptance=(
+                        command.successful_terminal_acceptance
+                    ),
                 ))
             # Authority: "A successful exact-release terminal import
             # acceptance supersedes an operator-owned `unsearchable` search
             # stop and records the request as `imported`." —
             # https://github.com/abl030/cratedigger/issues/737#issuecomment-5013436918
-            if (
-                operator_stop_was_current
-                and not command.successful_terminal_acceptance
-            ):
-                row = transition_db.get_request(command.request_id)
-                if row is None:
-                    raise RuntimeError(
-                        "locked operator-stop row vanished during terminal outcome"
-                    )
-                current_status = str(row["status"])
-                if not operator_search_stop_is_current(current_status):
-                    applied.append(transitions.require_transition_applied(
-                        transitions.finalize_request(
-                            transition_db,
-                            command.request_id,
-                            transitions.RequestTransition.to_manual(
-                                from_status=current_status,
-                            ),
-                        )
-                    ))
             for entry in command.denylists:
                 if self._persist_terminal_denylist(
                     command.request_id,

--- a/lib/pipeline_db/transfer_ledger.py
+++ b/lib/pipeline_db/transfer_ledger.py
@@ -40,8 +40,8 @@ from lib.pipeline_db._shared import TransferLedgerRow
 # reaper/convergence paths may still need their ownership evidence while the
 # request is being retried. Pending intents have no ownership value and are
 # bounded solely by the retention window. Accepted rows for everything else
-# (imported, manual, replaced, or a missing request) are also fair game once
-# past that window.
+# (imported, unsearchable, replaced, or a missing request) are also fair game
+# once past that window.
 _ACTIVE_REQUEST_STATUSES = ("wanted", "downloading")
 
 

--- a/lib/search_classification.py
+++ b/lib/search_classification.py
@@ -14,7 +14,7 @@ searches that ran during that cycle into one of five buckets:
 * ``E_mixed`` — fits none of A/B/D cleanly.
 * ``resolved`` — the request moved past ``wanted`` during the cycle (we
   see this when the request status is, e.g., ``imported``, ``downloading``,
-  or ``manual``).
+  or ``unsearchable``).
 
 The classifier is a pure function so the wrap-time DB writer can reuse it
 and any future triage / dry-run surface (e.g. a PR4 inspector) can
@@ -118,7 +118,7 @@ def classify_failure_class(
     Decision order (intentional — earlier branches dominate):
 
     1. ``current_status != 'wanted'``  → ``resolved`` (the cycle was
-       overtaken by an import / manual review / download).
+       overtaken by an import / operator search stop / download).
     2. Empty ``searches``               → ``None`` (no signal).
     3. ``found`` count >= 1 (and still ``wanted``)
                                         → ``D_found_but_no_import``.

--- a/lib/terminal_outcomes.py
+++ b/lib/terminal_outcomes.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from lib.pipeline_db.download_log import DownloadLogOutcome
 
 
-OPERATOR_SEARCH_STOP_STATUS = "manual"
+OPERATOR_SEARCH_STOP_STATUS = "unsearchable"
 
 
 def operator_search_stop_is_current(status: str | None) -> bool:

--- a/lib/transitions.py
+++ b/lib/transitions.py
@@ -4,7 +4,7 @@ Pure functions for transition validation. The imperative apply_transition()
 delegates to pipeline_db methods and is the single entry point for all
 state mutations.
 
-Active statuses: wanted, downloading, imported, manual.
+Active statuses: wanted, downloading, imported, unsearchable.
 Terminal audit status: replaced (no outgoing lifecycle transitions).
 """
 
@@ -89,7 +89,8 @@ class _OmittedField:
 _OMITTED = _OmittedField()
 
 
-RequestStatus = Literal["wanted", "downloading", "imported", "manual"]
+RequestStatus = Literal[
+    "wanted", "downloading", "imported", "unsearchable"]
 
 
 class TransitionConflictKind(str, Enum):
@@ -172,7 +173,7 @@ _IMPORTED_FIELDS = frozenset({
 })
 
 _DOWNLOADING_FIELDS = frozenset({"state_json"})
-_MANUAL_FIELDS = frozenset()
+_UNSEARCHABLE_FIELDS = _WANTED_FIELDS
 _RESERVED_FIELDS = frozenset({"from_status", "attempt_type"})
 
 
@@ -212,8 +213,8 @@ def _validate_transition_fields(
     if target_status == "imported":
         _reject_unknown_fields(target_status, fields, _IMPORTED_FIELDS)
         return
-    if target_status == "manual":
-        _reject_unknown_fields(target_status, fields, _MANUAL_FIELDS)
+    if target_status == "unsearchable":
+        _reject_unknown_fields(target_status, fields, _UNSEARCHABLE_FIELDS)
         return
     if target_status == "downloading":
         _reject_unknown_fields(target_status, fields, _DOWNLOADING_FIELDS)
@@ -374,12 +375,27 @@ class RequestTransition:
         )
 
     @classmethod
-    def to_manual(
+    def to_unsearchable(
         cls,
         *,
         from_status: str | None = None,
     ) -> "RequestTransition":
-        return cls(target_status="manual", from_status=from_status)
+        return cls(target_status="unsearchable", from_status=from_status)
+
+    @classmethod
+    def to_unsearchable_fields(
+        cls,
+        *,
+        from_status: str | None = None,
+        fields: Mapping[str, object],
+    ) -> "RequestTransition":
+        """Retain a search stop while applying Bad Rip search policy."""
+        _reject_unknown_fields("unsearchable", fields, _UNSEARCHABLE_FIELDS)
+        return cls(
+            target_status="unsearchable",
+            from_status=from_status,
+            fields=dict(fields),
+        )
 
     @classmethod
     def status_only(
@@ -392,8 +408,8 @@ class RequestTransition:
             return cls.to_wanted(from_status=from_status)
         if target_status == "imported":
             return cls.to_imported(from_status=from_status)
-        if target_status == "manual":
-            return cls.to_manual(from_status=from_status)
+        if target_status == "unsearchable":
+            return cls.to_unsearchable(from_status=from_status)
         if target_status == "downloading":
             raise ValueError("state_json is required for downloading transitions")
         raise ValueError(f"Unknown request status: {target_status!r}")
@@ -522,24 +538,22 @@ VALID_TRANSITIONS: dict[tuple[str, str], TransitionSideEffects] = {
     ("wanted", "downloading"): TransitionSideEffects(),
     ("downloading", "imported"): TransitionSideEffects(),
     ("downloading", "wanted"): TransitionSideEffects(record_attempt=True),
-    ("downloading", "manual"): TransitionSideEffects(),
-
-    # Manual status changes
-    ("wanted", "manual"): TransitionSideEffects(),
-    ("imported", "manual"): TransitionSideEffects(),
+    # Operator-owned reversible search stop. It cannot abandon an active
+    # download or retroactively stop an already-imported request.
+    ("wanted", "unsearchable"): TransitionSideEffects(),
     # Idempotent reset (re-queue from wanted, field-only update)
     ("wanted", "wanted"): TransitionSideEffects(clear_retry_counters=True),
 
-    # Re-queue (upgrade, retry from manual)
+    # Re-queue (upgrade, explicit operator resume)
     ("imported", "wanted"): TransitionSideEffects(clear_retry_counters=True),
-    ("manual", "wanted"): TransitionSideEffects(clear_retry_counters=True),
+    ("unsearchable", "wanted"): TransitionSideEffects(clear_retry_counters=True),
 
     # In-place update (quality gate accept, bitrate update)
     ("imported", "imported"): TransitionSideEffects(),
-    ("manual", "manual"): TransitionSideEffects(),
+    ("unsearchable", "unsearchable"): TransitionSideEffects(),
 
     # Admin overrides (force-import, web accept)
-    ("manual", "imported"): TransitionSideEffects(),
+    ("unsearchable", "imported"): TransitionSideEffects(),
     ("wanted", "imported"): TransitionSideEffects(),
 }
 

--- a/lib/youtube_ingest_service.py
+++ b/lib/youtube_ingest_service.py
@@ -111,10 +111,11 @@ OUTCOME_EXIT_CODE: dict[str, int] = {
 """Service ``SubmitOutcome`` → CLI exit code. U4 imports this directly."""
 
 
-# Request statuses that may be advanced into a YT rescue submission. Per
-# R3: ``wanted`` and ``manual`` only. ``downloading`` would race the slskd
-# pipeline; ``imported`` / ``replaced`` are terminal.
-_VALID_SUBMIT_STATUSES: frozenset[str] = frozenset({"wanted", "manual"})
+# Request statuses that may be advanced into a YT rescue submission.
+# ``unsearchable`` stops Soulseek search, not operator-requested imports.
+YOUTUBE_IMPORT_ALLOWED_REQUEST_STATUSES: frozenset[str] = frozenset(
+    {"wanted", "unsearchable"}
+)
 
 
 # ---------------------------------------------------------------------------
@@ -584,13 +585,13 @@ class YoutubeIngestService:
 
         # 2. Request status gate (R3).
         status = str(request_row.get("status") or "")
-        if status not in _VALID_SUBMIT_STATUSES:
+        if status not in YOUTUBE_IMPORT_ALLOWED_REQUEST_STATUSES:
             return SubmitResult(
                 outcome="wrong_state",
                 detail=(
                     f"request {request_id} is in status {status!r}; "
                     f"submit requires one of "
-                    f"{sorted(_VALID_SUBMIT_STATUSES)!r}"
+                    f"{sorted(YOUTUBE_IMPORT_ALLOWED_REQUEST_STATUSES)!r}"
                 ),
             )
 
@@ -782,7 +783,7 @@ class YoutubeIngestService:
                 ),
             )
         request_status = str(request_row.get("status") or "")
-        if request_status not in _VALID_SUBMIT_STATUSES:
+        if request_status not in YOUTUBE_IMPORT_ALLOWED_REQUEST_STATUSES:
             return self._terminal_failed(
                 download_log_id,
                 reason="request_no_longer_rescuable",
@@ -791,7 +792,7 @@ class YoutubeIngestService:
                 detail=(
                     f"request_id={request_id} is now status "
                     f"{request_status!r}; rescue requires one of "
-                    f"{sorted(_VALID_SUBMIT_STATUSES)!r}"
+                    f"{sorted(YOUTUBE_IMPORT_ALLOWED_REQUEST_STATUSES)!r}"
                 ),
             )
 
@@ -921,7 +922,7 @@ class YoutubeIngestService:
                 extra_metadata=_cleanup_metadata(cleanup_error),
             )
         latest_status = str(latest_request_row.get("status") or "")
-        if latest_status not in _VALID_SUBMIT_STATUSES:
+        if latest_status not in YOUTUBE_IMPORT_ALLOWED_REQUEST_STATUSES:
             cleanup_error = self._cleanup_ytdlp_run(run)
             return self._terminal_failed(
                 download_log_id,

--- a/migrations/056_unsearchable_request_status.sql
+++ b/migrations/056_unsearchable_request_status.sql
@@ -1,0 +1,17 @@
+-- Rename the operator-owned search stop and remove its unused reason field.
+-- Updating only status deliberately preserves updated_at on affected rows.
+
+ALTER TABLE album_requests
+    DROP CONSTRAINT album_requests_status_check;
+
+UPDATE album_requests
+SET status = 'unsearchable'
+WHERE status = 'manual';
+
+ALTER TABLE album_requests
+    ADD CONSTRAINT album_requests_status_check
+    CHECK(status IN (
+        'wanted', 'downloading', 'imported', 'unsearchable', 'replaced'
+    ));
+
+ALTER TABLE album_requests DROP COLUMN manual_reason;

--- a/scripts/importer.py
+++ b/scripts/importer.py
@@ -47,11 +47,13 @@ from lib.pipeline_db import (
 )
 from lib.import_manifest import audio_relative_paths
 from lib.quality import ActiveDownloadFileState, ActiveDownloadState
-from lib.youtube_ingest_service import YoutubeImportPayload
+from lib.youtube_ingest_service import (
+    YOUTUBE_IMPORT_ALLOWED_REQUEST_STATUSES,
+    YoutubeImportPayload,
+)
 
 logger = logging.getLogger("cratedigger-importer")
 RESTART_REQUEUE_MESSAGE = "Importer restarted while job was running; retry queued"
-YOUTUBE_IMPORT_ALLOWED_REQUEST_STATUSES = frozenset({"wanted", "manual"})
 
 
 def _job_result(outcome: DispatchOutcome) -> dict[str, Any]:
@@ -408,7 +410,7 @@ def execute_youtube_import_job(
             False,
             (
                 f"Album request {request_id} is status {status!r}; "
-                "YouTube import requires wanted/manual"
+                "YouTube import requires wanted/unsearchable"
             ),
         )
 
@@ -421,7 +423,7 @@ def execute_youtube_import_job(
     # active_download_state untouched on the row, and the downstream
     # update_download_state_current_path call inside
     # _materialize_processing_dir is gated by status='downloading' so
-    # it no-ops for wanted/manual rows.
+    # it no-ops for wanted/unsearchable rows.
     state = ActiveDownloadState(
         filetype=row.get("target_format") or "opus",
         enqueued_at="",

--- a/scripts/pipeline_cli/__init__.py
+++ b/scripts/pipeline_cli/__init__.py
@@ -4,7 +4,7 @@ Split from the 3,810-line ``scripts/pipeline_cli.py`` monolith into one
 module per command family, mirroring the ``web/routes/`` layout (same
 mechanical pattern as the ``lib/quality/`` split, issue #477):
 
-    album_requests.py   list / add / status / retry / cancel / set /
+    album_requests.py   list / add / status / set /
                        set-intent / disk-coverage + the MB-fetch helpers
                        (named album_requests, not requests, to avoid
                        shadowing the third-party ``requests`` package —
@@ -35,7 +35,7 @@ modules; tests and patch sites import those owners directly.
 
 Note on ``finalize_request``: it's a module-level DI seam
 (``finalize_request = transitions.finalize_request``) bound
-independently in BOTH ``album_requests.py`` (retry/cancel/set/set-intent)
+independently in BOTH ``album_requests.py`` (set/set-intent)
 and ``quality.py`` (repair-spectral) — same pattern as
 ``web.routes.pipeline_mutations.finalize_request`` / ``harness.import_one.finalize_request``.
 Patches targeting a specific command's test must patch the module that
@@ -60,10 +60,8 @@ logging.basicConfig(
 from scripts.pipeline_cli.album_requests import (
     VALID_STATUSES,
     cmd_add,
-    cmd_cancel,
     cmd_disk_coverage,
     cmd_list,
-    cmd_retry,
     cmd_set,
     cmd_set_intent,
     cmd_status,
@@ -124,7 +122,6 @@ __all__ = [
     "cmd_add",
     "cmd_beets_distance",
     "cmd_ban_source",
-    "cmd_cancel",
     "cmd_disk_coverage",
     "cmd_force_import",
     "cmd_import_jobs",
@@ -136,7 +133,6 @@ __all__ = [
     "cmd_query",
     "cmd_repair_spectral",
     "cmd_replace",
-    "cmd_retry",
     "cmd_routes",
     "cmd_search_plan_advance",
     "cmd_search_plan_dry_run",

--- a/scripts/pipeline_cli/album_requests.py
+++ b/scripts/pipeline_cli/album_requests.py
@@ -1,6 +1,6 @@
 """pipeline-cli request-lifecycle commands (#495 carve).
 
-``list`` / ``add`` / ``status`` / ``retry`` / ``cancel`` / ``set`` /
+``list`` / ``add`` / ``status`` / ``set`` /
 ``set-intent`` / ``disk-coverage`` — the core CRUD-ish surface over
 ``album_requests``, plus the MusicBrainz-fetch helpers the ``add`` path
 needs.
@@ -65,7 +65,7 @@ def _request_fields_applied_or_report(
         actual_status=None if row is None else str(row["status"]),
     ))
 
-VALID_STATUSES = ["wanted", "imported", "manual"]
+VALID_STATUSES = ["wanted", "imported", "unsearchable"]
 
 
 def _mb_api() -> str:
@@ -450,42 +450,10 @@ def cmd_status(db, args):
         return
     total = sum(counts.values())
     print(f"  Pipeline DB status ({total} total):\n")
-    for status in ["wanted", "downloading", "imported", "manual"]:
+    for status in ["wanted", "downloading", "imported", "unsearchable"]:
         c = counts.get(status, 0)
         if c > 0:
             print(f"    {status:15s} {c:4d}")
-
-
-def cmd_retry(db, args):
-    req = db.get_request(args.id)
-    if not req:
-        print(f"  Request {args.id} not found.")
-        return 2
-    result = finalize_request(
-        db,
-        args.id,
-        transitions.RequestTransition.to_wanted(from_status=req["status"]),
-    )
-    if not _transition_applied_or_report(result):
-        return 4
-    print(f"  Reset to wanted: [{args.id}] {req['artist_name']} - {req['album_title']}")
-    return 0
-
-
-def cmd_cancel(db, args):
-    req = db.get_request(args.id)
-    if not req:
-        print(f"  Request {args.id} not found.")
-        return 2
-    result = finalize_request(
-        db,
-        args.id,
-        transitions.RequestTransition.to_manual(from_status=req["status"]),
-    )
-    if not _transition_applied_or_report(result):
-        return 4
-    print(f"  Marked for manual download: [{args.id}] {req['artist_name']} - {req['album_title']}")
-    return 0
 
 
 def cmd_set(db, args):
@@ -590,8 +558,8 @@ def cmd_set_intent(db, args):
 
 
 def add_album_requests_subparsers(sub: argparse._SubParsersAction) -> None:
-    """Add ``list`` / ``add`` / ``status`` / ``disk-coverage`` / ``retry`` /
-    ``cancel`` / ``set`` / ``set-intent`` (#521 carve out of
+    """Add ``list`` / ``add`` / ``status`` / ``disk-coverage`` / ``set`` /
+    ``set-intent`` (#521 carve out of
     ``routes_meta._build_parser``, verbatim argument definitions)."""
     # list
     p_list = sub.add_parser("list", help="List album requests")
@@ -631,14 +599,6 @@ def add_album_requests_subparsers(sub: argparse._SubParsersAction) -> None:
         action="store_true",
         help="Also include beets albums with no active pipeline row",
     )
-
-    # retry
-    p_retry = sub.add_parser("retry", help="Reset a failed request to wanted")
-    p_retry.add_argument("id", type=int, help="Request ID")
-
-    # cancel
-    p_cancel = sub.add_parser("cancel", help="Cancel a request (set to skipped)")
-    p_cancel.add_argument("id", type=int, help="Request ID")
 
     # set
     p_set = sub.add_parser("set", help="Change the status of a request")

--- a/scripts/pipeline_cli/cli.py
+++ b/scripts/pipeline_cli/cli.py
@@ -23,10 +23,8 @@ from scripts.pipeline_cli.quality import cmd_quality, cmd_repair_spectral
 from scripts.pipeline_cli.replace import cmd_replace
 from scripts.pipeline_cli.album_requests import (
     cmd_add,
-    cmd_cancel,
     cmd_disk_coverage,
     cmd_list,
-    cmd_retry,
     cmd_set,
     cmd_set_intent,
     cmd_status,
@@ -111,8 +109,6 @@ def main():
         "query": cmd_query,
         "status": cmd_status,
         "disk-coverage": cmd_disk_coverage,
-        "retry": cmd_retry,
-        "cancel": cmd_cancel,
         "set": cmd_set,
         "set-intent": cmd_set_intent,
         "show": cmd_show,

--- a/scripts/pipeline_cli/destructive.py
+++ b/scripts/pipeline_cli/destructive.py
@@ -40,7 +40,7 @@ def _open_beets(path: str) -> BeetsDB:
 
 
 def cmd_ban_source(db, args) -> int:
-    """Ban one request's exact release and requeue it."""
+    """Ban an exact source; preserve unsearchable or requeue as wanted."""
     try:
         beets = _open_beets(args.beets_db)
     except FileNotFoundError as exc:
@@ -60,6 +60,7 @@ def cmd_ban_source(db, args) -> int:
             "status": "ok",
             "request_id": result.request_id,
             "release_id": result.release_id,
+            "request_status": result.request_status,
             "username": result.username,
             "beets_removed": result.beets_removed,
             "hashes_recorded": result.hashes_recorded,
@@ -216,7 +217,8 @@ def add_destructive_subparsers(sub: argparse._SubParsersAction) -> None:
     ban = sub.add_parser(
         "ban-source",
         help="Mark a request's server-resolved exact release as a bad rip, "
-             "remove it from beets, and requeue it.",
+             "remove it from beets, preserve an unsearchable stop, or "
+             "otherwise requeue it as wanted.",
     )
     ban.add_argument("request_id", type=int)
     ban.add_argument("--confirm", choices=("BAN",), required=True)

--- a/scripts/pipeline_cli/routes_meta.py
+++ b/scripts/pipeline_cli/routes_meta.py
@@ -45,7 +45,7 @@ def _build_parser() -> tuple[
     parser.add_argument("--dsn", default=DEFAULT_DSN, help="PostgreSQL connection string")
     sub = parser.add_subparsers(dest="command")
 
-    # list / add / status / disk-coverage / retry / cancel / set / set-intent
+    # list / add / status / disk-coverage / set / set-intent
     add_album_requests_subparsers(sub)
 
     # query

--- a/scripts/pipeline_cli/search_plan.py
+++ b/scripts/pipeline_cli/search_plan.py
@@ -138,7 +138,7 @@ def cmd_search_plan_regenerate(db, args):
         "error_message": result.error_message,
     }
     # Add an executability hint so operators don't misread "200 / success"
-    # on an imported/manual request as "now downloading".
+    # on an imported/unsearchable request as "now downloading".
     req = db.get_request(int(args.id))
     if req is not None:
         payload["request_status"] = req.get("status")

--- a/scripts/pipeline_cli/show.py
+++ b/scripts/pipeline_cli/show.py
@@ -120,8 +120,7 @@ def _render_search_forensics_summary(
     """Build the U7 forensic summary block printed above search history.
 
     Inputs:
-    - ``request_row``: the row dict from ``PipelineDB.get_request``. Used
-      for ``manual_reason`` (None when not exhausted / pre-U7).
+    - ``request_row``: the row dict from ``PipelineDB.get_request``.
     - ``latest_search``: the most recent ``search_log`` row dict (already
       ordered newest-first by ``get_search_history``). The candidates
       JSONB blob is decoded here via ``msgspec.convert(blob,
@@ -137,18 +136,13 @@ def _render_search_forensics_summary(
     lines: list[str] = ["", "  Search Forensics:"]
     variant = latest_search.get("variant")
     final_state = latest_search.get("final_state")
-    manual_reason = request_row.get("manual_reason")
-
     if variant:
         lines.append(f"    variant:        {variant}")
     if final_state:
         lines.append(f"    final_state:    {final_state}")
-    if manual_reason:
-        lines.append(f"    manual_reason:  {manual_reason}")
-
     raw_candidates = latest_search.get("candidates")
     if raw_candidates is None:
-        if not (variant or final_state or manual_reason):
+        if not (variant or final_state):
             lines.append("    (no forensic data yet)")
         else:
             lines.append("    candidates:     (none captured)")
@@ -311,8 +305,8 @@ def cmd_show(db, args):
     searches = db.get_search_history(req['id'])
     if searches:
         # U7: print a forensic summary above the row table — the most
-        # recent variant + final_state, the request's manual_reason if
-        # populated, and the top-3 candidates from the latest search_log
+        # recent variant + final_state and the top-3 candidates from the
+        # latest search_log
         # row's JSONB blob. The blob is decoded once via msgspec.convert
         # per single-decode-site discipline (code-quality.md § Wire-
         # boundary types). Older rows / NULL blobs render gracefully.

--- a/scripts/pipeline_cli/youtube.py
+++ b/scripts/pipeline_cli/youtube.py
@@ -233,7 +233,7 @@ def cmd_youtube_rescue(db, args, *, service_factory=None):
       * 2 — ``request_not_found``
       * 3 — ``no_resolver_mapping``, ``track_count_precheck_failed``
             (semantic input violations)
-      * 4 — ``wrong_state`` (request is not ``wanted`` / ``manual``),
+      * 4 — ``wrong_state`` (request is not ``wanted`` / ``unsearchable``),
             ``in_flight`` (an existing ``youtube_running`` row already
             owns this request — re-issue once it's terminal)
       * 5 — ``transient`` (DB / MB-mirror hiccup; retry)

--- a/scripts/web_dev_server.py
+++ b/scripts/web_dev_server.py
@@ -33,14 +33,20 @@ sys.path.insert(0, str(REPO_ROOT))
 
 FALLBACK_FIXTURES: dict[str, dict[str, Any]] = {
     "/api/pipeline/all": {
-        "counts": {"wanted": 0, "downloading": 0, "imported": 0, "manual": 0},
+        "counts": {
+            "wanted": 0, "downloading": 0, "imported": 0,
+            "unsearchable": 0,
+        },
         "wanted": [],
         "downloading": [],
         "imported": [],
-        "manual": [],
+        "unsearchable": [],
     },
     "/api/pipeline/status": {
-        "counts": {"wanted": 0, "downloading": 0, "imported": 0, "manual": 0},
+        "counts": {
+            "wanted": 0, "downloading": 0, "imported": 0,
+            "unsearchable": 0,
+        },
         "wanted": [],
     },
     "/api/pipeline/log": {

--- a/tests/fakes/pipeline_db.py
+++ b/tests/fakes/pipeline_db.py
@@ -193,6 +193,27 @@ class _FakeTerminalTransitionsDB:
             )
         return True
 
+    def apply_terminal_metadata_without_transition(
+        self,
+        request_id: int,
+        *,
+        expected_status: str,
+        fields: dict[str, object],
+    ) -> bool:
+        row = self._db._requests.get(request_id)
+        if row is None or row.get("status") != expected_status:
+            return False
+        if not fields:
+            return True
+        applied = self._db.update_request_fields(
+            request_id,
+            expected_status=expected_status,
+            **fields,
+        )
+        if applied:
+            self._boundary("request.metadata")
+        return applied
+
     def record_attempt(
         self,
         request_id: int,
@@ -1312,11 +1333,13 @@ class FakePipelineDB:
         transition: transitions.RequestTransition,
         *,
         operator_stop_was_current: bool,
+        successful_terminal_acceptance: bool,
     ) -> tuple[transitions.TransitionApplied, ...]:
-        if not (
+        preserve_stop = (
             operator_stop_was_current
-            and transition.target_status == "wanted"
-        ):
+            and not successful_terminal_acceptance
+        )
+        if not preserve_stop:
             return (transitions.require_transition_applied(
                 transitions.finalize_request(
                     transition_db,
@@ -1335,10 +1358,12 @@ class FakePipelineDB:
             ),)
         current_status = str(row["status"])
         applied: list[transitions.TransitionApplied] = []
-        has_policy_effect = bool(transition.fields) or (
-            transition.attempt_type is not None
-        )
-        if has_policy_effect:
+        if transition.target_status == "wanted":
+            has_policy_effect = bool(transition.fields) or (
+                transition.attempt_type is not None
+            )
+            if not has_policy_effect:
+                return ()
             if not transition_db.apply_wanted_policy_without_requeue(
                 request_id,
                 expected_status=current_status,
@@ -1353,17 +1378,34 @@ class FakePipelineDB:
                 from_status=current_status,
                 target_status=current_status,
             ))
-        if current_status != "manual":
-            applied.append(transitions.require_transition_applied(
-                transitions.finalize_request(
-                    transition_db,
-                    request_id,
-                    transitions.RequestTransition.to_manual(
-                        from_status=current_status,
-                    ),
+            return tuple(applied)
+        if transition.attempt_type is not None:
+            raise ValueError(
+                f"{transition.target_status} transition cannot record an attempt"
+            )
+        if transition.target_status in {"imported", "unsearchable"}:
+            if not transition.fields:
+                return ()
+            if not transition_db.apply_terminal_metadata_without_transition(
+                request_id,
+                expected_status=current_status,
+                fields=dict(transition.fields),
+            ):
+                raise RuntimeError(
+                    "locked operator-stop row changed during terminal metadata"
                 )
-            ))
-        return tuple(applied)
+            return (transitions.TransitionApplied(
+                request_id=request_id,
+                from_status=current_status,
+                target_status=current_status,
+            ),)
+        return (transitions.require_transition_applied(
+            transitions.finalize_request(
+                transition_db,
+                request_id,
+                transition,
+            )
+        ),)
 
     def persist_import_terminal_outcome(
         self,
@@ -1380,17 +1422,36 @@ class FakePipelineDB:
         try:
             transition_db = _FakeTerminalTransitionsDB(self, boundary)
             applied = []
-            operator_stop_was_current = operator_search_stop_is_current(
+            locked_status = (
                 str(self._requests[command.request_id]["status"])
                 if command.request_id in self._requests
                 else None
             )
+            operator_stop_was_current = operator_search_stop_is_current(
+                locked_status
+            )
             if command.initial_transition is not None:
+                if (
+                    operator_stop_was_current
+                    and not command.successful_terminal_acceptance
+                    and command.initial_transition.from_status is not None
+                    and command.initial_transition.from_status != locked_status
+                ):
+                    transitions.require_transition_applied(
+                        transitions.finalize_request(
+                            transition_db,
+                            command.request_id,
+                            command.initial_transition,
+                        )
+                    )
                 applied.extend(self._apply_terminal_request_transition(
                     transition_db,
                     command.request_id,
                     command.initial_transition,
                     operator_stop_was_current=operator_stop_was_current,
+                    successful_terminal_acceptance=(
+                        command.successful_terminal_acceptance
+                    ),
                 ))
             download_log_id = cast(Any, self.log_download)(
                 request_id=command.request_id,
@@ -1403,27 +1464,10 @@ class FakePipelineDB:
                     command.request_id,
                     transition,
                     operator_stop_was_current=operator_stop_was_current,
+                    successful_terminal_acceptance=(
+                        command.successful_terminal_acceptance
+                    ),
                 ))
-            if (
-                operator_stop_was_current
-                and not command.successful_terminal_acceptance
-            ):
-                row = transition_db.get_request(command.request_id)
-                if row is None:
-                    raise RuntimeError(
-                        "locked operator-stop row vanished during terminal outcome"
-                    )
-                current_status = str(row["status"])
-                if not operator_search_stop_is_current(current_status):
-                    applied.append(transitions.require_transition_applied(
-                        transitions.finalize_request(
-                            transition_db,
-                            command.request_id,
-                            transitions.RequestTransition.to_manual(
-                                from_status=current_status,
-                            ),
-                        )
-                    ))
             cooled: set[str] = set()
             for entry in command.denylists:
                 denied_before = len(self.denylist)
@@ -1715,7 +1759,6 @@ class FakePipelineDB:
             row["next_retry_after"] = None
             row["last_attempt_at"] = None
         row["active_download_state"] = None
-        row["manual_reason"] = None
         row["updated_at"] = now
         if "search_filetype_override" in fields:
             row["search_filetype_override"] = fields["search_filetype_override"]
@@ -1761,7 +1804,6 @@ class FakePipelineDB:
         now = _utcnow()
         row["status"] = "wanted"
         row["active_download_state"] = None
-        row["manual_reason"] = None
         row["updated_at"] = now
         if "search_filetype_override" in fields:
             row["search_filetype_override"] = fields["search_filetype_override"]
@@ -2237,7 +2279,6 @@ class FakePipelineDB:
         now = _utcnow()
         row["status"] = "wanted"
         row["active_download_state"] = None
-        row["manual_reason"] = None
         row["updated_at"] = now
         self.status_history.append((request_id, "wanted"))
         self.record_attempt(
@@ -3352,7 +3393,6 @@ class FakePipelineDB:
             "current_lossless_source_v0_probe_avg_bitrate": None,
             "current_lossless_source_v0_probe_median_bitrate": None,
             "active_download_state": None,
-            "manual_reason": None,
             # U1 persisted-search-plans cursor fields.
             "active_plan_id": None,
             "next_plan_ordinal": 0,

--- a/tests/fixtures/web/default/api__pipeline__all.json
+++ b/tests/fixtures/web/default/api__pipeline__all.json
@@ -3,10 +3,10 @@
     "wanted": 0,
     "downloading": 0,
     "imported": 0,
-    "manual": 0
+    "unsearchable": 0
   },
   "wanted": [],
   "downloading": [],
   "imported": [],
-  "manual": []
+  "unsearchable": []
 }

--- a/tests/fixtures/web/errors/api__pipeline__all.json
+++ b/tests/fixtures/web/errors/api__pipeline__all.json
@@ -3,10 +3,10 @@
     "wanted": 9,
     "downloading": 1,
     "imported": 418,
-    "manual": 12
+    "unsearchable": 12
   },
   "wanted": [],
   "downloading": [],
   "imported": [],
-  "manual": []
+  "unsearchable": []
 }

--- a/tests/fixtures/web/gas-evidence/api__pipeline__8860.json
+++ b/tests/fixtures/web/gas-evidence/api__pipeline__8860.json
@@ -88,6 +88,5 @@
     }
   ],
   "last_search": null,
-  "manual_reason": null,
   "beets_tracks": []
 }

--- a/tests/fixtures/web/peers/api__pipeline__all.json
+++ b/tests/fixtures/web/peers/api__pipeline__all.json
@@ -3,10 +3,10 @@
     "wanted": 16,
     "downloading": 2,
     "imported": 418,
-    "manual": 7
+    "unsearchable": 7
   },
   "wanted": [],
   "downloading": [],
   "imported": [],
-  "manual": []
+  "unsearchable": []
 }

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -92,7 +92,6 @@ def make_request_row(**overrides: Any) -> dict[str, Any]:
         "current_lossless_source_v0_probe_avg_bitrate": None,
         "current_lossless_source_v0_probe_median_bitrate": None,
         "active_download_state": None,
-        "manual_reason": None,
         # U1 persisted-search-plans cursor fields (migration 014).
         "active_plan_id": None,
         "next_plan_ordinal": 0,

--- a/tests/test_album_source.py
+++ b/tests/test_album_source.py
@@ -106,7 +106,7 @@ class TestDatabaseSourceRejectAndRequeueSeam(unittest.TestCase):
         is therefore proof that the seam resolved from_status itself.
         """
         fake_db = FakePipelineDB()
-        fake_db.seed_request(make_request_row(id=42, status="manual"))
+        fake_db.seed_request(make_request_row(id=42, status="unsearchable"))
 
         source = DatabaseSource.__new__(DatabaseSource)
         source._db = fake_db  # type: ignore[assignment]
@@ -314,7 +314,7 @@ class TestDatabaseSource(unittest.TestCase):
             album_title="B",
             source="request",
         )
-        db.update_status(req_id, "manual")
+        db.update_status(req_id, "unsearchable")
         record = _make_record(db_request_id=req_id, db_source="request")
         bv_result = ValidationResult(valid=False, distance=0.35, scenario="high_distance")
 

--- a/tests/test_album_source.py
+++ b/tests/test_album_source.py
@@ -98,7 +98,7 @@ class TestDatabaseSourceRejectAndRequeueSeam(unittest.TestCase):
         """``reject_and_requeue`` lets the shared transition seam look up
         ``from_status`` from the DB instead of pinning it at the call site.
 
-        End-to-end: seed a row in ``manual``, call ``reject_and_requeue``
+        End-to-end: seed a row in ``unsearchable``, call ``reject_and_requeue``
         without any ``from_status`` argument, observe the row land in
         ``wanted``. If the source had hard-coded ``from_status="wanted"``
         (or any other non-current value), the transition guard would have

--- a/tests/test_destructive_authority.py
+++ b/tests/test_destructive_authority.py
@@ -19,6 +19,7 @@ from lib.destructive_release_service import (
     BanSourceLockContended,
     BanSourceReleaseMismatch,
     BanSourceRequest,
+    BanSourceSuccess,
     BanSourceTransitionConflict,
     DeleteImporterBusy,
     DeleteLockContended,
@@ -227,6 +228,8 @@ class TestBanSourceAuthority(unittest.TestCase):
         )
 
         self.assertNotIsInstance(result, BanSourceTransitionConflict)
+        assert isinstance(result, BanSourceSuccess)
+        self.assertEqual(result.request_status, "unsearchable")
         row = self.db.request(41)
         self.assertEqual(row["status"], "unsearchable")
         self.assertIsNone(row["imported_path"])

--- a/tests/test_destructive_authority.py
+++ b/tests/test_destructive_authority.py
@@ -206,6 +206,36 @@ class TestBanSourceAuthority(unittest.TestCase):
         self.assertIsInstance(result, BanSourceTransitionConflict)
         self._assert_no_mutation()
 
+    def test_unsearchable_bad_rip_preserves_search_stop(self) -> None:
+        """Bad Rip bans the source and removes the copy without searching."""
+        self.db.seed_request(make_request_row(
+            id=41,
+            status="unsearchable",
+            mb_release_id=RELEASE_A,
+            imported_path="/Beets/Artist/Album",
+        ))
+        self.db.log_download(
+            request_id=41,
+            soulseek_username="bad-peer",
+            outcome="success",
+        )
+
+        result = ban_source(
+            pipeline_db=self.db,
+            beets_db=self.beets,
+            request=BanSourceRequest(request_id=41),
+        )
+
+        self.assertNotIsInstance(result, BanSourceTransitionConflict)
+        row = self.db.request(41)
+        self.assertEqual(row["status"], "unsearchable")
+        self.assertIsNone(row["imported_path"])
+        self.assertEqual(
+            [(entry.request_id, entry.username) for entry in self.db.denylist],
+            [(41, "bad-peer")],
+        )
+        self.assertEqual(self.db.download_logs[-1].outcome, "curator_ban")
+
 
 class TestLibraryDeleteAuthority(unittest.TestCase):
     def setUp(self) -> None:

--- a/tests/test_destructive_authority_generated.py
+++ b/tests/test_destructive_authority_generated.py
@@ -315,6 +315,8 @@ class TestGeneratedDestructiveAuthority(unittest.TestCase):
         )
 
         self.assertIsInstance(result, BanSourceSuccess)
+        assert isinstance(result, BanSourceSuccess)
+        self.assertEqual(result.request_status, db.request(41)["status"])
         assert_ban_searchability_preserved(
             initial_status=initial_status,
             final_status=str(db.request(41)["status"]),

--- a/tests/test_destructive_authority_generated.py
+++ b/tests/test_destructive_authority_generated.py
@@ -102,6 +102,18 @@ def assert_rejection_preserved_state(
         raise AssertionError("destructive rejection mutated owned state")
 
 
+def assert_ban_searchability_preserved(
+    *, initial_status: str, final_status: str,
+) -> None:
+    """Bad Rip changes source authority, not operator searchability."""
+    expected = "unsearchable" if initial_status == "unsearchable" else "wanted"
+    if final_status != expected:
+        raise AssertionError(
+            f"bad rip changed searchability: {initial_status!r} -> "
+            f"{final_status!r}; expected {expected!r}"
+        )
+
+
 def assert_delete_postcondition(
     *,
     outcome: str,
@@ -282,6 +294,32 @@ def _configure_lock_world(
 
 
 class TestGeneratedDestructiveAuthority(unittest.TestCase):
+    @given(initial_status=st.sampled_from(("imported", "unsearchable")))
+    @example(initial_status="unsearchable")
+    def test_successful_ban_preserves_searchability(
+        self,
+        initial_status: str,
+    ) -> None:
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=41,
+            status=initial_status,
+            mb_release_id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        ))
+        beets = FakeBeetsDB()
+
+        result = ban_source(
+            pipeline_db=db,
+            beets_db=beets,
+            request=BanSourceRequest(41),
+        )
+
+        self.assertIsInstance(result, BanSourceSuccess)
+        assert_ban_searchability_preserved(
+            initial_status=initial_status,
+            final_status=str(db.request(41)["status"]),
+        )
+
     @example(
         mb_id="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
         discogs_id="12856590",
@@ -1058,6 +1096,13 @@ class TestGeneratedDestructiveAuthority(unittest.TestCase):
 
 
 class TestDestructiveAuthorityCheckerKnownBad(unittest.TestCase):
+    def test_ban_searchability_checker_kills_resume_mutant(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "changed searchability"):
+            assert_ban_searchability_preserved(
+                initial_status="unsearchable",
+                final_status="wanted",
+            )
+
     def test_checker_trips_on_fault_injected_production_mutation(self) -> None:
         class FaultInjectingPipelineDB(FakePipelineDB):
             inject_mutation = False

--- a/tests/test_dispatch_core.py
+++ b/tests/test_dispatch_core.py
@@ -502,7 +502,7 @@ class TestDispatchCoreOrchestration(unittest.TestCase):
         db.seed_request(make_request_row(
             id=42,
             mb_release_id="mbid-123",
-            status="manual",
+            status="unsearchable",
             verified_lossless=False,
         ))
         proof = VerifiedLosslessProof(

--- a/tests/test_dispatch_from_db.py
+++ b/tests/test_dispatch_from_db.py
@@ -126,7 +126,7 @@ class TestDispatchFromDbOrchestration(unittest.TestCase):
         req_kwargs = {
             "id": 42,
             "mb_release_id": "mbid-123",
-            "status": "manual",
+            "status": "unsearchable",
             "artist_name": "Son Ambulance",
             "album_title": "Someone Else's Deja Vu",
             "min_bitrate": 180,
@@ -248,7 +248,7 @@ class TestDispatchFromDbOrchestration(unittest.TestCase):
     def test_successful_force_import_preserves_stop_without_terminal_acceptance(self):
         r = self._dispatch()
         self.assertTrue(r["result"].success)
-        self.assertEqual(r["db"].request(42)["status"], "manual")
+        self.assertEqual(r["db"].request(42)["status"], "unsearchable")
 
     def test_terminally_accepted_force_import_marks_imported(self):
         r = self._dispatch(quality_gate_plan=QualityGatePlan(
@@ -309,13 +309,13 @@ class TestDispatchFromDbOrchestration(unittest.TestCase):
         ir = make_import_result(decision="downgrade",
                                 new_min_bitrate=128, prev_min_bitrate=180)
         r = self._dispatch(ir=ir)
-        self.assertEqual(r["db"].request(42)["status"], "manual")
+        self.assertEqual(r["db"].request(42)["status"], "unsearchable")
 
     def test_transcode_downgrade_does_not_requeue(self):
         ir = make_import_result(decision="transcode_downgrade",
                                 new_min_bitrate=190, prev_min_bitrate=320)
         r = self._dispatch(ir=ir)
-        self.assertEqual(r["db"].request(42)["status"], "manual")
+        self.assertEqual(r["db"].request(42)["status"], "unsearchable")
 
     # --- Audit trail ---
 
@@ -364,7 +364,7 @@ class TestDispatchFromDbOrchestration(unittest.TestCase):
         db.seed_request(make_request_row(
             id=42,
             mb_release_id="mbid-123",
-            status="manual",
+            status="unsearchable",
             artist_name="Son Ambulance",
             album_title="Someone Else's Deja Vu",
         ))
@@ -445,7 +445,7 @@ class TestDispatchFromDbOrchestration(unittest.TestCase):
         db.seed_request(make_request_row(
             id=42,
             mb_release_id="mbid-123",
-            status="manual",
+            status="unsearchable",
             artist_name="Son Ambulance",
             album_title="Someone Else's Deja Vu",
         ))
@@ -527,7 +527,7 @@ class TestDispatchFromDbOrchestration(unittest.TestCase):
         db.seed_request(make_request_row(
             id=42,
             mb_release_id="mbid-123",
-            status="manual",
+            status="unsearchable",
             artist_name="Son Ambulance",
             album_title="Someone Else's Deja Vu",
         ))
@@ -590,7 +590,7 @@ class TestDispatchFromDbOrchestration(unittest.TestCase):
         db.seed_request(make_request_row(
             id=42,
             mb_release_id="mbid-123",
-            status="manual",
+            status="unsearchable",
             artist_name="Son Ambulance",
             album_title="Someone Else's Deja Vu",
         ))
@@ -664,7 +664,7 @@ class TestDispatchFromDbOrchestration(unittest.TestCase):
         db.seed_request(make_request_row(
             id=42,
             mb_release_id="mbid-zero",
-            status="manual",
+            status="unsearchable",
             artist_name="The Bug Tester",
             album_title="Zero Rows Affected",
         ))
@@ -771,7 +771,7 @@ class TestDispatchFromDbAdvisoryLock(unittest.TestCase):
     def _seed_db(self) -> "FakePipelineDB":
         db = FakePipelineDB()
         db.seed_request(make_request_row(
-            id=42, mb_release_id="mbid-123", status="manual",
+            id=42, mb_release_id="mbid-123", status="unsearchable",
             artist_name="Son Ambulance", album_title="Someone Else's Deja Vu",
         ))
         _seed_single_track(db)
@@ -824,7 +824,7 @@ class TestDispatchFromDbAdvisoryLock(unittest.TestCase):
         # No download_log rows
         self.assertEqual(db.download_logs, [])
         # Status unchanged
-        self.assertEqual(db.request(42)["status"], "manual")
+        self.assertEqual(db.request(42)["status"], "unsearchable")
         # No denylist / cooldown / attempt recording
         self.assertEqual(db.denylist, [])
         self.assertEqual(db.recorded_attempts, [])
@@ -873,7 +873,7 @@ class TestDispatchFromDbRuntimeConfigSeam(unittest.TestCase):
         db.seed_request(make_request_row(
             id=42,
             mb_release_id="mbid-123",
-            status="manual",
+            status="unsearchable",
             artist_name="Artist",
             album_title="Album",
         ))
@@ -952,7 +952,7 @@ class TestDispatchFromDbPrecondition(unittest.TestCase):
         db.seed_request(make_request_row(
             id=42,
             mb_release_id="mbid-123",
-            status="manual",
+            status="unsearchable",
             artist_name="Artist",
             album_title="Album",
         ))
@@ -981,7 +981,7 @@ class TestDispatchFromDbPrecondition(unittest.TestCase):
             ext.run.assert_not_called()
             # No download_log row written; the request status is untouched.
             self.assertEqual(db.download_logs, [])
-            self.assertEqual(db.request(42)["status"], "manual")
+            self.assertEqual(db.request(42)["status"], "unsearchable")
         finally:
             import shutil
             shutil.rmtree(tmpdir, ignore_errors=True)

--- a/tests/test_dispatch_outcomes_generated.py
+++ b/tests/test_dispatch_outcomes_generated.py
@@ -534,7 +534,7 @@ def _run_have_analysis_abort(
     db = FakePipelineDB()
     db.seed_request(make_request_row(
         id=42,
-        status="manual" if mode == "force" else "downloading",
+        status="unsearchable" if mode == "force" else "downloading",
         search_filetype_override=search_override,
         active_download_state={"files": [], "filetype": "flac"},
     ))
@@ -802,7 +802,7 @@ def assert_have_analysis_abort_is_non_quality(
 
     assert_download_log_row_created(db)
     row = db.request(42)
-    expected_status = "wanted" if mode == "auto" else "manual"
+    expected_status = "wanted" if mode == "auto" else "unsearchable"
     if row["status"] != expected_status:
         raise AssertionError(
             f"HAVE-analysis abort left status={row['status']!r}, "
@@ -1035,7 +1035,7 @@ class TestGeneratedOperatorRetainedLifecycle(unittest.TestCase):
 
     @given(
         decision=st.sampled_from(tuple(sorted(_AUTOMATIC_RETAINED_ACTIONS))),
-        initial_status=st.sampled_from(("wanted", "manual")),
+        initial_status=st.sampled_from(("wanted", "unsearchable")),
     )
     def test_retained_policy_preserves_starting_search_lifecycle(
         self,
@@ -1176,7 +1176,7 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
         with self.assertRaises(AssertionError):
             assert_operator_retained_lifecycle(
                 db,
-                initial_status="manual",
+                initial_status="unsearchable",
                 expected_override="lossless",
             )
 

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -3229,7 +3229,7 @@ class TestHarvestTerminalTransferEvidence(unittest.TestCase):
 
         def get_downloading_then_flip():
             rows = original_get_downloading()
-            fake_db._requests[1]["status"] = "manual"
+            fake_db._requests[1]["status"] = "unsearchable"
             return rows
 
         cast(Any, fake_db).get_downloading = get_downloading_then_flip

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -650,7 +650,7 @@ class TestFakePipelineDB(unittest.TestCase):
             41, expected_status="wanted",
         ))
         self.assertFalse(db.update_request_fields(
-            41, expected_status="manual",
+            41, expected_status="unsearchable",
         ))
         self.assertFalse(db.update_request_fields(42))
         self.assertFalse(db.update_request_fields(
@@ -681,7 +681,7 @@ class TestFakePipelineDB(unittest.TestCase):
                 self.assertEqual(db.request(41), before)
 
         with self.assertRaises(ValueError):
-            db.update_request_fields(41, status="manual")
+            db.update_request_fields(41, status="unsearchable")
         self.assertEqual(db.request(41), before)
 
     def test_metadata_writers_reject_malformed_and_lifecycle_fields(self):
@@ -1054,27 +1054,12 @@ class TestFakePipelineDB(unittest.TestCase):
             self.assertFalse(acquired)
         self.assertEqual(db.advisory_lock_calls, [(0x1234, 42)])
 
-    def test_reset_to_wanted_clears_manual_reason(self):
-        """U6 fake parity: re-queue clears ``manual_reason`` and counters."""
-        db = FakePipelineDB()
-        db.seed_request(make_request_row(
-            id=42, status="manual", manual_reason="search_exhausted",
-            search_attempts=7,
-        ))
-
-        db.reset_to_wanted(42)
-
-        row = db.request(42)
-        self.assertEqual(row["status"], "wanted")
-        self.assertEqual(row["search_attempts"], 0)
-        self.assertIsNone(row["manual_reason"])
-
     def test_wanted_resets_accept_explicit_previous_bitrate(self):
         """Fake parity: explicit history wins over derived old-min capture."""
         db = FakePipelineDB()
         db.seed_request(make_request_row(
             id=42,
-            status="manual",
+            status="unsearchable",
             min_bitrate=320,
             prev_min_bitrate=192,
         ))
@@ -1087,7 +1072,7 @@ class TestFakePipelineDB(unittest.TestCase):
 
         self.assertTrue(db.reset_to_wanted(
             42,
-            expected_status="manual",
+            expected_status="unsearchable",
             min_bitrate=224,
             prev_min_bitrate=256,
         ))
@@ -6135,8 +6120,8 @@ class TestFakeRequestUniqueMbReleaseId(unittest.TestCase):
         db.seed_request(make_request_row(
             id=1, mb_release_id="mbid-x", status="wanted"))
         db.seed_request(make_request_row(
-            id=1, mb_release_id="mbid-x", status="manual"))
-        self.assertEqual(db.request(1)["status"], "manual")
+            id=1, mb_release_id="mbid-x", status="unsearchable"))
+        self.assertEqual(db.request(1)["status"], "unsearchable")
 
     def test_seed_request_allows_multiple_null_mb_release_ids(self):
         # PG UNIQUE permits any number of NULLs (Discogs-only rows).

--- a/tests/test_field_resolver_service.py
+++ b/tests/test_field_resolver_service.py
@@ -1677,7 +1677,7 @@ class TestApplyResolveAllResult(unittest.TestCase):
             "track_artist": None,
         }])
         self.assertTrue(db.update_status(
-            request_id, "manual", expected_status="wanted",
+            request_id, "unsearchable", expected_status="wanted",
         ))
         before_row = copy.deepcopy(db.get_request(request_id))
         before_tracks = db.get_tracks(request_id)

--- a/tests/test_import_dispatch.py
+++ b/tests/test_import_dispatch.py
@@ -336,7 +336,7 @@ class TestRecordRejectionAndRequeueSeam(unittest.TestCase):
         from lib.dispatch import _record_rejection_and_maybe_requeue
 
         db = FakePipelineDB()
-        db.seed_request(make_request_row(id=42, status="manual"))
+        db.seed_request(make_request_row(id=42, status="unsearchable"))
 
         _record_rejection_and_maybe_requeue(
             db,  # type: ignore[arg-type]
@@ -643,7 +643,7 @@ class TestRejectImportFromEvidenceDecisionCallerLifecycle(unittest.TestCase):
 
     Automatic imports pass ``requeue_on_failure=True`` so a bad candidate
     self-heals to ``wanted``. Force imports pass False because the operator's
-    ``manual`` (next-step ``unsearchable``) status must not be cleared by a
+    ``unsearchable`` status must not be cleared by a
     candidate-integrity fact.
     """
 
@@ -797,10 +797,10 @@ class TestRejectImportFromEvidenceDecisionCallerLifecycle(unittest.TestCase):
             requeue_on_failure=False,
             pending=True,
             search_filetype_override=QUALITY_UPGRADE_TIERS,
-            initial_status="manual",
+            initial_status="unsearchable",
         )
 
-        self.assertEqual(db.request(42)["status"], "manual")
+        self.assertEqual(db.request(42)["status"], "unsearchable")
         self.assertEqual(db.download_logs[-1].outcome, "rejected")
         self.assertEqual(db.denylist, [])
         self.assertEqual(db.download_logs[-1].outcome, "rejected")
@@ -828,7 +828,7 @@ class TestHaveAnalysisErrorAbort(unittest.TestCase):
             db = FakePipelineDB()
             db.seed_request(make_request_row(
                 id=42,
-                status="manual" if force else "downloading",
+                status="unsearchable" if force else "downloading",
                 search_filetype_override="lossless",
                 active_download_state={"files": [], "filetype": "flac"},
             ))
@@ -918,7 +918,7 @@ class TestHaveAnalysisErrorAbort(unittest.TestCase):
         self._persist_failed_outcome(db, outcome)
 
         row = db.request(42)
-        self.assertEqual(row["status"], "manual")
+        self.assertEqual(row["status"], "unsearchable")
         self.assertEqual(row["validation_attempts"], 0)
         self.assertIsNone(row["next_retry_after"])
         self.assertEqual(row["search_filetype_override"], "lossless")
@@ -1196,11 +1196,11 @@ class TestDispatchImport(unittest.TestCase):
                         make_import_result(decision=decision),
                         scenario=scenario,
                         force=force,
-                        initial_status="manual",
+                        initial_status="unsearchable",
                         queued=True,
                     )
                     row = result["db"].request(42)
-                    self.assertEqual(row["status"], "manual")
+                    self.assertEqual(row["status"], "unsearchable")
                     self.assertEqual(
                         row["search_filetype_override"], expected_override)
                     self.assertEqual(
@@ -1614,7 +1614,7 @@ class TestDispatchImport(unittest.TestCase):
         self.assertEqual(db.download_logs[0].beets_scenario,
                          "duplicate_remove_guard_failed")
         self.assertEqual(db.request(42)["status"], "wanted")
-        self.assertNotEqual(db.request(42)["status"], "manual")
+        self.assertNotEqual(db.request(42)["status"], "unsearchable")
         self.assertEqual(len(db.denylist), 1)
         self.assertEqual(db.denylist[0].username, "user1")
         ext.cleanup.assert_not_called()

--- a/tests/test_import_manifest.py
+++ b/tests/test_import_manifest.py
@@ -120,7 +120,7 @@ class TestForceImportManifestGuard(unittest.TestCase):
         db.seed_request(make_request_row(
             id=42,
             mb_release_id="mbid-123",
-            status="manual",
+            status="unsearchable",
             artist_name="Bon Iver",
             album_title="Bon Iver",
         ))
@@ -173,7 +173,7 @@ class TestForceImportManifestGuard(unittest.TestCase):
         self.assertIn("12 Wash.opus", outcome.message)
         # The candidate fact is recorded, but the operator-owned search stop
         # and the Wrong Matches entry are both preserved.
-        self.assertEqual(db.request(42)["status"], "manual")
+        self.assertEqual(db.request(42)["status"], "unsearchable")
         outcomes = [(log.outcome, log.beets_scenario) for log in db.download_logs]
         self.assertIn(("rejected", "untracked_audio"), outcomes)
         rejection = next(
@@ -194,7 +194,7 @@ class TestForceImportManifestGuard(unittest.TestCase):
         db.seed_request(make_request_row(
             id=42,
             mb_release_id="mbid-123",
-            status="manual",
+            status="unsearchable",
         ))
         db.set_tracks(42, [{"track_number": 1, "title": "One"}])
 
@@ -225,7 +225,7 @@ class TestForceImportManifestGuard(unittest.TestCase):
         self.assertFalse(outcome.success)
         self.assertEqual(outcome.code, DISPATCH_CODE_IMPORT_MANIFEST_REJECTED)
         self.assertIn("manifest has 2 audio files", outcome.message)
-        self.assertEqual(db.request(42)["status"], "manual")
+        self.assertEqual(db.request(42)["status"], "unsearchable")
         outcomes = [(log.outcome, log.beets_scenario) for log in db.download_logs]
         self.assertIn(("rejected", "untracked_audio"), outcomes)
         self.assertEqual(len(db.denylist), 0)
@@ -235,7 +235,7 @@ class TestForceImportManifestGuard(unittest.TestCase):
         db.seed_request(make_request_row(
             id=42,
             mb_release_id="mbid-123",
-            status="manual",
+            status="unsearchable",
         ))
         db.set_tracks(42, [
             {"track_number": 1, "title": "One"},
@@ -258,7 +258,7 @@ class TestForceImportManifestGuard(unittest.TestCase):
         self.assertFalse(outcome.success)
         self.assertEqual(outcome.code, DISPATCH_CODE_IMPORT_MANIFEST_REJECTED)
         self.assertIn("3 audio files", outcome.message)
-        self.assertEqual(db.request(42)["status"], "manual")
+        self.assertEqual(db.request(42)["status"], "unsearchable")
         outcomes = [(log.outcome, log.beets_scenario) for log in db.download_logs]
         self.assertIn(("rejected", "untracked_audio"), outcomes)
         self.assertEqual(len(db.denylist), 0)
@@ -271,7 +271,7 @@ class TestForceImportManifestGuard(unittest.TestCase):
         db.seed_request(make_request_row(
             id=42,
             mb_release_id="mbid-123",
-            status="manual",
+            status="unsearchable",
         ))
 
         with tempfile.TemporaryDirectory() as root:
@@ -288,7 +288,7 @@ class TestForceImportManifestGuard(unittest.TestCase):
         self.assertFalse(outcome.success)
         self.assertEqual(outcome.code, DISPATCH_CODE_IMPORT_MANIFEST_REJECTED)
         self.assertIn("requires either an origin audio manifest", outcome.message)
-        self.assertEqual(db.request(42)["status"], "manual")
+        self.assertEqual(db.request(42)["status"], "unsearchable")
         outcomes = [(log.outcome, log.beets_scenario) for log in db.download_logs]
         self.assertIn(("rejected", "unverifiable_source"), outcomes)
         self.assertEqual(len(db.denylist), 0)
@@ -304,7 +304,7 @@ class TestForceImportManifestGuard(unittest.TestCase):
         db.seed_request(make_request_row(
             id=42,
             mb_release_id="mbid-123",
-            status="manual",
+            status="unsearchable",
         ))
         db.set_tracks(42, [
             {"track_number": 1, "title": "One"},
@@ -326,7 +326,7 @@ class TestForceImportManifestGuard(unittest.TestCase):
         # Preserve-folder code (importer skips deletion) — a non-empty source
         # must never route through the rmtree-ing QUALITY_PIPELINE_REJECTED.
         self.assertEqual(outcome.code, DISPATCH_CODE_IMPORT_MANIFEST_REJECTED)
-        self.assertEqual(db.request(42)["status"], "manual")
+        self.assertEqual(db.request(42)["status"], "unsearchable")
         outcomes = [(log.outcome, log.beets_scenario) for log in db.download_logs]
         self.assertIn(("rejected", "incomplete_fileset"), outcomes)
         # Missing audio is not the peer's fault — never denylist.
@@ -341,7 +341,7 @@ class TestForceImportManifestGuard(unittest.TestCase):
         db.seed_request(make_request_row(
             id=42,
             mb_release_id="mbid-123",
-            status="manual",
+            status="unsearchable",
         ))
         db.set_tracks(42, [
             {"track_number": 1, "title": "One"},
@@ -373,7 +373,7 @@ class TestForceImportManifestGuard(unittest.TestCase):
 
         self.assertFalse(outcome.success)
         self.assertEqual(outcome.code, DISPATCH_CODE_IMPORT_MANIFEST_REJECTED)
-        self.assertEqual(db.request(42)["status"], "manual")
+        self.assertEqual(db.request(42)["status"], "unsearchable")
         outcomes = [(log.outcome, log.beets_scenario) for log in db.download_logs]
         self.assertIn(("rejected", "incomplete_fileset"), outcomes)
         self.assertEqual(len(db.denylist), 0)

--- a/tests/test_import_one_stages.py
+++ b/tests/test_import_one_stages.py
@@ -104,7 +104,6 @@ class TestPipelineDbUpdate(unittest.TestCase):
 
         import_one.update_pipeline_db(
             42,
-            "imported",
             imported_path="/Beets/Artist/Album",
             distance=0.12,
             scenario="preflight_existing",
@@ -139,56 +138,10 @@ class TestPipelineDbUpdate(unittest.TestCase):
         stderr = io.StringIO()
 
         with patch("sys.stderr", stderr):
-            import_one.update_pipeline_db(42, "imported")
+            import_one.update_pipeline_db(42)
 
         self.assertEqual(db.close_calls, 1)
         self.assertIn("Pipeline DB update failed", stderr.getvalue())
-
-    @patch("harness.import_one.finalize_request")
-    @patch("lib.pipeline_db.PipelineDB")
-    def test_update_pipeline_db_distinguishes_transition_whitelist_errors(
-        self,
-        mock_db_cls,
-        mock_finalize,
-    ) -> None:
-        from harness import import_one
-
-        db = FakePipelineDB()
-        mock_db_cls.return_value = db
-        stderr = io.StringIO()
-
-        with patch("sys.stderr", stderr):
-            import_one.update_pipeline_db(
-                42,
-                "wanted",
-                imported_path="/Beets/Artist/Album",
-            )
-
-        mock_finalize.assert_not_called()
-        self.assertEqual(db.close_calls, 1)
-        self.assertIn("Pipeline DB transition rejected", stderr.getvalue())
-        self.assertIn("imported_path", stderr.getvalue())
-
-    @patch("harness.import_one.finalize_request")
-    @patch("lib.pipeline_db.PipelineDB")
-    def test_update_pipeline_db_rejects_unknown_status_and_closes_db(
-        self,
-        mock_db_cls,
-        mock_finalize,
-    ) -> None:
-        from harness import import_one
-
-        db = FakePipelineDB()
-        mock_db_cls.return_value = db
-        stderr = io.StringIO()
-
-        with patch("sys.stderr", stderr):
-            import_one.update_pipeline_db(42, "queued")
-
-        mock_finalize.assert_not_called()
-        self.assertEqual(db.close_calls, 1)
-        self.assertIn("Pipeline DB transition rejected", stderr.getvalue())
-        self.assertIn("queued", stderr.getvalue())
 
 
 # ============================================================================

--- a/tests/test_import_preview.py
+++ b/tests/test_import_preview.py
@@ -487,7 +487,7 @@ class TestImportPreviewPath(unittest.TestCase):
         db.seed_request(make_request_row(
             id=42,
             mb_release_id="mbid-42",
-            status="manual",
+            status="unsearchable",
             min_bitrate=180,
             current_lossless_source_v0_probe_min_bitrate=128,
             current_lossless_source_v0_probe_avg_bitrate=171,

--- a/tests/test_import_queue.py
+++ b/tests/test_import_queue.py
@@ -530,7 +530,7 @@ class TestImporterWorker(unittest.TestCase):
         db = FakePipelineDB()
         db.seed_request(make_request_row(
             id=42,
-            status="manual",
+            status="unsearchable",
             min_bitrate=116,
             verified_lossless=False,
             current_spectral_grade="likely_transcode",
@@ -640,7 +640,7 @@ class TestImporterWorker(unittest.TestCase):
             db.seed_request(make_request_row(
                 id=42,
                 mb_release_id="mbid-123",
-                status="manual",
+                status="unsearchable",
             ))
             log_id = self._log_wrong_match(db, failed_path=source)
             job = db.enqueue_import_job(
@@ -692,7 +692,7 @@ class TestImporterWorker(unittest.TestCase):
         through the REAL manifest guard (no mocked dispatch).
 
         Proves the two halves compose: the guard preserves the operator-owned
-        ``manual`` status AND its audit row does NOT inflate Wrong Matches,
+        ``unsearchable`` status AND its audit row does NOT inflate Wrong Matches,
         while the importer preserves the original WM entry for review (the
         ``IMPORT_MANIFEST_REJECTED`` code skips cleanup). beets never runs —
         the guard rejects upstream of it.
@@ -709,7 +709,7 @@ class TestImporterWorker(unittest.TestCase):
             db.seed_request(make_request_row(
                 id=42,
                 mb_release_id="mbid-123",
-                status="manual",
+                status="unsearchable",
             ))
             # One expected track but two audio files on disk → extra audio.
             db.set_tracks(42, [{"track_number": 1, "title": "One"}])
@@ -733,7 +733,7 @@ class TestImporterWorker(unittest.TestCase):
 
             assert updated is not None
             self.assertEqual(updated.status, "failed")
-            self.assertEqual(db.request(42)["status"], "manual")
+            self.assertEqual(db.request(42)["status"], "unsearchable")
             self.assertEqual(db.request(42)["validation_attempts"], 0)
             # The dead WM entry is preserved (extra audio → operator review),
             # and the audit row did NOT create a second entry.
@@ -776,7 +776,7 @@ class TestImporterWorker(unittest.TestCase):
             db.seed_request(make_request_row(
                 id=42,
                 mb_release_id="mbid-123",
-                status="manual",
+                status="unsearchable",
             ))
             db.set_tracks(42, [
                 {"track_number": 1, "title": "One"},
@@ -807,7 +807,7 @@ class TestImporterWorker(unittest.TestCase):
                 "under-count force-import must NOT delete the operator's folder")
             self.assertTrue(os.path.isfile(os.path.join(source, "01.mp3")))
             # The operator-owned request state is not this guard's to clear.
-            self.assertEqual(db.request(42)["status"], "manual")
+            self.assertEqual(db.request(42)["status"], "unsearchable")
             self.assertEqual(db.request(42)["validation_attempts"], 0)
             # WM entry preserved (something to inspect), no duplicate.
             self.assertEqual(len(db.get_wrong_matches()), 1)
@@ -2783,7 +2783,7 @@ class TestExecuteYoutubeImportJob(unittest.TestCase):
     """U9: importer dispatcher for ``youtube_import`` job_type.
 
     Covers AE7 (happy-path import to terminal state), AE8 (long-tail
-    rescue audit chain), AE9 (rescue from ``manual``), the preview-worker
+    rescue audit chain), AE9 (rescue from ``unsearchable``), the preview-worker
     front-gate path-resolution divergence, no-cooldown-leakage, and
     payload type-validation.
 
@@ -3058,9 +3058,9 @@ class TestExecuteYoutubeImportJob(unittest.TestCase):
         # Current category is cleared (the rescue IS the resolution).
         self.assertIsNone(row["unfindable_category"])
 
-    def test_rescue_from_manual_transitions_manual_to_imported(self):
-        """AE9: a request started in ``manual`` status transitions
-        ``manual → imported`` through the same single source-agnostic
+    def test_rescue_from_unsearchable_transitions_to_imported(self):
+        """AE9: a request started ``unsearchable`` transitions to
+        ``imported`` through the same single source-agnostic
         write site (``mark_imported_with_rescue``)."""
         from scripts import importer
         from lib import transitions
@@ -3069,9 +3069,9 @@ class TestExecuteYoutubeImportJob(unittest.TestCase):
             db = FakePipelineDB()
             db.seed_request(make_request_row(
                 id=42,
-                status="manual",
+                status="unsearchable",
                 active_download_state=None,
-                mb_release_id="mbid-yt-from-manual",
+                mb_release_id="mbid-yt-from-unsearchable",
                 unfindable_category="album_absent_artist_present",
                 unfindable_categorised_at=datetime(
                     2026, 5, 1, tzinfo=timezone.utc),
@@ -3087,11 +3087,13 @@ class TestExecuteYoutubeImportJob(unittest.TestCase):
                     cast(Any, db),
                     42,
                     transitions.RequestTransition.to_imported(
-                        from_status="manual",
+                        from_status="unsearchable",
                     ),
                 )
                 return CompletionDispatched(
-                    outcome=DispatchOutcome(True, "Imported from manual"))
+                    outcome=DispatchOutcome(
+                        True, "Imported from unsearchable"
+                    ))
 
             with patch(
                 "lib.download_processing.process_completed_album",

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -1823,7 +1823,7 @@ class TestForceImportSlice(unittest.TestCase):
 
         db = FakePipelineDB()
         db.seed_request(make_request_row(
-            id=42, status="manual", mb_release_id="mbid-123",
+            id=42, status="unsearchable", mb_release_id="mbid-123",
             min_bitrate=180, current_spectral_bitrate=128,
             # Stale distance from a prior auto-import attempt: the force
             # import (which bypasses the distance check, so no measurement
@@ -1904,7 +1904,7 @@ class TestForceImportSlice(unittest.TestCase):
         row = db.request(42)
         # Decision 19 keeps the quality/search policy identical; terminal
         # persistence preserves the current operator-owned search stop.
-        self.assertEqual(row["status"], "manual")
+        self.assertEqual(row["status"], "unsearchable")
         # #550 defect #4: force import bypasses the beets distance check —
         # no measurement exists, so the write is NULL (was a fabricated
         # 0.0), overwriting the stale 0.31 seeded above.
@@ -1931,7 +1931,7 @@ class TestForceImportSlice(unittest.TestCase):
 
         db = FakePipelineDB()
         db.seed_request(make_request_row(
-            id=833, status="manual", mb_release_id="mbid-go-team",
+            id=833, status="unsearchable", mb_release_id="mbid-go-team",
             imported_path="/mnt/virtio/music/slskd/failed_imports/stale-source",
         ))
         # Track rows satisfy the force-import untracked-audio guard.
@@ -2615,7 +2615,7 @@ class TestReleaseLockContention(unittest.TestCase):
                                      release_id_to_lock_key)
 
         db = FakePipelineDB()
-        # Force-import typically runs against an 'imported' or 'manual'
+        # Force-import typically runs against an 'imported' or 'unsearchable'
         # row; pick 'imported' as the representative starting state.
         db.seed_request(make_request_row(
             id=42, mb_release_id=self.MBID, status="imported"))
@@ -4194,10 +4194,8 @@ class TestSearchExhaustionResetsCounterSlice(unittest.TestCase):
     - happy path: search_log row written with outcome='exhausted'; the
       request stays ``wanted`` and ``search_attempts`` is reset to 0 so
       the variant ladder wraps back to default on the next cycle.
-    - re-queue via ``apply_transition`` (operator-driven manual→wanted)
-      clears ``manual_reason`` and ``search_attempts`` — this seam is
-      independent of the exhaustion path but worth covering since
-      ``manual_reason`` exists for future operator-hold workflows.
+    - re-queue via ``apply_transition`` (operator-driven
+      unsearchable→wanted) clears ``search_attempts``.
     """
 
     def setUp(self):
@@ -4277,7 +4275,6 @@ class TestSearchExhaustionResetsCounterSlice(unittest.TestCase):
         self.assertEqual(row["status"], "wanted")
         self.assertEqual(row["next_plan_ordinal"], 0)
         self.assertEqual(row["plan_cycle_count"], 0)
-        self.assertIsNone(row["manual_reason"])
         # Backoff applies (non-consuming method increments scheduler
         # counters), so the request is currently parked behind a
         # ``next_retry_after``. Asserting status alone is the right
@@ -4293,23 +4290,20 @@ class TestSearchExhaustionResetsCounterSlice(unittest.TestCase):
         db = FakePipelineDB()
         rid = db.add_request(
             artist_name="A", album_title="B", source="request",
-            mb_release_id="mb-req", status="manual",
+            mb_release_id="mb-req", status="unsearchable",
         )
-        # Simulate prior state: search_attempts=7, manual_reason populated.
-        db.update_request_fields(
-            rid, search_attempts=7, manual_reason="search_exhausted")
+        db.update_request_fields(rid, search_attempts=7)
 
         # The web UI button / pipeline-cli requeue / importer requeue all
-        # funnel through apply_transition('manual' -> 'wanted'). Cast to
+        # funnel through apply_transition('unsearchable' -> 'wanted'). Cast to
         # the concrete type — FakePipelineDB is duck-typed for the
         # methods apply_transition uses (get_request, reset_to_wanted).
         apply_transition(
-            cast(PipelineDB, db), rid, "wanted", from_status="manual")
+            cast(PipelineDB, db), rid, "wanted", from_status="unsearchable")
 
         row = db.request(rid)
         self.assertEqual(row["status"], "wanted")
         self.assertEqual(row["search_attempts"], 0)
-        self.assertIsNone(row["manual_reason"])
         # Re-queued request is back in the wanted pool.
         wanted_ids = [r["id"] for r in db.get_wanted()]
         self.assertIn(rid, wanted_ids)
@@ -4423,7 +4417,7 @@ class TestImportSubprocessStartedFlag(unittest.TestCase):
 
         db = FakePipelineDB()
         db.seed_request(make_request_row(
-            id=42, status="manual",
+            id=42, status="unsearchable",
             mb_release_id="mbid-123",
         ))
         existing = ActiveDownloadState(
@@ -6064,7 +6058,7 @@ class TestImporterRequeueToPreviewSlice(unittest.TestCase):
             db.seed_request(make_request_row(
                 id=42,
                 mb_release_id="mbid-requeue",
-                status="manual",
+                status="unsearchable",
                 artist_name="A",
                 album_title="B",
             ))
@@ -6376,7 +6370,7 @@ class TestU5PreviewWorkerLifecycleSlice(unittest.TestCase):
         )
         db.seed_request(make_request_row(
             id=request_id,
-            status="manual",
+            status="unsearchable",
             mb_release_id="mbid-u5",
         ))
         download_log_id = db.log_download(
@@ -6398,7 +6392,7 @@ class TestU5PreviewWorkerLifecycleSlice(unittest.TestCase):
 
     def test_ae6_source_vanished_preserves_operator_status(self):
         """AE6: ffmpeg ENOENT during measurement → measurement_failed,
-        request remains manual, job → failed, download_log carries the typed
+        request remains unsearchable, job → failed, download_log carries the typed
         payload."""
         from lib.import_preview import ImportPreviewResult
         from lib.quality import MeasurementFailure
@@ -6435,7 +6429,7 @@ class TestU5PreviewWorkerLifecycleSlice(unittest.TestCase):
         # Worker surface: preview_status reflects the new state, job failed.
         self.assertEqual(updated.preview_status, "measurement_failed")
         self.assertEqual(updated.status, "failed")
-        self.assertEqual(db.request(42)["status"], "manual")
+        self.assertEqual(db.request(42)["status"], "unsearchable")
         # Two download_log rows: the original rejected entry + the new
         # measurement_failed one.
         outcomes = [log.outcome for log in db.download_logs]
@@ -6449,7 +6443,7 @@ class TestU5PreviewWorkerLifecycleSlice(unittest.TestCase):
 
     def test_ae5_snapshot_stale_preserves_operator_status(self):
         """AE5: snapshot mismatch after retry → measurement_failed,
-        request remains manual."""
+        request remains unsearchable."""
         from lib.import_preview import ImportPreviewResult
         from lib.quality import MeasurementFailure
         from scripts import import_preview_worker
@@ -6483,7 +6477,7 @@ class TestU5PreviewWorkerLifecycleSlice(unittest.TestCase):
 
         assert updated is not None
         self.assertEqual(updated.preview_status, "measurement_failed")
-        self.assertEqual(db.request(43)["status"], "manual")
+        self.assertEqual(db.request(43)["status"], "unsearchable")
 
     def test_request_not_found_no_finalize_subcase(self):
         """request_id=None subcase: the self-heal helper raises (the
@@ -6631,7 +6625,7 @@ class TestU6ImporterPreimportDecideSlice(unittest.TestCase):
     entry point), and asserts the rejection side effects fire:
 
       * ``download_log`` row with the reject scenario and validation_result
-      * operator-owned request status stays ``manual``
+      * operator-owned request status stays ``unsearchable``
       * beets is NEVER touched (``sp.run`` is asserted not-called)
       * staged dir cleanup happens for auto-import scenarios
 
@@ -6656,7 +6650,7 @@ class TestU6ImporterPreimportDecideSlice(unittest.TestCase):
 
         db.seed_request(make_request_row(
             id=request_id,
-            status="manual",
+            status="unsearchable",
             mb_release_id=f"mbid-u6-{request_id}",
             artist_name="Test Artist",
             album_title="Test Album",
@@ -6813,7 +6807,7 @@ class TestU6ImporterPreimportDecideSlice(unittest.TestCase):
 
     def test_audio_corrupt_evidence_preserves_operator_status(self):
         """AE2: candidate evidence with audio_corrupt=True → preimport_decide
-        rejects without clearing manual, download_log carries the scenario,
+        rejects without clearing unsearchable, download_log carries the scenario,
         beets (sp.run) is never invoked."""
         import msgspec
         from lib.quality import SpectralAnalysisDetail, SpectralDetail
@@ -6843,7 +6837,7 @@ class TestU6ImporterPreimportDecideSlice(unittest.TestCase):
             # Need to enqueue first to get the job id for owner_id
             from lib.import_queue import IMPORT_JOB_FORCE
             db.seed_request(make_request_row(
-                id=42, status="manual", mb_release_id="mbid-u6-corrupt",
+                id=42, status="unsearchable", mb_release_id="mbid-u6-corrupt",
             ))
             # Track rows satisfy the force-import untracked-audio guard.
             db.set_tracks(42, [{"track_number": 1, "title": "Track"}])
@@ -6887,7 +6881,7 @@ class TestU6ImporterPreimportDecideSlice(unittest.TestCase):
             "beets import_one.py must not run when preimport_decide rejects")
         # Force rejection must not clear the operator-owned search short-circuit.
         row = db.request(42)
-        self.assertEqual(row["status"], "manual")
+        self.assertEqual(row["status"], "unsearchable")
         self.assertEqual(row["validation_attempts"], 0)
         # download_log row records the rejection scenario.
         outcomes = [(log.outcome, log.beets_scenario) for log in db.download_logs]
@@ -6903,7 +6897,7 @@ class TestU6ImporterPreimportDecideSlice(unittest.TestCase):
         )
 
     def test_nested_layout_evidence_preserves_operator_status(self):
-        """AE3: nested evidence rejects without clearing manual status."""
+        """AE3: nested evidence rejects without clearing unsearchable."""
         from lib.quality_evidence import snapshot_audio_files
 
         db = FakePipelineDB()
@@ -6916,7 +6910,7 @@ class TestU6ImporterPreimportDecideSlice(unittest.TestCase):
             files = snapshot_audio_files(tmpdir)
             from lib.import_queue import IMPORT_JOB_FORCE
             db.seed_request(make_request_row(
-                id=43, status="manual", mb_release_id="mbid-u6-nested",
+                id=43, status="unsearchable", mb_release_id="mbid-u6-nested",
             ))
             # Track rows satisfy the force-import untracked-audio guard.
             db.set_tracks(43, [{"track_number": 1, "title": "Track"}])
@@ -6944,7 +6938,7 @@ class TestU6ImporterPreimportDecideSlice(unittest.TestCase):
         self.assertIn("nested_layout", result.message or "")
         self.assertEqual(ext.run.call_count, 0)
         row = db.request(43)
-        self.assertEqual(row["status"], "manual")
+        self.assertEqual(row["status"], "unsearchable")
         outcomes = [(log.outcome, log.beets_scenario) for log in db.download_logs]
         self.assertIn(("rejected", "nested_layout"), outcomes)
         # nested_layout is a folder-shape problem, not a peer-quality problem
@@ -6965,7 +6959,7 @@ class TestU6ImporterPreimportDecideSlice(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             from lib.import_queue import IMPORT_JOB_FORCE
             db.seed_request(make_request_row(
-                id=44, status="manual", mb_release_id="mbid-u6-empty",
+                id=44, status="unsearchable", mb_release_id="mbid-u6-empty",
             ))
             job = db.enqueue_import_job(
                 IMPORT_JOB_FORCE,
@@ -6992,7 +6986,7 @@ class TestU6ImporterPreimportDecideSlice(unittest.TestCase):
         self.assertIn("empty_fileset", result.message or "")
         self.assertEqual(ext.run.call_count, 0)
         row = db.request(44)
-        self.assertEqual(row["status"], "manual")
+        self.assertEqual(row["status"], "unsearchable")
         outcomes = [(log.outcome, log.beets_scenario) for log in db.download_logs]
         self.assertIn(("rejected", "empty_fileset"), outcomes)
         # empty_fileset is a missing-audio fault, not a peer-quality problem —
@@ -7013,7 +7007,7 @@ class TestU6ImporterPreimportDecideSlice(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             from lib.import_queue import IMPORT_JOB_FORCE
             db.seed_request(make_request_row(
-                id=46, status="manual", mb_release_id="mbid-u6-empty-tracks",
+                id=46, status="unsearchable", mb_release_id="mbid-u6-empty-tracks",
             ))
             db.set_tracks(46, [{"track_number": 1, "title": "Track"}])
             job = db.enqueue_import_job(
@@ -7041,7 +7035,7 @@ class TestU6ImporterPreimportDecideSlice(unittest.TestCase):
         self.assertIn("empty_fileset", result.message or "")
         self.assertEqual(ext.run.call_count, 0)
         row = db.request(46)
-        self.assertEqual(row["status"], "manual")
+        self.assertEqual(row["status"], "unsearchable")
         outcomes = [(log.outcome, log.beets_scenario) for log in db.download_logs]
         self.assertIn(("rejected", "empty_fileset"), outcomes)
 
@@ -7074,7 +7068,7 @@ class TestU6ImporterPreimportDecideSlice(unittest.TestCase):
             ]
             from lib.import_queue import IMPORT_JOB_FORCE
             db.seed_request(make_request_row(
-                id=45, status="manual", mb_release_id="mbid-u6-spectral",
+                id=45, status="unsearchable", mb_release_id="mbid-u6-spectral",
                 current_spectral_grade="likely_transcode",
                 current_spectral_bitrate=128,
             ))
@@ -7343,7 +7337,7 @@ class TestPreviewWorkerNeverDecidesSlice(unittest.TestCase):
         )
         db.seed_request(make_request_row(
             id=request_id,
-            status="manual",
+            status="unsearchable",
             mb_release_id=f"mbid-bocfix-{request_id}",
             artist_name="Boards of Canada",
             album_title="Geogaddi",
@@ -7548,7 +7542,7 @@ class TestPreviewWorkerNeverDecidesSlice(unittest.TestCase):
             assert updated is not None
             self.assertEqual(updated.preview_status, "measurement_failed")
             self.assertEqual(updated.status, "failed")
-            self.assertEqual(db.request(41)["status"], "manual")
+            self.assertEqual(db.request(41)["status"], "unsearchable")
             failures = [
                 log for log in db.download_logs
                 if log.outcome == "measurement_failed"
@@ -7704,7 +7698,7 @@ class TestPreviewWorkerNeverDecidesSlice(unittest.TestCase):
             # The non-quality failure is explicit in the audit trail.
             outcomes = [(log.outcome, log.beets_scenario) for log in db.download_logs]
             self.assertIn(("have_analysis_error", "have_analysis_error"), outcomes)
-            self.assertEqual(db.request(42)["status"], "manual")
+            self.assertEqual(db.request(42)["status"], "unsearchable")
 
     def test_clean_upgrade_persists_evidence_and_importer_accepts(self):
         """Happy path: suspect spectral but a clear bitrate upgrade.
@@ -7878,7 +7872,7 @@ class TestPreviewWorkerNeverDecidesSlice(unittest.TestCase):
             self.assertEqual(result.code, "have_analysis_error")
             self.assertIn("Installed HAVE analysis failed", result.message or "")
             self.assertEqual(ext.run.call_count, 0)
-            self.assertEqual(db.request(44)["status"], "manual")
+            self.assertEqual(db.request(44)["status"], "unsearchable")
             outcomes = [(log.outcome, log.beets_scenario) for log in db.download_logs]
             self.assertIn(("have_analysis_error", "have_analysis_error"), outcomes)
 
@@ -7896,7 +7890,7 @@ class TestWrongMatchCleanupFKChainAvoidsRemeasurement(unittest.TestCase):
         from tests.helpers import make_request_row as _make_req
         db = FakePipelineDB()
         db.seed_request(_make_req(
-            id=1, status="manual", mb_release_id="mbid-1",
+            id=1, status="unsearchable", mb_release_id="mbid-1",
         ))
         db.log_download(
             1,
@@ -8078,7 +8072,7 @@ class TestWrongMatchStaleEvidenceRefreshSlice(unittest.TestCase):
 
             db = FakePipelineDB()
             db.seed_request(make_request_row(
-                id=1, status="manual", mb_release_id="mbid-1",
+                id=1, status="unsearchable", mb_release_id="mbid-1",
             ))
             db.log_download(
                 1,
@@ -8330,7 +8324,7 @@ class TestWrongMatchTriageRejectsSameSourceDuplicate(unittest.TestCase):
         db = FakePipelineDB()
         db.seed_request(make_request_row(
             id=3779,
-            status="manual",
+            status="unsearchable",
             mb_release_id=self.MB_RELEASE_ID,
         ))
 
@@ -8465,7 +8459,7 @@ class TestWrongMatchTriageRejectsSameSourceDuplicate(unittest.TestCase):
         db = FakePipelineDB()
         db.seed_request(make_request_row(
             id=3780,
-            status="manual",
+            status="unsearchable",
             mb_release_id=self.MB_RELEASE_ID,
         ))
 
@@ -8543,7 +8537,7 @@ class TestWrongMatchTriageRejectsSameSourceDuplicate(unittest.TestCase):
         # must compress it to "lossless".
         db.seed_request(make_request_row(
             id=3781,
-            status="manual",
+            status="unsearchable",
             mb_release_id=self.MB_RELEASE_ID,
             search_filetype_override=QUALITY_UPGRADE_TIERS,
         ))
@@ -9997,10 +9991,10 @@ class TestReplaceFullPath(unittest.TestCase):
         self.assertIsNone(new["active_download_state"])
 
     def test_manual_variant(self):
-        """``status='manual'`` behaves like ``wanted`` for fs cleanup:
+        """``status='unsearchable'`` behaves like ``wanted`` for fs cleanup:
         the old release is displaced whenever its id resolves."""
         from lib.mbid_replace_service import RESULT_REPLACED
-        _db, result, _, _, mocks = self._run(old_status="manual")
+        _db, result, _, _, mocks = self._run(old_status="unsearchable")
         self.assertEqual(result.outcome, RESULT_REPLACED)
         mocks["remove"].assert_called_once()
 

--- a/tests/test_js_artist_page.mjs
+++ b/tests/test_js_artist_page.mjs
@@ -468,11 +468,11 @@ console.log('ownership credit variants preserve the established contract');
     'foreign credit lands in Other releases');
 }
 
-console.log('in-flight lens includes downloading/manual and excludes ambient states');
+console.log('in-flight lens includes only downloading requests');
 {
   const albums = [
     library({ id: 1, album: 'DL', pipeline_status: 'downloading', pipeline_id: 11 }),
-    library({ id: 2, album: 'Manual', pipeline_status: 'manual', pipeline_id: 12 }),
+    library({ id: 2, album: 'Stopped', pipeline_status: 'unsearchable', pipeline_id: 12 }),
     library({ id: 3, album: 'Wanted', pipeline_status: 'wanted', pipeline_id: 13 }),
     library({ id: 4, album: 'Imported', pipeline_status: 'imported', pipeline_id: 14 }),
     library({ id: 5, album: 'None', pipeline_status: null }),
@@ -482,8 +482,8 @@ console.log('in-flight lens includes downloading/manual and excludes ambient sta
     }),
   ];
   assertEqual(classify([], albums).inFlight.map(row => row.album).join(','),
-    'DL,Manual,Pipeline-only DL',
-    'downloading/manual are visible regardless of library ownership');
+    'DL,Pipeline-only DL',
+    'downloading is visible regardless of library ownership');
 }
 
 console.log('empty and orphan-only artist worlds remain renderable');

--- a/tests/test_js_discography.mjs
+++ b/tests/test_js_discography.mjs
@@ -130,7 +130,7 @@ console.log('splitPressings() — partition + hoist invariants over the status/o
     { in_library: false, pipeline_status: 'downloading' },
     { in_library: true, pipeline_status: 'wanted' },
     { in_library: false, pipeline_status: 'imported' },
-    { in_library: false, pipeline_status: 'manual' },
+    { in_library: false, pipeline_status: 'unsearchable' },
     { in_library: false, pipeline_status: 'replaced' },
     { in_library: true, pipeline_status: 'replaced' },
   ];

--- a/tests/test_js_library.mjs
+++ b/tests/test_js_library.mjs
@@ -4,7 +4,9 @@
  */
 
 import {
+  banSourceConfirmationMessage,
   buildDeleteConfirmHtml,
+  describeBanSourceSuccess,
   describeBeetsDeletion,
   renderLibraryDetailBody,
 } from '../web/js/library.js';
@@ -130,16 +132,39 @@ function expectedJsArg(value) {
     .replace(/\\/g, '&#92;');
 }
 
-function libraryDetail(releaseId) {
+function libraryDetail(releaseId, pipelineStatus = 'wanted') {
   return renderLibraryDetailBody({
     mb_albumid: releaseId,
     pipeline_id: 1712,
-    pipeline_status: 'wanted',
+    pipeline_status: pipelineStatus,
     pipeline_source: 'request',
     artist: 'Artist',
     album: 'Album',
     tracks: [],
   }, 42);
+}
+
+console.log('Bad Rip copy distinguishes requeue from preserved search stop');
+{
+  const confirmation = banSourceConfirmationMessage();
+  assertContains(confirmation, 'remain unsearchable', 'confirmation explains preserved stop');
+  assertContains(confirmation, 'reset to wanted', 'confirmation explains ordinary requeue');
+  assertContains(
+    describeBanSourceSuccess({
+      request_status: 'unsearchable', username: 'bad-peer',
+      beets_removed: true, hashes_recorded: 2,
+    }),
+    'remains unsearchable',
+    'success copy reports the preserved search stop',
+  );
+  assertContains(
+    describeBanSourceSuccess({
+      request_status: 'wanted', username: null,
+      beets_removed: false, hashes_recorded: 0,
+    }),
+    'requeued as wanted',
+    'success copy reports the ordinary requeue',
+  );
 }
 
 console.log('Library quality controls — adversarial deterministic release-id pin');
@@ -179,6 +204,26 @@ console.log('Library quality controls — generated critical-character property 
   try { new Function('window', oldHandler); } catch (_) { oldCompiles = false; }
   if (!oldCompiles) passed++;
   else { failed++; console.error('  FAIL: known-bad raw library interpolation unexpectedly compiles'); }
+}
+
+console.log('Library status controls disable invalid unsearchable transitions');
+{
+  const imported = libraryDetail('release-id', 'imported');
+  assertContains(imported, "class=\"p-btn active-status\" onclick=\"event.stopPropagation(); window.setLibQuality(&quot;release-id&quot;, 'imported', null)\">imported</button>", 'imported remains visibly current');
+  assertExcludes(imported, "window.setLibQuality(&quot;release-id&quot;, 'unsearchable'", 'imported cannot invoke unsearchable');
+  assertContains(imported, 'disabled aria-disabled="true">unsearchable</button>', 'invalid imported stop is disabled');
+
+  const downloading = libraryDetail('release-id', 'downloading');
+  assertContains(downloading, 'disabled aria-disabled="true">downloading</button>', 'downloading remains visibly current');
+  assertExcludes(downloading, "window.setLibQuality(&quot;release-id&quot;, 'unsearchable'", 'downloading cannot invoke unsearchable');
+  assertContains(downloading, 'disabled aria-disabled="true">unsearchable</button>', 'invalid downloading stop is disabled');
+
+  const wanted = libraryDetail('release-id', 'wanted');
+  assertContains(wanted, "window.setLibQuality(&quot;release-id&quot;, 'unsearchable', null)", 'wanted may become unsearchable');
+
+  const stopped = libraryDetail('release-id', 'unsearchable');
+  assertContains(stopped, "window.setLibQuality(&quot;release-id&quot;, 'unsearchable', null)", 'current unsearchable state remains an active control');
+  assertContains(stopped, 'class="p-btn active-status"', 'unsearchable remains visibly current');
 }
 
 console.log(`\n${passed} passed, ${failed} failed`);

--- a/tests/test_js_library.mjs
+++ b/tests/test_js_library.mjs
@@ -148,7 +148,7 @@ console.log('Library quality controls — adversarial deterministic release-id p
   const html = libraryDetail(id);
   const arg = expectedJsArg(id);
   assertContains(html, `window.setLibQuality(${arg}, 'wanted', null)`, 'wanted control encodes release id');
-  assertContains(html, `window.setLibQuality(${arg}, 'manual', null)`, 'manual control encodes release id');
+  assertContains(html, `window.setLibQuality(${arg}, 'unsearchable', null)`, 'unsearchable control encodes release id');
   assertContains(html, `window.setLibQuality(${arg}, null, parseInt(v))`, 'min-bitrate control encodes release id');
   assertExcludes(html, `window.setLibQuality('${id}'`, 'known-bad raw single-quoted interpolation is absent');
 }

--- a/tests/test_js_pipeline.mjs
+++ b/tests/test_js_pipeline.mjs
@@ -44,6 +44,25 @@ console.log('renderPipelineNav() refreshes the dashboard subtab');
   assertContains(html, 'window.loadPipelineDashboard()', 'dashboard refresh reloads dashboard metrics');
   assertContains(html, 'subtab-refresh', 'refresh uses shared subtab layout');
 }
+console.log('pipeline status controls disable invalid unsearchable transitions');
+{
+  const imported = __test__.renderPipelineStatusButtons(42, 'imported');
+  assertContains(imported, "class=\"p-btn active-status\" onclick=\"event.stopPropagation(); window.updateStatus(42, 'imported')\">imported</button>", 'imported remains visibly current');
+  assertExcludes(imported, "window.updateStatus(42, 'unsearchable')", 'imported cannot invoke unsearchable');
+  assertContains(imported, 'disabled aria-disabled="true">unsearchable</button>', 'invalid imported stop is disabled');
+
+  const downloading = __test__.renderPipelineStatusButtons(42, 'downloading');
+  assertContains(downloading, 'disabled aria-disabled="true">downloading</button>', 'downloading remains visibly current');
+  assertExcludes(downloading, "window.updateStatus(42, 'unsearchable')", 'downloading cannot invoke unsearchable');
+  assertContains(downloading, 'disabled aria-disabled="true">unsearchable</button>', 'invalid downloading stop is disabled');
+
+  const wanted = __test__.renderPipelineStatusButtons(42, 'wanted');
+  assertContains(wanted, "window.updateStatus(42, 'unsearchable')", 'wanted may become unsearchable');
+
+  const stopped = __test__.renderPipelineStatusButtons(42, 'unsearchable');
+  assertContains(stopped, "window.updateStatus(42, 'unsearchable')", 'current unsearchable state remains an active control');
+  assertContains(stopped, 'class="p-btn active-status"', 'unsearchable remains visibly current');
+}
 console.log('request detail caps history and collapses tracks');
 {
   const history = Array.from({ length: 12 }, (_, id) => ({

--- a/tests/test_js_release_actions.mjs
+++ b/tests/test_js_release_actions.mjs
@@ -271,7 +271,7 @@ clearStore();
   const state = buildReleaseActionState({
     id: 'rel-14',
     in_library: false,
-    pipeline_status: 'manual',
+    pipeline_status: 'unsearchable',
     pipeline_id: 600,
   });
   const html = renderAcquireActionButton(state, { hideDisabled: true });
@@ -308,7 +308,7 @@ clearStore();
     { in_library: false, beets_album_id: null, pipeline_status: 'wanted', pipeline_id: 101 },
     { in_library: false, beets_album_id: null, pipeline_status: 'downloading', pipeline_id: 102 },
     { in_library: false, beets_album_id: null, pipeline_status: 'imported', pipeline_id: 103 },
-    { in_library: false, beets_album_id: null, pipeline_status: 'manual', pipeline_id: 104 },
+    { in_library: false, beets_album_id: null, pipeline_status: 'unsearchable', pipeline_id: 104 },
     { in_library: true, beets_album_id: null, pipeline_status: null, pipeline_id: null },
     { in_library: true, beets_album_id: 42, pipeline_status: null, pipeline_id: null },
     { in_library: true, beets_album_id: 43, pipeline_status: 'wanted', pipeline_id: 105 },
@@ -338,19 +338,19 @@ clearStore();
   }
 }
 
-console.log('Acquire button — manual review → disabled Add request');
+console.log('Acquire button — unsearchable → disabled Add request');
 clearStore();
 {
   const state = buildReleaseActionState({
     id: 'rel-8',
     in_library: false,
-    pipeline_status: 'manual',
+    pipeline_status: 'unsearchable',
     pipeline_id: 600,
   });
   const html = renderActionToolbar(state);
-  assertContains(html, '>Add request</button>', 'manual falls through to disabled Add request');
-  assertExcludes(html, 'window.addRelease', 'Add disabled in manual state');
-  assertExcludes(html, 'window.disambRemove', 'no Remove handler in manual state');
+  assertContains(html, '>Add request</button>', 'unsearchable falls through to disabled Add request');
+  assertExcludes(html, 'window.addRelease', 'Add disabled in unsearchable state');
+  assertExcludes(html, 'window.disambRemove', 'no Remove handler in unsearchable state');
 }
 
 console.log('Acquire button — minimal input never crashes');

--- a/tests/test_js_util.mjs
+++ b/tests/test_js_util.mjs
@@ -3,7 +3,7 @@
  * Run with: node tests/test_js_util.mjs
  */
 
-import { qualityLabel, qualityLabelShort, toAWST, awstDate, awstTime, awstDateTime, esc, jsArg, overrideToIntent, detectSource, externalReleaseUrl, sourceLabel, youtubeBrowseUrl, manualReasonLabel, renderForensicBlock, parsePastedId, youtubeSectionState, consoleEmphasis } from '../web/js/util.js';
+import { qualityLabel, qualityLabelShort, toAWST, awstDate, awstTime, awstDateTime, esc, jsArg, overrideToIntent, detectSource, externalReleaseUrl, sourceLabel, youtubeBrowseUrl, renderForensicBlock, parsePastedId, youtubeSectionState, consoleEmphasis } from '../web/js/util.js';
 import { state } from '../web/js/state.js';
 import { applyLabelFilters, sortByYearDesc, buildLabelSearchUrl, buildLabelDetailUrl, loadLabelReleases, parseYear, renderLabelLinks, distinctFormats, renderPaginationControls, renderLabelRows } from '../web/js/labels.js';
 import { __test__ as longTailTest } from '../web/js/long_tail.js';
@@ -487,16 +487,6 @@ assertEqual(nanBoth.length, 3, 'both NaN bounds → no filter');
 const mixedNan = applyLabelFilters(NAN_ROWS, { yearMin: NaN, yearMax: 2005 });
 assertEqual(mixedNan.map(r => r.id).join(','), '1',
   'valid yearMax with NaN yearMin still filters correctly');
-
-// --- manualReasonLabel tests ---
-console.log('manualReasonLabel()');
-assertEqual(manualReasonLabel(null), '', 'null → empty string');
-assertEqual(manualReasonLabel(undefined), '', 'undefined → empty string');
-assertEqual(manualReasonLabel(''), '', 'empty string → empty string');
-assertEqual(manualReasonLabel('search_exhausted'), 'search exhausted',
-  'search_exhausted → friendly label');
-assertEqual(manualReasonLabel('custom_reason'), 'custom_reason',
-  'unknown reason passes through unchanged');
 
 // --- renderForensicBlock tests ---
 console.log('renderForensicBlock()');

--- a/tests/test_library_album_detail_service.py
+++ b/tests/test_library_album_detail_service.py
@@ -215,7 +215,7 @@ class TestLibraryAlbumDetailService(unittest.TestCase):
             pipeline_request=make_request_row(
                 id=42,
                 mb_release_id=RELEASE_ID,
-                status="manual",
+                status="unsearchable",
                 source="request",
             ),
             download_history=[_history_row(

--- a/tests/test_mbid_replace_service.py
+++ b/tests/test_mbid_replace_service.py
@@ -1196,7 +1196,7 @@ class TestReplaceHappyPath(_ServiceCase):
         self.assertEqual(kwargs.get("clear_pipeline_state"), False)
 
     @given(old_status=st.sampled_from(
-        ["wanted", "downloading", "manual", "imported"]))
+        ["wanted", "downloading", "unsearchable", "imported"]))
     def test_replace_displaces_old_install_for_every_source_status(
         self, old_status,
     ):
@@ -1231,7 +1231,7 @@ class TestReplaceHappyPath(_ServiceCase):
 
     def test_happy_path_manual(self):
         self._patch_externals()
-        db, _, svc = self._replace(old_status="manual")
+        db, _, svc = self._replace(old_status="unsearchable")
         result = svc.replace_request_mbid(
             42, target_mb_release_id=NEW_MBID,
         )

--- a/tests/test_migrator.py
+++ b/tests/test_migrator.py
@@ -3983,7 +3983,10 @@ class TestUnsearchableRequestStatusMigration(unittest.TestCase):
                             FROM album_requests
                             WHERE mb_release_id = 'manual-before-056'
                         """)
-                        status, timestamp_preserved = cur.fetchone()
+                        row = cur.fetchone()
+                        self.assertIsNotNone(row)
+                        assert row is not None
+                        status, timestamp_preserved = row
                         self.assertEqual(status, "unsearchable")
                         self.assertTrue(timestamp_preserved)
                         cur.execute("""

--- a/tests/test_migrator.py
+++ b/tests/test_migrator.py
@@ -3385,7 +3385,7 @@ class TestPinStatusDomainMigration(unittest.TestCase):
         dsn = _create_fresh_database(name)
         try:
             applied = apply_migrations(dsn, DEFAULT_MIGRATIONS_DIR)
-            self.assertEqual(applied[-1].version, 55)
+            self.assertEqual(applied[-1].version, 56)
             self.assertEqual(
                 self._query(
                     dsn,
@@ -3928,6 +3928,77 @@ class TestEvidenceTwoAxisVocabularyMigration(unittest.TestCase):
                                     'fp-invalid-version-055',
                                     '/invalid-version', NOW(), 2
                                 )
+                            """)
+                finally:
+                    conn.close()
+        finally:
+            _drop_database(name)
+
+
+@requires_postgres
+class TestUnsearchableRequestStatusMigration(unittest.TestCase):
+    """Migration 056 renames lifecycle state without rewriting timestamps."""
+
+    def _copy_through(self, target: str, version: int) -> None:
+        for migration in discover_migrations(DEFAULT_MIGRATIONS_DIR):
+            if migration.version <= version:
+                shutil.copy2(migration.path, target)
+
+    def test_renames_manual_rows_drops_dead_reason_and_closes_domain(self) -> None:
+        name = "cratedigger_test_unsearchable_status_056"
+        dsn = _create_fresh_database(name)
+        try:
+            with tempfile.TemporaryDirectory() as migrations_dir:
+                self._copy_through(migrations_dir, 55)
+                apply_migrations(dsn, migrations_dir)
+                conn = psycopg2.connect(dsn)
+                conn.autocommit = True
+                try:
+                    with conn.cursor() as cur:
+                        cur.execute("""
+                            INSERT INTO album_requests (
+                                mb_release_id, artist_name, album_title,
+                                source, status, manual_reason, updated_at
+                            ) VALUES (
+                                'manual-before-056', 'Artist', 'Album',
+                                'request', 'manual', 'obsolete',
+                                '2000-01-02T03:04:05Z'
+                            )
+                        """)
+                finally:
+                    conn.close()
+
+                self._copy_through(migrations_dir, 56)
+                applied = apply_migrations(dsn, migrations_dir)
+                self.assertEqual([migration.version for migration in applied], [56])
+
+                conn = psycopg2.connect(dsn)
+                conn.autocommit = True
+                try:
+                    with conn.cursor() as cur:
+                        cur.execute("""
+                            SELECT status,
+                                   updated_at =
+                                       '2000-01-02T03:04:05Z'::timestamptz
+                            FROM album_requests
+                            WHERE mb_release_id = 'manual-before-056'
+                        """)
+                        status, timestamp_preserved = cur.fetchone()
+                        self.assertEqual(status, "unsearchable")
+                        self.assertTrue(timestamp_preserved)
+                        cur.execute("""
+                            SELECT column_name
+                            FROM information_schema.columns
+                            WHERE table_schema = 'public'
+                              AND table_name = 'album_requests'
+                              AND column_name = 'manual_reason'
+                        """)
+                        self.assertIsNone(cur.fetchone())
+                        with self.assertRaises(psycopg2.errors.CheckViolation):
+                            cur.execute("""
+                                INSERT INTO album_requests (
+                                    artist_name, album_title, source, status
+                                ) VALUES ('A', 'B', 'request', 'manual')
                             """)
                 finally:
                     conn.close()

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -25,6 +25,7 @@ import scripts.pipeline_cli.long_tail as pipeline_cli_long_tail
 from scripts import pipeline_cli
 from tests.fakes import FakeBeetsDB, FakePipelineDB
 from tests.helpers import make_album_quality_evidence, make_request_row
+from lib.destructive_release_service import BanSourceSuccess
 from lib.transitions import TransitionConflict, TransitionConflictKind
 from tests.test_beets_db import _create_test_db, _insert_album
 
@@ -4530,6 +4531,38 @@ class TestDestructiveCliAdapters(unittest.TestCase):
         self.assertEqual(rc, 3)
         self.assertEqual(json.loads(output.getvalue())["error"], "release_mismatch")
         self.assertEqual(db.denylist, [])
+
+    @patch("scripts.pipeline_cli.destructive.ban_source")
+    def test_ban_source_success_reports_resulting_searchability(
+        self, mock_ban_source,
+    ) -> None:
+        db = FakePipelineDB()
+        args = SimpleNamespace(
+            request_id=41,
+            release_id=RELEASE_A,
+            beets_db=self.beets_path,
+        )
+        for request_status in ("wanted", "unsearchable"):
+            with self.subTest(request_status=request_status):
+                mock_ban_source.return_value = BanSourceSuccess(
+                    request_id=41,
+                    release_id=RELEASE_A,
+                    request_status=request_status,
+                    username="bad-peer",
+                    beets_removed=True,
+                    hashes_recorded=2,
+                    cleanup_errors=(),
+                    hash_capture_errors=(),
+                )
+                output = io.StringIO()
+                with self._env(), redirect_stdout(output):
+                    rc = pipeline_cli.cmd_ban_source(db, args)
+
+                self.assertEqual(rc, 0)
+                self.assertEqual(
+                    json.loads(output.getvalue())["request_status"],
+                    request_status,
+                )
 
     def test_library_delete_lock_contention_returns_state_exit_4(self) -> None:
         db = FakePipelineDB()

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -25,7 +25,6 @@ import scripts.pipeline_cli.long_tail as pipeline_cli_long_tail
 from scripts import pipeline_cli
 from tests.fakes import FakeBeetsDB, FakePipelineDB
 from tests.helpers import make_album_quality_evidence, make_request_row
-from lib.destructive_release_service import BanSourceSuccess
 from lib.transitions import TransitionConflict, TransitionConflictKind
 from tests.test_beets_db import _create_test_db, _insert_album
 
@@ -4532,37 +4531,35 @@ class TestDestructiveCliAdapters(unittest.TestCase):
         self.assertEqual(json.loads(output.getvalue())["error"], "release_mismatch")
         self.assertEqual(db.denylist, [])
 
-    @patch("scripts.pipeline_cli.destructive.ban_source")
-    def test_ban_source_success_reports_resulting_searchability(
-        self, mock_ban_source,
-    ) -> None:
-        db = FakePipelineDB()
+    def test_ban_source_success_reports_resulting_searchability(self) -> None:
         args = SimpleNamespace(
             request_id=41,
             release_id=RELEASE_A,
             beets_db=self.beets_path,
         )
-        for request_status in ("wanted", "unsearchable"):
-            with self.subTest(request_status=request_status):
-                mock_ban_source.return_value = BanSourceSuccess(
-                    request_id=41,
-                    release_id=RELEASE_A,
-                    request_status=request_status,
-                    username="bad-peer",
-                    beets_removed=True,
-                    hashes_recorded=2,
-                    cleanup_errors=(),
-                    hash_capture_errors=(),
-                )
-                output = io.StringIO()
-                with self._env(), redirect_stdout(output):
-                    rc = pipeline_cli.cmd_ban_source(db, args)
+        with patch("lib.beets_album_op.sp.run") as mock_beet:
+            mock_beet.return_value = SimpleNamespace(
+                returncode=1,
+                stderr="isolated test: album retained",
+            )
+            for request_status in ("wanted", "unsearchable"):
+                with self.subTest(request_status=request_status):
+                    db = FakePipelineDB()
+                    db.seed_request(make_request_row(
+                        id=41,
+                        status=request_status,
+                        mb_release_id=RELEASE_A,
+                    ))
+                    output = io.StringIO()
+                    with self._env(), redirect_stdout(output):
+                        rc = pipeline_cli.cmd_ban_source(db, args)
 
-                self.assertEqual(rc, 0)
-                self.assertEqual(
-                    json.loads(output.getvalue())["request_status"],
-                    request_status,
-                )
+                    self.assertEqual(rc, 0)
+                    self.assertEqual(
+                        json.loads(output.getvalue())["request_status"],
+                        request_status,
+                    )
+            self.assertEqual(mock_beet.call_count, 2)
 
     def test_library_delete_lock_contention_returns_state_exit_4(self) -> None:
         db = FakePipelineDB()

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -467,64 +467,9 @@ class TestCmdList(unittest.TestCase):
         self.assertNotIn("Two", text)
 
 
-class TestCmdRetry(unittest.TestCase):
-    def setUp(self):
-        self.db = make_db()
-
-    def tearDown(self):
-        self.db.close()
-
-    def test_retry_resets_to_wanted(self):
-        req_id = self.db.add_request(mb_release_id="a", artist_name="A", album_title="B", source="request")
-        self.db.update_status(req_id, "imported")
-        args = MagicMock(id=req_id)
-        pipeline_cli.cmd_retry(self.db, args)
-        req = self.db.get_request(req_id)
-        assert req is not None
-        self.assertEqual(req["status"], "wanted")
-
-    @patch("scripts.pipeline_cli.album_requests.finalize_request")
-    def test_retry_maps_stale_transition_to_nonzero_without_success(
-        self, mock_transition,
-    ):
-        req_id = self.db.add_request(
-            mb_release_id="retry-conflict", artist_name="A",
-            album_title="B", source="request")
-        mock_transition.return_value = TransitionConflict(
-            request_id=req_id,
-            target_status="wanted",
-            kind=TransitionConflictKind.stale_source,
-            expected_status="imported",
-            actual_status="replaced",
-        )
-
-        out = io.StringIO()
-        with redirect_stdout(out):
-            rc = pipeline_cli.cmd_retry(self.db, MagicMock(id=req_id))
-
-        self.assertEqual(rc, 4)
-        self.assertEqual(json.loads(out.getvalue())["error"], "transition_conflict")
-
-
-class TestCmdCancel(unittest.TestCase):
-    def setUp(self):
-        self.db = make_db()
-
-    def tearDown(self):
-        self.db.close()
-
-    def test_cancel_sets_manual(self):
-        req_id = self.db.add_request(mb_release_id="a", artist_name="A", album_title="B", source="request")
-        args = MagicMock(id=req_id)
-        pipeline_cli.cmd_cancel(self.db, args)
-        req = self.db.get_request(req_id)
-        assert req is not None
-        self.assertEqual(req["status"], "manual")
-
-
 class TestCmdSet(unittest.TestCase):
     def test_same_status_is_idempotent_for_operator_statuses(self):
-        for index, status in enumerate(("wanted", "imported", "manual"), 1):
+        for index, status in enumerate(("wanted", "imported", "unsearchable"), 1):
             with self.subTest(status=status):
                 db = FakePipelineDB()
                 db.seed_request(make_request_row(id=index, status=status))
@@ -538,17 +483,17 @@ class TestCmdSet(unittest.TestCase):
                 self.assertEqual(rc, 0)
                 self.assertEqual(db.get_request(index), before)
 
-    def test_imported_to_manual_is_supported(self):
+    def test_imported_to_unsearchable_is_rejected(self):
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=8, status="imported"))
 
         rc = pipeline_cli.cmd_set(
             cast(Any, db),
-            MagicMock(id=8, status="manual"),
+            MagicMock(id=8, status="unsearchable"),
         )
 
-        self.assertEqual(rc, 0)
-        self.assertEqual(db.request(8)["status"], "manual")
+        self.assertEqual(rc, 4)
+        self.assertEqual(db.request(8)["status"], "imported")
 
     @patch("builtins.print")
     @patch("scripts.pipeline_cli.album_requests.finalize_request")
@@ -560,7 +505,7 @@ class TestCmdSet(unittest.TestCase):
         db = FakePipelineDB()
         db.seed_request(make_request_row(
             id=9,
-            status="manual",
+            status="unsearchable",
             artist_name="A",
             album_title="B",
         ))
@@ -572,7 +517,7 @@ class TestCmdSet(unittest.TestCase):
         self.assertIs(called_db, db)
         self.assertEqual(request_id, 9)
         self.assertEqual(transition.target_status, "imported")
-        self.assertEqual(transition.from_status, "manual")
+        self.assertEqual(transition.from_status, "unsearchable")
 
 
 class TestTracksFromMbRelease(unittest.TestCase):
@@ -592,7 +537,7 @@ class TestCmdForceImport(unittest.TestCase):
 
         db = FakePipelineDB()
         db.seed_request(make_request_row(
-            id=123, status="manual", min_bitrate=320,
+            id=123, status="unsearchable", min_bitrate=320,
             mb_release_id="mbid-123", artist_name="Artist", album_title="Album",
         ))
         # Seed a download_log entry that ``get_download_log_entry`` will
@@ -2113,7 +2058,7 @@ class TestCmdShowSearchForensics(unittest.TestCase):
     No TEST_DB_DSN required — drives ``cmd_show`` against a
     ``_ForensicsDB`` (typed FakePipelineDB subclass) seeded with the
     forensic blob the test author cared about, and verifies the printed
-    text contains variant + final_state + manual_reason + the top-3
+    text contains variant + final_state + the top-3
     candidate table from the JSONB blob.
     """
 
@@ -2129,9 +2074,7 @@ class TestCmdShowSearchForensics(unittest.TestCase):
 
     def test_show_renders_variant_final_state_and_top_3(self):
         db = _ForensicsDB()
-        db.seed_request(self._row(
-            id=1843, manual_reason=None, status="wanted",
-        ))
+        db.seed_request(self._row(id=1843, status="wanted"))
         # JSONB candidates blob — psycopg2 returns parsed Python list.
         candidates_blob = [
             {"username": "alice", "dir": "A\\Album", "filetype": "flac",
@@ -2173,28 +2116,10 @@ class TestCmdShowSearchForensics(unittest.TestCase):
         self.assertGreater(bob_idx, carol_idx)
         self.assertEqual(dave_idx, -1, "4th candidate must be truncated")
 
-    def test_show_renders_manual_reason_chip(self):
-        db = _ForensicsDB()
-        db.seed_request(self._row(
-            id=2, manual_reason="search_exhausted", status="manual",
-        ))
-        db.set_stub_search_history([{
-            "id": 1, "request_id": 2, "query": "q",
-            "result_count": 0, "elapsed_s": 0.1, "outcome": "exhausted",
-            "created_at": "2026-04-29T00:00:00+00:00",
-            "candidates": None,
-            "variant": "exhausted", "final_state": None,
-        }])
-
-        out = self._capture(db, 2)
-
-        self.assertIn("manual_reason:  search_exhausted", out)
-        self.assertIn("variant:        exhausted", out)
-
     def test_show_handles_null_candidates_gracefully(self):
         """Historical row with NULL candidates → no crash, no top list."""
         db = _ForensicsDB()
-        db.seed_request(self._row(id=3, manual_reason=None))
+        db.seed_request(self._row(id=3))
         db.set_stub_search_history([{
             "id": 1, "request_id": 3, "query": "q",
             "result_count": None, "elapsed_s": None, "outcome": "timeout",
@@ -2205,14 +2130,14 @@ class TestCmdShowSearchForensics(unittest.TestCase):
         out = self._capture(db, 3)
 
         # Pre-U1 / NULL row prints the "no forensic data" sentinel because
-        # variant + final_state + manual_reason are all NULL.
+        # variant + final_state are both NULL.
         self.assertIn("(no forensic data yet)", out)
         # And the per-row table renders the variant column as a dash.
         self.assertIn("-", out)
 
     def test_show_handles_empty_candidates_list(self):
         db = _ForensicsDB()
-        db.seed_request(self._row(id=4, manual_reason=None))
+        db.seed_request(self._row(id=4))
         db.set_stub_search_history([{
             "id": 1, "request_id": 4, "query": "q",
             "result_count": 0, "elapsed_s": 0.1, "outcome": "no_results",
@@ -2228,7 +2153,7 @@ class TestCmdShowSearchForensics(unittest.TestCase):
 
     def test_show_renders_youtube_history_source_and_metadata(self):
         db = _ForensicsDB()
-        db.seed_request(self._row(id=5, manual_reason=None))
+        db.seed_request(self._row(id=5))
         log_id = db.insert_youtube_running(
             request_id=5,
             browse_id="MPREb_cli_show",
@@ -2258,7 +2183,7 @@ class TestCmdShowSearchForensics(unittest.TestCase):
 
     def test_show_renders_have_analysis_failure_diagnostics(self):
         db = _ForensicsDB()
-        db.seed_request(self._row(id=6, manual_reason=None))
+        db.seed_request(self._row(id=6))
         db.set_stub_download_history([{
             "id": 711,
             "request_id": 6,

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -1614,7 +1614,7 @@ class TestUpdateStatus(unittest.TestCase):
         self.db.close()
 
     def test_status_transitions(self):
-        for s in ["wanted", "imported", "manual"]:
+        for s in ["wanted", "imported", "unsearchable"]:
             self.db.update_status(self.req_id, s)
             req = self.db.get_request(self.req_id)
             assert req is not None
@@ -1758,7 +1758,7 @@ class TestTrackManagement(unittest.TestCase):
             self.req_id, expected_status="wanted",
         ))
         self.assertFalse(self.db.update_request_fields(
-            self.req_id, expected_status="manual",
+            self.req_id, expected_status="unsearchable",
         ))
         self.assertFalse(self.db.update_request_fields(replaced_id))
         self.assertFalse(self.db.update_request_fields(
@@ -1799,7 +1799,7 @@ class TestTrackManagement(unittest.TestCase):
                 self.assertEqual(self.db.get_request(self.req_id), before)
 
         with self.assertRaises(ValueError):
-            self.db.update_request_fields(self.req_id, status="manual")
+            self.db.update_request_fields(self.req_id, status="unsearchable")
         self.assertEqual(self.db.get_request(self.req_id), before)
 
     def test_metadata_update_rejects_malformed_identifier(self):
@@ -2047,7 +2047,7 @@ class TestTrackManagement(unittest.TestCase):
         self.assertEqual(applied, [False])
         self.assertEqual(self.db.get_request(self.req_id), frozen_row)
 
-    def test_field_resolver_snapshot_loses_to_wanted_manual_transition(self):
+    def test_field_resolver_snapshot_loses_to_unsearchable_transition(self):
         """Real PG barrier: stale resolver output cannot touch parent/child."""
         from lib.field_resolver_service import (
             ResolveAllResult,
@@ -2083,21 +2083,21 @@ class TestTrackManagement(unittest.TestCase):
         worker.start()
         self.assertTrue(entered.wait(timeout=10))
         self.assertTrue(self.db.update_status(
-            self.req_id, "manual", expected_status="wanted",
+            self.req_id, "unsearchable", expected_status="wanted",
         ))
-        manual_row = self.db.get_request(self.req_id)
-        manual_tracks = self.db.get_tracks(self.req_id)
-        assert manual_row is not None
+        stopped_row = self.db.get_request(self.req_id)
+        stopped_tracks = self.db.get_tracks(self.req_id)
+        assert stopped_row is not None
         release.set()
         worker.join(timeout=10)
 
         self.assertFalse(worker.is_alive())
         self.assertEqual(applied, [False])
-        self.assertEqual(self.db.get_request(self.req_id), manual_row)
-        self.assertEqual(self.db.get_tracks(self.req_id), manual_tracks)
-        self.assertIsNone(manual_row["release_group_year"])
-        self.assertFalse(manual_row["is_va_compilation"])
-        self.assertIsNone(manual_tracks[0]["track_artist"])
+        self.assertEqual(self.db.get_request(self.req_id), stopped_row)
+        self.assertEqual(self.db.get_tracks(self.req_id), stopped_tracks)
+        self.assertIsNone(stopped_row["release_group_year"])
+        self.assertFalse(stopped_row["is_va_compilation"])
+        self.assertIsNone(stopped_tracks[0]["track_artist"])
 
 
 @requires_postgres
@@ -3806,29 +3806,6 @@ class TestResetToWanted(unittest.TestCase):
         self.assertEqual(req["min_bitrate"], 320)
         self.assertEqual(req["prev_min_bitrate"], 256)
 
-    def test_clears_manual_reason(self):
-        """U6: re-queue clears ``manual_reason`` alongside attempt counters.
-
-        Single-seam reset: every re-queue path funnels through
-        ``reset_to_wanted``, so this one assertion covers web UI button,
-        ``pipeline-cli`` requeue, and importer requeue transparently.
-        """
-        req_id = self._make_request("clear-mr")
-        # Bump search_attempts and populate manual_reason as if the
-        # variant ladder had exhausted earlier.
-        self.db._execute(
-            "UPDATE album_requests SET search_attempts = 7, manual_reason = %s "
-            "WHERE id = %s",
-            ("search_exhausted", req_id),
-        )
-        self.db.conn.commit()
-        self.db.reset_to_wanted(req_id)
-        req = self.db.get_request(req_id)
-        assert req is not None
-        self.assertEqual(req["search_attempts"], 0)
-        self.assertIsNone(req["manual_reason"])
-
-
 @requires_postgres
 class TestClearOnDiskQualityFields(unittest.TestCase):
     """``clear_on_disk_quality_fields`` is the write-side half of the
@@ -4014,7 +3991,7 @@ class TestApplyTransitionDB(unittest.TestCase):
             with ThreadPoolExecutor(max_workers=2) as pool:
                 results = list(pool.map(
                     lambda pair: race(*pair),
-                    ((self.db, "manual"), (db_two, "imported")),
+                    ((self.db, "unsearchable"), (db_two, "imported")),
                 ))
         finally:
             db_two.close()
@@ -4025,7 +4002,7 @@ class TestApplyTransitionDB(unittest.TestCase):
             sum(isinstance(result, TransitionConflict) for result in results), 1)
         row = self.db.get_request(req_id)
         assert row is not None
-        self.assertIn(row["status"], {"manual", "imported"})
+        self.assertIn(row["status"], {"unsearchable", "imported"})
 
     def test_replaced_row_is_frozen_across_every_status_writer(self):
         from lib.transitions import TransitionConflict, apply_transition
@@ -5229,18 +5206,18 @@ class TestDownloadingStatus(unittest.TestCase):
         ads = req["active_download_state"]
         self.assertEqual(ads["filetype"], "flac")
 
-    def test_set_downloading_noop_from_manual(self):
-        """set_downloading() returns False when status is manual."""
+    def test_set_downloading_noop_from_unsearchable(self):
+        """set_downloading() returns False when status is unsearchable."""
         req_id = self.db.add_request(
             mb_release_id="guard-man", artist_name="A", album_title="B",
             source="request")
-        self.db.update_status(req_id, "manual")
+        self.db.update_status(req_id, "unsearchable")
         state_json = json.dumps({"filetype": "flac", "enqueued_at": "t", "files": []})
         result = self.db.set_downloading(req_id, state_json)
         self.assertFalse(result)
         req = self.db.get_request(req_id)
         assert req is not None
-        self.assertEqual(req["status"], "manual")
+        self.assertEqual(req["status"], "unsearchable")
 
     def test_update_download_state(self):
         """update_download_state() rewrites JSONB without changing status."""
@@ -9830,7 +9807,7 @@ class TestSearchRequests(unittest.TestCase):
             source="request", mb_release_id="sr-2", status="wanted")
         self.db.add_request(
             artist_name="100% Wool", album_title="Felt",
-            source="request", mb_release_id="sr-3", status="manual")
+            source="request", mb_release_id="sr-3", status="unsearchable")
 
     def tearDown(self):
         self.db.close()
@@ -10161,7 +10138,7 @@ class TestGetPipelineOverlay(unittest.TestCase):
             db.update_request_fields(rid, min_bitrate=320)
             db.add_request(
                 mb_release_id="overlay-parity-2", artist_name="C",
-                album_title="D", source="request", status="manual")
+                album_title="D", source="request", status="unsearchable")
             rids[id(db)] = rid
         mbids = ["overlay-parity-1", "overlay-parity-2", "nope"]
         real = self.db.get_pipeline_overlay(mbids)

--- a/tests/test_quarantine_triage_generated.py
+++ b/tests/test_quarantine_triage_generated.py
@@ -28,7 +28,7 @@ REFERENCE_KINDS = (
 REQUEST_STATUSES = (
     "wanted",
     "downloading",
-    "manual",
+    "unsearchable",
     "imported",
     "replaced",
 )

--- a/tests/test_repair.py
+++ b/tests/test_repair.py
@@ -46,10 +46,10 @@ class TestFindInconsistencies(unittest.TestCase):
         self.assertEqual(len(issues), 0,
                          "wanted + imported_path is a valid upgrade-search state")
 
-    def test_manual_with_imported_path_is_fine(self):
-        """Same rationale as wanted: manual status after a force-import
+    def test_unsearchable_with_imported_path_is_fine(self):
+        """Same rationale as wanted: unsearchable after a force-import
         could legitimately carry imported_path until the row is cleared."""
-        rows = [{"id": 4, "status": "manual",
+        rows = [{"id": 4, "status": "unsearchable",
                  "active_download_state": None,
                  "imported_path": "/Beets/Artist/Album"}]
         issues = find_inconsistencies(rows)

--- a/tests/test_replaced_write_audit.py
+++ b/tests/test_replaced_write_audit.py
@@ -66,7 +66,7 @@ _REVIEWED_DYNAMIC_SQL_CALLS: dict[tuple[str, int, str], str] = {
     ("lib/pipeline_db/terminal_outcomes.py", 89, "741f55b2f7eee516"): (
         "terminal metadata keys use the existing validated request-field vocabulary"
     ),
-    ("lib/pipeline_db/terminal_outcomes.py", 289, "6cfaff9c6507c211"): (
+    ("lib/pipeline_db/terminal_outcomes.py", 304, "6cfaff9c6507c211"): (
         "terminal attempt kind is restricted to the fixed retry-counter vocabulary"
     ),
     ("lib/beets_db.py", 339, "8f86dc625b889913"): (
@@ -84,16 +84,16 @@ _REVIEWED_DYNAMIC_SQL_CALLS: dict[tuple[str, int, str], str] = {
     ("lib/pipeline_db/dashboard.py", 481, "5e3b8177198ccbed"): (
         "dashboard WHERE and ORDER fragments come from closed enum branches"
     ),
-    ("lib/pipeline_db/download_log.py", 737, "d21a8be0a38ad4f3"): (
+    ("lib/pipeline_db/download_log.py", 736, "d21a8be0a38ad4f3"): (
         "validation key is selected from a closed server-owned vocabulary"
     ),
-    ("lib/pipeline_db/download_log.py", 795, "e0154e89026dc8ef"): (
+    ("lib/pipeline_db/download_log.py", 794, "e0154e89026dc8ef"): (
         "validation key is selected from a closed server-owned vocabulary"
     ),
-    ("lib/pipeline_db/download_log.py", 813, "1ca75e0c21fa6d7e"): (
+    ("lib/pipeline_db/download_log.py", 812, "1ca75e0c21fa6d7e"): (
         "validation key is closed vocabulary and IN list is value placeholders"
     ),
-    ("lib/pipeline_db/download_log.py", 830, "d87a36ba1d1768e7"): (
+    ("lib/pipeline_db/download_log.py", 829, "d87a36ba1d1768e7"): (
         "JSON path key is selected from a closed server-owned vocabulary"
     ),
     ("lib/pipeline_db/import_jobs.py", 105, "ecf3d1844c67f653"): (
@@ -129,13 +129,13 @@ _REVIEWED_DYNAMIC_SQL_CALLS: dict[tuple[str, int, str], str] = {
         "metadata keys are validated identifiers, lifecycle fields are reserved, "
         "and values use one typed JSONB record parameter"
     ),
-    ("lib/pipeline_db/requests.py", 1343, "0e292421052b4282"): (
+    ("lib/pipeline_db/requests.py", 1339, "0e292421052b4282"): (
         "optional LIMIT is normalized through int before interpolation"
     ),
-    ("lib/pipeline_db/requests.py", 1358, "f027e891f4828e53"): (
+    ("lib/pipeline_db/requests.py", 1354, "f027e891f4828e53"): (
         "ORDER is selected from two literals and LIMIT remains a value placeholder"
     ),
-    ("lib/pipeline_db/requests.py", 1543, "714da98640ff84f0"): (
+    ("lib/pipeline_db/requests.py", 1539, "714da98640ff84f0"): (
         "attempt kind is validated against the fixed retry-counter vocabulary"
     ),
     ("lib/pipeline_db/search_plan.py", 949, "3df0db818cab2f3c"): (
@@ -150,19 +150,19 @@ _REVIEWED_DYNAMIC_SQL_CALLS: dict[tuple[str, int, str], str] = {
 # beside the implementation they review; movement or SQL-shape drift fails the
 # ratchet just like the dynamic-SQL exceptions above.
 _REVIEWED_STATUS_SQL_CALLS: dict[tuple[str, int, str], str] = {
-    ("lib/pipeline_db/terminal_outcomes.py", 131, "72791581d0b54266"): (
+    ("lib/pipeline_db/terminal_outcomes.py", 131, "e0057766c732179a"): (
         "atomic terminal transition mirrors typed wanted CAS inside one transaction"
     ),
-    ("lib/pipeline_db/terminal_outcomes.py", 190, "9ab1fc9fb20fb77b"): (
+    ("lib/pipeline_db/terminal_outcomes.py", 190, "6d280a5c4dbb4e32"): (
         "atomic preview recovery accepts only downloading as its exact source"
     ),
-    ("lib/pipeline_db/terminal_outcomes.py", 330, "786d2b82f14ac409"): (
+    ("lib/pipeline_db/terminal_outcomes.py", 345, "786d2b82f14ac409"): (
         "atomic terminal import CASes status with rescue audit in the same transaction"
     ),
-    ("lib/pipeline_db/terminal_outcomes.py", 370, "0a9c4396d1185b94"): (
+    ("lib/pipeline_db/terminal_outcomes.py", 385, "0a9c4396d1185b94"): (
         "atomic terminal typed transition CASes the source status selected by the DAG"
     ),
-    ("lib/pipeline_db/download_log.py", 403, "b04c5ae9eb3423c1"): (
+    ("lib/pipeline_db/download_log.py", 403, "6c7d7519e8c91827"): (
         "atomic abandoned-import recovery performs downloading-to-wanted CAS"
     ),
     ("lib/pipeline_db/requests.py", 288, "558917722283199d"): (
@@ -177,16 +177,16 @@ _REVIEWED_STATUS_SQL_CALLS: dict[tuple[str, int, str], str] = {
     ("lib/pipeline_db/requests.py", 904, "c99b75cd27718b63"): (
         "typed imported transition CASes status with rescue audit atomically"
     ),
-    ("lib/pipeline_db/requests.py", 1044, "624291485d30cd9b"): (
+    ("lib/pipeline_db/requests.py", 1040, "0e937f9ab5227f21"): (
         "typed reset-to-wanted transition CASes its captured source status"
     ),
-    ("lib/pipeline_db/requests.py", 1113, "96c221e77f54ca60"): (
+    ("lib/pipeline_db/requests.py", 1109, "cfedc69363af13f0"): (
         "automatic recovery accepts only downloading as its exact source"
     ),
-    ("lib/pipeline_db/requests.py", 1158, "2b2c27302b2ab78e"): (
+    ("lib/pipeline_db/requests.py", 1154, "2b2c27302b2ab78e"): (
         "typed download claim accepts only the explicit wanted source status"
     ),
-    ("lib/pipeline_db/requests.py", 1194, "186e1c3ba3188478"): (
+    ("lib/pipeline_db/requests.py", 1190, "186e1c3ba3188478"): (
         "plan-aware download claim uses an exact wanted source predicate"
     ),
 }
@@ -400,7 +400,7 @@ def _execute_params_argument(node: ast.Call) -> ast.expr | None:
 
 
 _ACTIVE_REQUEST_STATUSES = frozenset({
-    "wanted", "downloading", "imported", "manual",
+    "wanted", "downloading", "imported", "unsearchable",
 })
 
 
@@ -560,7 +560,7 @@ def _target_status_predicates(
     scope: ast.AST,
 ) -> tuple[bool, bool, bool]:
     """Return terminal guard, exact-source CAS, and invalid status CAS."""
-    active_values = {"'wanted'", "'downloading'", "'imported'", "'manual'"}
+    active_values = {"'wanted'", "'downloading'", "'imported'", "'unsearchable'"}
     if any(
         token_depth == depth and token.lower() == "or"
         for token, token_depth in tokens[start:end]
@@ -1342,7 +1342,7 @@ def thaw(cur, request_id):
         source = """
 def thaw(cur, request_id):
     cur.execute(
-        "UPDATE album_requests SET status = 'manual' "
+        "UPDATE album_requests SET status = 'unsearchable' "
         "WHERE id = %s AND status != 'replaced'",
         (request_id,),
     )
@@ -1356,7 +1356,7 @@ def thaw(cur, request_id):
         source = """
 def thaw(cur, request_id, source_status):
     cur.execute(
-        "UPDATE album_requests SET status = 'manual' "
+        "UPDATE album_requests SET status = 'unsearchable' "
         "WHERE id = %s AND status = %s",
         (request_id, source_status),
     )

--- a/tests/test_request_finalization.py
+++ b/tests/test_request_finalization.py
@@ -341,8 +341,8 @@ class TestRequestStatusWriteVisitor(unittest.TestCase):
 
     def test_rejects_non_downloading_module_constant_in_download_module(self) -> None:
         tree = ast.parse(
-            "STATUS_MANUAL = 'manual'\n"
-            "apply_transition(db, 42, STATUS_MANUAL)\n"
+            "STATUS_UNSEARCHABLE = 'unsearchable'\n"
+            "apply_transition(db, 42, STATUS_UNSEARCHABLE)\n"
         )
         visitor = _RequestStatusWriteVisitor(
             "lib/download.py",

--- a/tests/test_request_lifecycle_generated.py
+++ b/tests/test_request_lifecycle_generated.py
@@ -74,7 +74,7 @@ from tests.fakes import FakePipelineDB
 from tests.helpers import make_active_download_state_json
 
 LEGAL_STATUSES = frozenset(
-    {"wanted", "downloading", "imported", "manual", "replaced"})
+    {"wanted", "downloading", "imported", "unsearchable", "replaced"})
 
 _IDENTITY_FIELDS = ("mb_release_id", "source", "created_at")
 
@@ -213,13 +213,13 @@ class TestReadOnlyMetadataCasGenerated(unittest.TestCase):
         exists=True,
         status="wanted",
         include_expected_status=False,
-        expected_status="manual",
+        expected_status="unsearchable",
     )
     @example(
         exists=True,
         status="wanted",
         include_expected_status=True,
-        expected_status="manual",
+        expected_status="unsearchable",
     )
     @example(
         exists=True,
@@ -278,7 +278,7 @@ class TestReadOnlyMetadataCasGenerated(unittest.TestCase):
         value=st.one_of(st.none(), st.integers(), st.text(max_size=24)),
     )
     @example(field="status", value="replaced")
-    @example(field="status", value="manual")
+    @example(field="status", value="unsearchable")
     @example(field="mb_release_id", value="different-pressing")
     def test_reserved_lifecycle_and_identity_fields_cannot_be_smuggled(
         self,
@@ -303,14 +303,14 @@ class TestReadOnlyMetadataCasGenerated(unittest.TestCase):
 
 class TestWantedQualityFieldsGenerated(unittest.TestCase):
     @given(
-        source_status=st.sampled_from(["downloading", "imported", "manual"]),
+        source_status=st.sampled_from(["downloading", "imported", "unsearchable"]),
         current_min_bitrate=st.one_of(st.none(), st.integers(1, 2000)),
         current_prev_min_bitrate=st.one_of(st.none(), st.integers(1, 2000)),
         next_min_bitrate=st.one_of(st.none(), st.integers(1, 2000)),
         explicit_prev_min_bitrate=st.one_of(st.none(), st.integers(1, 2000)),
     )
     @example(
-        source_status="manual",
+        source_status="unsearchable",
         current_min_bitrate=320,
         current_prev_min_bitrate=192,
         next_min_bitrate=245,
@@ -366,13 +366,13 @@ class TestResolverSourceStatusGenerated(unittest.TestCase):
     @given(
         exists=st.booleans(),
         status=st.sampled_from(
-            ["wanted", "downloading", "imported", "manual"],
+            ["wanted", "downloading", "imported", "unsearchable"],
         ),
         expected_status=st.sampled_from(
-            ["wanted", "downloading", "imported", "manual"],
+            ["wanted", "downloading", "imported", "unsearchable"],
         ),
     )
-    @example(exists=True, status="manual", expected_status="wanted")
+    @example(exists=True, status="unsearchable", expected_status="wanted")
     @example(exists=True, status="wanted", expected_status="wanted")
     @example(exists=False, status="wanted", expected_status="wanted")
     def test_stale_source_cannot_mutate_ancestor_or_children(
@@ -542,25 +542,33 @@ class RequestLifecycleMachine(RuleBasedStateMachine):
 
     @precondition(lambda self: self._ids_with_status("wanted", "downloading"))
     @rule(data=st.data())
-    def flag_manual(self, data) -> None:
+    def apply_operator_search_stop(self, data) -> None:
         rid = data.draw(
             st.sampled_from(self._ids_with_status("wanted", "downloading")),
-            label="manual target")
+            label="search-stop target")
+        before = copy.deepcopy(self._row(rid))
         from_status = self._row(rid)["status"]
         ok = finalize_request(
-            self.db, rid, RequestTransition.to_manual(from_status=from_status))
+            self.db, rid, RequestTransition.to_unsearchable(from_status=from_status))
         row = self._row(rid)
-        if not isinstance(ok, TransitionApplied) or row["status"] != "manual":
+        if from_status == "wanted":
+            if (
+                not isinstance(ok, TransitionApplied)
+                or row["status"] != "unsearchable"
+            ):
+                raise AssertionError(
+                    f"wanted->unsearchable failed: ok={ok}, "
+                    f"status={row['status']!r}")
+        elif not isinstance(ok, TransitionConflict) or row != before:
             raise AssertionError(
-                f"{from_status}->manual failed: ok={ok}, "
-                f"status={row['status']!r}")
+                f"downloading->unsearchable must be a no-op conflict: {ok}")
 
-    @precondition(lambda self: self._ids_with_status("imported", "manual"))
+    @precondition(lambda self: self._ids_with_status("imported", "unsearchable"))
     @rule(data=st.data())
     def requeue_from_terminal(self, data) -> None:
-        """Operator requeue (upgrade / retry-from-manual): clears counters."""
+        """Operator requeue (upgrade / resume search): clears counters."""
         rid = data.draw(
-            st.sampled_from(self._ids_with_status("imported", "manual")),
+            st.sampled_from(self._ids_with_status("imported", "unsearchable")),
             label="requeue-from-terminal target")
         from_status = self._row(rid)["status"]
         ok = finalize_request(
@@ -579,7 +587,7 @@ class RequestLifecycleMachine(RuleBasedStateMachine):
     @rule(
         data=st.data(),
         target_status=st.sampled_from(
-            ("wanted", "downloading", "imported", "manual")),
+            ("wanted", "downloading", "imported", "unsearchable")),
         explicit_source=st.booleans(),
     )
     def attempt_any_transition(
@@ -599,7 +607,7 @@ class RequestLifecycleMachine(RuleBasedStateMachine):
         actual = str(before["status"])
         claimed_source = actual if explicit_source else None
         if explicit_source and data.draw(st.booleans(), label="stale snapshot"):
-            claimed_source = "wanted" if actual != "wanted" else "manual"
+            claimed_source = "wanted" if actual != "wanted" else "unsearchable"
 
         if target_status == "wanted":
             command = RequestTransition.to_wanted(from_status=claimed_source)
@@ -611,7 +619,7 @@ class RequestLifecycleMachine(RuleBasedStateMachine):
         elif target_status == "imported":
             command = RequestTransition.to_imported(from_status=claimed_source)
         else:
-            command = RequestTransition.to_manual(from_status=claimed_source)
+            command = RequestTransition.to_unsearchable(from_status=claimed_source)
 
         result = finalize_request(self.db, rid, command)
         after = self._row(rid)
@@ -628,7 +636,7 @@ class RequestLifecycleMachine(RuleBasedStateMachine):
         assert_transition_result_matches(before, after, target_status, result)
 
     @precondition(lambda self: self._ids_with_status(
-        "wanted", "downloading", "imported", "manual"))
+        "wanted", "downloading", "imported", "unsearchable"))
     @rule(data=st.data())
     def replace(self, data) -> None:
         """Replace (issue-#282 shape): the old row flips to 'replaced' and
@@ -637,7 +645,7 @@ class RequestLifecycleMachine(RuleBasedStateMachine):
         rid = data.draw(
             st.sampled_from(
                 self._ids_with_status(
-                    "wanted", "downloading", "imported", "manual")),
+                    "wanted", "downloading", "imported", "unsearchable")),
             label="replace target")
         if self._row(rid).get("active_plan_id") is None:
             self.db.create_successful_search_plan(
@@ -911,9 +919,9 @@ class TestLifecycleCheckersTripOnViolations(unittest.TestCase):
 
     def test_trips_when_applied_target_did_not_land(self):
         row = {"id": 1, "status": "wanted"}
-        applied = TransitionApplied(1, "wanted", "manual")
+        applied = TransitionApplied(1, "wanted", "unsearchable")
         with self.assertRaises(AssertionError):
-            assert_transition_result_matches(row, row, "manual", applied)
+            assert_transition_result_matches(row, row, "unsearchable", applied)
 
     def test_read_only_cas_checker_trips_on_false_success_and_mutation(self):
         with self.assertRaises(AssertionError):

--- a/tests/test_search_classification.py
+++ b/tests/test_search_classification.py
@@ -97,9 +97,9 @@ class TestClassifyFailureClass(unittest.TestCase):
             FAILURE_CLASS_RESOLVED,
         ),
         (
-            "resolved: status=manual overrides A-dominant pattern",
+            "resolved: status=unsearchable overrides A-dominant pattern",
             _no_results(10),
-            "manual",
+            "unsearchable",
             FAILURE_CLASS_RESOLVED,
         ),
         # 7. Edge: zero searches in cycle with status=wanted → None.

--- a/tests/test_search_plan_service.py
+++ b/tests/test_search_plan_service.py
@@ -312,7 +312,7 @@ class TestSearchPlanServiceRegenerate(unittest.TestCase):
         self.assertEqual(len(latest_failed), 1)
 
     def test_regeneration_works_for_non_wanted_status(self):
-        """Imported / manual / downloading requests can still regenerate."""
+        """Imported / unsearchable / downloading requests can regenerate."""
         self._seed_with_active_plan(11)
         self.db.request(11)["status"] = "imported"
         result = self.svc.generate_for_request(11, regenerate=True)

--- a/tests/test_slskd_events.py
+++ b/tests/test_slskd_events.py
@@ -231,7 +231,7 @@ class TestIngestStamping(SlskdEventIngestCase):
         self.assertIsNone(self.file_local_path())
 
     def test_non_downloading_row_is_not_updated(self):
-        self.seed_downloading(status="manual")
+        self.seed_downloading(status="unsearchable")
         self.slskd.events.set_events([
             self.event(
                 id="ev-1", timestamp="2026-07-01T10:00:00.0000000Z",

--- a/tests/test_terminal_outcome_callers.py
+++ b/tests/test_terminal_outcome_callers.py
@@ -123,7 +123,7 @@ class TestTerminalOutcomeCallers(unittest.TestCase):
 
     def test_preview_worker_uses_one_terminal_persistence_call(self) -> None:
         db = FakePipelineDB()
-        db.seed_request(make_request_row(id=42, status="manual"))
+        db.seed_request(make_request_row(id=42, status="unsearchable"))
         job = db.enqueue_import_job(
             IMPORT_JOB_FORCE,
             request_id=42,
@@ -155,7 +155,7 @@ class TestTerminalOutcomeCallers(unittest.TestCase):
         self.assertEqual(updated.status, "failed")
         self.assertEqual(len(db.persist_preview_terminal_outcome_calls), 1)
         self.assertEqual(len(db.download_logs), 1)
-        self.assertEqual(db.request(42)["status"], "manual")
+        self.assertEqual(db.request(42)["status"], "unsearchable")
         command = db.persist_preview_terminal_outcome_calls[0]
         self.assertIsNone(command.request_transition)
 

--- a/tests/test_terminal_outcomes.py
+++ b/tests/test_terminal_outcomes.py
@@ -101,6 +101,22 @@ class ObservedOperatorPipelineDB(PipelineDB):
             expected_status=expected_status,
         )
 
+    def reset_to_wanted(
+        self,
+        request_id: int,
+        *,
+        expected_status: str | None = None,
+        clear_retry_counters: bool = True,
+        **extra: Any,
+    ) -> bool:
+        self.cas_started.set()
+        return super().reset_to_wanted(
+            request_id,
+            expected_status=expected_status,
+            clear_retry_counters=clear_retry_counters,
+            **extra,
+        )
+
 
 def _snapshot(db: PipelineDB, request_id: int, job_id: int) -> dict[str, object]:
     request_cur = db._execute(
@@ -500,7 +516,7 @@ class TestTerminalOutcomeAtomicity(unittest.TestCase):
         db, request_id, job_id = _seed_running_preview()
         self.addCleanup(db.close)
         db._execute(
-            "UPDATE album_requests SET status = 'manual' WHERE id = %s",
+            "UPDATE album_requests SET status = 'unsearchable' WHERE id = %s",
             (request_id,),
         )
         result = db.persist_preview_terminal_outcome(PreviewTerminalOutcome(
@@ -523,14 +539,14 @@ class TestTerminalOutcomeAtomicity(unittest.TestCase):
 
         request = db.get_request(request_id)
         assert request is not None
-        self.assertEqual(request["status"], "manual")
+        self.assertEqual(request["status"], "unsearchable")
         self.assertEqual(result.transitions, ())
 
     def test_import_rejection_preserves_operator_stop_and_policy_effects(self):
         db, request_id, job_id = _seed_running_import()
         self.addCleanup(db.close)
         db._execute(
-            "UPDATE album_requests SET status = 'manual', min_bitrate = 320 "
+            "UPDATE album_requests SET status = 'unsearchable', min_bitrate = 320 "
             "WHERE id = %s",
             (request_id,),
         )
@@ -538,7 +554,7 @@ class TestTerminalOutcomeAtomicity(unittest.TestCase):
             request_id=request_id,
             import_job_id=job_id,
             initial_transition=transitions.RequestTransition.to_wanted(
-                from_status="downloading",
+                from_status="unsearchable",
                 attempt_type="validation",
                 search_filetype_override="lossless",
                 min_bitrate=245,
@@ -557,19 +573,23 @@ class TestTerminalOutcomeAtomicity(unittest.TestCase):
 
         request = db.get_request(request_id)
         assert request is not None
-        self.assertEqual(request["status"], "manual")
+        self.assertEqual(request["status"], "unsearchable")
         self.assertEqual(request["validation_attempts"], 1)
         self.assertEqual(request["search_filetype_override"], "lossless")
         self.assertEqual(request["min_bitrate"], 245)
         self.assertEqual(request["prev_min_bitrate"], 320)
         self.assertEqual(
             tuple(item.target_status for item in result.transitions),
-            ("manual",),
+            ("unsearchable",),
         )
 
     def test_operator_action_waiting_behind_terminal_lock_retries(self):
         assert TEST_DSN is not None
         seed, request_id, job_id = _seed_running_import()
+        seed._execute(
+            "UPDATE album_requests SET status = 'unsearchable' WHERE id = %s",
+            (request_id,),
+        )
         seed.close()
         locked = threading.Event()
         release = threading.Event()
@@ -592,7 +612,7 @@ class TestTerminalOutcomeAtomicity(unittest.TestCase):
             request_id=request_id,
             import_job_id=job_id,
             initial_transition=transitions.RequestTransition.to_wanted(
-                from_status="downloading",
+                from_status="unsearchable",
                 attempt_type="validation",
             ),
             audit=TerminalDownloadAudit(
@@ -613,17 +633,17 @@ class TestTerminalOutcomeAtomicity(unittest.TestCase):
             except BaseException as exc:
                 terminal_errors.append(exc)
 
-        def apply_operator_stop() -> None:
+        def clear_operator_stop() -> None:
             operator_results.append(transitions.finalize_operator_request(
                 operator_db,
                 request_id,
-                transitions.RequestTransition.to_manual(
-                    from_status="downloading",
+                transitions.RequestTransition.to_wanted(
+                    from_status="unsearchable",
                 ),
             ))
 
         terminal_thread = threading.Thread(target=persist_terminal)
-        operator_thread = threading.Thread(target=apply_operator_stop)
+        operator_thread = threading.Thread(target=clear_operator_stop)
         terminal_thread.start()
         self.assertTrue(locked.wait(timeout=10))
         operator_thread.start()
@@ -643,14 +663,14 @@ class TestTerminalOutcomeAtomicity(unittest.TestCase):
         self.addCleanup(observer.close)
         request = observer.get_request(request_id)
         assert request is not None
-        self.assertEqual(request["status"], "manual")
-        self.assertEqual(request["validation_attempts"], 1)
+        self.assertEqual(request["status"], "wanted")
+        self.assertEqual(request["validation_attempts"], 0)
 
     def test_same_status_operator_action_still_serializes_behind_lock(self):
         assert TEST_DSN is not None
         seed, request_id, job_id = _seed_running_import()
         seed._execute(
-            "UPDATE album_requests SET status = 'manual' WHERE id = %s",
+            "UPDATE album_requests SET status = 'unsearchable' WHERE id = %s",
             (request_id,),
         )
         seed.close()
@@ -674,7 +694,7 @@ class TestTerminalOutcomeAtomicity(unittest.TestCase):
             request_id=request_id,
             import_job_id=job_id,
             initial_transition=transitions.RequestTransition.to_imported(
-                from_status="manual",
+                from_status="unsearchable",
                 imported_path="/music/Atomic/Outcome",
             ),
             audit=TerminalDownloadAudit(outcome="success"),
@@ -695,8 +715,8 @@ class TestTerminalOutcomeAtomicity(unittest.TestCase):
             operator_results.append(transitions.finalize_operator_request(
                 operator_db,
                 request_id,
-                transitions.RequestTransition.to_manual(
-                    from_status="manual",
+                transitions.RequestTransition.to_unsearchable(
+                    from_status="unsearchable",
                 ),
             ))
 
@@ -721,13 +741,13 @@ class TestTerminalOutcomeAtomicity(unittest.TestCase):
         self.addCleanup(observer.close)
         request = observer.get_request(request_id)
         assert request is not None
-        self.assertEqual(request["status"], "manual")
+        self.assertEqual(request["status"], "unsearchable")
 
     def test_import_terminal_policy_preserves_current_operator_stop(self):
         db, request_id, job_id = _seed_running_import()
         self.addCleanup(db.close)
         db._execute(
-            "UPDATE album_requests SET status = 'manual' WHERE id = %s",
+            "UPDATE album_requests SET status = 'unsearchable' WHERE id = %s",
             (request_id,),
         )
 
@@ -737,19 +757,19 @@ class TestTerminalOutcomeAtomicity(unittest.TestCase):
 
         request = db.get_request(request_id)
         assert request is not None
-        self.assertEqual(request["status"], "manual")
+        self.assertEqual(request["status"], "unsearchable")
         self.assertEqual(request["search_filetype_override"], "lossless")
         self.assertEqual(request["min_bitrate"], 320)
         self.assertEqual(
             tuple(item.target_status for item in result.transitions),
-            ("imported", "imported", "manual"),
+            ("unsearchable", "unsearchable"),
         )
 
     def test_import_terminal_policy_does_not_restore_cleared_stop(self):
         db, request_id, job_id = _seed_running_import()
         self.addCleanup(db.close)
         db._execute(
-            "UPDATE album_requests SET status = 'manual' WHERE id = %s",
+            "UPDATE album_requests SET status = 'unsearchable' WHERE id = %s",
             (request_id,),
         )
         command = _searching_import_outcome(request_id, job_id)
@@ -773,7 +793,7 @@ class TestTerminalOutcomeAtomicity(unittest.TestCase):
         db, request_id, job_id = _seed_running_import()
         self.addCleanup(db.close)
         db._execute(
-            "UPDATE album_requests SET status = 'manual' WHERE id = %s",
+            "UPDATE album_requests SET status = 'unsearchable' WHERE id = %s",
             (request_id,),
         )
         command = _searching_import_outcome(request_id, job_id)
@@ -807,7 +827,7 @@ class TestTerminalOutcomeAtomicity(unittest.TestCase):
         db, request_id, job_id = _seed_running_import()
         self.addCleanup(db.close)
         db._execute(
-            "UPDATE album_requests SET status = 'manual' WHERE id = %s",
+            "UPDATE album_requests SET status = 'unsearchable' WHERE id = %s",
             (request_id,),
         )
 
@@ -826,7 +846,7 @@ class TestTerminalOutcomeAtomicity(unittest.TestCase):
 
         request = db.get_request(request_id)
         assert request is not None
-        self.assertEqual(request["status"], "manual")
+        self.assertEqual(request["status"], "unsearchable")
 
     def test_import_success_round_trip_returns_complete_bundle(self):
         db, request_id, job_id = _seed_running_import(unfindable=True)
@@ -1014,7 +1034,7 @@ class TestTerminalOutcomeAtomicity(unittest.TestCase):
         db, request_id, job_id = _seed_running_import()
         self.addCleanup(db.close)
         db._execute(
-            "UPDATE album_requests SET status = 'manual' WHERE id = %s",
+            "UPDATE album_requests SET status = 'unsearchable' WHERE id = %s",
             (request_id,),
         )
         before = _snapshot(db, request_id, job_id)

--- a/tests/test_terminal_outcomes_generated.py
+++ b/tests/test_terminal_outcomes_generated.py
@@ -59,7 +59,7 @@ def assert_operator_stop_matches_terminal_acceptance(
     successful_terminal_acceptance: bool,
 ) -> None:
     """Only explicit successful acceptance may supersede the search stop."""
-    expected = "imported" if successful_terminal_acceptance else "manual"
+    expected = "imported" if successful_terminal_acceptance else "unsearchable"
     if status != expected:
         raise AssertionError(
             f"terminal_acceptance={successful_terminal_acceptance!r} left "
@@ -159,8 +159,7 @@ class TestTerminalOutcomeGenerated(unittest.TestCase):
         db = FakePipelineDB()
         db.seed_request(make_request_row(
             id=42,
-            status="manual",
-            manual_reason="operator_stop",
+            status="unsearchable",
         ))
         job = db.enqueue_import_job(
             IMPORT_JOB_FORCE,
@@ -214,7 +213,7 @@ class TestTerminalOutcomeGenerated(unittest.TestCase):
     def test_terminal_acceptance_checker_trips_on_wrong_status(self) -> None:
         for successful_terminal_acceptance, status in (
             (False, "imported"),
-            (True, "manual"),
+            (True, "unsearchable"),
         ):
             with self.subTest(
                 successful_terminal_acceptance=(
@@ -284,10 +283,9 @@ class TestTerminalOutcomeGenerated(unittest.TestCase):
         db = FakePipelineDB()
         db.seed_request(make_request_row(
             id=42,
-            status="manual",
+            status="unsearchable",
             min_bitrate=existing_min_bitrate,
             prev_min_bitrate=192,
-            manual_reason="operator_stop",
         ))
         job = db.enqueue_import_job(
             IMPORT_JOB_FORCE,
@@ -309,7 +307,7 @@ class TestTerminalOutcomeGenerated(unittest.TestCase):
             request_id=42,
             import_job_id=claimed.id,
             initial_transition=transitions.RequestTransition.to_wanted_fields(
-                from_status="downloading",
+                from_status="unsearchable",
                 attempt_type=attempt_type,
                 fields=fields,
             ),
@@ -323,8 +321,7 @@ class TestTerminalOutcomeGenerated(unittest.TestCase):
         ))
 
         row = db.request(42)
-        self.assertEqual(row["status"], "manual")
-        self.assertEqual(row["manual_reason"], "operator_stop")
+        self.assertEqual(row["status"], "unsearchable")
         self.assertEqual(row["search_filetype_override"], search_override)
         self.assertEqual(
             row[f"{attempt_type}_attempts"] if attempt_type else 0,

--- a/tests/test_transfer_ledger_generated.py
+++ b/tests/test_transfer_ledger_generated.py
@@ -209,7 +209,8 @@ class LedgerPruneRow:
     accepted: bool
 
 
-_STATUSES = ("wanted", "downloading", "imported", "manual", "replaced")
+_STATUSES = (
+    "wanted", "downloading", "imported", "unsearchable", "replaced")
 _RETENTION_DAYS = 90
 _RETENTION_SECONDS = _RETENTION_DAYS * 24 * 60 * 60
 _PRUNE_NOW = datetime(2026, 1, 1, tzinfo=timezone.utc)

--- a/tests/test_transitions.py
+++ b/tests/test_transitions.py
@@ -31,11 +31,11 @@ class TestValidateTransition(unittest.TestCase):
     def test_downloading_to_wanted(self):
         self.assertTrue(validate_transition("downloading", "wanted"))
 
-    def test_downloading_to_manual(self):
-        self.assertTrue(validate_transition("downloading", "manual"))
+    def test_downloading_to_unsearchable_is_invalid(self):
+        self.assertFalse(validate_transition("downloading", "unsearchable"))
 
-    def test_wanted_to_manual(self):
-        self.assertTrue(validate_transition("wanted", "manual"))
+    def test_wanted_to_unsearchable(self):
+        self.assertTrue(validate_transition("wanted", "unsearchable"))
 
     def test_imported_to_wanted(self):
         self.assertTrue(validate_transition("imported", "wanted"))
@@ -43,27 +43,27 @@ class TestValidateTransition(unittest.TestCase):
     def test_imported_to_imported(self):
         self.assertTrue(validate_transition("imported", "imported"))
 
-    def test_imported_to_manual(self):
-        self.assertTrue(validate_transition("imported", "manual"))
+    def test_imported_to_unsearchable_is_invalid(self):
+        self.assertFalse(validate_transition("imported", "unsearchable"))
 
-    def test_manual_to_wanted(self):
-        self.assertTrue(validate_transition("manual", "wanted"))
+    def test_unsearchable_to_wanted(self):
+        self.assertTrue(validate_transition("unsearchable", "wanted"))
 
-    def test_manual_to_manual(self):
-        self.assertTrue(validate_transition("manual", "manual"))
+    def test_unsearchable_to_unsearchable(self):
+        self.assertTrue(validate_transition("unsearchable", "unsearchable"))
 
     # Invalid transitions
     def test_imported_to_downloading_invalid(self):
         self.assertFalse(validate_transition("imported", "downloading"))
 
-    def test_manual_to_downloading_invalid(self):
-        self.assertFalse(validate_transition("manual", "downloading"))
+    def test_unsearchable_to_downloading_invalid(self):
+        self.assertFalse(validate_transition("unsearchable", "downloading"))
 
     def test_wanted_to_imported(self):
         self.assertTrue(validate_transition("wanted", "imported"))
 
-    def test_manual_to_imported(self):
-        self.assertTrue(validate_transition("manual", "imported"))
+    def test_unsearchable_to_imported(self):
+        self.assertTrue(validate_transition("unsearchable", "imported"))
 
     def test_downloading_to_downloading_invalid(self):
         self.assertFalse(validate_transition("downloading", "downloading"))
@@ -96,12 +96,12 @@ class TestTransitionSideEffects(unittest.TestCase):
         self.assertTrue(fx.clear_retry_counters)
         self.assertFalse(fx.record_attempt)
 
-    def test_manual_to_wanted_clears_retry_counters(self):
-        fx = VALID_TRANSITIONS[("manual", "wanted")]
+    def test_unsearchable_to_wanted_clears_retry_counters(self):
+        fx = VALID_TRANSITIONS[("unsearchable", "wanted")]
         self.assertTrue(fx.clear_retry_counters)
 
-    def test_wanted_to_manual_no_effects(self):
-        fx = VALID_TRANSITIONS[("wanted", "manual")]
+    def test_wanted_to_unsearchable_no_effects(self):
+        fx = VALID_TRANSITIONS[("wanted", "unsearchable")]
         self.assertFalse(fx.record_attempt)
         self.assertFalse(fx.clear_retry_counters)
 
@@ -118,13 +118,14 @@ class TestTransitionTable(unittest.TestCase):
             self.assertIsInstance(fx, TransitionSideEffects,
                                  f"({from_s}, {to_s}) is not TransitionSideEffects")
 
-    def test_exactly_13_transitions(self):
-        self.assertEqual(len(VALID_TRANSITIONS), 13)
+    def test_exactly_11_transitions(self):
+        self.assertEqual(len(VALID_TRANSITIONS), 11)
 
     def test_all_statuses_reachable(self):
         """Every status appears as a target at least once."""
         targets = {to_s for _, to_s in VALID_TRANSITIONS}
-        self.assertEqual(targets, {"wanted", "downloading", "imported", "manual"})
+        self.assertEqual(
+            targets, {"wanted", "downloading", "imported", "unsearchable"})
 
 
 class TestApplyTransition(unittest.TestCase):
@@ -222,10 +223,10 @@ class TestApplyTransition(unittest.TestCase):
 
     def test_invalid_transition_fails_closed_before_any_mutation_seam(self):
         """An invalid edge is a typed conflict and never reaches a writer."""
-        db = self._make_db("manual")
+        db = self._make_db("unsearchable")
         before_history = list(db.status_history)
         result = apply_transition(
-            cast(Any, db), 1, "downloading", from_status="manual",
+            cast(Any, db), 1, "downloading", from_status="unsearchable",
             state_json='{}',
         )
 
@@ -233,7 +234,7 @@ class TestApplyTransition(unittest.TestCase):
         assert isinstance(result, TransitionConflict)
         self.assertEqual(result.kind, TransitionConflictKind.invalid_edge)
         self.assertEqual(db.status_history, before_history)
-        self.assertEqual(db.request(1)["status"], "manual")
+        self.assertEqual(db.request(1)["status"], "unsearchable")
 
     def test_downloading_guard_logs_when_set_downloading_refuses(self):
         """When ``set_downloading`` returns False (row no longer wanted),
@@ -272,22 +273,24 @@ class TestApplyTransition(unittest.TestCase):
         self.assertEqual(result.kind, TransitionConflictKind.not_found)
         self.assertIsNone(db._requests.get(999))
 
-    def test_wanted_to_manual_sets_status(self):
+    def test_wanted_to_unsearchable_sets_status(self):
         db = self._make_db("wanted")
         result = apply_transition(
-            cast(Any, db), 1, "manual", from_status="wanted")
+            cast(Any, db), 1, "unsearchable", from_status="wanted")
         self.assertIsInstance(result, TransitionApplied)
-        self.assertEqual(db.request(1)["status"], "manual")
+        self.assertEqual(db.request(1)["status"], "unsearchable")
 
-    def test_imported_to_manual_sets_status(self):
+    def test_imported_to_unsearchable_is_a_conflict(self):
         db = self._make_db("imported")
         result = apply_transition(
-            cast(Any, db), 1, "manual", from_status="imported")
-        self.assertIsInstance(result, TransitionApplied)
-        self.assertEqual(db.request(1)["status"], "manual")
+            cast(Any, db), 1, "unsearchable", from_status="imported")
+        self.assertIsInstance(result, TransitionConflict)
+        assert isinstance(result, TransitionConflict)
+        self.assertEqual(result.kind, TransitionConflictKind.invalid_edge)
+        self.assertEqual(db.request(1)["status"], "imported")
 
     def test_operator_same_status_is_byte_identical_success(self):
-        for status in ("wanted", "imported", "manual"):
+        for status in ("wanted", "imported", "unsearchable"):
             with self.subTest(status=status):
                 db = self._make_db(status)
                 before = db.request(1)
@@ -301,7 +304,7 @@ class TestApplyTransition(unittest.TestCase):
         before = db.request(1)
 
         result = apply_transition(
-            cast(Any, db), 1, "manual", from_status="wanted")
+            cast(Any, db), 1, "unsearchable", from_status="wanted")
 
         self.assertIsInstance(result, TransitionConflict)
         assert isinstance(result, TransitionConflict)
@@ -313,7 +316,7 @@ class TestApplyTransition(unittest.TestCase):
         db = self._make_db("replaced")
         before = db.request(1)
 
-        for target in ("wanted", "manual", "imported", "downloading"):
+        for target in ("wanted", "unsearchable", "imported", "downloading"):
             kwargs = {"state_json": "{}"} if target == "downloading" else {}
             result = apply_transition(
                 cast(Any, db), 1, target, from_status="replaced", **kwargs)
@@ -376,7 +379,7 @@ class TestRequestTransition(unittest.TestCase):
             RequestTransition.to_imported_fields(fields={"state_json": "{}"})
 
     def test_transition_fields_are_immutable(self):
-        transition = RequestTransition.to_manual(from_status="wanted")
+        transition = RequestTransition.to_unsearchable(from_status="wanted")
 
         with self.assertRaises(TypeError):
             cast(Any, transition.fields)["imported_path"] = "/Beets/Artist/Album"
@@ -421,7 +424,7 @@ class TestFinalizeRequest(unittest.TestCase):
         self.assertEqual(row["prev_min_bitrate"], 320)
         self.assertEqual(row["download_attempts"], 1)
 
-    def test_operator_command_rebases_once_after_a_terminal_cas_wins(self):
+    def test_operator_stop_rebases_to_conflict_after_terminal_import_wins(self):
         class RacingFakePipelineDB(FakePipelineDB):
             terminal_won = False
 
@@ -435,7 +438,7 @@ class TestFinalizeRequest(unittest.TestCase):
             ) -> bool:
                 if not self.terminal_won:
                     self.terminal_won = True
-                    self._requests[request_id]["status"] = "wanted"
+                    self._requests[request_id]["status"] = "imported"
                     return False
                 return super().update_status(
                     request_id,
@@ -445,24 +448,26 @@ class TestFinalizeRequest(unittest.TestCase):
                 )
 
         db = RacingFakePipelineDB()
-        db.seed_request(make_request_row(id=42, status="downloading"))
+        db.seed_request(make_request_row(id=42, status="wanted"))
 
         result = finalize_operator_request(
             cast(Any, db),
             42,
-            RequestTransition.to_manual(from_status="downloading"),
+            RequestTransition.to_unsearchable(from_status="wanted"),
         )
 
-        self.assertIsInstance(result, TransitionApplied)
-        self.assertEqual(db.request(42)["status"], "manual")
+        self.assertIsInstance(result, TransitionConflict)
+        assert isinstance(result, TransitionConflict)
+        self.assertEqual(result.kind, TransitionConflictKind.invalid_edge)
+        self.assertEqual(db.request(42)["status"], "imported")
 
-    def test_explicit_previous_bitrate_survives_manual_requeue(self):
+    def test_explicit_previous_bitrate_survives_operator_requeue(self):
         """The typed wanted command's public fields reach the reset CAS."""
         db = FakePipelineDB()
         db.seed_request(
             make_request_row(
                 id=42,
-                status="manual",
+                status="unsearchable",
                 min_bitrate=320,
                 prev_min_bitrate=192,
             ),
@@ -472,7 +477,7 @@ class TestFinalizeRequest(unittest.TestCase):
             cast(Any, db),
             42,
             RequestTransition.to_wanted(
-                from_status="manual",
+                from_status="unsearchable",
                 min_bitrate=245,
                 prev_min_bitrate=256,
             ),
@@ -488,12 +493,12 @@ class TestFinalizeRequest(unittest.TestCase):
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=42, status="wanted"))
         transition = RequestTransition(
-            "manual",
+            "unsearchable",
             from_status="wanted",
             fields={"imported_path": "/Beets/Artist/Album"},
         )
 
-        with self.assertRaisesRegex(ValueError, "manual transitions"):
+        with self.assertRaisesRegex(ValueError, "unsearchable transitions"):
             finalize_request(cast(Any, db), 42, transition)
 
         # ValueError fires upstream of any DB mutation — row unchanged.

--- a/tests/test_wrong_match_policy_generated.py
+++ b/tests/test_wrong_match_policy_generated.py
@@ -117,7 +117,7 @@ class TestGeneratedWrongMatchPolicy(unittest.TestCase):
     )
     @example(
         scenario="bad_audio_hash",
-        request_status="manual",
+        request_status="unsearchable",
         include_replaced=True,
     )
     @example(
@@ -154,7 +154,7 @@ class TestGeneratedWrongMatchPolicy(unittest.TestCase):
         scenario=st.one_of(st.none(), st.text(max_size=40)),
         request_status=st.one_of(
             st.none(),
-            st.sampled_from(("wanted", "downloading", "manual", "imported", "replaced")),
+            st.sampled_from(("wanted", "downloading", "unsearchable", "imported", "replaced")),
         ),
         include_replaced=st.booleans(),
     )

--- a/tests/test_wrong_matches_cleanup.py
+++ b/tests/test_wrong_matches_cleanup.py
@@ -26,7 +26,7 @@ class TestWrongMatchCleanup(unittest.TestCase):
             artist_name="Artist",
             album_title="Album",
             mb_release_id="mbid-1",
-            status="manual",
+            status="unsearchable",
         ))
         return db
 
@@ -304,7 +304,7 @@ class TestWrongMatchDeleteService(unittest.TestCase):
             artist_name="Artist",
             album_title="Album",
             mb_release_id="mbid-1",
-            status="manual",
+            status="unsearchable",
         ))
         return db
 
@@ -456,7 +456,7 @@ class TestWrongMatchDeleteService(unittest.TestCase):
             artist_name="Other",
             album_title="Album",
             mb_release_id="mbid-2",
-            status="manual",
+            status="unsearchable",
         ))
         root1, source1 = make_failed_import_source()
         root2, source2 = make_failed_import_source()

--- a/tests/test_youtube_ingest_service.py
+++ b/tests/test_youtube_ingest_service.py
@@ -239,10 +239,10 @@ class TestSubmitHappyPath(unittest.TestCase):
             [f"vid-{i + 1}" for i in range(EXPECTED_TRACKS)],
         )
 
-    def test_manual_request_accepted_covers_ae9(self) -> None:
-        """AE9: rescue from ``manual`` status is identical to wanted."""
+    def test_unsearchable_request_accepted_covers_ae9(self) -> None:
+        """AE9: rescue from ``unsearchable`` is identical to wanted."""
         pdb = FakePipelineDB()
-        _seed_wanted_request(pdb, request_id=99, status="manual")
+        _seed_wanted_request(pdb, request_id=99, status="unsearchable")
         _seed_resolver_row(pdb)
         svc = _make_service(pdb)
 
@@ -315,7 +315,7 @@ class TestSubmitWrongState(unittest.TestCase):
             [e for e in pdb.download_logs if e.source == "youtube"], [])
 
     def test_forbidden_statuses_subtest_table(self) -> None:
-        """Every non-{wanted, manual} status rejects with ``wrong_state``."""
+        """Every non-{wanted, unsearchable} status rejects as wrong-state."""
         forbidden_statuses = ("downloading", "imported", "replaced")
         for status in forbidden_statuses:
             with self.subTest(status=status):

--- a/tests/web/test_routes_pipeline.py
+++ b/tests/web/test_routes_pipeline.py
@@ -250,7 +250,7 @@ class TestPipelineRouteContracts(_FakeDbWebServerCase):
     def test_have_analysis_error_copy_respects_operator_stop(self):
         classified = classify_log_entry(LogEntry(
             outcome="have_analysis_error",
-            request_status="manual",
+            request_status="unsearchable",
         ))
 
         self.assertIn("Operator search stop remains in place", classified.verdict)
@@ -945,7 +945,7 @@ class TestPipelineRouteContracts(_FakeDbWebServerCase):
         status, data = self._get("/api/pipeline/all")
 
         self.assertEqual(status, 200)
-        _assert_required_fields(self, data, {"counts", "wanted", "downloading", "imported", "manual",
+        _assert_required_fields(self, data, {"counts", "wanted", "downloading", "imported", "unsearchable",
                                              "imported_total", "imported_truncated"},
                                 "pipeline all response")
         _assert_required_fields(self, data["wanted"][0], self.PIPELINE_ITEM_REQUIRED_FIELDS,
@@ -1002,7 +1002,7 @@ class TestPipelineRouteContracts(_FakeDbWebServerCase):
         self.assertEqual(data["items"], [])
 
     DETAIL_RESPONSE_REQUIRED_FIELDS = {
-        "request", "history", "tracks", "manual_reason", "last_search",
+        "request", "history", "tracks", "last_search",
     }
     LAST_SEARCH_REQUIRED_FIELDS = {
         "variant", "final_state", "outcome", "top_candidates",
@@ -1022,10 +1022,8 @@ class TestPipelineRouteContracts(_FakeDbWebServerCase):
                                 "pipeline detail request")
         _assert_required_fields(self, data["history"][0], self.HISTORY_REQUIRED_FIELDS,
                                 "pipeline detail history item")
-        # Default mock state: no search history → last_search is None and
-        # manual_reason is None. Both keys are still present.
+        # Default mock state: no search history → last_search is None.
         self.assertIsNone(data["last_search"])
-        self.assertIsNone(data["manual_reason"])
 
     def test_pipeline_detail_surfaces_last_search_top_candidates(self):
         """When the latest search_log row has candidates, the route emits the
@@ -1147,20 +1145,6 @@ class TestPipelineRouteContracts(_FakeDbWebServerCase):
         self.assertEqual(data["last_search"]["top_candidates"], [])
         self.assertEqual(data["last_search"]["variant"],
                          "v2_artist_album_no_year")
-
-    def test_pipeline_detail_surfaces_manual_reason(self):
-        """manual_reason='search_exhausted' is exposed on the detail response."""
-        row = self.db.get_request(100)
-        assert row is not None
-        self.db.seed_request({
-            **row,
-            "status": "manual",
-            "manual_reason": "search_exhausted",
-        })
-        status, data = self._get("/api/pipeline/100")
-
-        self.assertEqual(status, 200)
-        self.assertEqual(data["manual_reason"], "search_exhausted")
 
     def test_pipeline_detail_history_surfaces_wrong_match_triage_audit(self):
         self.db.log_download(

--- a/tests/web/test_routes_pipeline_dashboard.py
+++ b/tests/web/test_routes_pipeline_dashboard.py
@@ -141,6 +141,9 @@ class TestPipelineDashboardRouteContracts(_FakeDbWebServerCase):
         self.db.seed_request(make_request_row(
             id=9104, status="downloading", mb_release_id="dash-in-flight",
         ))
+        self.db.seed_request(make_request_row(
+            id=9105, status="unsearchable", mb_release_id="dash-stopped",
+        ))
         beets = FakeBeetsDB()
         beets.set_album_exists("dash-on-disk", True)
         # The class setUp baseline (id=100, imported) must read as
@@ -159,8 +162,8 @@ class TestPipelineDashboardRouteContracts(_FakeDbWebServerCase):
             self, dc["counts"], self.DISK_COVERAGE_COUNT_FIELDS,
             "pipeline dashboard disk coverage counts")
         # Only off-disk `imported` rows are drift — wanted (not yet
-        # acquired), downloading (in flight), and manual (staged for
-        # review) are all expected to be absent from beets.
+        # acquired), downloading (in flight), and unsearchable (operator
+        # search stop) are all expected to be absent from beets.
         self.assertEqual([r["id"] for r in dc["drift_rows"]], [9102])
         _assert_required_fields(
             self, dc["drift_rows"][0], self.DISK_COVERAGE_ROW_FIELDS,

--- a/tests/web/test_routes_pipeline_mutations.py
+++ b/tests/web/test_routes_pipeline_mutations.py
@@ -629,7 +629,7 @@ class TestPipelineMutationRouteContracts(_FakeDbWebServerCase):
 
     @patch("web.routes.pipeline_mutations.finalize_request")
     def test_pipeline_update_contract(self, _mock_transition):
-        status, data = self._post("/api/pipeline/update", {"id": 100, "status": "manual"})
+        status, data = self._post("/api/pipeline/update", {"id": 100, "status": "unsearchable"})
 
         self.assertEqual(status, 200)
         _assert_required_fields(self, data, self.UPDATE_REQUIRED_FIELDS,
@@ -637,7 +637,7 @@ class TestPipelineMutationRouteContracts(_FakeDbWebServerCase):
 
     def test_pipeline_update_same_status_is_idempotent_for_operator_statuses(self):
         for index, request_status in enumerate(
-            ("wanted", "imported", "manual"),
+            ("wanted", "imported", "unsearchable"),
             start=601,
         ):
             with self.subTest(status=request_status):
@@ -657,21 +657,21 @@ class TestPipelineMutationRouteContracts(_FakeDbWebServerCase):
                 self.assertEqual(data["new_status"], request_status)
                 self.assertEqual(self.db.get_request(index), before)
 
-    def test_pipeline_update_imported_to_manual(self):
+    def test_pipeline_update_imported_to_unsearchable_is_rejected(self):
         self.db.seed_request(make_request_row(
             id=604,
             status="imported",
-            mb_release_id="imported-to-manual",
+            mb_release_id="imported-to-unsearchable",
         ))
 
         status, data = self._post(
             "/api/pipeline/update",
-            {"id": 604, "status": "manual"},
+            {"id": 604, "status": "unsearchable"},
         )
 
-        self.assertEqual(status, 200)
-        self.assertEqual(data["new_status"], "manual")
-        self.assertEqual(self.db.request(604)["status"], "manual")
+        self.assertEqual(status, 409)
+        self.assertEqual(data["error"], "transition_conflict")
+        self.assertEqual(self.db.request(604)["status"], "imported")
 
     @patch("web.routes.pipeline_mutations.finalize_request")
     def test_pipeline_update_maps_stale_transition_to_409_without_success(
@@ -679,14 +679,14 @@ class TestPipelineMutationRouteContracts(_FakeDbWebServerCase):
     ):
         mock_transition.return_value = TransitionConflict(
             request_id=100,
-            target_status="manual",
+            target_status="unsearchable",
             kind=TransitionConflictKind.stale_source,
             expected_status="imported",
             actual_status="replaced",
         )
 
         status, data = self._post(
-            "/api/pipeline/update", {"id": 100, "status": "manual"})
+            "/api/pipeline/update", {"id": 100, "status": "unsearchable"})
 
         self.assertEqual(status, 409)
         self.assertEqual(data["error"], "transition_conflict")
@@ -736,9 +736,10 @@ class TestPipelineMutationRouteContracts(_FakeDbWebServerCase):
     @patch("web.routes.pipeline_mutations.finalize_request")
     def test_pipeline_set_quality_contract(self, mock_transition):
         mock_transition.side_effect = transitions.finalize_request
+        self.db.request(100)["status"] = "wanted"
         status, data = self._post(
             "/api/pipeline/set-quality",
-            {"mb_release_id": "abc-123", "status": "manual", "min_bitrate": 245},
+            {"mb_release_id": "abc-123", "status": "unsearchable", "min_bitrate": 245},
         )
 
         self.assertEqual(status, 200)
@@ -752,14 +753,14 @@ class TestPipelineMutationRouteContracts(_FakeDbWebServerCase):
         mock_transition.side_effect = transitions.finalize_request
         self.db.seed_request(make_request_row(
             id=100,
-            status="imported",
+            status="wanted",
             mb_release_id="12856590",
             discogs_release_id=None,
         ))
 
         status, data = self._post(
             "/api/pipeline/set-quality",
-            {"mb_release_id": " 0012856590 ", "status": "manual", "min_bitrate": 245},
+            {"mb_release_id": " 0012856590 ", "status": "unsearchable", "min_bitrate": 245},
         )
 
         self.assertEqual(status, 200)

--- a/tests/web/test_routes_pipeline_mutations.py
+++ b/tests/web/test_routes_pipeline_mutations.py
@@ -86,6 +86,7 @@ class TestPipelineMutationRouteContracts(_FakeDbWebServerCase):
     }
     BAN_SOURCE_REQUIRED_FIELDS = {
         "status", "username", "beets_removed", "hashes_recorded",
+        "request_status",
     }
     FORCE_IMPORT_REQUIRED_FIELDS = {
         "status", "request_id", "artist", "album", "message",
@@ -863,6 +864,29 @@ class TestPipelineMutationRouteContracts(_FakeDbWebServerCase):
         self.assertEqual(status, 200)
         _assert_required_fields(self, data, self.BAN_SOURCE_REQUIRED_FIELDS,
                                 "pipeline ban-source response")
+        self.assertEqual(data["request_status"], "wanted")
+
+    @patch("web.routes.pipeline_mutations.finalize_request")
+    def test_pipeline_ban_source_reports_preserved_search_stop(
+        self, _mock_transition,
+    ):
+        import web.server as srv
+        release_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        self.db.seed_request(make_request_row(
+            id=102, status="unsearchable", mb_release_id=release_id,
+        ))
+        old_beets = srv._beets
+        srv._beets = FakeBeetsDB()
+        try:
+            status, data = self._post(
+                "/api/pipeline/ban-source",
+                {"request_id": 102, "confirm": "BAN", "mb_release_id": release_id},
+            )
+        finally:
+            srv._beets = old_beets
+
+        self.assertEqual(status, 200)
+        self.assertEqual(data["request_status"], "unsearchable")
 
     def test_pipeline_ban_source_requires_confirmation(self):
         status, data = self._post(

--- a/tests/web/test_server_endpoints.py
+++ b/tests/web/test_server_endpoints.py
@@ -158,7 +158,7 @@ class TestServerEndpoints(_FakeDbWebServerCase):
         status, data = self._get("/api/pipeline/all")
         self.assertEqual(status, 200)
         self.assertIn("counts", data)
-        for key in ("wanted", "downloading", "imported", "manual"):
+        for key in ("wanted", "downloading", "imported", "unsearchable"):
             self.assertIn(key, data)
 
     def test_pipeline_status_includes_downloading(self):

--- a/web/classify.py
+++ b/web/classify.py
@@ -817,7 +817,7 @@ def _classify(
         )
         if entry.request_status == "wanted":
             lifecycle = "Search remains open; a future download will retry."
-        elif entry.request_status in {"manual", "unsearchable"}:
+        elif entry.request_status == "unsearchable":
             lifecycle = "Operator search stop remains in place."
         else:
             lifecycle = "The request lifecycle was preserved."

--- a/web/index.html
+++ b/web/index.html
@@ -396,7 +396,8 @@
   .p-forensic-table th { color: #666; text-align: left; font-weight: 500; padding: 2px 6px 2px 0; }
   .p-forensic-table td { color: #aaa; padding: 1px 6px 1px 0; }
   .p-btn { padding: 4px 12px; border: 1px solid #444; background: #222; color: #aaa; border-radius: 4px; cursor: pointer; font-size: 0.78em; }
-  .p-btn:hover { background: #333; color: #eee; }
+  .p-btn:hover:not(:disabled) { background: #333; color: #eee; }
+  .p-btn:disabled { opacity: 0.5; cursor: default; }
   .p-btn.active-status { border-color: #6a9; color: #6a9; background: #2a3a2a; }
   /* Browse search bar: one wrapping flex row. On narrow screens the
      input claims a full-width row of its own so it stays typeable —

--- a/web/index.html
+++ b/web/index.html
@@ -95,7 +95,8 @@
   .badge-wanted { background: #5a3a1a; color: #fa6; }
   .badge-downloading { background: #1a3a5a; color: #6cf; }
   .badge-imported { background: #1a4a2a; color: #6d6; }
-  .badge-manual { background: #3a3a3a; color: #aaa; }
+  .badge-muted { background: #3a3a3a; color: #aaa; }
+  .badge-unsearchable { background: #3a3a3a; color: #aaa; }
   .badge-sublabel { background: #2a2a3a; color: #9ac; font-style: italic; }
   .status-card { background: #1a1a1a; padding: 16px; border-radius: 8px; margin-bottom: 12px; }
   .status-counts { display: flex; gap: 8px; margin-bottom: 16px; flex-wrap: wrap; }
@@ -383,10 +384,6 @@
      it to two lines; the full text stays in the hover title. */
   .r-summary { display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; text-align: left; }
   .p-actions { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
-  /* Manual-reason chip — small inline tag near the request title or status.
-     Currently used for `search_exhausted` (red/amber) flips written by the
-     variant ladder when all variants exhaust without finding a candidate. */
-  .p-manual-chip { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: 0.7em; font-weight: 600; margin-left: 6px; background: #4a2a1a; color: #d96; }
   /* Forensic block — collapsed by default summary of the most recent search
      row (variant + final_state + top-3 candidates). Click toggles open. */
   .p-forensic { margin-top: 8px; font-size: 0.78em; color: #888; }

--- a/web/js/artist_page.js
+++ b/web/js/artist_page.js
@@ -122,8 +122,7 @@ export function classifyArtistRows({
   }
 
   const inFlight = (libraryAlbums || []).filter(
-    album => album.pipeline_status === 'downloading'
-      || album.pipeline_status === 'manual');
+    album => album.pipeline_status === 'downloading');
 
   // Suppress the library-feed fallback only through exact identities from
   // the displayed row or its associated counterpart. A counterpart can

--- a/web/js/badges.js
+++ b/web/js/badges.js
@@ -33,7 +33,7 @@ import { qualityLabelShort } from './util.js';
  *   matters: Opus 128 is transparent, MP3 128 is poor — same bitrate,
  *   different rank).
  * @property {string|null|undefined} [pipeline_status]
- *   'wanted' | 'downloading' | 'imported' | 'manual' | null
+ *   'wanted' | 'downloading' | 'imported' | 'unsearchable' | null
  * @property {boolean} [pipeline_verified_lossless] - The tracked install
  *   carries a verified-lossless proof (terminal quality identity).
  * @property {boolean} [pipeline_provisional] - The tracked install is an
@@ -76,6 +76,6 @@ export function renderStatusBadges(item) {
   if (pStatus === 'wanted') html += '<span class="badge badge-wanted">wanted</span>';
   if (pStatus === 'downloading') html += '<span class="badge badge-downloading">downloading</span>';
   if (pStatus === 'imported') html += '<span class="badge badge-imported">imported</span>';
-  if (pStatus === 'manual') html += '<span class="badge badge-manual">manual</span>';
+  if (pStatus === 'unsearchable') html += '<span class="badge badge-unsearchable">unsearchable</span>';
   return html;
 }

--- a/web/js/library.js
+++ b/web/js/library.js
@@ -180,9 +180,7 @@ export function renderLibraryDetailBody(data, id) {
       const pStatus = data.pipeline_status || '';
       html += `<div class="p-actions" style="margin-top:10px;">
         <span class="p-detail-label" style="line-height:28px;">Status:</span>
-        <button class="p-btn ${pStatus === 'wanted' ? 'active-status' : ''}" onclick="event.stopPropagation(); window.setLibQuality(${releaseArg}, 'wanted', null)">wanted</button>
-        <button class="p-btn ${pStatus === 'imported' ? 'active-status' : ''}" onclick="event.stopPropagation(); window.setLibQuality(${releaseArg}, 'imported', null)">imported</button>
-        <button class="p-btn ${pStatus === 'unsearchable' ? 'active-status' : ''}" onclick="event.stopPropagation(); window.setLibQuality(${releaseArg}, 'unsearchable', null)">unsearchable</button>
+        ${renderLibraryStatusButtons(releaseArg, pStatus)}
       </div>`;
       html += `<div class="p-actions" style="margin-top:6px;">
         <span class="p-detail-label" style="line-height:28px;">Min bitrate:</span>
@@ -238,17 +236,64 @@ export function renderLibraryDetailBody(data, id) {
 }
 
 /**
+ * Render lifecycle actions without offering an invalid search-stop edge.
+ * @param {string} releaseArg - HTML-safe JavaScript string literal.
+ * @param {string} status
+ * @returns {string}
+ */
+function renderLibraryStatusButtons(releaseArg, status) {
+  const downloading = status === 'downloading'
+    ? '<button class="p-btn active-status" disabled aria-disabled="true">downloading</button>'
+    : '';
+  const canSetUnsearchable = status === 'wanted' || status === 'unsearchable';
+  const unsearchable = canSetUnsearchable
+    ? `<button class="p-btn ${status === 'unsearchable' ? 'active-status' : ''}" onclick="event.stopPropagation(); window.setLibQuality(${releaseArg}, 'unsearchable', null)">unsearchable</button>`
+    : '<button class="p-btn" disabled aria-disabled="true">unsearchable</button>';
+  return `${downloading}
+        <button class="p-btn ${status === 'wanted' ? 'active-status' : ''}" onclick="event.stopPropagation(); window.setLibQuality(${releaseArg}, 'wanted', null)">wanted</button>
+        <button class="p-btn ${status === 'imported' ? 'active-status' : ''}" onclick="event.stopPropagation(); window.setLibQuality(${releaseArg}, 'imported', null)">imported</button>
+        ${unsearchable}`;
+}
+
+export function banSourceConfirmationMessage() {
+  return 'Mark this album as a bad rip?\n'
+    + 'The album will be removed from beets and any recorded uploader denylisted. '
+    + 'If the request is unsearchable, it will remain unsearchable; otherwise it will be reset to wanted.';
+}
+
+/**
+ * @param {{request_status: string, username?: string|null,
+ *   beets_removed?: boolean, hashes_recorded?: number}} data
+ * @returns {string}
+ */
+export function describeBanSourceSuccess(data) {
+  if (data.request_status !== 'wanted' && data.request_status !== 'unsearchable') {
+    throw new Error(`Unexpected Bad Rip request status: ${data.request_status}`);
+  }
+  const removed = data.beets_removed ? 'removed from beets' : 'not in beets';
+  const hashCount = data.hashes_recorded ?? 0;
+  const hashes = `${hashCount} hash${hashCount === 1 ? '' : 'es'} recorded`;
+  const lifecycle = data.request_status === 'unsearchable'
+    ? 'request remains unsearchable'
+    : 'request requeued as wanted';
+  return data.username
+    ? `Banned ${data.username}: ${removed}, ${hashes}, ${lifecycle}.`
+    : `Album ${removed} (no Soulseek user on record), ${hashes}, ${lifecycle}.`;
+}
+
+/**
  * Mark an imported album as a bad rip (issue #188).
  * The route resolves the supplying user from download_log, hashes the
  * imported tracks (tag-stripped), persists known-bad hashes, denylists
- * the user, removes from beets, and requeues. The frontend does not
- * need to know the username.
+ * the user, and removes from beets. An existing unsearchable stop is
+ * preserved; every other supported state is reset to wanted. The frontend
+ * does not need to know the username.
  *
  * @param {number} requestId
  * @param {string} mbid
  */
 export async function banSource(requestId, mbid) {
-  if (!confirm('Mark this album as a bad rip?\nThe most recent uploader will be denylisted, the album removed from beets, and the request requeued.')) return;
+  if (!confirm(banSourceConfirmationMessage())) return;
   try {
     const r = await fetch(`${API}/api/pipeline/ban-source`, {
       method: 'POST',
@@ -267,12 +312,7 @@ export async function banSource(requestId, mbid) {
     const partial = data.partial_failures || {};
     const cleanupErrs = partial.cleanup_errors || [];
     const hashErrs = partial.hash_capture_errors || [];
-    const removed = data.beets_removed ? 'removed from beets' : 'not in beets';
-    const hashCount = data.hashes_recorded ?? 0;
-    const hashes = `${hashCount} hash${hashCount === 1 ? '' : 'es'} recorded`;
-    const head = data.username
-      ? `Banned ${data.username}: ${removed}, ${hashes}, requeued.`
-      : `Album ${removed} (no Soulseek user on record), ${hashes}, requeued.`;
+    const head = describeBanSourceSuccess(data);
     if (cleanupErrs.length > 0 || hashErrs.length > 0) {
       const warnings = [];
       if (cleanupErrs.length) warnings.push(`${cleanupErrs.length} beet remove failure(s)`);

--- a/web/js/library.js
+++ b/web/js/library.js
@@ -182,7 +182,7 @@ export function renderLibraryDetailBody(data, id) {
         <span class="p-detail-label" style="line-height:28px;">Status:</span>
         <button class="p-btn ${pStatus === 'wanted' ? 'active-status' : ''}" onclick="event.stopPropagation(); window.setLibQuality(${releaseArg}, 'wanted', null)">wanted</button>
         <button class="p-btn ${pStatus === 'imported' ? 'active-status' : ''}" onclick="event.stopPropagation(); window.setLibQuality(${releaseArg}, 'imported', null)">imported</button>
-        <button class="p-btn ${pStatus === 'manual' ? 'active-status' : ''}" onclick="event.stopPropagation(); window.setLibQuality(${releaseArg}, 'manual', null)">manual</button>
+        <button class="p-btn ${pStatus === 'unsearchable' ? 'active-status' : ''}" onclick="event.stopPropagation(); window.setLibQuality(${releaseArg}, 'unsearchable', null)">unsearchable</button>
       </div>`;
       html += `<div class="p-actions" style="margin-top:6px;">
         <span class="p-detail-label" style="line-height:28px;">Min bitrate:</span>

--- a/web/js/long_tail_console.js
+++ b/web/js/long_tail_console.js
@@ -518,7 +518,7 @@ function renderUnfindableBody(triage) {
     ? `<div class="lt-rollup">artist probe: ${unfindable.last_artist_probe_match_count} match${unfindable.last_artist_probe_match_count === 1 ? '' : 'es'}${unfindable.last_artist_probe_at ? ` · ${esc(consoleTimestamp(unfindable.last_artist_probe_at))}` : ''}</div>`
     : '';
   return `<div class="lt-unfindable-cat">
-      <span class="badge badge-manual">${esc(String(unfindable.category))}</span>
+      <span class="badge badge-muted">${esc(String(unfindable.category))}</span>
       ${catAt ? `<span class="lt-meta-chip">categorised ${esc(catAt)}</span>` : ''}
     </div>${rollup}${probe}`;
 }
@@ -584,7 +584,7 @@ function renderRescuesBody(history, inFlightFlag) {
     (h) => h.outcome === 'youtube_failed' || h.outcome === 'youtube_success');
   if (terminal && terminal.outcome === 'youtube_failed') {
     const reason = youtubeFailureReason(terminal);
-    return `<div class="lt-rescue-status"><span class="badge badge-manual">last rescue failed</span> <span class="lt-rescue-reason">${esc(reason)}</span></div>`;
+    return `<div class="lt-rescue-status"><span class="badge badge-muted">last rescue failed</span> <span class="lt-rescue-reason">${esc(reason)}</span></div>`;
   }
   if (rows.length === 0) {
     return '<div class="lt-panel-empty">No rescue attempts yet.</div>';
@@ -1221,7 +1221,7 @@ export function rescueOutcomeCopy(result) {
     case 'wrong_state':
       return {
         title: 'Request changed',
-        detail: 'This request is no longer wanted/manual — refresh and try again.',
+        detail: 'This request is no longer wanted/unsearchable — refresh and try again.',
         tone: 'error',
       };
     case 'no_resolver_mapping':

--- a/web/js/pipeline.js
+++ b/web/js/pipeline.js
@@ -193,6 +193,26 @@ function renderPipelineNav() {
 }
 
 /**
+ * Render lifecycle actions without offering an invalid search-stop edge.
+ * @param {string|number} requestId
+ * @param {string} status
+ * @returns {string}
+ */
+function renderPipelineStatusButtons(requestId, status) {
+  const downloading = status === 'downloading'
+    ? '<button class="p-btn active-status" disabled aria-disabled="true">downloading</button>'
+    : '';
+  const canSetUnsearchable = status === 'wanted' || status === 'unsearchable';
+  const unsearchable = canSetUnsearchable
+    ? `<button class="p-btn ${status === 'unsearchable' ? 'active-status' : ''}" onclick="event.stopPropagation(); window.updateStatus(${requestId}, 'unsearchable')">unsearchable</button>`
+    : '<button class="p-btn" disabled aria-disabled="true">unsearchable</button>';
+  return `${downloading}
+      <button class="p-btn ${status === 'wanted' ? 'active-status' : ''}" onclick="event.stopPropagation(); window.updateStatus(${requestId}, 'wanted')">wanted</button>
+      <button class="p-btn ${status === 'imported' ? 'active-status' : ''}" onclick="event.stopPropagation(); window.updateStatus(${requestId}, 'imported')">imported</button>
+      ${unsearchable}`;
+}
+
+/**
  * Toggle detail panel for a pipeline or recents item.
  * @param {string|number} elId - DOM id for the detail panel
  * @param {number} [requestId] - album_requests.id (defaults to elId for pipeline tab)
@@ -230,9 +250,7 @@ export async function toggleDetail(elId, requestId) {
     // Status change buttons
     html += `<div class="p-actions">
       <span class="p-detail-label" style="line-height:28px;">Status:</span>
-      <button class="p-btn ${req.status === 'wanted' ? 'active-status' : ''}" onclick="event.stopPropagation(); window.updateStatus(${id}, 'wanted')">wanted</button>
-      <button class="p-btn ${req.status === 'imported' ? 'active-status' : ''}" onclick="event.stopPropagation(); window.updateStatus(${id}, 'imported')">imported</button>
-      <button class="p-btn ${req.status === 'unsearchable' ? 'active-status' : ''}" onclick="event.stopPropagation(); window.updateStatus(${id}, 'unsearchable')">unsearchable</button>`;
+      ${renderPipelineStatusButtons(id, req.status)}`;
     // Bad-rip reuses the library renderer — pipelineId + releaseId are all
     // it needs from state. Hidden when either is absent (issue #188).
     html += renderBadRipButton(/** @type {any} */ ({pipelineId: id, releaseId: req.mb_release_id}), {
@@ -352,6 +370,7 @@ export async function updateStatus(id, newStatus) {
 
 export const __test__ = {
   renderPipelineNav,
+  renderPipelineStatusButtons,
   renderCurrentQualityRow,
   renderRequestEvidenceSections,
 };

--- a/web/js/pipeline.js
+++ b/web/js/pipeline.js
@@ -1,6 +1,6 @@
 // @ts-check
 import { state, API, toast } from './state.js';
-import { esc, qualityLabel, manualReasonLabel, renderForensicBlock } from './util.js';
+import { esc, qualityLabel, renderForensicBlock } from './util.js';
 import { renderDownloadHistoryItem } from './history.js';
 import {
   renderBeetsTrackRow, renderExpectedTrackRow, renderDetailRow, renderExternalLinkRow, toggleExpand,
@@ -212,13 +212,6 @@ export async function toggleDetail(elId, requestId) {
     const history = data.history || [];
 
     let html = '';
-    // Manual-reason chip (e.g. search_exhausted) — surfaces the reason a
-    // request landed in `manual` so the operator does not have to query
-    // JSONB. Hidden when null (manually-set or pre-U7 rows).
-    const reasonLabel = manualReasonLabel(data.manual_reason);
-    if (reasonLabel) {
-      html += renderDetailRow('Manual reason', `<span class="p-manual-chip">${esc(reasonLabel)}</span>`);
-    }
     // External link (MB or Discogs)
     html += renderExternalLinkRow(req.mb_release_id || '');
     if (req.imported_path) {
@@ -239,7 +232,7 @@ export async function toggleDetail(elId, requestId) {
       <span class="p-detail-label" style="line-height:28px;">Status:</span>
       <button class="p-btn ${req.status === 'wanted' ? 'active-status' : ''}" onclick="event.stopPropagation(); window.updateStatus(${id}, 'wanted')">wanted</button>
       <button class="p-btn ${req.status === 'imported' ? 'active-status' : ''}" onclick="event.stopPropagation(); window.updateStatus(${id}, 'imported')">imported</button>
-      <button class="p-btn ${req.status === 'manual' ? 'active-status' : ''}" onclick="event.stopPropagation(); window.updateStatus(${id}, 'manual')">manual</button>`;
+      <button class="p-btn ${req.status === 'unsearchable' ? 'active-status' : ''}" onclick="event.stopPropagation(); window.updateStatus(${id}, 'unsearchable')">unsearchable</button>`;
     // Bad-rip reuses the library renderer — pipelineId + releaseId are all
     // it needs from state. Hidden when either is absent (issue #188).
     html += renderBadRipButton(/** @type {any} */ ({pipelineId: id, releaseId: req.mb_release_id}), {

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -188,19 +188,6 @@ export function youtubeBrowseUrl(browseId) {
 }
 
 /**
- * Map a `manual_reason` enum value to a short, human-friendly label for the
- * inline chip on the request-detail view. Returns the empty string for
- * NULL / unknown reasons so the caller can branch on truthiness.
- * @param {string|null|undefined} reason
- * @returns {string}
- */
-export function manualReasonLabel(reason) {
-  if (!reason) return '';
-  if (reason === 'search_exhausted') return 'search exhausted';
-  return reason;
-}
-
-/**
  * @typedef {Object} CandidateScore
  * @property {string} username
  * @property {string} dir

--- a/web/routes/browse.py
+++ b/web/routes/browse.py
@@ -73,7 +73,8 @@ def get_library_artist(h: BaseHTTPRequestHandler, params: dict[str, list[str]]) 
 
 # Badge priority when several requests map to one release group — show
 # the most active state.
-_PIPELINE_BADGE_PRIORITY = {"downloading": 0, "wanted": 1, "manual": 2, "imported": 3}
+_PIPELINE_BADGE_PRIORITY = {
+    "downloading": 0, "wanted": 1, "unsearchable": 2, "imported": 3}
 
 
 ArtistPipelineKey = tuple[str, str, str]

--- a/web/routes/pipeline.py
+++ b/web/routes/pipeline.py
@@ -312,7 +312,8 @@ def get_pipeline_all(h, params: dict[str, list[str]]) -> None:
     all_data: dict[str, object] = {"counts": counts}
     status_items: dict[str, list[dict]] = {}
     all_ids: list[int] = []
-    statuses: tuple[str, ...] = ("wanted", "downloading", "imported", "manual")
+    statuses: tuple[str, ...] = (
+        "wanted", "downloading", "imported", "unsearchable")
     # ``?include_replaced=true`` opt-in surfaces the frozen audit rows
     # for operators reviewing past Replace actions (R30). Default off so
     # the standard view stays focused on active work.
@@ -440,7 +441,6 @@ def get_pipeline_detail(h, params: dict[str, list[str]], req_id_str: str) -> Non
         "request": s._serialize_row(req),
         "tracks": tracks,
         "history": history_items,
-        "manual_reason": req.get("manual_reason"),
         "last_search": last_search,
     }
     mbid = req.get("mb_release_id")

--- a/web/routes/pipeline_dashboard.py
+++ b/web/routes/pipeline_dashboard.py
@@ -28,8 +28,8 @@ def _dashboard_disk_coverage(s) -> dict[str, object] | None:
     Only ``imported`` claims beets presence, so ``drift_rows`` carries
     off-disk ``imported`` rows only (a release that vanished from beets
     is the Lucksmiths-class out-of-band drift signal). Off-disk wanted
-    (not yet acquired), downloading (in flight), and manual (staged for
-    review) rows are lifecycle-normal, not drift."""
+    (not yet acquired), downloading (in flight), and unsearchable
+    (operator search stop) rows are lifecycle-normal, not drift."""
     beets = s._beets_db()
     if beets is None:
         return None

--- a/web/routes/pipeline_mutations.py
+++ b/web/routes/pipeline_mutations.py
@@ -924,6 +924,7 @@ def post_pipeline_ban_source(h, body: dict) -> None:
         partial_failures["hash_capture_errors"] = hash_capture_errors
     payload: dict[str, object] = {
         "status": "ok",
+        "request_status": result.request_status,
         "username": result.username,
         "beets_removed": result.beets_removed,
         "hashes_recorded": result.hashes_recorded,
@@ -1087,7 +1088,8 @@ ROUTES: list[RouteRegistration] = [
     route(
         "POST", "/api/pipeline/ban-source", post_pipeline_ban_source,
         "Mark a server-resolved rip as bad: denylist, hash + bad-byte "
-        "ripple-stop, and remove from beets. Requires confirm='BAN'.",
+        "ripple-stop, remove from beets, and preserve unsearchable or reset "
+        "wanted. Requires confirm='BAN'.",
         classified=True,
     ),
     route(

--- a/web/routes/pipeline_mutations.py
+++ b/web/routes/pipeline_mutations.py
@@ -421,7 +421,7 @@ def post_pipeline_add(h, body: dict) -> None:
 
 class PipelineUpdateRequest(BaseModel):
     id: int = Field(gt=0)
-    status: Literal["wanted", "imported", "manual"]
+    status: Literal["wanted", "imported", "unsearchable"]
 
 
 def post_pipeline_update(h, body: dict) -> None:
@@ -619,7 +619,7 @@ def post_pipeline_upgrade(h, body: dict) -> None:
 
 class PipelineSetQualityRequest(BaseModel):
     mb_release_id: str = Field(min_length=1)
-    status: Literal["", "wanted", "imported", "manual"] = ""
+    status: Literal["", "wanted", "imported", "unsearchable"] = ""
     min_bitrate: int | None = None
 
 
@@ -647,7 +647,7 @@ def post_pipeline_set_quality(h, body: dict) -> None:
         min_bitrate = int(min_bitrate)
 
     if new_status:
-        if new_status not in ("wanted", "imported", "manual"):
+        if new_status not in ("wanted", "imported", "unsearchable"):
             h._error(f"Invalid status: {new_status}")
             return
         if new_status == "imported":
@@ -680,31 +680,22 @@ def post_pipeline_set_quality(h, body: dict) -> None:
                     fields=wanted_fields,
                 ),
             )
-        else:
+        elif new_status == "unsearchable":
+            unsearchable_fields: dict[str, object] = {}
+            if min_bitrate is not None:
+                unsearchable_fields["min_bitrate"] = min_bitrate
             result = finalize_request(
                 s._db(),
                 req_id,
-                transitions.RequestTransition.status_only(
-                    new_status,
+                transitions.RequestTransition.to_unsearchable_fields(
                     from_status=existing["status"],
+                    fields=unsearchable_fields,
                 ),
             )
+        else:
+            raise AssertionError(f"unhandled pipeline status {new_status!r}")
         if not _transition_applied_or_respond(h, result):
             return
-        if min_bitrate is not None and new_status == "manual":
-            applied = s._db().update_request_fields(
-                req_id,
-                expected_status="manual",
-                min_bitrate=min_bitrate,
-            )
-            if not _request_fields_applied_or_respond(
-                h,
-                s._db(),
-                req_id,
-                expected_status="manual",
-                applied=applied,
-            ):
-                return
     elif min_bitrate is not None:
         if existing["status"] == "replaced":
             result = finalize_request(
@@ -826,7 +817,7 @@ def post_pipeline_set_intent(h, body: dict) -> None:
             "requeued": True,
         })
     else:
-        # Just update the persistent intent for next search (wanted or manual)
+        # Just update the persistent intent for the next search or resume.
         update_fields = {"target_format": target_format}
         if should_clear_lossless_search_override(
             new_target_format=target_format,

--- a/web/routes/youtube.py
+++ b/web/routes/youtube.py
@@ -268,7 +268,7 @@ def post_pipeline_youtube_rescue(h, body: dict, req_id_str: str) -> None:
       * 400 — body validation failure (missing ``browse_id`` etc.) or
         invalid URL ``request_id``
       * 404 — ``request_not_found``
-      * 409 — ``wrong_state`` (request is not ``wanted`` / ``manual``),
+      * 409 — ``wrong_state`` (request is not ``wanted`` / ``unsearchable``),
               ``in_flight`` (an existing ``youtube_running`` row already
               owns this request — re-issue once it's terminal)
       * 422 — ``no_resolver_mapping`` (run the YouTube album resolver


### PR DESCRIPTION
## Summary

- replace the ambiguous `manual` request lifecycle with the explicit `unsearchable` search stop, including migration of existing rows without timestamp churn, a closed status constraint, and removal of `manual_reason`
- centralize the exact lifecycle graph and terminal arbitration so only a successful exact-release terminal acceptance may supersede `unsearchable`; invalid `downloading`/`imported` to `unsearchable` transitions fail closed
- keep Bad Rip source banning orthogonal to searchability: an `unsearchable` request remains stopped, while supported searchable states return to `wanted`, with the resulting status exposed consistently through service, CLI, API, and UI
- remove obsolete retry/cancel lifecycle actions and align pipeline, library, dashboard, fixtures, CLI help, API route metadata, and operator docs with the new vocabulary

This is the lifecycle/status deliverable of #737. The issue remains open for its next scoped deliverable.

## Validation

- independent review of the exact integrated SHA: clean
- `nix-shell --run "pyright --threads 4"`: 0 errors
- `nix-shell --run "bash scripts/run_tests.sh"`: 6,223 tests passed, no skips
- browser loop against an ephemeral migrated PostgreSQL copy of real production row 993: `unsearchable` renders as the active stop, and the invalid imported-to-unsearchable control is disabled
- issue-closing reference audit passed for branch commits and this PR body

Refs #737
