### PR TITLE
test: add the real-storage lifecycle world model

### DIFF
--- a/docs/generated-testing.md
+++ b/docs/generated-testing.md
@@ -1,9 +1,11 @@
 # Generated (property-based) testing
 
 Issue #548. Hypothesis-driven generated tests assert **policy invariants**
-over large generated state spaces instead of hand-picked examples. They are
-ordinary members of the unittest suite — no separate runner, no seed
-bookkeeping, no standing service.
+over large generated state spaces instead of hand-picked examples. The normal
+pure/fake-backed modules are ordinary members of the unittest suite — no seed
+bookkeeping or standing service. The heavyweight cross-engine world model has
+its own direct runner while issue #743 measures its cost; suite and scheduled
+placement are deliberately separate follow-up decisions.
 
 ## Bug hunting — the house method
 
@@ -72,6 +74,38 @@ presence-probe worlds, and notifier
 target/observation worlds are generated in the two Python modules above; a
 second JavaScript property stack would duplicate those policies rather than
 exercise a new invariant.
+
+## Heavy cross-engine world model
+
+`tests/world_model/state_machine.py` drives real production request transitions
+against a throwaway PostgreSQL database while a real pinned-Beets library adds,
+removes, and moves generated tagged audio. It checks the shared
+`lib/world_invariants.py` bank after every rule. Its first rule tranche covers
+request creation, initial import, same-pressing upgrade/re-import, exact-release
+membership, imported-path coherence, and exclusive physical album folders.
+
+It is intentionally named outside unittest's `test*.py` discovery pattern.
+Run the deterministic pin and generated state machine directly:
+
+```bash
+nix-shell --run "python3 -m unittest tests.world_model.state_machine -v"
+```
+
+The temporary PostgreSQL, Beets SQLite database, library tree, and generated
+audio are local and disposable; this runner never reads or mutates production.
+The initial measured budget is six examples of eight stateful steps. On doc1
+on 2026-07-19, the direct two-test module reported 7.0 test-seconds (excluding
+dev-shell startup). That is a baseline, not a placement decision. Override the
+budget for exploration without changing code:
+
+```bash
+CRATEDIGGER_WORLD_EXAMPLES=20 CRATEDIGGER_WORLD_STEPS=20 \
+  nix-shell --run "python3 -m unittest tests.world_model.state_machine -v"
+```
+
+Do not add this runner to `scripts/run_tests.sh` or schedule it merely because
+the core exists. Issue #743 records runtime and fault-injection evidence first;
+standard-suite and scheduled-depth choices belong to a follow-up PR.
 
 ## Two tiers, one knob
 

--- a/lib/dispatch/core.py
+++ b/lib/dispatch/core.py
@@ -102,11 +102,17 @@ def dispatch_import_core(
     current_evidence_loader: Callable[
         ..., "CurrentEvidenceActionResult | None"
     ] | None = None,
+    beets_library_db_path: str | None = None,
+    beets_library_root: str | None = None,
 ) -> "DispatchOutcome":
     """Core import dispatch — takes plain params + PipelineDB directly.
 
     Runs import_one.py, parses result, dispatches on decision (mark_done/failed,
     denylist, quality gate, media server notifiers, cleanup). Returns DispatchOutcome.
+
+    ``beets_library_db_path`` / ``beets_library_root`` are explicit storage
+    seams for isolated real-Beets worlds. Production leaves the DB path unset
+    and derives the root from ``cfg.beets_directory`` as before.
 
     Used by the auto-import flow in ``lib.download`` and by
     ``dispatch_import_from_db()`` (force-import).
@@ -115,6 +121,12 @@ def dispatch_import_core(
     from lib.util import trigger_jellyfin_scan as _trigger_jellyfin
 
     source_dirs = normalize_source_dirs(source_dirs or [])
+    if beets_library_root is not None:
+        effective_beets_library_root = beets_library_root
+    elif cfg is not None:
+        effective_beets_library_root = getattr(cfg, "beets_directory", "")
+    else:
+        effective_beets_library_root = ""
 
     # Operation identity is distinct from the eventual download-log outcome:
     # an automatic attempt can still reject or fail after this start message.
@@ -233,7 +245,7 @@ def dispatch_import_core(
                     else None
                 ),
                 attempt_have_audit_available=attempt_result.audit is not None,
-                beets_library_root=getattr(cfg, "beets_directory", "") if cfg is not None else "",
+                beets_library_root=effective_beets_library_root,
                 **evidence_gate_kwargs,
             )
             if (
@@ -558,9 +570,8 @@ def dispatch_import_core(
                             ),
                             source_candidate=evidence_gate.candidate,
                             import_result=ir,
-                            beets_library_root=(
-                                cfg.beets_directory if cfg is not None else ""
-                            ),
+                            beets_library_db_path=beets_library_db_path,
+                            beets_library_root=effective_beets_library_root,
                         )
                     except Exception as exc:
                         logger.exception(

--- a/lib/dispatch/evidence_gate.py
+++ b/lib/dispatch/evidence_gate.py
@@ -335,6 +335,7 @@ def _refresh_current_evidence_after_import(
     quality_ranks: "QualityRankConfig | None",
     source_candidate: AlbumQualityEvidence | None = None,
     import_result: ImportResult | None = None,
+    beets_library_db_path: str | None = None,
     beets_library_root: str = "",
 ) -> EvidenceBuildResult:
     """Persist current evidence for the just-imported Beets album.
