### PR TITLE
test: add randomized real-storage world hammer

### DIFF
--- a/docs/generated-testing.md
+++ b/docs/generated-testing.md
@@ -80,10 +80,12 @@ exercise a new invariant.
 
 `tests/world_model/state_machine.py` drives real production request transitions
 against a throwaway PostgreSQL database while a real pinned-Beets library adds,
-removes, and moves generated tagged audio. It checks the shared
-`lib/world_invariants.py` bank after every rule. Its first rule tranche covers
-request creation, initial import, same-pressing upgrade/re-import, exact-release
-membership, imported-path coherence, and exclusive physical album folders.
+removes, and moves generated tagged audio. Its rules cover request creation,
+ordinary and force import, same-pressing upgrade/re-import, Replace, ban-source,
+wrong-match deletion, and reset. After every rule it checks the shared
+`lib/world_invariants.py` bank: folder exclusivity, replaced-row freezing,
+status/membership, evidence/disk coherence, proof-lock terminality, search-tier
+monotonicity, and denylist authority.
 
 It is intentionally named outside unittest's `test*.py` discovery pattern.
 Run the deterministic pin and generated state machine directly:
@@ -94,10 +96,11 @@ nix-shell --run "python3 -m unittest tests.world_model.state_machine -v"
 
 The temporary PostgreSQL, Beets SQLite database, library tree, and generated
 audio are local and disposable; this runner never reads or mutates production.
