### PR TITLE
World census seeds and isolated mirror harness

### DIFF
--- a/docs/generated-testing.md
+++ b/docs/generated-testing.md
@@ -88,6 +88,16 @@ wrong-match deletion, and reset. After every rule it checks the shared
 status/membership, evidence/disk coherence, proof-lock terminality, search-tier
 monotonicity, and denylist authority.
 
+Every generated world is initialized from the anonymized categorical corpus in
+`tests/world_model/census_seeds.py`. The corpus was captured read-only from
+doc2 on 2026-07-19 and retains only row-shape facts and capture-time counts:
+status, MusicBrainz/dual identity shape, null/presence patterns, evidence
+lineage, legacy search overrides, format casing, spectral provenance, and V0
+presence. It contains no request/release IDs, artist/title metadata, peer names,
+or paths. A deterministic pin proves that touching an installed lineage-1 seed
+through the production import path rebuilds current lineage-4 evidence; the
+state machine samples the coherent subset as its real initial state.
+
 It is intentionally named outside unittest's `test*.py` discovery pattern.
 Run the deterministic pin and generated state machine directly:
 
@@ -98,7 +108,7 @@ nix-shell --run "python3 -m unittest tests.world_model.state_machine -v"
 The temporary PostgreSQL, Beets SQLite database, library tree, and generated
 audio are local and disposable; this runner never reads or mutates production.
 The deterministic direct budget is six examples of eight stateful steps. On
-doc1 on 2026-07-19, the full six-test lifecycle module reported 8.796
+doc1 on 2026-07-19, the census-seeded seven-test lifecycle module reported 10.431
 test-seconds (excluding dev-shell startup). That is a baseline, not a placement
 decision. Override the deterministic budget for a one-off run without changing
 code:
@@ -138,12 +148,31 @@ wrapper wall time). That measured depth remains operator-only and is not part of
 `scripts/run_tests.sh`; suite/nightly placement is still the explicit follow-up
 decision recorded on issue #743.
 
-The current hammer uses the in-process production adapter that performs real
+The default hammer uses the in-process production adapter that performs real
 Beets model/database/filesystem mutations beneath the real dispatch services.
-The mirror-backed `run_beets_harness.sh` subprocess variant described in issue
-#743 needs a catalogue of real release identities and metadata. It remains a
-dependency of the census-seed slice rather than silently substituting generated
-nonexistent MBIDs or touching the deployed library.
+An opt-in profile crosses the real `import_one.py` →
+`run_beets_harness.sh` subprocess boundary and performs exact-ID lookup against
+an explicitly supplied MusicBrainz mirror origin:
+
+```bash
+nix-shell --run "scripts/world_model_burst.sh \
+  --engine mirror-harness \
+  --mirror-url http://192.168.1.35:5200 \
+  --examples 2 --steps 5"
+```
+
+The mirror fixture is public catalogue metadata selected independently of the
+production collection. `BEETSDIR` and `BEETS_DB` are both forced to the
+per-world scratch tree for each synchronous subprocess, the deployed runtime
+config is masked so it cannot override them, and all three environment values
+are restored afterward; the pipeline database is still ephemeral. Only the
+mirror is read. The profile
+loads the shipped path template, exact-ID duplicate keys, inline field, match
+policy, and MusicBrainz plugin; unrelated production fetchart/lyrics/scrub hooks
+stay disabled so the boundary test cannot make external content requests. A
+2-world × 5-step mirror smoke completed cleanly in 5 seconds on doc1 on
+2026-07-19. It remains operator-only: neither this profile nor the in-process
+hammer has been added to standard discovery or a schedule.
 
 When the hammer finds a defect:
 