@@ -354,6 +355,10 @@ def _refresh_current_evidence_after_import(
     forward ``verified_lossless_proof`` and is preserved for non-post-import
     callers (e.g., wrong-match triage backfilling library evidence for
     pre-refactor albums).
+
+    ``beets_library_db_path`` selects an isolated real Beets database for
+    world-model runs. Normal production callers omit it and retain the
+    module-configured read-only library path.
     """
 
     from lib.beets_db import BeetsDB
@@ -366,7 +371,14 @@ def _refresh_current_evidence_after_import(
     # BeetsDB docstring. Both the U10 propagation path and the legacy
     # ``backfill_current_evidence_from_album_info`` path depend on an
     # absolute ``album_info.album_path`` to read the just-imported files.
-    with BeetsDB(library_root=beets_library_root) as beets:
+    if beets_library_db_path is None:
+        beets_handle = BeetsDB(library_root=beets_library_root)
+    else:
+        beets_handle = BeetsDB(
+            beets_library_db_path,
+            library_root=beets_library_root,
+        )
+    with beets_handle as beets:
         album_info = beets.get_album_info(mb_release_id, cfg)
     if album_info is None:
         return EvidenceBuildResult(None, "empty_current", "album not in beets")

--- a/lib/world_invariants.py
+++ b/lib/world_invariants.py
@@ -1,0 +1,223 @@
+"""Cross-engine world invariants shared by fuzzing and live audit (#743)."""
+
+from __future__ import annotations
+
+import os
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import msgspec
+
+
+class LibraryAlbumSnapshot(msgspec.Struct, frozen=True):
+    """The exact release identity and paths represented by one Beets album."""
+
+    album_id: int
+    release_id: str
+    album_path: str
+    item_paths: tuple[str, ...]
+
+
+class RequestMembershipSnapshot(msgspec.Struct, frozen=True):
+    """The request fields needed to compare pipeline state with Beets."""
+
+    request_id: int
+    release_id: str
+    status: str
+    imported_path: str | None
+
+
+class WorldViolation(msgspec.Struct, frozen=True):
+    """One deterministic invariant violation suitable for CLI/API output."""
+
+    code: str
+    detail: str
+    request_id: int | None = None
+    release_id: str | None = None
+    album_ids: tuple[int, ...] = ()
+
+
+def _normal_path(path: str) -> str:
+    return os.path.normcase(os.path.abspath(os.path.normpath(path)))
+
+
+def check_folder_exclusivity(
+    albums: Sequence[LibraryAlbumSnapshot],
+) -> tuple[WorldViolation, ...]:
+    """Require one album per folder and every item directly in that folder."""
+
+    violations: list[WorldViolation] = []
+    folder_owners: dict[str, list[LibraryAlbumSnapshot]] = defaultdict(list)
+
+    for album in albums:
+        if not album.item_paths:
+            violations.append(WorldViolation(
+                code="album_empty",
+                detail=(
+                    f"beets album {album.album_id} for release "
+                    f"{album.release_id!r} has no items"
+                ),
+                release_id=album.release_id,
+                album_ids=(album.album_id,),
+            ))
+            continue
+        folder = _normal_path(album.album_path)
+        folder_owners[folder].append(album)
+        for item_path in album.item_paths:
+            item_folder = _normal_path(os.path.dirname(item_path))
+            if item_folder != folder:
+                violations.append(WorldViolation(
+                    code="item_outside_album_folder",
+                    detail=(
+                        f"beets album {album.album_id} item {item_path!r} "
+                        f"is outside album folder {album.album_path!r}"
+                    ),
+                    release_id=album.release_id,
+                    album_ids=(album.album_id,),
+                ))
+
+    for folder, owners in sorted(folder_owners.items()):
+        if len(owners) < 2:
+            continue
+        album_ids = tuple(sorted(album.album_id for album in owners))
+        release_ids = tuple(sorted(album.release_id for album in owners))
+        violations.append(WorldViolation(
+            code="folder_shared",
+            detail=(
+                f"beets albums {album_ids!r} for releases {release_ids!r} "
+                f"share folder {folder!r}"
+            ),
+            album_ids=album_ids,
+        ))
+
+    return tuple(violations)
+
+
+def check_library_filesystem(
+    albums: Sequence[LibraryAlbumSnapshot],
+) -> tuple[WorldViolation, ...]:
+    """Require every snapshot path to name the physical library state."""
+
+    violations: list[WorldViolation] = []
+    for album in albums:
+        if not os.path.isdir(album.album_path):
+            violations.append(WorldViolation(
+                code="album_folder_missing",
+                detail=(
+                    f"beets album {album.album_id} folder "
+                    f"{album.album_path!r} is absent"
+                ),
+                release_id=album.release_id,
+                album_ids=(album.album_id,),
+            ))
+        for item_path in album.item_paths:
+            if os.path.isfile(item_path):
+                continue
+            violations.append(WorldViolation(
+                code="album_item_missing",
+                detail=(
+                    f"beets album {album.album_id} item "
+                    f"{item_path!r} is absent"
+                ),
+                release_id=album.release_id,
+                album_ids=(album.album_id,),
+            ))
+    return tuple(violations)
+
+
+def assert_replaced_row_frozen(
+    snapshot: Mapping[str, Any],
+    row: Mapping[str, Any],
+) -> None:
+    """A superseded request is a byte-frozen historical audit record."""
+
+    if row == snapshot:
+        return
+    diffs = {
+        key: (snapshot.get(key), row.get(key))
+        for key in set(snapshot) | set(row)
+        if snapshot.get(key) != row.get(key)
+    }
+    request_id = snapshot.get("id", "unknown")
+    raise AssertionError(
+        f"replaced request {request_id} mutated after supersede: {diffs}"
+    )
+
+
+def check_status_membership(
+    requests: Sequence[RequestMembershipSnapshot],
+    albums: Sequence[LibraryAlbumSnapshot],
+) -> tuple[WorldViolation, ...]:
+    """Require every imported request to resolve to one exact Beets pressing."""
+
+    by_release: dict[str, list[LibraryAlbumSnapshot]] = defaultdict(list)
+    for album in albums:
+        by_release[album.release_id].append(album)
+
+    violations: list[WorldViolation] = []
+    for request in requests:
+        if request.status != "imported":
+            continue
+        matches = by_release.get(request.release_id, [])
+        if not matches:
+            violations.append(WorldViolation(
+                code="imported_release_missing",
+                detail=(
+                    f"imported request {request.request_id} release "
+                    f"{request.release_id!r} is absent from Beets"
+                ),
+                request_id=request.request_id,
+                release_id=request.release_id,
+            ))
+            continue
+        if len(matches) > 1:
+            album_ids = tuple(sorted(album.album_id for album in matches))
+            violations.append(WorldViolation(
+                code="imported_release_duplicate",
+                detail=(
+                    f"imported request {request.request_id} release "
+                    f"{request.release_id!r} resolves to Beets albums "
+                    f"{album_ids!r}"
+                ),
+                request_id=request.request_id,
+                release_id=request.release_id,
+                album_ids=album_ids,
+            ))
+            continue
+        if not request.imported_path:
+            violations.append(WorldViolation(
+                code="imported_path_missing",
+                detail=f"imported request {request.request_id} has no imported_path",
+                request_id=request.request_id,
+                release_id=request.release_id,
+                album_ids=(matches[0].album_id,),
+            ))
+            continue
+        actual = _normal_path(matches[0].album_path)
+        expected = _normal_path(request.imported_path)
+        if actual != expected:
+            violations.append(WorldViolation(
+                code="imported_path_mismatch",
+                detail=(
+                    f"imported request {request.request_id} points at "
+                    f"{request.imported_path!r}; Beets uses "
+                    f"{matches[0].album_path!r}"
+                ),
+                request_id=request.request_id,
+                release_id=request.release_id,
+                album_ids=(matches[0].album_id,),
+            ))
+
+    return tuple(violations)
+
+
+__all__ = [
+    "LibraryAlbumSnapshot",
+    "RequestMembershipSnapshot",
+    "WorldViolation",
+    "assert_replaced_row_frozen",
+    "check_folder_exclusivity",
+    "check_library_filesystem",
+    "check_status_membership",
+]

--- a/tests/beets_world.py
+++ b/tests/beets_world.py
@@ -1,0 +1,333 @@
+"""Shared real-Beets scratch world for stateful lifecycle testing (#743)."""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+from beets import config as beets_config
+from beets import library as beets_library
+from beets import plugins as beets_plugins
+from beets.util import MoveOperation
+from mediafile import MediaFile
+
+from lib.release_identity import detect_release_source
+from lib.world_invariants import LibraryAlbumSnapshot
+
+
+@dataclass(frozen=True)
+class ShippedBeetsWorldConfig:
+    default_path_template: str
+    album_fields: tuple[tuple[str, str], ...]
+    duplicate_album_keys: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class BeetsWorldRelease:
+    release_id: str
+    artist: str
+    album: str
+    year: int
+    codec: str = "flac"
+    track_count: int = 2
+    label: str = ""
+    catalognum: str = ""
+    albumdisambig: str = ""
+    releasegroupdisambig: str = ""
+
+
+def extract_shipped_beets_world_config(
+    repo_root: str | os.PathLike[str],
+) -> ShippedBeetsWorldConfig:
+    """Extract the path/duplicate contract from the Nix module source."""
+
+    module_path = Path(repo_root) / "nix" / "module.nix"
+    source = module_path.read_text(encoding="utf-8")
+
+    default_match = re.search(
+        r'default\s*=\s*"(\$albumartist[^"]+)";',
+        source,
+    )
+    if default_match is None:
+        raise AssertionError("paths.default template not found in nix/module.nix")
+
+    album_fields = tuple(sorted(re.findall(
+        r'album_fields\.(\w+)\s*=\s*"([^"]+)";',
+        source,
+    )))
+    if not any(name == "path_disambig" for name, _ in album_fields):
+        raise AssertionError(
+            "album_fields.path_disambig not extracted from nix/module.nix "
+            f"(got {[name for name, _ in album_fields]!r})"
+        )
+
+    duplicate_block = re.search(
+        r"duplicate_keys\s*=\s*\{\s*"
+        r"album\s*=\s*\[([^\]]+)\]",
+        source,
+        flags=re.DOTALL,
+    )
+    if duplicate_block is None:
+        raise AssertionError(
+            "import.duplicate_keys.album not found in nix/module.nix"
+        )
+    duplicate_keys = tuple(re.findall(r'"([^"]+)"', duplicate_block.group(1)))
+    if set(duplicate_keys) != {"mb_albumid", "discogs_albumid"}:
+        raise AssertionError(
+            "shipped duplicate keys must be exact release identifiers; "
+            f"got {duplicate_keys!r}"
+        )
+
+    return ShippedBeetsWorldConfig(
+        default_path_template=default_match.group(1),
+        album_fields=album_fields,
+        duplicate_album_keys=duplicate_keys,
+    )
+
+
+class BeetsWorld:
+    """One isolated Beets SQLite database plus real tagged audio files."""
+
+    def __init__(self, repo_root: str | os.PathLike[str]) -> None:
+        self._tmp = tempfile.TemporaryDirectory(prefix="cratedigger_beets_world_")
+        self._closed = False
+        self.root = Path(self._tmp.name)
+        self.library_root = self.root / "library"
+        self.incoming_root = self.root / "incoming"
+        self.library_db = self.root / "beets-library.db"
+        self.library_root.mkdir()
+        self.incoming_root.mkdir()
+        self.shipped = extract_shipped_beets_world_config(repo_root)
+        self._import_counter = 0
+        try:
+            self._configure_beets()
+            self.library = beets_library.Library(
+                str(self.library_db),
+                str(self.library_root),
+            )
+        except BaseException:
+            self._closed = True
+            self._tmp.cleanup()
+            raise
+
+    def _configure_beets(self) -> None:
+        beets_config["directory"].set(str(self.library_root))
+        beets_config["library"].set(str(self.library_db))
+        beets_config["asciify_paths"].set(True)
+        beets_config["clutter"].set([
+            "Thumbs.DB",
+            "Thumbs.db",
+            ".DS_Store",
+            "*.jpg",
+            "*.png",
+            "AlbumArt*",
+            "Folder.*",
+            "desktop.ini",
+            "cratedigger.json",
+        ])
+        beets_config["import"]["duplicate_keys"]["album"].set(
+            list(self.shipped.duplicate_album_keys)
+        )
+        beets_config["paths"]["default"].set(
+            self.shipped.default_path_template
+        )
+        beets_config["plugins"].set(["inline"])
+        for name, expression in self.shipped.album_fields:
+            beets_config["album_fields"][name].set(expression)
+        beets_plugins.load_plugins()
+        getters = beets_plugins.album_field_getters()
+        if "path_disambig" not in getters:
+            raise RuntimeError(
+                "real Beets inline plugin did not load shipped path_disambig; "
+                "run the world model in a fresh interpreter"
+            )
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            # Pinned Beets exposes connection cleanup as Database._close().
+            # Closing it explicitly keeps repeated Hypothesis worlds from
+            # leaking one SQLite connection apiece.
+            self.library._close()
+        finally:
+            self._tmp.cleanup()
+
+    def __enter__(self) -> "BeetsWorld":
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self.close()
+
+    @staticmethod
+    def _decode_path(path: object) -> str:
+        if isinstance(path, bytes):
+            return os.fsdecode(path)
+        if isinstance(path, str):
+            return path
+        if isinstance(path, os.PathLike):
+            return os.fsdecode(os.fspath(path))
+        raise TypeError(f"unsupported Beets path type: {type(path).__name__}")
+
+    def _absolute_path(self, path: object) -> str:
+        decoded = self._decode_path(path)
+        if os.path.isabs(decoded):
+            return decoded
+        return str(self.library_root / decoded)
+
+    def _make_audio(self, path: Path, *, codec: str, frequency: int) -> None:
+        if shutil.which("ffmpeg") is None:
+            raise RuntimeError("ffmpeg is required; run inside nix-shell")
+        codec_key = codec.casefold()
+        if codec_key == "flac":
+            encoder_args = ["-c:a", "flac"]
+        elif codec_key == "mp3":
+            encoder_args = ["-c:a", "libmp3lame", "-b:a", "192k"]
+        else:
+            raise ValueError(f"unsupported scratch-world codec {codec!r}")
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-hide_banner",
+                "-loglevel",
+                "error",
+                "-f",
+                "lavfi",
+                "-i",
+                f"sine=frequency={frequency}:duration=0.08",
+                *encoder_args,
+                str(path),
+            ],
+            check=True,
+            capture_output=True,
+        )
+
+    def _tag_audio(
+        self,
+        path: Path,
+        release: BeetsWorldRelease,
+        *,
+        track: int,
+    ) -> None:
+        media = MediaFile(path)
+        media.artist = release.artist
+        media.albumartist = release.artist
+        media.album = release.album
+        media.title = f"Track {track}"
+        media.track = track
+        media.tracktotal = release.track_count
+        media.disc = 1
+        media.disctotal = 1
+        media.year = release.year
+        media.save()
+
+    def _release_identity_values(self, release_id: str) -> dict[str, object]:
+        if detect_release_source(release_id) == "discogs":
+            return {
+                "mb_albumid": "",
+                "discogs_albumid": int(release_id),
+            }
+        return {
+            "mb_albumid": release_id,
+            "discogs_albumid": 0,
+        }
+
+    def _album_release_id(self, album: object) -> str:
+        discogs_id = getattr(album, "discogs_albumid", 0)
+        if discogs_id:
+            return str(discogs_id)
+        return str(getattr(album, "mb_albumid", "") or "")
+
+    def import_release(
+        self,
+        release: BeetsWorldRelease,
+        *,
+        source_dir: str | os.PathLike[str] | None = None,
+    ) -> LibraryAlbumSnapshot:
+        """Perform the real Beets add/remove/move sequence without network."""
+
+        if release.track_count < 1:
+            raise ValueError("track_count must be positive")
+        self._import_counter += 1
+        if source_dir is None:
+            source_path = (
+                self.incoming_root / f"attempt-{self._import_counter:04d}"
+            )
+        else:
+            source_path = Path(source_dir)
+        source_path.mkdir(parents=True)
+
+        items: list[beets_library.Item] = []
+        identity_values = self._release_identity_values(release.release_id)
+        extension = release.codec.casefold()
+        for track in range(1, release.track_count + 1):
+            path = source_path / f"{track:02d} Track {track}.{extension}"
+            self._make_audio(
+                path,
+                codec=release.codec,
+                frequency=300 + (self._import_counter * 20) + track,
+            )
+            self._tag_audio(path, release, track=track)
+            item = beets_library.Item.from_path(str(path))
+            item.update({
+                "artist": release.artist,
+                "albumartist": release.artist,
+                "album": release.album,
+                "title": f"Track {track}",
+                "track": track,
+                "tracktotal": release.track_count,
+                "disc": 1,
+                "disctotal": 1,
+                "year": release.year,
+                "label": release.label,
+                "catalognum": release.catalognum,
+                "albumdisambig": release.albumdisambig,
+                "releasegroupdisambig": release.releasegroupdisambig,
+                **identity_values,
+            })
+            items.append(item)
+
+        duplicate_albums = [
+            album
+            for album in self.library.albums()
+            if self._album_release_id(album) == release.release_id
+        ]
+        album = self.library.add_album(items)
+        for duplicate in duplicate_albums:
+            duplicate.remove(delete=True)
+        album.move(MoveOperation.MOVE)
+        return self.snapshot_album(album)
+
+    def snapshot_album(self, album: object) -> LibraryAlbumSnapshot:
+        raw_items = list(album.items())  # type: ignore[attr-defined]
+        item_paths = tuple(
+            self._absolute_path(item.path)
+            for item in raw_items
+        )
+        if not item_paths:
+            album_path = ""
+        else:
+            album_path = os.path.dirname(item_paths[0])
+        return LibraryAlbumSnapshot(
+            album_id=int(album.id),  # type: ignore[attr-defined]
+            release_id=self._album_release_id(album),
+            album_path=album_path,
+            item_paths=item_paths,
+        )
+
+    def snapshots(self) -> tuple[LibraryAlbumSnapshot, ...]:
+        return tuple(self.snapshot_album(album) for album in self.library.albums())
+
+
+__all__ = [
+    "BeetsWorld",
+    "BeetsWorldRelease",
+    "ShippedBeetsWorldConfig",
+    "extract_shipped_beets_world_config",
+]