-The initial measured budget is six examples of eight stateful steps. On doc1
-on 2026-07-19, the direct two-test module reported 7.0 test-seconds (excluding
-dev-shell startup). That is a baseline, not a placement decision. Override the
-budget for exploration without changing code:
+The deterministic direct budget is six examples of eight stateful steps. On
+doc1 on 2026-07-19, the full six-test lifecycle module reported 8.796
+test-seconds (excluding dev-shell startup). That is a baseline, not a placement
+decision. Override the deterministic budget for a one-off run without changing
+code:
 
 ```bash
 CRATEDIGGER_WORLD_EXAMPLES=20 CRATEDIGGER_WORLD_STEPS=20 \
@@ -107,6 +110,49 @@ CRATEDIGGER_WORLD_EXAMPLES=20 CRATEDIGGER_WORLD_STEPS=20 \
 Do not add this runner to `scripts/run_tests.sh` or schedule it merely because
 the core exists. Issue #743 records runtime and fault-injection evidence first;
 standard-suite and scheduled-depth choices belong to a follow-up PR.
+
+### Randomized lifecycle hammer
+
+The operator burst wrapper runs the same real-storage state machine with fresh
+Hypothesis entropy, a persistent replay database, and a default budget of 25
+worlds × 100 steps:
+
+```bash
+nix-shell --run "scripts/world_model_burst.sh"
+nix-shell --run "scripts/world_model_burst.sh --examples 10 --steps 50"
+nix-shell --run "scripts/world_model_burst.sh --print-config"
+```
+
+Every invocation unsets an ambient `TEST_DB_DSN` before importing the test
+fixture, forcing a new ephemeral PostgreSQL instance. Beets SQLite, generated
+audio, and the library tree remain per-world temporary state. The Hypothesis
+database defaults to `.hypothesis/world-model` (gitignored): it replays a found
+failure first on the next run, but is never a committed artifact. Randomized
+failures print a reproduction blob and shrink to a minimal operation sequence.
+
+On doc1 on 2026-07-19, the initial 3-world × 20-step randomized smoke completed
+all six module tests in 8.470 test-seconds (10 seconds wrapper wall time). The
+default 25 × 100 profile completed cleanly in 449.930 test-seconds (451 seconds
+wrapper wall time). That measured depth remains operator-only and is not part of
+`scripts/run_tests.sh`; suite/nightly placement is still the explicit follow-up
+decision recorded on issue #743.
+
+The current hammer uses the in-process production adapter that performs real
+Beets model/database/filesystem mutations beneath the real dispatch services.
+The mirror-backed `run_beets_harness.sh` subprocess variant described in issue
+#743 needs a catalogue of real release identities and metadata. It remains a
+dependency of the census-seed slice rather than silently substituting generated
+nonexistent MBIDs or touching the deployed library.
+
+When the hammer finds a defect:
+
+1. Keep the replay database local and reproduce the shrunk operation sequence.
+2. Fix the production boundary or the world mapping, stating which was wrong.
+3. Promote the sequence to a named method on `TestPinnedLifecycleWorld`.
+4. Run that named pin directly, then rerun the randomized profile that found it.
+
+Never commit the Hypothesis database, a seed log, or an opaque JSON snapshot.
+The readable named lifecycle is the durable regression artifact.
 
 ## Two tiers, one knob
 

--- a/scripts/world_model_burst.sh
+++ b/scripts/world_model_burst.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Randomized real-PostgreSQL/real-Beets lifecycle hammer for issue #743.
+#
+# Run inside nix-shell. This intentionally remains separate from
+# scripts/run_tests.sh: its default 25 x 100 stateful budget is operator work,
+# not a standard-suite gate.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+usage() {
+    cat <<'EOF'
+Usage: scripts/world_model_burst.sh [options]
+
+Run the randomized real-storage lifecycle hammer against a fresh ephemeral
+PostgreSQL server and disposable Beets library.
+
+Options:
+  --examples N      generated worlds (default: 25)
+  --steps N         stateful steps per world (default: 100)
+  --database PATH   Hypothesis replay database (default: .hypothesis/world-model)
+  --print-config    print the resolved configuration without starting a world
+  -h, --help        show this help
+
+Environment equivalents: CRATEDIGGER_WORLD_EXAMPLES,
+CRATEDIGGER_WORLD_STEPS, and CRATEDIGGER_WORLD_DATABASE.
+EOF
+}
+
+examples="${CRATEDIGGER_WORLD_EXAMPLES:-25}"
+steps="${CRATEDIGGER_WORLD_STEPS:-100}"
+database="${CRATEDIGGER_WORLD_DATABASE:-.hypothesis/world-model}"
+print_config=false
+
+while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+        --examples)
+            [[ "$#" -ge 2 ]] || { echo "--examples requires a value" >&2; exit 2; }
+            examples="$2"
+            shift 2
+            ;;
+        --steps)
+            [[ "$#" -ge 2 ]] || { echo "--steps requires a value" >&2; exit 2; }
+            steps="$2"
+            shift 2
+            ;;
+        --database)
+            [[ "$#" -ge 2 ]] || { echo "--database requires a value" >&2; exit 2; }
+            database="$2"
+            shift 2
+            ;;
+        --print-config)
+            print_config=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "unknown option: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+positive_integer() {
+    [[ "$1" =~ ^[1-9][0-9]*$ ]]
+}
+
+if ! positive_integer "$examples"; then
+    echo "examples must be a positive integer (got '$examples')" >&2
+    exit 2
+fi
+if ! positive_integer "$steps"; then
+    echo "steps must be a positive integer (got '$steps')" >&2
+    exit 2
+fi
+if [[ -z "$database" ]]; then
+    echo "database path must be non-empty" >&2
+    exit 2
+fi
+
+# tests/conftest.py accepts an externally supplied TEST_DB_DSN for ordinary
+# integration-test use. A hammer must never inherit that authority: force the
+# fixture to start its own disposable PostgreSQL instance every time.
+unset TEST_DB_DSN
+if [[ -v TEST_DB_DSN ]]; then
+    postgres_mode=external
+else
+    postgres_mode=ephemeral
+fi
+
+export CRATEDIGGER_WORLD_EXAMPLES="$examples"
+export CRATEDIGGER_WORLD_STEPS="$steps"
+export CRATEDIGGER_WORLD_RANDOMIZED=1
+export CRATEDIGGER_WORLD_DATABASE="$database"
+
+if [[ "$print_config" == true ]]; then
+    echo "examples=$examples"
+    echo "steps=$steps"
+    echo "randomized=true"
+    echo "postgres=$postgres_mode"
+    echo "beets=disposable"
+    echo "engine=in-process-production-adapter"
+    echo "database=$database"
+    exit 0
+fi
+
+echo "world-model burst: examples=$examples steps=$steps database=$database"
+echo "storage: fresh ephemeral PostgreSQL + disposable real Beets library"
+started=$SECONDS
+set +e
+python3 -m unittest tests.world_model.state_machine -v
+status=$?
+set -e
+elapsed=$((SECONDS - started))
+
+if [[ "$status" -ne 0 ]]; then
+    echo "world-model burst: FAILED after ${elapsed}s" >&2
+    echo "Promote the shrunk operation sequence to TestPinnedLifecycleWorld;" >&2
+    echo "never commit the replay database or an opaque failure artifact." >&2
+    exit "$status"
+fi
+
+echo "world-model burst: ALL GREEN in ${elapsed}s"

--- a/tests/test_world_model_burst.py
+++ b/tests/test_world_model_burst.py
@@ -1,0 +1,80 @@
+"""Operator contract for the heavyweight #743 world-model burst runner."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "world_model_burst.sh"
+
+
+class TestWorldModelBurstScript(unittest.TestCase):
+    def _run(
+        self,
+        *args: str,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(SCRIPT), *args],
+            cwd=REPO_ROOT,
+            env={**os.environ, **(env or {})},
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+    def test_print_config_reports_randomized_ephemeral_world(self) -> None:
+        result = self._run(
+            "--print-config",
+            env={
+                "CRATEDIGGER_WORLD_EXAMPLES": "12",
+                "CRATEDIGGER_WORLD_STEPS": "34",
+                "CRATEDIGGER_WORLD_DATABASE": ".hypothesis/custom-world",
+                # A hammer invocation must never inherit an arbitrary DB.
+                "TEST_DB_DSN": "postgresql://production.invalid/cratedigger",
+            },
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("examples=12", result.stdout)
+        self.assertIn("steps=34", result.stdout)
+        self.assertIn("randomized=true", result.stdout)
+        self.assertIn("postgres=ephemeral", result.stdout)
+        self.assertIn("database=.hypothesis/custom-world", result.stdout)
+
+    def test_command_line_budget_overrides_environment(self) -> None:
+        result = self._run(
+            "--examples",
+            "7",
+            "--steps",
+            "19",
+            "--print-config",
+            env={
+                "CRATEDIGGER_WORLD_EXAMPLES": "2",
+                "CRATEDIGGER_WORLD_STEPS": "3",
+            },
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("examples=7", result.stdout)
+        self.assertIn("steps=19", result.stdout)
+
+    def test_non_positive_budget_is_rejected_before_world_start(self) -> None:
+        result = self._run("--examples", "0", "--print-config")
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("positive integer", result.stderr)
+
+    def test_help_is_side_effect_free(self) -> None:
+        result = self._run("--help")
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("randomized real-storage lifecycle hammer", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/world_model/state_machine.py
+++ b/tests/world_model/state_machine.py
@@ -4,9 +4,9 @@ This module is intentionally outside unittest discovery. Run it directly:
 
     nix-shell --run "python3 -m unittest tests.world_model.state_machine -v"
 
-Its default generated budget is deliberately small while issue #743 measures
-the real runtime. ``CRATEDIGGER_WORLD_EXAMPLES`` and
-``CRATEDIGGER_WORLD_STEPS`` can increase that budget without changing code.
+Direct invocation uses a small deterministic budget. The operator-only
+``scripts/world_model_burst.sh`` switches the same machine to randomized
+generation with a replay database and a much deeper lifecycle budget.
 """
 
 from __future__ import annotations
@@ -16,6 +16,7 @@ import sys
 import unittest
 
 from hypothesis import HealthCheck, settings
+from hypothesis.database import DirectoryBasedExampleDatabase
 from hypothesis import strategies as st
 from hypothesis.stateful import (
     RuleBasedStateMachine,
@@ -316,12 +317,24 @@ class LifecycleWorldMachine(RuleBasedStateMachine):
 
 
 TestGeneratedLifecycleWorld = LifecycleWorldMachine.TestCase
+_RANDOMIZED = os.environ.get("CRATEDIGGER_WORLD_RANDOMIZED") == "1"
+_DATABASE = (
+    DirectoryBasedExampleDatabase(
+        os.environ.get(
+            "CRATEDIGGER_WORLD_DATABASE",
+            ".hypothesis/world-model",
+        )
+    )
+    if _RANDOMIZED
+    else None
+)
 TestGeneratedLifecycleWorld.settings = settings(
     max_examples=int(os.environ.get("CRATEDIGGER_WORLD_EXAMPLES", "6")),
     stateful_step_count=int(os.environ.get("CRATEDIGGER_WORLD_STEPS", "8")),
     deadline=None,
-    derandomize=True,
-    database=None,
+    derandomize=not _RANDOMIZED,
+    database=_DATABASE,
+    print_blob=_RANDOMIZED,
     suppress_health_check=(HealthCheck.too_slow,),
 )
 


### PR DESCRIPTION
## Summary

- add `scripts/world_model_burst.sh`, an operator-only randomized profile for the real PostgreSQL + real Beets lifecycle state machine
- default to 25 generated worlds × 100 stateful steps, with CLI/environment budget overrides
- persist Hypothesis replay state under the gitignored `.hypothesis/world-model` path and print reproduction blobs for failures
- force every burst onto a fresh ephemeral PostgreSQL instance by scrubbing any ambient `TEST_DB_DSN`
- document the shrink-to-named-`TestPinnedLifecycleWorld` promotion workflow and measured runtime

## Runtime evidence

On doc1 on 2026-07-19:

- 3 × 20 randomized smoke: 8.470 test-seconds / 10 seconds wrapper wall time
- default 25 × 100 randomized hammer: 449.930 test-seconds / 451 seconds wrapper wall time, all green

The heavyweight runner remains outside `scripts/run_tests.sh` and no schedule is installed. Standard-suite/nightly placement is still the explicit follow-up decision on #743.

## Safety qualification

Fault injection removed the `TEST_DB_DSN` scrub. The runner contract then reported `postgres=external` and failed, proving the safety test constrains the actual boundary. The scrub was restored before commit.

The current hammer uses PR #753's in-process production adapter over real Beets database/filesystem mutations. The issue's mirror-backed `run_beets_harness.sh` variant requires a catalogue of real release identities and metadata; that dependency is recorded for the census-seed slice rather than substituting nonexistent generated MBIDs or touching production.

## Validation

- `nix-shell --run "pyright --threads 4"` — clean
- `nix-shell --run "bash scripts/run_tests.sh"` — 6,269 tests, OK in 358.253s
- pushed SHA verified: `f0e0c8990a8fea3fe8da8f32d5ca846ea79db687`

Production was not read or mutated by this PR.

Refs #743