--- a/lib/validation_envelope.py
+++ b/lib/validation_envelope.py
@@ -78,7 +78,9 @@ class ValidationResultEnvelope(msgspec.Struct, frozen=True):
     would reject valid historical audit rows.
     """
 
-    valid: bool = False
+    # ``None`` distinguishes curator-ban/legacy envelopes that omit the key
+    # from a real ValidationResult verdict, whose writer always emits a bool.
+    valid: bool | None = None
     scenario: str | None = None
     detail: str | None = None
     distance: float | None = None

--- a/lib/world_invariants.py
+++ b/lib/world_invariants.py
@@ -11,6 +11,7 @@ import msgspec
 
 from lib.quality import ImportResult, dispatch_action
 from lib.quality.decisions import post_import_search_action_if_known
+from lib.validation_envelope import decode_validation_envelope
 
 
 class LibraryAlbumSnapshot(msgspec.Struct, frozen=True):
@@ -448,6 +449,23 @@ def derive_denylist_authorities(
     for entry in history:
         if entry.get("soulseek_username") != username:
             continue
+        try:
+            validation = decode_validation_envelope(
+                entry.get("validation_result")
+            )
+        except (
+            ValueError,
+            TypeError,
+            msgspec.ValidationError,
+        ):
+            validation = None
+        if (
+            entry.get("outcome") == "rejected"
+            and validation is not None
+            and validation.valid is False
+        ):
+            decisions.add("validation_reject")
+
         raw_result = entry.get("import_result")
         if isinstance(raw_result, str):
             encoded_result = raw_result

--- a/scripts/world_model_burst.sh
+++ b/scripts/world_model_burst.sh
@@ -19,17 +19,22 @@ Options:
   --examples N      generated worlds (default: 25)
   --steps N         stateful steps per world (default: 100)
   --database PATH   Hypothesis replay database (default: .hypothesis/world-model)
+  --engine NAME     in-process or mirror-harness (default: in-process)
+  --mirror-url URL  read-only MB mirror origin required by mirror-harness
   --print-config    print the resolved configuration without starting a world
   -h, --help        show this help
 
 Environment equivalents: CRATEDIGGER_WORLD_EXAMPLES,
-CRATEDIGGER_WORLD_STEPS, and CRATEDIGGER_WORLD_DATABASE.
+CRATEDIGGER_WORLD_STEPS, CRATEDIGGER_WORLD_DATABASE,
+CRATEDIGGER_WORLD_ENGINE, and CRATEDIGGER_WORLD_MIRROR_URL.
 EOF
 }
 
 examples="${CRATEDIGGER_WORLD_EXAMPLES:-25}"
 steps="${CRATEDIGGER_WORLD_STEPS:-100}"
 database="${CRATEDIGGER_WORLD_DATABASE:-.hypothesis/world-model}"
+engine="${CRATEDIGGER_WORLD_ENGINE:-in-process}"
+mirror_url="${CRATEDIGGER_WORLD_MIRROR_URL:-}"
 print_config=false
 
 while [[ "$#" -gt 0 ]]; do
@@ -47,6 +52,16 @@ while [[ "$#" -gt 0 ]]; do
         --database)
             [[ "$#" -ge 2 ]] || { echo "--database requires a value" >&2; exit 2; }
             database="$2"
+            shift 2
+            ;;
+        --engine)
+            [[ "$#" -ge 2 ]] || { echo "--engine requires a value" >&2; exit 2; }
+            engine="$2"
+            shift 2
+            ;;
+        --mirror-url)
+            [[ "$#" -ge 2 ]] || { echo "--mirror-url requires a value" >&2; exit 2; }
+            mirror_url="$2"
             shift 2
             ;;
         --print-config)
@@ -81,6 +96,14 @@ if [[ -z "$database" ]]; then
     echo "database path must be non-empty" >&2
     exit 2
 fi
+if [[ "$engine" != "in-process" && "$engine" != "mirror-harness" ]]; then
+    echo "engine must be in-process or mirror-harness (got '$engine')" >&2
+    exit 2
+fi
+if [[ "$engine" == "mirror-harness" && -z "$mirror_url" ]]; then
+    echo "--mirror-url is required for mirror-harness" >&2
+    exit 2
+fi
 
 # tests/conftest.py accepts an externally supplied TEST_DB_DSN for ordinary
 # integration-test use. A hammer must never inherit that authority: force the
@@ -96,6 +119,8 @@ export CRATEDIGGER_WORLD_EXAMPLES="$examples"
 export CRATEDIGGER_WORLD_STEPS="$steps"
 export CRATEDIGGER_WORLD_RANDOMIZED=1
 export CRATEDIGGER_WORLD_DATABASE="$database"
+export CRATEDIGGER_WORLD_ENGINE="$engine"
+export CRATEDIGGER_WORLD_MIRROR_URL="$mirror_url"
 
 if [[ "$print_config" == true ]]; then
     echo "examples=$examples"
@@ -103,16 +128,26 @@ if [[ "$print_config" == true ]]; then
     echo "randomized=true"
     echo "postgres=$postgres_mode"
     echo "beets=disposable"
-    echo "engine=in-process-production-adapter"
+    echo "engine=$engine"
+    if [[ "$engine" == "mirror-harness" ]]; then
+        echo "mirror_url=$mirror_url"
+    fi
     echo "database=$database"
     exit 0
 fi
 
 echo "world-model burst: examples=$examples steps=$steps database=$database"
 echo "storage: fresh ephemeral PostgreSQL + disposable real Beets library"
+if [[ "$engine" == "mirror-harness" ]]; then
+    test_module=tests.world_model.mirror_harness
+    echo "import boundary: real run_beets_harness.sh subprocess via $mirror_url"
+else
+    test_module=tests.world_model.state_machine
+    echo "import boundary: in-process production adapter"
+fi
 started=$SECONDS
 set +e
-python3 -m unittest tests.world_model.state_machine -v
+python3 -m unittest "$test_module" -v
 status=$?
 set -e
 elapsed=$((SECONDS - started))

--- a/tests/beets_world.py
+++ b/tests/beets_world.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
+import json
 import os
 import re
 import shutil
@@ -9,6 +12,8 @@ import subprocess
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
 
 from beets import config as beets_config
 from beets import library as beets_library
@@ -39,6 +44,16 @@ class BeetsWorldRelease:
     catalognum: str = ""
     albumdisambig: str = ""
     releasegroupdisambig: str = ""
+    track_titles: tuple[str, ...] = ()
+
+    def track_title(self, track: int) -> str:
+        if self.track_titles:
+            if len(self.track_titles) != self.track_count:
+                raise ValueError(
+                    "track_titles length must equal track_count in scratch world"
+                )
+            return self.track_titles[track - 1]
+        return f"Track {track}"
 
 
 def extract_shipped_beets_world_config(
@@ -90,16 +105,103 @@ def extract_shipped_beets_world_config(
     )
 
 
+def build_subprocess_beets_config(
+    shipped: ShippedBeetsWorldConfig,
+    *,
+    library_root: Path,
+    library_db: Path,
+    import_log: Path,
+    mirror_url: str,
+) -> dict[str, Any]:
+    """Render the load-bearing shipped contract for a disposable harness."""
+
+    parsed = urlsplit(mirror_url)
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.netloc
+        or parsed.path not in {"", "/"}
+        or parsed.query
+        or parsed.fragment
+        or parsed.username is not None
+        or parsed.password is not None
+    ):
+        raise ValueError("mirror URL must be an http(s) origin without credentials")
+    return {
+        "directory": str(library_root),
+        "library": str(library_db),
+        "asciify_paths": True,
+        "clutter": [
+            "Thumbs.DB",
+            "Thumbs.db",
+            ".DS_Store",
+            "*.jpg",
+            "*.png",
+            "AlbumArt*",
+            "Folder.*",
+            "desktop.ini",
+            "cratedigger.json",
+        ],
+        "import": {
+            "copy": False,
+            "write": True,
+            "move": True,
+            "timid": False,
+            "incremental": False,
+            "log": str(import_log),
+            "languages": ["en"],
+            "duplicate_keys": {
+                "album": list(shipped.duplicate_album_keys),
+                "item": ["artist", "title"],
+            },
+        },
+        "paths": {
+            "default": shipped.default_path_template,
+            "singleton": "Non-Album/$artist/$title",
+            "comp": (
+                "Compilations/$album%aunique{albumartist album,path_disambig}/"
+                "$track $title"
+            ),
+        },
+        "album_fields": dict(shipped.album_fields),
+        "musicbrainz": {
+            "host": parsed.netloc,
+            "https": parsed.scheme == "https",
+            "ratelimit": 100,
+        },
+        "match": {
+            "ignore_video_tracks": False,
+            "strong_rec_thresh": 0.10,
+            "medium_rec_thresh": 0.25,
+            "preferred": {
+                "countries": ["AU", "US", "GB|UK"],
+                "media": ["Digital Media|File", "CD"],
+                "original_year": True,
+            },
+        },
+        # The scratch profile intentionally loads only lookup + path plugins.
+        # Production fetchart/lyrics/scrub hooks would add unrelated external
+        # writes/network effects to an exact-ID mirror contract test.
+        "plugins": ["musicbrainz", "inline"],
+        "chroma": {"auto": False},
+    }
+
+
 class BeetsWorld:
     """One isolated Beets SQLite database plus real tagged audio files."""
 
-    def __init__(self, repo_root: str | os.PathLike[str]) -> None:
+    def __init__(
+        self,
+        repo_root: str | os.PathLike[str],
+        *,
+        subprocess_mirror_url: str | None = None,
+    ) -> None:
         self._tmp = tempfile.TemporaryDirectory(prefix="cratedigger_beets_world_")
         self._closed = False
         self.root = Path(self._tmp.name)
         self.library_root = self.root / "library"
         self.incoming_root = self.root / "incoming"
         self.library_db = self.root / "beets-library.db"
+        self.beets_config_dir = self.root / "beets-config"
         self.library_root.mkdir()
         self.incoming_root.mkdir()
         self.shipped = extract_shipped_beets_world_config(repo_root)
@@ -110,6 +212,8 @@ class BeetsWorld:
                 str(self.library_db),
                 str(self.library_root),
             )
+            if subprocess_mirror_url is not None:
+                self._configure_subprocess(subprocess_mirror_url)
         except BaseException:
             self._closed = True
             self._tmp.cleanup()
@@ -146,6 +250,54 @@ class BeetsWorld:
                 "real Beets inline plugin did not load shipped path_disambig; "
                 "run the world model in a fresh interpreter"
             )
+
+    def _configure_subprocess(self, mirror_url: str) -> None:
+        self.beets_config_dir.mkdir()
+        config = build_subprocess_beets_config(
+            self.shipped,
+            library_root=self.library_root,
+            library_db=self.library_db,
+            import_log=self.root / "beets-import.log",
+            mirror_url=mirror_url,
+        )
+        (self.beets_config_dir / "config.yaml").write_text(
+            json.dumps(config, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+    @contextmanager
+    def subprocess_environment(self) -> Iterator[None]:
+        """Point one synchronous harness call at this scratch Beets world."""
+
+        if not self.beets_config_dir.is_dir():
+            raise RuntimeError("scratch subprocess Beets config is not enabled")
+        prior = os.environ.get("BEETSDIR")
+        prior_db = os.environ.get("BEETS_DB")
+        prior_runtime = os.environ.get("CRATEDIGGER_RUNTIME_CONFIG")
+        os.environ["BEETSDIR"] = str(self.beets_config_dir)
+        os.environ["BEETS_DB"] = str(self.library_db)
+        # lib.util.beets_subprocess_env deliberately gives the deployed
+        # runtime config precedence over BEETSDIR. Mask that config while the
+        # test subprocess runs, otherwise invoking this profile on doc2 could
+        # select the deployed Beets config despite the scratch override.
+        os.environ["CRATEDIGGER_RUNTIME_CONFIG"] = str(
+            self.beets_config_dir / "runtime-config-disabled.ini"
+        )
+        try:
+            yield
+        finally:
+            if prior is None:
+                os.environ.pop("BEETSDIR", None)
+            else:
+                os.environ["BEETSDIR"] = prior
+            if prior_db is None:
+                os.environ.pop("BEETS_DB", None)
+            else:
+                os.environ["BEETS_DB"] = prior_db
+            if prior_runtime is None:
+                os.environ.pop("CRATEDIGGER_RUNTIME_CONFIG", None)
+            else:
+                os.environ["CRATEDIGGER_RUNTIME_CONFIG"] = prior_runtime
 
     def close(self) -> None:
         if self._closed:
@@ -189,6 +341,8 @@ class BeetsWorld:
             encoder_args = ["-c:a", "flac"]
         elif codec_key == "mp3":
             encoder_args = ["-c:a", "libmp3lame", "-b:a", "192k"]
+        elif codec_key == "opus":
+            encoder_args = ["-c:a", "libopus", "-b:a", "128k"]
         else:
             raise ValueError(f"unsupported scratch-world codec {codec!r}")
         subprocess.run(
@@ -219,7 +373,7 @@ class BeetsWorld:
         media.artist = release.artist
         media.albumartist = release.artist
         media.album = release.album
-        media.title = f"Track {track}"
+        media.title = release.track_title(track)
         media.track = track
         media.tracktotal = release.track_count
         media.disc = 1
@@ -305,7 +459,7 @@ class BeetsWorld:
                 "artist": release.artist,
                 "albumartist": release.artist,
                 "album": release.album,
-                "title": f"Track {track}",
+                "title": release.track_title(track),
                 "track": track,
                 "tracktotal": release.track_count,
                 "disc": 1,
@@ -367,5 +521,6 @@ __all__ = [
     "BeetsWorld",
     "BeetsWorldRelease",
     "ShippedBeetsWorldConfig",
+    "build_subprocess_beets_config",
     "extract_shipped_beets_world_config",
 ]

--- a/tests/test_beets_world_config.py
+++ b/tests/test_beets_world_config.py
@@ -3,9 +3,17 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
+import tempfile
 import unittest
+from unittest.mock import patch
 
-from tests.beets_world import extract_shipped_beets_world_config
+from lib.util import beets_subprocess_env
+from tests.beets_world import (
+    BeetsWorld,
+    build_subprocess_beets_config,
+    extract_shipped_beets_world_config,
+)
 
 
 class TestShippedBeetsWorldConfig(unittest.TestCase):
@@ -27,6 +35,80 @@ class TestShippedBeetsWorldConfig(unittest.TestCase):
             set(shipped.duplicate_album_keys),
             {"mb_albumid", "discogs_albumid"},
         )
+
+    def test_subprocess_config_is_disposable_exact_id_and_mirror_backed(self) -> None:
+        repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+        shipped = extract_shipped_beets_world_config(repo_root)
+
+        config = build_subprocess_beets_config(
+            shipped,
+            library_root=Path("/tmp/world/library"),
+            library_db=Path("/tmp/world/library.db"),
+            import_log=Path("/tmp/world/import.log"),
+            mirror_url="http://mirror.invalid:5200",
+        )
+
+        self.assertEqual(config["directory"], "/tmp/world/library")
+        self.assertEqual(config["library"], "/tmp/world/library.db")
+        self.assertEqual(
+            config["import"]["duplicate_keys"]["album"],
+            ["mb_albumid", "discogs_albumid"],
+        )
+        self.assertEqual(config["plugins"], ["musicbrainz", "inline"])
+        self.assertEqual(
+            config["musicbrainz"],
+            {"host": "mirror.invalid:5200", "https": False, "ratelimit": 100},
+        )
+        self.assertIn("%aunique", config["paths"]["default"])
+
+    def test_subprocess_config_rejects_non_origin_mirror_urls(self) -> None:
+        repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+        shipped = extract_shipped_beets_world_config(repo_root)
+
+        with self.assertRaisesRegex(ValueError, "origin"):
+            build_subprocess_beets_config(
+                shipped,
+                library_root=Path("/tmp/world/library"),
+                library_db=Path("/tmp/world/library.db"),
+                import_log=Path("/tmp/world/import.log"),
+                mirror_url="http://mirror.invalid:5200/ws/2",
+            )
+
+    def test_subprocess_environment_never_reads_the_deployed_beets_db(self) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            deployed_runtime = Path(root) / "deployed-runtime.ini"
+            deployed_runtime.write_text(
+                "[Beets]\nconfig_dir = /deployed/config\n",
+                encoding="utf-8",
+            )
+            world = object.__new__(BeetsWorld)
+            world.beets_config_dir = Path(root) / "config"
+            world.beets_config_dir.mkdir()
+            world.library_db = Path(root) / "scratch-library.db"
+            with patch.dict(
+                os.environ,
+                {
+                    "BEETSDIR": "/deployed/config",
+                    "BEETS_DB": "/deployed/library.db",
+                    "CRATEDIGGER_RUNTIME_CONFIG": str(deployed_runtime),
+                },
+            ):
+                with world.subprocess_environment():
+                    subprocess_env = beets_subprocess_env()
+                    self.assertEqual(
+                        subprocess_env["BEETSDIR"],
+                        str(world.beets_config_dir),
+                    )
+                    self.assertEqual(
+                        subprocess_env["BEETS_DB"],
+                        str(world.library_db),
+                    )
+                self.assertEqual(os.environ["BEETSDIR"], "/deployed/config")
+                self.assertEqual(os.environ["BEETS_DB"], "/deployed/library.db")
+                self.assertEqual(
+                    os.environ["CRATEDIGGER_RUNTIME_CONFIG"],
+                    str(deployed_runtime),
+                )
 
 
 if __name__ == "__main__":

--- a/tests/test_validation_envelope.py
+++ b/tests/test_validation_envelope.py
@@ -23,6 +23,7 @@ class TestDecodeValidationEnvelope(unittest.TestCase):
 
     def test_none_decodes_to_empty_envelope(self) -> None:
         env = decode_validation_envelope(None)
+        self.assertIsNone(env.valid)
         self.assertIsNone(env.failed_path)
         self.assertEqual(env.source_dirs, [])
         self.assertIsNone(env.wrong_match_triage)
@@ -58,6 +59,7 @@ class TestDecodeValidationEnvelope(unittest.TestCase):
             "cleanup_errors": [],
         })
         self.assertEqual(env.scenario, "curator_ban")
+        self.assertIsNone(env.valid)
         self.assertIsNone(env.failed_path)
         self.assertIsNone(env.wrong_match_triage)
 

--- a/tests/test_world_census_seeds.py
+++ b/tests/test_world_census_seeds.py
@@ -1,0 +1,58 @@
+"""Deterministic pins for the anonymized production-world census (#743)."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+import unittest
+
+from tests.world_model.census_seeds import (
+    STATEFUL_WORLD_CENSUS_SEEDS,
+    WORLD_CENSUS_SEEDS,
+    assert_census_seed_anonymized,
+)
+
+
+class TestWorldCensusSeeds(unittest.TestCase):
+    def test_corpus_covers_live_status_lineage_and_legacy_policy_shapes(self) -> None:
+        self.assertEqual(
+            {seed.status for seed in WORLD_CENSUS_SEEDS},
+            {"downloading", "imported", "replaced", "unsearchable", "wanted"},
+        )
+        self.assertEqual(
+            {seed.lineage_version for seed in WORLD_CENSUS_SEEDS},
+            {0, 1, 3, 4},
+        )
+        self.assertIn(
+            "lossless,mp3 v0,mp3 320,aac,opus,ogg",
+            {seed.search_override for seed in WORLD_CENSUS_SEEDS},
+        )
+        self.assertIn("Opus", {seed.storage_format for seed in WORLD_CENSUS_SEEDS})
+        self.assertIn("MP3", {seed.storage_format for seed in WORLD_CENSUS_SEEDS})
+        self.assertTrue(all(seed.observed_rows > 0 for seed in WORLD_CENSUS_SEEDS))
+
+    def test_committed_census_contains_no_production_identity_or_path(self) -> None:
+        for seed in WORLD_CENSUS_SEEDS:
+            assert_census_seed_anonymized(seed)
+
+    def test_stateful_subset_is_drawn_only_from_captured_request_shapes(self) -> None:
+        self.assertTrue(STATEFUL_WORLD_CENSUS_SEEDS)
+        self.assertTrue(
+            set(STATEFUL_WORLD_CENSUS_SEEDS).issubset(WORLD_CENSUS_SEEDS)
+        )
+        self.assertEqual(
+            {seed.status for seed in STATEFUL_WORLD_CENSUS_SEEDS},
+            {"imported", "wanted"},
+        )
+
+    def test_anonymization_checker_trips_on_a_planted_path(self) -> None:
+        known_bad = replace(
+            WORLD_CENSUS_SEEDS[0],
+            name="mnt_virtio_music_private",
+        )
+
+        with self.assertRaisesRegex(AssertionError, "anonymized"):
+            assert_census_seed_anonymized(known_bad)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_world_census_seeds_generated.py
+++ b/tests/test_world_census_seeds_generated.py
@@ -1,0 +1,27 @@
+"""Generated contracts for every committed production-world census seed."""
+
+from __future__ import annotations
+
+import unittest
+
+from hypothesis import given, strategies as st
+
+import tests._hypothesis_profiles  # noqa: F401  (loads active profile)
+from tests.world_model.census_seeds import (
+    WORLD_CENSUS_SEEDS,
+    WorldCensusSeed,
+    assert_census_seed_anonymized,
+)
+
+
+class TestWorldCensusSeedsGenerated(unittest.TestCase):
+    @given(seed=st.sampled_from(WORLD_CENSUS_SEEDS))
+    def test_every_sampled_seed_remains_anonymized(
+        self,
+        seed: WorldCensusSeed,
+    ) -> None:
+        assert_census_seed_anonymized(seed)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_world_invariants.py
+++ b/tests/test_world_invariants.py
@@ -6,6 +6,9 @@ import os
 import tempfile
 import unittest
 
+import msgspec
+
+from lib.quality import ValidationResult
 from lib.world_invariants import (
     DenylistAuthoritySnapshot,
     EvidenceDiskSnapshot,
@@ -121,6 +124,70 @@ class TestWorldInvariantPins(unittest.TestCase):
                 history=[],
             ),
             ("requeue_lossless",),
+        )
+
+    def test_invalid_validation_authorizes_only_its_exact_source_peer(self) -> None:
+        validation = msgspec.to_builtins(ValidationResult(
+            valid=False,
+            scenario="high_distance",
+            soulseek_username="validation-peer",
+        ))
+        assert isinstance(validation, dict)
+        history = [{
+            "outcome": "rejected",
+            "soulseek_username": "validation-peer",
+            "validation_result": validation,
+        }]
+
+        self.assertEqual(
+            derive_denylist_authorities(
+                username="validation-peer",
+                reason="beets validation rejected",
+                history=history,
+            ),
+            ("validation_reject",),
+        )
+        self.assertEqual(
+            derive_denylist_authorities(
+                username="different-peer",
+                reason="beets validation rejected",
+                history=history,
+            ),
+            (),
+        )
+        self.assertEqual(
+            derive_denylist_authorities(
+                username="validation-peer",
+                reason="curator ban",
+                history=[{
+                    **history[0],
+                    "validation_result": {"scenario": "curator_ban"},
+                }],
+            ),
+            (),
+        )
+        self.assertEqual(
+            derive_denylist_authorities(
+                username="validation-peer",
+                reason="transport failed",
+                history=[{**history[0], "outcome": "failed"}],
+            ),
+            (),
+        )
+        valid_history = [{
+            **history[0],
+            "validation_result": msgspec.to_builtins(ValidationResult(
+                valid=True,
+                scenario="strong_match",
+            )),
+        }]
+        self.assertEqual(
+            derive_denylist_authorities(
+                username="validation-peer",
+                reason="manual note",
+                history=valid_history,
+            ),
+            (),
         )
 
 