--- a/tests/test_beets_world_config.py
+++ b/tests/test_beets_world_config.py
@@ -1,0 +1,33 @@
+"""Pins for the shared scratch-Beets shipped-config extraction (#743)."""
+
+from __future__ import annotations
+
+import os
+import unittest
+
+from tests.beets_world import extract_shipped_beets_world_config
+
+
+class TestShippedBeetsWorldConfig(unittest.TestCase):
+    def test_extracts_load_bearing_shipped_import_contract(self) -> None:
+        repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+        shipped = extract_shipped_beets_world_config(repo_root)
+
+        self.assertIn("%aunique{albumartist album,path_disambig}", shipped.default_path_template)
+        self.assertEqual(
+            dict(shipped.album_fields),
+            {
+                "path_disambig": (
+                    "albumdisambig or releasegroupdisambig or catalognum "
+                    "or label or str(year)"
+                ),
+            },
+        )
+        self.assertEqual(
+            set(shipped.duplicate_album_keys),
+            {"mb_albumid", "discogs_albumid"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_harness_beets2_contract.py
+++ b/tests/test_harness_beets2_contract.py
@@ -283,20 +283,13 @@ with tempfile.TemporaryDirectory() as d:
 def _shipped_aunique_config() -> dict:
     """Extract the shipped beets path template + inline album_fields from
     nix/module.nix — the test patrols what production actually renders."""
-    import re
+    from tests.beets_world import extract_shipped_beets_world_config
 
-    src = open(os.path.join(_REPO, "nix", "module.nix")).read()
-    m = re.search(r'default = "(\$albumartist[^"]+)";', src)
-    assert m, "paths.default template not found in nix/module.nix"
-    fields = dict(re.findall(r'album_fields\.(\w+) = "([^"]+)";', src))
-    # Fail loudly if a nix restyle stops the regex from seeing the shipped
-    # disambiguator — a vacuous sweep would keep passing while no longer
-    # exercising the production expression (review nit, PR #742).
-    assert "path_disambig" in fields, (
-        f"album_fields.path_disambig not extracted from nix/module.nix "
-        f"(got {sorted(fields)}); update the extraction regex"
-    )
-    return {"template": m.group(1), "album_fields": fields}
+    shipped = extract_shipped_beets_world_config(_REPO)
+    return {
+        "template": shipped.default_path_template,
+        "album_fields": dict(shipped.album_fields),
+    }
 
 
 class TestAuniqueCollisionContract(unittest.TestCase):

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -9743,6 +9743,41 @@ class TestRefreshCurrentEvidenceUsesBeetsLibraryRoot(unittest.TestCase):
             "propagation silently no-ops.",
         )
 
+    def test_refresh_constructs_beets_db_with_explicit_library_path(self) -> None:
+        from lib.dispatch import _refresh_current_evidence_after_import
+
+        captured: list[tuple[str, str]] = []
+
+        class FakeBeetsDB:
+            def __init__(self, db_path: str = "", *, library_root: str = "") -> None:
+                captured.append((db_path, library_root))
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+            def get_album_info(self, mb_release_id, cfg):
+                return None
+
+        with patch("lib.beets_db.BeetsDB", FakeBeetsDB):
+            _refresh_current_evidence_after_import(
+                db=None,  # type: ignore[arg-type]
+                request_id=1,
+                mb_release_id="mbid-test",
+                quality_ranks=None,
+                source_candidate=None,
+                import_result=None,
+                beets_library_db_path="/tmp/world/beets-library.db",
+                beets_library_root="/tmp/world/library",
+            )
+
+        self.assertEqual(
+            captured,
+            [("/tmp/world/beets-library.db", "/tmp/world/library")],
+        )
+
     def test_dispatch_passes_cfg_beets_directory_to_refresh(self) -> None:
         # Inspect the call site source to confirm cfg.beets_directory
         # is wired to beets_library_root. Static check is sufficient and
@@ -9754,14 +9789,18 @@ class TestRefreshCurrentEvidenceUsesBeetsLibraryRoot(unittest.TestCase):
         # The call must include the beets_library_root kwarg sourced
         # from cfg.beets_directory (with a None-safe fallback).
         self.assertIn("_refresh_current_evidence_after_import(", src)
-        # Look for the wiring after the function call. Pattern:
-        #   beets_library_root=(... cfg.beets_directory ...)
+        # Look for the resolved wiring after the function call. The explicit
+        # world-model root may override cfg, but production still derives the
+        # default from cfg.beets_directory.
         refresh_block_start = src.index(
             "_refresh_current_evidence_after_import("
         )
         refresh_block = src[refresh_block_start:refresh_block_start + 1500]
-        self.assertIn("beets_library_root=", refresh_block)
-        self.assertIn("cfg.beets_directory", refresh_block)
+        self.assertIn(
+            "beets_library_root=effective_beets_library_root",
+            refresh_block,
+        )
+        self.assertIn('getattr(cfg, "beets_directory", "")', src)
 
 
 class TestReplaceFullPath(unittest.TestCase):

--- a/tests/test_request_lifecycle_generated.py
+++ b/tests/test_request_lifecycle_generated.py
@@ -70,6 +70,7 @@ from lib.search_plan_service import (
     RESULT_REQUEST_REPLACED,
     SearchPlanService,
 )
+from lib.world_invariants import assert_replaced_row_frozen
 from tests.fakes import FakePipelineDB
 from tests.helpers import make_active_download_state_json
 
@@ -91,18 +92,6 @@ def assert_statuses_legal(rows: list[dict]) -> None:
         if row["status"] not in LEGAL_STATUSES:
             raise AssertionError(
                 f"request {row['id']} has illegal status {row['status']!r}")
-
-
-def assert_replaced_row_frozen(snapshot: dict, row: dict) -> None:
-    """A replaced row is a frozen audit record — byte-identical forever."""
-    if row != snapshot:
-        diffs = {
-            key: (snapshot.get(key), row.get(key))
-            for key in set(snapshot) | set(row)
-            if snapshot.get(key) != row.get(key)
-        }
-        raise AssertionError(
-            f"replaced request {snapshot['id']} mutated after supersede: {diffs}")
 
 
 def assert_replaced_tracks_frozen(

--- a/tests/test_world_invariants.py
+++ b/tests/test_world_invariants.py
@@ -1,0 +1,162 @@
+"""Deterministic pins for the cross-engine world invariant bank (#743)."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+
+from lib.world_invariants import (
+    LibraryAlbumSnapshot,
+    RequestMembershipSnapshot,
+    assert_replaced_row_frozen,
+    check_folder_exclusivity,
+    check_library_filesystem,
+    check_status_membership,
+)
+
+
+class TestWorldInvariantPins(unittest.TestCase):
+    def test_distinct_folders_and_imported_membership_are_coherent(self) -> None:
+        albums = (
+            LibraryAlbumSnapshot(
+                album_id=1,
+                release_id="release-a",
+                album_path="/library/Artist/2001 - Album",
+                item_paths=(
+                    "/library/Artist/2001 - Album/01 First.flac",
+                    "/library/Artist/2001 - Album/02 Second.flac",
+                ),
+            ),
+            LibraryAlbumSnapshot(
+                album_id=2,
+                release_id="release-b",
+                album_path="/library/Artist/2001 - Album [2002]",
+                item_paths=(
+                    "/library/Artist/2001 - Album [2002]/01 First.mp3",
+                ),
+            ),
+        )
+        requests = (
+            RequestMembershipSnapshot(
+                request_id=10,
+                release_id="release-a",
+                status="imported",
+                imported_path="/library/Artist/2001 - Album",
+            ),
+            # Backfill/upgrade worlds legitimately remain wanted while an
+            # exact pressing is already installed.
+            RequestMembershipSnapshot(
+                request_id=11,
+                release_id="release-b",
+                status="wanted",
+                imported_path="/library/Artist/2001 - Album [2002]",
+            ),
+        )
+
+        self.assertEqual(check_folder_exclusivity(albums), ())
+        self.assertEqual(check_status_membership(requests, albums), ())
+
+
+class TestWorldInvariantCheckersTripOnKnownBad(unittest.TestCase):
+    def test_folder_checker_trips_on_passenger_shared_folder(self) -> None:
+        folder = "/library/Lisa Hannigan/2011 - Passenger"
+        violations = check_folder_exclusivity((
+            LibraryAlbumSnapshot(
+                album_id=1,
+                release_id="old-pressing",
+                album_path=folder,
+                item_paths=(f"{folder}/01 Home.flac",),
+            ),
+            LibraryAlbumSnapshot(
+                album_id=2,
+                release_id="new-pressing",
+                album_path=folder,
+                item_paths=(f"{folder}/02 Passenger.mp3",),
+            ),
+        ))
+
+        self.assertIn("folder_shared", {v.code for v in violations})
+
+    def test_folder_checker_trips_when_item_escapes_album_folder(self) -> None:
+        violations = check_folder_exclusivity((
+            LibraryAlbumSnapshot(
+                album_id=1,
+                release_id="release-a",
+                album_path="/library/Artist/Album",
+                item_paths=("/library/Artist/Other/01 Track.flac",),
+            ),
+        ))
+
+        self.assertIn("item_outside_album_folder", {v.code for v in violations})
+
+    def test_folder_checker_trips_on_empty_album(self) -> None:
+        violations = check_folder_exclusivity((
+            LibraryAlbumSnapshot(
+                album_id=1,
+                release_id="release-a",
+                album_path="/library/Artist/Album",
+                item_paths=(),
+            ),
+        ))
+
+        self.assertIn("album_empty", {v.code for v in violations})
+
+    def test_filesystem_checker_trips_on_missing_folder_and_item(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            missing_folder = os.path.join(tmpdir, "missing-album")
+            violations = check_library_filesystem((LibraryAlbumSnapshot(
+                album_id=1,
+                release_id="release-a",
+                album_path=missing_folder,
+                item_paths=(os.path.join(missing_folder, "01 Track.flac"),),
+            ),))
+
+        self.assertEqual(
+            {v.code for v in violations},
+            {"album_folder_missing", "album_item_missing"},
+        )
+
+    def test_replaced_checker_trips_on_thawed_audit_row(self) -> None:
+        before = {"id": 41, "status": "replaced", "updated_at": "t0"}
+        after = {"id": 41, "status": "wanted", "updated_at": "t1"}
+
+        with self.assertRaisesRegex(AssertionError, "mutated after supersede"):
+            assert_replaced_row_frozen(before, after)
+
+    def test_membership_checker_trips_on_missing_imported_release(self) -> None:
+        violations = check_status_membership((
+            RequestMembershipSnapshot(
+                request_id=10,
+                release_id="missing-release",
+                status="imported",
+                imported_path="/library/Artist/Album",
+            ),
+        ), ())
+
+        self.assertIn("imported_release_missing", {v.code for v in violations})
+
+    def test_membership_checker_trips_on_duplicate_exact_release(self) -> None:
+        albums = (
+            LibraryAlbumSnapshot(1, "release-a", "/library/A", ("/library/A/1.flac",)),
+            LibraryAlbumSnapshot(2, "release-a", "/library/B", ("/library/B/1.flac",)),
+        )
+        violations = check_status_membership((
+            RequestMembershipSnapshot(10, "release-a", "imported", "/library/A"),
+        ), albums)
+
+        self.assertIn("imported_release_duplicate", {v.code for v in violations})
+
+    def test_membership_checker_trips_on_imported_path_drift(self) -> None:
+        albums = (
+            LibraryAlbumSnapshot(1, "release-a", "/library/Actual", ("/library/Actual/1.flac",)),
+        )
+        violations = check_status_membership((
+            RequestMembershipSnapshot(10, "release-a", "imported", "/library/Stale"),
+        ), albums)
+
+        self.assertIn("imported_path_mismatch", {v.code for v in violations})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_world_invariants_generated.py
+++ b/tests/test_world_invariants_generated.py
@@ -1,0 +1,136 @@
+"""Generated properties for the cross-engine world invariant bank (#743)."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+
+from hypothesis import given, strategies as st
+
+import tests._hypothesis_profiles  # noqa: F401  (loads active profile)
+from lib.world_invariants import (
+    LibraryAlbumSnapshot,
+    RequestMembershipSnapshot,
+    check_folder_exclusivity,
+    check_library_filesystem,
+    check_status_membership,
+)
+
+
+_SEGMENT = st.text(
+    alphabet=st.characters(
+        blacklist_categories=("Cs",),
+        blacklist_characters=("/", "\x00"),
+    ),
+    min_size=1,
+    max_size=20,
+)
+
+
+class TestWorldInvariantGenerated(unittest.TestCase):
+    @given(release_ids=st.lists(_SEGMENT, min_size=1, max_size=8, unique=True))
+    def test_unique_release_folders_are_coherent(self, release_ids: list[str]) -> None:
+        albums: list[LibraryAlbumSnapshot] = []
+        requests: list[RequestMembershipSnapshot] = []
+        for index, release_id in enumerate(release_ids, start=1):
+            folder = os.path.join("/library", f"album-{index}")
+            albums.append(LibraryAlbumSnapshot(
+                album_id=index,
+                release_id=release_id,
+                album_path=folder,
+                item_paths=(os.path.join(folder, "01 Track.flac"),),
+            ))
+            requests.append(RequestMembershipSnapshot(
+                request_id=index,
+                release_id=release_id,
+                status="imported",
+                imported_path=folder,
+            ))
+
+        self.assertEqual(check_folder_exclusivity(tuple(albums)), ())
+        self.assertEqual(
+            check_status_membership(tuple(requests), tuple(albums)),
+            (),
+        )
+
+    @given(
+        release_a=_SEGMENT,
+        release_b=_SEGMENT.filter(lambda value: bool(value)),
+        folder=_SEGMENT,
+    )
+    def test_any_shared_folder_is_rejected(
+        self,
+        release_a: str,
+        release_b: str,
+        folder: str,
+    ) -> None:
+        shared = os.path.join("/library", folder)
+        violations = check_folder_exclusivity((
+            LibraryAlbumSnapshot(1, release_a, shared, (os.path.join(shared, "1.flac"),)),
+            LibraryAlbumSnapshot(2, release_b, shared, (os.path.join(shared, "2.flac"),)),
+        ))
+
+        self.assertIn("folder_shared", {v.code for v in violations})
+
+    @given(
+        album_id=st.integers(min_value=1),
+        release_id=_SEGMENT,
+        folder=_SEGMENT,
+    )
+    def test_any_empty_album_is_rejected(
+        self,
+        album_id: int,
+        release_id: str,
+        folder: str,
+    ) -> None:
+        violations = check_folder_exclusivity((LibraryAlbumSnapshot(
+            album_id,
+            release_id,
+            os.path.join("/library", folder),
+            (),
+        ),))
+
+        self.assertIn("album_empty", {v.code for v in violations})
+
+    @given(release_id=_SEGMENT, folder=_SEGMENT)
+    def test_any_missing_physical_album_is_rejected(
+        self,
+        release_id: str,
+        folder: str,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            missing = os.path.join(tmpdir, f"missing-{folder}")
+            violations = check_library_filesystem((LibraryAlbumSnapshot(
+                1,
+                release_id,
+                missing,
+                (os.path.join(missing, "01 Track.flac"),),
+            ),))
+
+        self.assertIn("album_folder_missing", {v.code for v in violations})
+        self.assertIn("album_item_missing", {v.code for v in violations})
+
+    @given(
+        release_id=_SEGMENT,
+        imported_path=_SEGMENT,
+    )
+    def test_imported_without_exact_release_is_always_rejected(
+        self,
+        release_id: str,
+        imported_path: str,
+    ) -> None:
+        violations = check_status_membership((
+            RequestMembershipSnapshot(
+                1,
+                release_id,
+                "imported",
+                os.path.join("/library", imported_path),
+            ),
+        ), ())
+
+        self.assertIn("imported_release_missing", {v.code for v in violations})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/world_model/__init__.py
+++ b/tests/world_model/__init__.py
@@ -1,0 +1,1 @@
+"""Directly runnable heavyweight cross-engine world model (#743)."""

--- a/tests/world_model/state_machine.py
+++ b/tests/world_model/state_machine.py
@@ -1,0 +1,172 @@
+"""Heavy real-PostgreSQL/real-Beets add/import/upgrade world model (#743).
+
+This module is intentionally outside unittest discovery. Run it directly:
+
+    nix-shell --run "python3 -m unittest tests.world_model.state_machine -v"
+
+Its default generated budget is deliberately small while issue #743 measures
+the real runtime. ``CRATEDIGGER_WORLD_EXAMPLES`` and
+``CRATEDIGGER_WORLD_STEPS`` can increase that budget without changing code.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+from hypothesis import HealthCheck, settings
+from hypothesis import strategies as st
+from hypothesis.stateful import (
+    RuleBasedStateMachine,
+    invariant,
+    precondition,
+    rule,
+)
+
+# Start a throwaway PostgreSQL and apply the real migration stack before the
+# world imports TEST_DB_DSN. This never connects to production.
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+import conftest  # noqa: E402, F401
+
+from tests.beets_world import BeetsWorldRelease  # noqa: E402
+from tests.world_model.support import LifecycleWorld, repository_root  # noqa: E402
+
+
+TEST_DSN = os.environ.get("TEST_DB_DSN")
+if not TEST_DSN:
+    raise RuntimeError(
+        "world model requires ephemeral PostgreSQL; run it inside nix-shell"
+    )
+
+
+def _mb_release_id(counter: int) -> str:
+    return f"00000000-0000-4000-8000-{counter:012x}"
+
+
+def _discogs_release_id(counter: int) -> str:
+    return str(7_000_000 + counter)
+
+
+class TestPinnedLifecycleWorld(unittest.TestCase):
+    """Concrete regression pin for collision plus same-pressing upgrade."""
+
+    def test_two_pressings_then_upgrade_preserve_exact_membership(self) -> None:
+        assert TEST_DSN is not None
+        with LifecycleWorld(TEST_DSN, repository_root()) as world:
+            first_id = world.add_release(BeetsWorldRelease(
+                release_id="10000000-0000-4000-8000-000000000001",
+                artist="Passenger",
+                album="Collision Course",
+                year=2008,
+                label="Archive One",
+                catalognum="A-1",
+            ))
+            second_id = world.add_release(BeetsWorldRelease(
+                release_id="7000002",
+                artist="Passenger",
+                album="Collision Course",
+                year=2008,
+                codec="mp3",
+                label="Archive Two",
+                catalognum="B-2",
+            ))
+
+            world.import_request(first_id)
+            world.import_request(second_id)
+            world.import_request(first_id)
+
+            world.assert_invariants()
+            albums = world.beets.snapshots()
+            self.assertEqual(len(albums), 2)
+            self.assertEqual(
+                {album.release_id for album in albums},
+                {
+                    "10000000-0000-4000-8000-000000000001",
+                    "7000002",
+                },
+            )
+            self.assertEqual(
+                len({album.album_path for album in albums}),
+                2,
+            )
+
+
+class AddImportUpgradeMachine(RuleBasedStateMachine):
+    """Generate multi-pressing worlds and check after every real mutation."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        assert TEST_DSN is not None
+        self.world = LifecycleWorld(TEST_DSN, repository_root())
+        self._release_counter = 0
+
+    def teardown(self) -> None:
+        self.world.close()
+
+    @rule(
+        identity_source=st.sampled_from(("musicbrainz", "discogs")),
+        artist_index=st.integers(min_value=0, max_value=2),
+        album_index=st.integers(min_value=0, max_value=2),
+        year=st.integers(min_value=1960, max_value=2026),
+        label_index=st.integers(min_value=0, max_value=2),
+        codec=st.sampled_from(("flac", "mp3")),
+    )
+    def add_request(
+        self,
+        identity_source: str,
+        artist_index: int,
+        album_index: int,
+        year: int,
+        label_index: int,
+        codec: str,
+    ) -> None:
+        self._release_counter += 1
+        if identity_source == "discogs":
+            release_id = _discogs_release_id(self._release_counter)
+        else:
+            release_id = _mb_release_id(self._release_counter)
+        self.world.add_release(BeetsWorldRelease(
+            release_id=release_id,
+            artist=f"Archive Artist {artist_index}",
+            album=f"Recovered Album {album_index}",
+            year=year,
+            codec=codec,
+            label=f"Label {label_index}",
+            catalognum=f"CAT-{self._release_counter % 4}",
+        ))
+
+    @precondition(lambda self: bool(self.world.request_ids_with_status("wanted")))
+    @rule(data=st.data())
+    def import_wanted(self, data: st.DataObject) -> None:
+        request_id = data.draw(st.sampled_from(
+            self.world.request_ids_with_status("wanted")
+        ))
+        self.world.import_request(request_id)
+
+    @precondition(lambda self: bool(self.world.request_ids_with_status("imported")))
+    @rule(data=st.data())
+    def upgrade_imported(self, data: st.DataObject) -> None:
+        request_id = data.draw(st.sampled_from(
+            self.world.request_ids_with_status("imported")
+        ))
+        self.world.import_request(request_id)
+
+    @invariant()
+    def cross_engine_invariants_hold(self) -> None:
+        self.world.assert_invariants()
+
+
+TestGeneratedLifecycleWorld = AddImportUpgradeMachine.TestCase
+TestGeneratedLifecycleWorld.settings = settings(
+    max_examples=int(os.environ.get("CRATEDIGGER_WORLD_EXAMPLES", "6")),
+    stateful_step_count=int(os.environ.get("CRATEDIGGER_WORLD_STEPS", "8")),
+    deadline=None,
+    derandomize=True,
+    database=None,
+    suppress_health_check=(HealthCheck.too_slow,),
+)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/world_model/support.py
+++ b/tests/world_model/support.py
@@ -1,0 +1,236 @@
+"""Real PostgreSQL + real Beets support for the heavyweight world model."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from lib.dispatch import dispatch_import_core
+from lib.dispatch.types import EvidenceImportGate, ImportOneRun
+from lib.quality import DownloadInfo
+from lib.release_identity import ReleaseIdentity
+from lib.transitions import (
+    RequestTransition,
+    finalize_request,
+    require_transition_applied,
+)
+from lib.world_invariants import (
+    RequestMembershipSnapshot,
+    WorldViolation,
+    check_folder_exclusivity,
+    check_library_filesystem,
+    check_status_membership,
+)
+from tests.beets_world import BeetsWorld, BeetsWorldRelease
+from tests.helpers import make_active_download_state_json, make_import_result
+from tests.test_pipeline_db import TEST_DSN, make_db
+
+
+class LifecycleWorld:
+    """One disposable pipeline DB slate coupled to one Beets library."""
+
+    def __init__(self, dsn: str, repo_root: str | os.PathLike[str]) -> None:
+        if TEST_DSN != dsn:
+            raise ValueError(
+                "world model must use tests.test_pipeline_db.make_db() "
+                "against its ephemeral TEST_DB_DSN"
+            )
+        self.db = make_db()
+        try:
+            self.beets = BeetsWorld(repo_root)
+        except BaseException:
+            self.db.close()
+            raise
+        self._release_by_request: dict[int, BeetsWorldRelease] = {}
+        self._dispatch_counter = 0
+
+    def close(self) -> None:
+        try:
+            self.beets.close()
+        finally:
+            self.db.close()
+
+    def __enter__(self) -> LifecycleWorld:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self.close()
+
+    def add_release(self, release: BeetsWorldRelease) -> int:
+        identity = ReleaseIdentity.from_id(release.release_id)
+        if identity is None:
+            raise ValueError(
+                f"world releases require an MB or Discogs id: {release.release_id!r}"
+            )
+        request_id = int(self.db.add_request(
+            artist_name=release.artist,
+            album_title=release.album,
+            source="request",
+            year=release.year,
+            mb_release_id=identity.release_id,
+            discogs_release_id=(
+                identity.release_id
+                if identity.source == "discogs"
+                else None
+            ),
+        ))
+        self._release_by_request[request_id] = release
+        return request_id
+
+    def import_request(self, request_id: int) -> None:
+        row = self._require_request(request_id)
+        status = str(row["status"])
+        is_upgrade = status == "imported"
+        raw_previous_min_bitrate = row.get("min_bitrate")
+        if is_upgrade and isinstance(raw_previous_min_bitrate, int):
+            previous_min_bitrate = raw_previous_min_bitrate
+        elif is_upgrade and raw_previous_min_bitrate is not None:
+            raise AssertionError(
+                "request min_bitrate has non-integer shape: "
+                f"{raw_previous_min_bitrate!r}"
+            )
+        else:
+            previous_min_bitrate = None
+        if status == "imported":
+            require_transition_applied(finalize_request(
+                self.db,
+                request_id,
+                RequestTransition.to_wanted(from_status="imported"),
+            ))
+            status = "wanted"
+        if status != "wanted":
+            raise AssertionError(
+                f"request {request_id} cannot import from {status!r}"
+            )
+
+        require_transition_applied(finalize_request(
+            self.db,
+            request_id,
+            RequestTransition.to_downloading(
+                from_status="wanted",
+                state_json=make_active_download_state_json([]),
+            ),
+        ))
+        release = self._release_by_request[request_id]
+        self._dispatch_counter += 1
+        staged_path = (
+            self.beets.incoming_root
+            / f"dispatch-{request_id}-{self._dispatch_counter:04d}"
+        )
+
+        def run_real_beets_import(**kwargs: Any) -> ImportOneRun:
+            album = self.beets.import_release(
+                release,
+                source_dir=str(kwargs["path"]),
+            )
+            result = make_import_result(
+                decision="import",
+                new_min_bitrate=900 + self._dispatch_counter,
+                prev_min_bitrate=previous_min_bitrate,
+                imported_path=album.album_path,
+                final_format=release.codec,
+            )
+            return ImportOneRun(
+                command=("in-process-beets-world",),
+                returncode=0,
+                stdout=result.to_sentinel_line(),
+                stderr="",
+                import_result=result,
+            )
+
+        outcome = dispatch_import_core(
+            path=str(staged_path),
+            mb_release_id=release.release_id,
+            request_id=request_id,
+            label=f"{release.artist} - {release.album}",
+            beets_harness_path="in-process-beets-world",
+            db=self.db,
+            dl_info=DownloadInfo(filetype=release.codec),
+            scenario="auto_import",
+            quality_gate_fn=self._noop_quality_gate,
+            run_import_fn=run_real_beets_import,
+            evidence_gate_fn=self._empty_evidence_gate,
+            beets_library_db_path=str(self.beets.library_db),
+            beets_library_root=str(self.beets.library_root),
+        )
+        if not outcome.success:
+            raise AssertionError(
+                "production dispatch rejected world import for request "
+                f"{request_id}: {outcome.code or outcome.message}"
+            )
+        if staged_path.exists():
+            raise AssertionError(
+                f"production dispatch left staged path behind: {staged_path}"
+            )
+
+    def request_ids_with_status(self, status: str) -> list[int]:
+        return [
+            request_id
+            for request_id in sorted(self._release_by_request)
+            if self._require_request(request_id)["status"] == status
+        ]
+
+    def violations(self) -> tuple[WorldViolation, ...]:
+        albums = self.beets.snapshots()
+        requests: list[RequestMembershipSnapshot] = []
+        for row in self.db.list_non_replaced_requests():
+            identity = ReleaseIdentity.from_fields(
+                row.get("mb_release_id"),
+                row.get("discogs_release_id"),
+            )
+            if identity is None:
+                raise AssertionError(
+                    f"request {row['id']} lost its exact release identity"
+                )
+            requests.append(RequestMembershipSnapshot(
+                request_id=int(row["id"]),
+                release_id=identity.release_id,
+                status=str(row["status"]),
+                imported_path=(
+                    str(row["imported_path"])
+                    if row.get("imported_path") is not None
+                    else None
+                ),
+            ))
+        return (
+            *check_folder_exclusivity(albums),
+            *check_library_filesystem(albums),
+            *check_status_membership(tuple(requests), albums),
+        )
+
+    def assert_invariants(self) -> None:
+        violations = self.violations()
+        if violations:
+            rendered = "\n".join(
+                f"{violation.code}: {violation.detail}"
+                for violation in violations
+            )
+            raise AssertionError(f"cross-engine world violations:\n{rendered}")
+
+    def _require_request(self, request_id: int) -> dict[str, object]:
+        row = self.db.get_request(request_id)
+        if row is None:
+            raise AssertionError(f"request {request_id} disappeared")
+        return row
+
+    @staticmethod
+    def _empty_evidence_gate(
+        *_args: object,
+        **_kwargs: object,
+    ) -> EvidenceImportGate:
+        # Evidence lifecycle rules arrive in PR2. PR1 still runs the real
+        # post-import scratch-Beets evidence refresh through dispatch.
+        return EvidenceImportGate()
+
+    @staticmethod
+    def _noop_quality_gate(**_kwargs: object) -> None:
+        # Proof-lock/terminal quality policy is PR2's invariant tranche.
+        return None
+
+
+def repository_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+__all__ = ["LifecycleWorld", "repository_root"]


### PR DESCRIPTION
## Summary

- add a shared real-Beets world using the pinned package, shipped path template, inline disambiguation field, duplicate-key policy, and generated FLAC/MP3 files
- add a real-Postgres/real-Beets lifecycle machine through production request, transition, and import-dispatch entry points for add, import, and same-release upgrade sequences
- add invariant checkers and deterministic/generated known-bad pins for folder exclusivity, filesystem coherence, replaced-row freezing, and exact status-to-library membership
- add explicit Beets database/root seams so the state machine cannot inspect or mutate the real library

The heavyweight machine is intentionally direct-run only for now. Its measured baseline on doc1 is about 7 test-seconds at 6 examples x 8 stateful steps; standard-suite integration and any scheduled hammer profile remain evidence-driven follow-up decisions.

## Validation

- `nix-shell --run "python3 -m unittest tests.world_model.state_machine -v"` — 2 passed, ~7.0s
- `nix-shell --run "python3 -m unittest tests.test_integration_slices -v"` — 167 passed
- focused world/invariant/config/lifecycle checks — 39 passed
- `nix-shell --run "pyright --threads 4"` — 0 findings
- `nix-shell --run "bash scripts/run_tests.sh"` — 6,239 passed in 322.443s
- fault injection proved the folder-sharing and imported-membership known-bad checkers fail when their corresponding production checker branches are disabled

## Scope

This is PR1 of the issue arc: rules `{add, import, upgrade}` and invariant bank items 1–3. Replace/ban/wrong-match/force operations, invariants 4–7, the hammer runner, and census/live-audit surfaces remain follow-up PRs.

No production services, data, or library files were changed.

Refs #743