--- a/tests/test_world_invariants_generated.py
+++ b/tests/test_world_invariants_generated.py
@@ -9,6 +9,7 @@ import unittest
 from hypothesis import given, strategies as st
 
 import tests._hypothesis_profiles  # noqa: F401  (loads active profile)
+from lib.quality import ValidationResult
 from lib.world_invariants import (
     DenylistAuthoritySnapshot,
     EvidenceDiskSnapshot,
@@ -22,6 +23,7 @@ from lib.world_invariants import (
     check_no_lossy_tier_widening,
     check_proof_lock_terminality,
     check_status_membership,
+    derive_denylist_authorities,
 )
 
 
@@ -240,6 +242,43 @@ class TestWorldInvariantGenerated(unittest.TestCase):
         ),))
 
         self.assertIn("denylist_without_authority", {v.code for v in violations})
+
+    @given(
+        username=_SEGMENT,
+        reason=_SEGMENT,
+        scenario=_SEGMENT,
+        as_jsonb=st.booleans(),
+        valid=st.booleans(),
+    )
+    def test_only_exact_peer_invalid_validation_authorizes_the_denylist(
+        self,
+        username: str,
+        reason: str,
+        scenario: str,
+        as_jsonb: bool,
+        valid: bool,
+    ) -> None:
+        result = ValidationResult(valid=valid, scenario=scenario)
+        validation_result: object = (
+            result.to_json()
+            if not as_jsonb
+            else {
+                "valid": valid,
+                "scenario": scenario,
+            }
+        )
+
+        authorities = derive_denylist_authorities(
+            username=username,
+            reason=reason,
+            history=[{
+                "outcome": "rejected",
+                "soulseek_username": username,
+                "validation_result": validation_result,
+            }],
+        )
+
+        self.assertEqual("validation_reject" in authorities, not valid)
 
 
 if __name__ == "__main__":

--- a/tests/test_world_model_burst.py
+++ b/tests/test_world_model_burst.py
@@ -63,6 +63,22 @@ class TestWorldModelBurstScript(unittest.TestCase):
         self.assertIn("examples=7", result.stdout)
         self.assertIn("steps=19", result.stdout)
 
+    def test_mirror_engine_requires_and_reports_explicit_read_only_origin(self) -> None:
+        missing = self._run("--engine", "mirror-harness", "--print-config")
+        self.assertEqual(missing.returncode, 2)
+        self.assertIn("--mirror-url", missing.stderr)
+
+        configured = self._run(
+            "--engine",
+            "mirror-harness",
+            "--mirror-url",
+            "http://mirror.invalid:5200",
+            "--print-config",
+        )
+        self.assertEqual(configured.returncode, 0, configured.stderr)
+        self.assertIn("engine=mirror-harness", configured.stdout)
+        self.assertIn("mirror_url=http://mirror.invalid:5200", configured.stdout)
+
     def test_non_positive_budget_is_rejected_before_world_start(self) -> None:
         result = self._run("--examples", "0", "--print-config")
 

--- a/tests/world_model/census_seeds.py
+++ b/tests/world_model/census_seeds.py
@@ -1,0 +1,233 @@
+"""Anonymized categorical seeds sampled read-only from doc2 on 2026-07-19.
+
+The corpus deliberately contains no request IDs, release IDs, artist/title
+metadata, peer names, or paths. Counts are capture-time prevalence evidence,
+not assertions about a live database that will continue changing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+import re
+
+
+@dataclass(frozen=True)
+class WorldCensusSeed:
+    """One exact request plus linked-evidence vocabulary/null row shape."""
+
+    name: str
+    observed_rows: int
+    status: str
+    identity_shape: str
+    search_override: str | None
+    has_imported_path: bool
+    has_current_evidence: bool
+    lineage_version: int
+    final_format: str | None
+    codec: str | None
+    storage_format: str | None
+    measured_format: str | None
+    spectral_grade: str | None
+    spectral_subject: str | None
+    spectral_provenance: str | None
+    v0_subject: str | None
+    v0_provenance: str | None
+    verified_lossless: bool
+
+    @property
+    def has_v0_metrics(self) -> bool:
+        return self.v0_subject is not None
+
+
+WORLD_CENSUS_SEEDS = (
+    WorldCensusSeed(
+        name="imported_mb_lineage1_verified_v0",
+        observed_rows=4063,
+        status="imported", identity_shape="musicbrainz", search_override=None,
+        has_imported_path=True, has_current_evidence=True, lineage_version=1,
+        final_format="opus 128", codec="opus", storage_format="Opus",
+        measured_format="Opus", spectral_grade="genuine",
+        spectral_subject="source", spectral_provenance="carried",
+        v0_subject="source", v0_provenance="measured", verified_lossless=True,
+    ),
+    WorldCensusSeed(
+        name="imported_mb_lineage4_verified_v0",
+        observed_rows=1284,
+        status="imported", identity_shape="musicbrainz", search_override=None,
+        has_imported_path=True, has_current_evidence=True, lineage_version=4,
+        final_format="opus 128", codec="opus", storage_format="Opus",
+        measured_format="Opus", spectral_grade="genuine",
+        spectral_subject="source", spectral_provenance="carried",
+        v0_subject="source", v0_provenance="carried", verified_lossless=True,
+    ),
+    WorldCensusSeed(
+        name="imported_mb_lineage4_verified_without_v0",
+        observed_rows=708,
+        status="imported", identity_shape="musicbrainz", search_override=None,
+        has_imported_path=True, has_current_evidence=True, lineage_version=4,
+        final_format="opus 128", codec="opus", storage_format="Opus",
+        measured_format="Opus", spectral_grade="genuine",
+        spectral_subject="source", spectral_provenance="carried",
+        v0_subject=None, v0_provenance=None, verified_lossless=True,
+    ),
+    WorldCensusSeed(
+        name="imported_dual_lineage1_verified_v0",
+        observed_rows=188,
+        status="imported", identity_shape="both", search_override=None,
+        has_imported_path=True, has_current_evidence=True, lineage_version=1,
+        final_format="opus 128", codec="opus", storage_format="Opus",
+        measured_format="Opus", spectral_grade="genuine",
+        spectral_subject="source", spectral_provenance="carried",
+        v0_subject="source", v0_provenance="measured", verified_lossless=True,
+    ),
+    WorldCensusSeed(
+        name="wanted_mb_pristine",
+        observed_rows=210,
+        status="wanted", identity_shape="musicbrainz", search_override=None,
+        has_imported_path=False, has_current_evidence=False, lineage_version=0,
+        final_format=None, codec=None, storage_format=None, measured_format=None,
+        spectral_grade=None, spectral_subject=None, spectral_provenance=None,
+        v0_subject=None, v0_provenance=None, verified_lossless=False,
+    ),
+    WorldCensusSeed(
+        name="wanted_mb_lineage1_without_imported_path",
+        observed_rows=249,
+        status="wanted", identity_shape="musicbrainz", search_override=None,
+        has_imported_path=False, has_current_evidence=True, lineage_version=1,
+        final_format=None, codec="mp3", storage_format="MP3",
+        measured_format="MP3", spectral_grade=None, spectral_subject=None,
+        spectral_provenance=None, v0_subject=None, v0_provenance=None,
+        verified_lossless=False,
+    ),
+    WorldCensusSeed(
+        name="wanted_mb_lossless_lineage1_installed",
+        observed_rows=97,
+        status="wanted", identity_shape="musicbrainz",
+        search_override="lossless", has_imported_path=True,
+        has_current_evidence=True, lineage_version=1, final_format="MP3",
+        codec="mp3", storage_format="MP3", measured_format="MP3",
+        spectral_grade="genuine", spectral_subject="installed",
+        spectral_provenance="measured", v0_subject="installed",
+        v0_provenance="measured", verified_lossless=False,
+    ),
+    WorldCensusSeed(
+        name="wanted_mb_three_tier_without_evidence",
+        observed_rows=86,
+        status="wanted", identity_shape="musicbrainz",
+        search_override="lossless,mp3 v0,mp3 320", has_imported_path=True,
+        has_current_evidence=False, lineage_version=0, final_format=None,
+        codec=None, storage_format=None, measured_format=None,
+        spectral_grade=None, spectral_subject=None, spectral_provenance=None,
+        v0_subject=None, v0_provenance=None, verified_lossless=False,
+    ),
+    WorldCensusSeed(
+        name="wanted_mb_full_legacy_ladder_lineage1",
+        observed_rows=40,
+        status="wanted", identity_shape="musicbrainz",
+        search_override="lossless,mp3 v0,mp3 320,aac,opus,ogg",
+        has_imported_path=True, has_current_evidence=True, lineage_version=1,
+        final_format="MP3", codec="mp3", storage_format="MP3",
+        measured_format="MP3", spectral_grade="likely_transcode",
+        spectral_subject="installed", spectral_provenance="measured",
+        v0_subject="installed", v0_provenance="measured",
+        verified_lossless=False,
+    ),
+    WorldCensusSeed(
+        name="wanted_mb_lineage3_without_imported_path",
+        observed_rows=19,
+        status="wanted", identity_shape="musicbrainz", search_override=None,
+        has_imported_path=False, has_current_evidence=True, lineage_version=3,
+        final_format=None, codec="mp3", storage_format="MP3",
+        measured_format="MP3", spectral_grade=None, spectral_subject=None,
+        spectral_provenance=None, v0_subject=None, v0_provenance=None,
+        verified_lossless=False,
+    ),
+    WorldCensusSeed(
+        name="downloading_mb_lineage3_likely_transcode",
+        observed_rows=1,
+        status="downloading", identity_shape="musicbrainz",
+        search_override=None, has_imported_path=False,
+        has_current_evidence=True, lineage_version=3, final_format=None,
+        codec="mp3", storage_format="MP3", measured_format="MP3",
+        spectral_grade="likely_transcode", spectral_subject="installed",
+        spectral_provenance="measured", v0_subject="installed",
+        v0_provenance="measured", verified_lossless=False,
+    ),
+    WorldCensusSeed(
+        name="unsearchable_mb_without_evidence",
+        observed_rows=2,
+        status="unsearchable", identity_shape="musicbrainz",
+        search_override=None, has_imported_path=False,
+        has_current_evidence=False, lineage_version=0, final_format=None,
+        codec=None, storage_format=None, measured_format=None,
+        spectral_grade=None, spectral_subject=None, spectral_provenance=None,
+        v0_subject=None, v0_provenance=None, verified_lossless=False,
+    ),
+    WorldCensusSeed(
+        name="replaced_mb_lineage1_without_measurement",
+        observed_rows=5,
+        status="replaced", identity_shape="musicbrainz", search_override=None,
+        has_imported_path=False, has_current_evidence=True, lineage_version=1,
+        final_format=None, codec="mp3", storage_format="MP3",
+        measured_format="MP3", spectral_grade=None, spectral_subject=None,
+        spectral_provenance=None, v0_subject=None, v0_provenance=None,
+        verified_lossless=False,
+    ),
+)
+
+
+_STATEFUL_NAMES = frozenset({
+    "imported_mb_lineage1_verified_v0",
+    "imported_mb_lineage4_verified_v0",
+    "imported_mb_lineage4_verified_without_v0",
+    "imported_dual_lineage1_verified_v0",
+    "wanted_mb_pristine",
+    "wanted_mb_lineage1_without_imported_path",
+    "wanted_mb_lossless_lineage1_installed",
+    "wanted_mb_three_tier_without_evidence",
+    "wanted_mb_full_legacy_ladder_lineage1",
+    "wanted_mb_lineage3_without_imported_path",
+})
+STATEFUL_WORLD_CENSUS_SEEDS = tuple(
+    seed for seed in WORLD_CENSUS_SEEDS if seed.name in _STATEFUL_NAMES
+)
+
+
+_UUID = re.compile(
+    r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b",
+    re.IGNORECASE,
+)
+_SAFE_NAME_TOKENS = frozenset({
+    "both", "downloading", "dual", "evidence", "full", "imported",
+    "installed", "ladder", "legacy", "lineage1", "lineage3", "lineage4",
+    "likely", "lossless", "mb", "measurement", "pristine", "replaced",
+    "path", "three", "tier", "transcode", "unsearchable", "v0", "verified",
+    "wanted", "without",
+})
+
+
+def assert_census_seed_anonymized(seed: WorldCensusSeed) -> None:
+    """Reject accidental production identity/path material in the corpus."""
+
+    rendered = repr(asdict(seed))
+    name_tokens = frozenset(seed.name.split("_"))
+    if (
+        not name_tokens
+        or not name_tokens.issubset(_SAFE_NAME_TOKENS)
+        or "/" in rendered
+        or "\\" in rendered
+        or _UUID.search(rendered) is not None
+    ):
+        raise AssertionError(f"census seed is not anonymized: {seed.name!r}")
+    if seed.observed_rows < 1:
+        raise AssertionError("census seed must represent at least one live row")
+    if seed.has_current_evidence != (seed.lineage_version > 0):
+        raise AssertionError("census evidence presence and lineage disagree")
+
+
+__all__ = [
+    "STATEFUL_WORLD_CENSUS_SEEDS",
+    "WORLD_CENSUS_SEEDS",
+    "WorldCensusSeed",
+    "assert_census_seed_anonymized",
+]

--- a/tests/world_model/mirror_harness.py
+++ b/tests/world_model/mirror_harness.py
@@ -1,0 +1,145 @@
+"""Operator-only real-harness world profile backed by a MusicBrainz mirror.
+
+This module is intentionally outside unittest discovery. Invoke it through
+``scripts/world_model_burst.sh --engine mirror-harness --mirror-url ORIGIN``.
+The release fixture is public MusicBrainz catalogue data selected independently
+of the production collection; every database, file, and Beets path is scratch.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+from hypothesis import HealthCheck, settings
+from hypothesis.database import DirectoryBasedExampleDatabase
+from hypothesis.stateful import RuleBasedStateMachine, invariant, precondition, rule
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+import conftest  # noqa: E402, F401
+
+from tests.beets_world import BeetsWorldRelease  # noqa: E402
+from tests.world_model.census_seeds import (  # noqa: E402
+    STATEFUL_WORLD_CENSUS_SEEDS,
+)
+from tests.world_model.support import LifecycleWorld, repository_root  # noqa: E402
+
+
+TEST_DSN = os.environ.get("TEST_DB_DSN")
+MIRROR_URL = os.environ.get("CRATEDIGGER_WORLD_MIRROR_URL", "")
+if not TEST_DSN:
+    raise RuntimeError("mirror world requires ephemeral PostgreSQL in nix-shell")
+if not MIRROR_URL:
+    raise RuntimeError("mirror world requires CRATEDIGGER_WORLD_MIRROR_URL")
+
+
+# Public, one-track official release; metadata was read from the MB mirror on
+# 2026-07-19. It is not sampled from album_requests or the Beets collection.
+PUBLIC_MIRROR_RELEASE = BeetsWorldRelease(
+    release_id="d399d08e-c5a1-4ab4-b1f3-a6d5e732b921",
+    artist="Cut Capers",
+    album="Test",
+    year=2019,
+    codec="mp3",
+    track_count=1,
+    track_titles=("I Know",),
+)
+PRISTINE_CENSUS_SEED = next(
+    seed
+    for seed in STATEFUL_WORLD_CENSUS_SEEDS
+    if seed.name == "wanted_mb_pristine"
+)
+
+
+def _open_world() -> LifecycleWorld:
+    assert TEST_DSN is not None
+    return LifecycleWorld(
+        TEST_DSN,
+        repository_root(),
+        import_engine="mirror-harness",
+        mirror_url=MIRROR_URL,
+    )
+
+
+class TestPinnedMirrorHarnessWorld(unittest.TestCase):
+    def test_public_exact_release_crosses_real_harness_subprocess(self) -> None:
+        with _open_world() as world:
+            request_id = world.seed_census_release(
+                PUBLIC_MIRROR_RELEASE,
+                PRISTINE_CENSUS_SEED,
+            )
+
+            self.assertTrue(world.import_request(request_id, codec="mp3"))
+            world.assert_invariants()
+            self.assertEqual(
+                {album.release_id for album in world.beets.snapshots()},
+                {PUBLIC_MIRROR_RELEASE.release_id},
+            )
+
+
+class MirrorHarnessWorldMachine(RuleBasedStateMachine):
+    """Hammer real service lifecycles after a guaranteed subprocess import."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.world = _open_world()
+        self.request_id = self.world.seed_census_release(
+            PUBLIC_MIRROR_RELEASE,
+            PRISTINE_CENSUS_SEED,
+        )
+        if not self.world.import_request(self.request_id, codec="mp3"):
+            raise AssertionError("initial mirror-harness import was rejected")
+
+    def teardown(self) -> None:
+        self.world.close()
+
+    @precondition(lambda self: bool(self.world.request_ids_with_status("wanted")))
+    @rule()
+    def reimport_exact_release(self) -> None:
+        self.world.import_request(self.request_id, codec="mp3")
+
+    @precondition(lambda self: bool(self.world.request_ids_with_status("wanted")))
+    @rule()
+    def force_import_exact_release(self) -> None:
+        self.world.force_import_request(self.request_id, codec="mp3")
+
+    @precondition(lambda self: bool(self.world.request_ids_with_album()))
+    @rule()
+    def ban_then_make_searchable(self) -> None:
+        self.world.ban_request_source(self.request_id)
+
+    @rule()
+    def delete_wrong_match(self) -> None:
+        self.world.delete_wrong_match(self.request_id)
+
+    @invariant()
+    def cross_engine_invariants_hold(self) -> None:
+        self.world.assert_invariants()
+
+
+TestGeneratedMirrorHarnessWorld = MirrorHarnessWorldMachine.TestCase
+_RANDOMIZED = os.environ.get("CRATEDIGGER_WORLD_RANDOMIZED") == "1"
+_DATABASE = (
+    DirectoryBasedExampleDatabase(
+        os.environ.get(
+            "CRATEDIGGER_WORLD_DATABASE",
+            ".hypothesis/world-model-mirror",
+        )
+    )
+    if _RANDOMIZED
+    else None
+)
+TestGeneratedMirrorHarnessWorld.settings = settings(
+    max_examples=int(os.environ.get("CRATEDIGGER_WORLD_EXAMPLES", "2")),
+    stateful_step_count=int(os.environ.get("CRATEDIGGER_WORLD_STEPS", "4")),
+    deadline=None,
+    derandomize=not _RANDOMIZED,
+    database=_DATABASE,
+    print_blob=_RANDOMIZED,
+    suppress_health_check=(HealthCheck.too_slow,),
+)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/world_model/state_machine.py
+++ b/tests/world_model/state_machine.py
@@ -20,6 +20,7 @@ from hypothesis.database import DirectoryBasedExampleDatabase
 from hypothesis import strategies as st
 from hypothesis.stateful import (
     RuleBasedStateMachine,
+    initialize,
     invariant,
     precondition,
     rule,
@@ -32,6 +33,10 @@ import conftest  # noqa: E402, F401
 
 from tests.beets_world import BeetsWorldRelease  # noqa: E402
 from tests.world_model.support import LifecycleWorld, repository_root  # noqa: E402
+from tests.world_model.census_seeds import (  # noqa: E402
+    STATEFUL_WORLD_CENSUS_SEEDS,
+    WorldCensusSeed,
+)
 
 
 TEST_DSN = os.environ.get("TEST_DB_DSN")
@@ -193,6 +198,33 @@ class TestPinnedLifecycleWorld(unittest.TestCase):
             self.assertFalse(world.force_import_request(request_id, codec="mp3"))
             world.assert_invariants()
 
+    def test_census_seed_rebuilds_legacy_evidence_on_touch(self) -> None:
+        seed = next(
+            seed
+            for seed in STATEFUL_WORLD_CENSUS_SEEDS
+            if seed.name == "wanted_mb_full_legacy_ladder_lineage1"
+        )
+        assert TEST_DSN is not None
+        with LifecycleWorld(TEST_DSN, repository_root()) as world:
+            request_id = world.seed_census_release(BeetsWorldRelease(
+                release_id="40000000-0000-4000-8000-000000000743",
+                artist="Census Archive",
+                album="Legacy Ladder",
+                year=2004,
+                codec="mp3",
+            ), seed)
+            before_id = world.db.get_request_current_evidence_id(request_id)
+            before = world.db.load_album_quality_evidence_by_id(before_id)
+            assert before is not None
+            self.assertEqual(before.lineage_version, 1)
+
+            self.assertTrue(world.import_request(request_id, codec="flac"))
+            after_id = world.db.get_request_current_evidence_id(request_id)
+            after = world.db.load_album_quality_evidence_by_id(after_id)
+            assert after is not None
+            self.assertEqual(after.lineage_version, 4)
+            world.assert_invariants()
+
 
 class LifecycleWorldMachine(RuleBasedStateMachine):
     """Generate operator lifecycles and check after every real mutation."""
@@ -205,6 +237,19 @@ class LifecycleWorldMachine(RuleBasedStateMachine):
 
     def teardown(self) -> None:
         self.world.close()
+
+    @initialize(seed=st.sampled_from(STATEFUL_WORLD_CENSUS_SEEDS))
+    def initialize_from_production_census(self, seed: WorldCensusSeed) -> None:
+        self._release_counter += 1
+        self.world.seed_census_release(BeetsWorldRelease(
+            release_id=_mb_release_id(self._release_counter),
+            artist="Census Artist",
+            album=f"Census Shape {seed.name}",
+            year=2000,
+            codec="flac" if seed.verified_lossless else "mp3",
+            label="Census Label",
+            catalognum=f"CENSUS-{self._release_counter}",
+        ), seed)
 
     @rule(
         identity_source=st.sampled_from(("musicbrainz", "discogs")),

--- a/tests/world_model/support.py
+++ b/tests/world_model/support.py
@@ -13,10 +13,15 @@ from lib.beets_db import BeetsDB
 from lib.config import CratediggerConfig
 from lib.destructive_release_service import (
     BanSourceRequest,
+    BanSourceReleaseMismatch,
     BanSourceSuccess,
     ban_source,
 )
-from lib.dispatch import dispatch_import_core, dispatch_import_from_db
+from lib.dispatch import (
+    dispatch_import_core,
+    dispatch_import_from_db,
+    run_import_one,
+)
 from lib.dispatch.types import ImportOneRun
 from lib.import_evidence import (
     ActionEvidenceProvenance,
@@ -69,26 +74,52 @@ from tests.helpers import (
     make_import_result,
 )
 from tests.test_pipeline_db import TEST_DSN, make_db
+from tests.world_model.census_seeds import (
+    STATEFUL_WORLD_CENSUS_SEEDS,
+    WorldCensusSeed,
+)
 
 
 class LifecycleWorld:
     """One disposable pipeline DB slate coupled to one Beets library."""
 
-    def __init__(self, dsn: str, repo_root: str | os.PathLike[str]) -> None:
+    def __init__(
+        self,
+        dsn: str,
+        repo_root: str | os.PathLike[str],
+        *,
+        import_engine: str = "in-process",
+        mirror_url: str | None = None,
+    ) -> None:
         if TEST_DSN != dsn:
             raise ValueError(
                 "world model must use tests.test_pipeline_db.make_db() "
                 "against its ephemeral TEST_DB_DSN"
             )
+        if import_engine not in {"in-process", "mirror-harness"}:
+            raise ValueError(f"unsupported world import engine: {import_engine!r}")
+        if import_engine == "mirror-harness" and not mirror_url:
+            raise ValueError("mirror-harness world requires a mirror URL")
+        self._import_engine = import_engine
+        self._repo_root = Path(repo_root)
+        self._beets_harness_path = str(
+            self._repo_root / "harness" / "run_beets_harness.sh"
+        )
         self.db = make_db()
         try:
-            self.beets = BeetsWorld(repo_root)
+            self.beets = BeetsWorld(
+                repo_root,
+                subprocess_mirror_url=(
+                    mirror_url if import_engine == "mirror-harness" else None
+                ),
+            )
         except BaseException:
             self.db.close()
             raise
         self._release_by_request: dict[int, BeetsWorldRelease] = {}
         self._dispatch_counter = 0
         self._operator_counter = 0
+        self._last_subprocess_run: ImportOneRun | None = None
         self._replaced_snapshots: dict[int, dict[str, object]] = {}
         self._transitions: list[LifecycleTransitionSnapshot] = []
 
@@ -131,11 +162,130 @@ class LifecycleWorld:
             {
                 "disc_number": 1,
                 "track_number": track,
-                "title": f"Track {track}",
+                "title": release.track_title(track),
             }
             for track in range(1, release.track_count + 1)
         ])
         self._release_by_request[request_id] = release
+        return request_id
+
+    def seed_census_release(
+        self,
+        release: BeetsWorldRelease,
+        seed: WorldCensusSeed,
+    ) -> int:
+        """Materialize one anonymized live row shape in disposable stores."""
+
+        if seed not in STATEFUL_WORLD_CENSUS_SEEDS:
+            raise ValueError(f"census seed is not stateful-safe: {seed.name}")
+
+        request_id = self.add_release(release)
+        album: LibraryAlbumSnapshot | None = None
+        if seed.has_current_evidence:
+            codec = seed.codec or release.codec
+            if not self.import_request(
+                request_id,
+                codec=codec,
+                verified_lossless=seed.verified_lossless,
+            ):
+                raise AssertionError(
+                    f"census seed import was rejected: {seed.name}"
+                )
+            album = self._album_for_release(release.release_id)
+            if album is None:
+                raise AssertionError(
+                    f"census seed did not create a Beets album: {seed.name}"
+                )
+
+        row = self._require_request(request_id)
+        if seed.status == "imported" and row["status"] != "imported":
+            if album is None:
+                raise AssertionError("imported census seed requires a Beets album")
+            require_transition_applied(finalize_request(
+                self.db,
+                request_id,
+                RequestTransition.to_imported(
+                    from_status=str(row["status"]),
+                    imported_path=album.album_path,
+                ),
+            ))
+        elif seed.status == "wanted" and row["status"] != "wanted":
+            self.reset_to_wanted(request_id)
+
+        imported_path: str | None
+        if seed.has_imported_path:
+            imported_path = (
+                album.album_path
+                if album is not None
+                else str(
+                    self.beets.library_root
+                    / f"legacy-installed-marker-{request_id}"
+                )
+            )
+        else:
+            imported_path = None
+        if not self.db.update_request_fields(
+            request_id,
+            expected_status=seed.status,
+            search_filetype_override=seed.search_override,
+            imported_path=imported_path,
+            final_format=seed.final_format,
+            current_spectral_grade=seed.spectral_grade,
+            verified_lossless=seed.verified_lossless,
+        ):
+            raise AssertionError(f"failed to apply census metadata: {seed.name}")
+
+        if seed.identity_shape == "both":
+            self.db._execute(
+                "UPDATE album_requests SET discogs_release_id = %s WHERE id = %s",
+                (str(8_000_000 + request_id), request_id),
+            )
+            self.db.conn.commit()
+
+        evidence_id = self.db.get_request_current_evidence_id(request_id)
+        if seed.has_current_evidence and evidence_id is None:
+            raise AssertionError(f"census evidence link missing: {seed.name}")
+        if evidence_id is not None:
+            self.db._execute(
+                """
+                UPDATE album_quality_evidence
+                SET lineage_version = %s,
+                    codec = %s,
+                    storage_format = %s,
+                    format = %s,
+                    spectral_grade = %s,
+                    spectral_subject = %s,
+                    spectral_provenance = %s,
+                    v0_min_bitrate_kbps = %s,
+                    v0_avg_bitrate_kbps = %s,
+                    v0_median_bitrate_kbps = %s,
+                    v0_subject = %s,
+                    v0_provenance = %s
+                WHERE id = %s
+                """,
+                (
+                    seed.lineage_version,
+                    seed.codec,
+                    seed.storage_format,
+                    seed.measured_format,
+                    seed.spectral_grade,
+                    seed.spectral_subject,
+                    seed.spectral_provenance,
+                    192 if seed.has_v0_metrics else None,
+                    205 if seed.has_v0_metrics else None,
+                    198 if seed.has_v0_metrics else None,
+                    seed.v0_subject,
+                    seed.v0_provenance,
+                    evidence_id,
+                ),
+            )
+            self.db.conn.commit()
+
+        row = self._require_request(request_id)
+        if row["status"] != seed.status:
+            raise AssertionError(
+                f"census seed status drifted: {row['status']!r} != {seed.status!r}"
+            )
         return request_id
 
     def import_request(
@@ -280,12 +430,20 @@ class LifecycleWorld:
             mb_release_id=release.release_id,
             request_id=request_id,
             label=f"{release.artist} - {release.album}",
-            beets_harness_path="in-process-beets-world",
+            beets_harness_path=(
+                self._beets_harness_path
+                if self._import_engine == "mirror-harness"
+                else "in-process-beets-world"
+            ),
             db=self.db,
             dl_info=DownloadInfo(filetype=attempt.codec),
             scenario="auto_import",
             force=False,
-            run_import_fn=run_real_beets_import,
+            run_import_fn=(
+                self._run_beets_subprocess
+                if self._import_engine == "mirror-harness"
+                else run_real_beets_import
+            ),
             candidate_download_log_id=origin_download_log_id,
             prevalidated_candidate_result=candidate_result,
             requeue_on_failure=True,
@@ -316,9 +474,11 @@ class LifecycleWorld:
             before_verified_lossless=before_verified_proof,
         ))
         if not outcome.success and outcome.code != "quality_pipeline_rejected":
+            subprocess_detail = self._subprocess_failure_detail()
             raise AssertionError(
                 "production dispatch rejected world import for request "
                 f"{request_id}: code={outcome.code!r} message={outcome.message!r} "
+                f"{subprocess_detail}"
             )
         if staged_path.exists() and outcome.success:
             raise AssertionError(
@@ -440,9 +600,17 @@ class LifecycleWorld:
             source_username=f"force-peer-{self._dispatch_counter}",
             download_log_id=download_log_id,
             cfg=CratediggerConfig(
-                beets_harness_path="in-process-force-beets-world",
+                beets_harness_path=(
+                    self._beets_harness_path
+                    if self._import_engine == "mirror-harness"
+                    else "in-process-force-beets-world"
+                ),
             ),
-            run_import_fn=run_real_beets_import,
+            run_import_fn=(
+                self._run_beets_subprocess
+                if self._import_engine == "mirror-harness"
+                else run_real_beets_import
+            ),
             beets_library_db_path=str(self.beets.library_db),
             beets_library_root=str(self.beets.library_root),
         )
@@ -466,9 +634,11 @@ class LifecycleWorld:
             before_verified_lossless=before_verified_proof,
         ))
         if not outcome.success and outcome.code != "quality_pipeline_rejected":
+            subprocess_detail = self._subprocess_failure_detail()
             raise AssertionError(
                 "production force import failed operationally: "
-                f"code={outcome.code!r} message={outcome.message!r}"
+                f"code={outcome.code!r} message={outcome.message!r} "
+                f"{subprocess_detail}"
             )
         return outcome.success
 
@@ -599,6 +769,21 @@ class LifecycleWorld:
                 ),
                 cleanup_release_fn=self._remove_release,
             )
+        if isinstance(result, BanSourceReleaseMismatch):
+            if not (
+                before.get("mb_release_id")
+                and before.get("discogs_release_id")
+            ):
+                raise AssertionError(
+                    f"single-identity ban-source mismatch: {result!r}"
+                )
+            if self._require_request(request_id) != before:
+                raise AssertionError("failed-closed dual-identity ban mutated request")
+            if self._album_fingerprint(
+                self._album_for_release(release.release_id)
+            ) != self._album_fingerprint(before_album):
+                raise AssertionError("failed-closed dual-identity ban mutated Beets")
+            return
         if not isinstance(result, BanSourceSuccess):
             raise AssertionError(f"production ban-source failed: {result!r}")
         after = self._require_request(request_id)
@@ -896,6 +1081,28 @@ class LifecycleWorld:
             beets_removed=removed > 0 and absent_after,
             absent_after=absent_after,
             selector_failures=(),
+        )
+
+    def _run_beets_subprocess(self, **kwargs: Any) -> ImportOneRun:
+        """Run the production subprocess boundary against scratch Beets only."""
+
+        subprocess_kwargs = dict(kwargs)
+        # The outer dispatch owns the ephemeral PG transition. Production's
+        # import_one compatibility write would duplicate it; omitting the ID
+        # keeps this profile focused on the real Beets/harness boundary.
+        subprocess_kwargs["request_id"] = None
+        with self.beets.subprocess_environment():
+            run = run_import_one(**subprocess_kwargs)
+        self._last_subprocess_run = run
+        return run
+
+    def _subprocess_failure_detail(self) -> str:
+        run = self._last_subprocess_run
+        if run is None:
+            return ""
+        stderr_tail = run.stderr[-4000:].strip()
+        return (
+            f"subprocess_rc={run.returncode} stderr_tail={stderr_tail!r}"
         )
 
     def _request_has_verified_proof(self, request_id: int) -> bool:


### PR DESCRIPTION
## Summary

- commit anonymized categorical row-shape seeds captured read-only from doc2 and initialize the lifecycle machine from the coherent imported/wanted subset
- recognize an exact-peer persisted invalid validation verdict as denylist authority through the canonical validation envelope
- add an opt-in real import_one.py -> run_beets_harness.sh profile against an explicit MusicBrainz mirror, with ephemeral PostgreSQL and scratch-only Beets config, database, library, and files

## Read-only production evidence

The exact branch code audited the live world without mutation:

- 8,479 active requests; 8,438 Beets albums; 7,965 linked evidence rows; 17,869 denylist rows
- 5,529 violations total
- denylist_without_authority fell from the provisional 12,249 false positives to 199 rows that genuinely lack a persisted authorizing decision
- remaining violation families are recorded as historical scar tissue; this PR performs no repair

The real mirror smoke used a public release selected independently of the collection. It read only the mirror; every mutable store and path was disposable.

## Validation

- focused deterministic/generated world tests: green
- direct census-seeded lifecycle module: green
- mirror subprocess profile: 2 worlds x 5 steps, green
- whole-repository Pyright: 0 errors
- standard suite: 6,320 tests passed in 380.582s

## Deliberately deferred

- no deployment or production mutation
- no production data repair
- no standard-suite placement decision for the heavyweight machine
- no nightly schedule decision

Refs #743