### PR TITLE
test: make Passenger the canonical folder-world pin

### DIFF
--- a/docs/generated-testing.md
+++ b/docs/generated-testing.md
@@ -88,6 +88,14 @@ wrong-match deletion, and reset. After every rule it checks the shared
 status/membership, evidence/disk coherence, proof-lock terminality, search-tier
 monotonicity, and denylist authority.
 
+The canonical folder-exclusivity pin is the real Lisa Hannigan `Passenger`
+shape from 2026-07-18: the existing ATO Records pressing is imported before a
+same-key sibling whose label is empty, then the first pressing is upgraded. A
+known-bad companion injects the exact historical `%aunique` template recovered
+from commit `76ad5a0d`; the lifecycle must report `folder_shared`. The current
+never-empty `path_disambig` policy must keep both exact pressings in distinct
+folders through the upgrade.
+
 Every generated world is initialized from the anonymized categorical corpus in
 `tests/world_model/census_seeds.py`. The corpus was captured read-only from
 doc2 on 2026-07-19 and retains only row-shape facts and capture-time counts:

--- a/tests/beets_world.py
+++ b/tests/beets_world.py
@@ -25,6 +25,16 @@ from lib.release_identity import detect_release_source
 from lib.world_invariants import LibraryAlbumSnapshot
 
 
+# Exact pre-2026-07-18 path policy recovered from commit 76ad5a0d. With an
+# already-sticky plain Passenger folder, ``label='ATO Records'`` versus an
+# empty sibling label lets the new pressing render the same plain directory.
+HISTORICAL_PASSENGER_PATH_TEMPLATE = (
+    "$albumartist/$year - $album%aunique{albumartist album,"
+    "albumtype year label catalognum albumdisambig releasegroupdisambig "
+    "short_mbid}/$track $title"
+)
+
+
 @dataclass(frozen=True)
 class ShippedBeetsWorldConfig:
     default_path_template: str
@@ -520,6 +530,7 @@ class BeetsWorld:
 __all__ = [
     "BeetsWorld",
     "BeetsWorldRelease",
+    "HISTORICAL_PASSENGER_PATH_TEMPLATE",
     "ShippedBeetsWorldConfig",
     "build_subprocess_beets_config",
     "extract_shipped_beets_world_config",

--- a/tests/test_harness_beets2_contract.py
+++ b/tests/test_harness_beets2_contract.py
@@ -201,11 +201,7 @@ ALBUM_FIELDS = shipped["album_fields"]
 
 # The pre-2026-07-18 poisoned template — the planted known-bad the sweep
 # must detect, proving the checker catches the class.
-OLD_TEMPLATE = (
-    "$albumartist/$year - $album%aunique{albumartist album,"
-    "albumtype year label catalognum albumdisambig releasegroupdisambig "
-    "short_mbid}/$track $title"
-)
+OLD_TEMPLATE = shipped["historical_passenger_template"]
 
 FIELD_STATES = [("", ""), ("X", ""), ("X", "X"), ("X", "Y")]
 SWEEP_FIELDS = ("albumdisambig", "releasegroupdisambig", "catalognum", "label")
@@ -283,12 +279,16 @@ with tempfile.TemporaryDirectory() as d:
 def _shipped_aunique_config() -> dict:
     """Extract the shipped beets path template + inline album_fields from
     nix/module.nix — the test patrols what production actually renders."""
-    from tests.beets_world import extract_shipped_beets_world_config
+    from tests.beets_world import (
+        HISTORICAL_PASSENGER_PATH_TEMPLATE,
+        extract_shipped_beets_world_config,
+    )
 
     shipped = extract_shipped_beets_world_config(_REPO)
     return {
         "template": shipped.default_path_template,
         "album_fields": dict(shipped.album_fields),
+        "historical_passenger_template": HISTORICAL_PASSENGER_PATH_TEMPLATE,
     }
 
 

--- a/tests/world_model/state_machine.py
+++ b/tests/world_model/state_machine.py
@@ -15,6 +15,7 @@ import os
 import sys
 import unittest
 
+from beets import config as beets_config
 from hypothesis import HealthCheck, settings
 from hypothesis.database import DirectoryBasedExampleDatabase
 from hypothesis import strategies as st
@@ -31,7 +32,10 @@ from hypothesis.stateful import (
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 import conftest  # noqa: E402, F401
 
-from tests.beets_world import BeetsWorldRelease  # noqa: E402
+from tests.beets_world import (  # noqa: E402
+    BeetsWorldRelease,
+    HISTORICAL_PASSENGER_PATH_TEMPLATE,
+)
 from tests.world_model.support import LifecycleWorld, repository_root  # noqa: E402
 from tests.world_model.census_seeds import (  # noqa: E402
     STATEFUL_WORLD_CENSUS_SEEDS,
@@ -57,27 +61,32 @@ def _discogs_release_id(counter: int) -> str:
 class TestPinnedLifecycleWorld(unittest.TestCase):
     """Concrete pins promoted from incidents and generated counterexamples."""
 
-    def test_two_pressings_then_upgrade_preserve_exact_membership(self) -> None:
+    @staticmethod
+    def _add_passenger_pressings(world: LifecycleWorld) -> tuple[int, int]:
+        """Recreate the exact same-key label shape from the live incident."""
+
+        first_id = world.add_release(BeetsWorldRelease(
+            release_id="dd578a59-ef6d-46fa-9f28-1e19c456dac8",
+            artist="Lisa Hannigan",
+            album="Passenger",
+            year=2011,
+            codec="mp3",
+            label="ATO Records",
+        ))
+        second_id = world.add_release(BeetsWorldRelease(
+            release_id="5e7a6000-ce08-4e7b-9773-22a26e0a2980",
+            artist="Lisa Hannigan",
+            album="Passenger",
+            year=2011,
+            codec="mp3",
+            label="",
+        ))
+        return first_id, second_id
+
+    def test_passenger_pressings_stay_disambiguated_through_upgrade(self) -> None:
         assert TEST_DSN is not None
         with LifecycleWorld(TEST_DSN, repository_root()) as world:
-            first_id = world.add_release(BeetsWorldRelease(
-                release_id="10000000-0000-4000-8000-000000000001",
-                artist="Passenger",
-                album="Collision Course",
-                year=2008,
-                codec="mp3",
-                label="Archive One",
-                catalognum="A-1",
-            ))
-            second_id = world.add_release(BeetsWorldRelease(
-                release_id="7000002",
-                artist="Passenger",
-                album="Collision Course",
-                year=2008,
-                codec="mp3",
-                label="Archive Two",
-                catalognum="B-2",
-            ))
+            first_id, second_id = self._add_passenger_pressings(world)
 
             world.import_request(first_id)
             world.import_request(second_id)
@@ -89,13 +98,42 @@ class TestPinnedLifecycleWorld(unittest.TestCase):
             self.assertEqual(
                 {album.release_id for album in albums},
                 {
-                    "10000000-0000-4000-8000-000000000001",
-                    "7000002",
+                    "dd578a59-ef6d-46fa-9f28-1e19c456dac8",
+                    "5e7a6000-ce08-4e7b-9773-22a26e0a2980",
                 },
             )
             self.assertEqual(
                 len({album.album_path for album in albums}),
                 2,
+            )
+
+    def test_passenger_historical_template_poison_is_caught(self) -> None:
+        """The real lifecycle invariant must kill the pre-fix path policy."""
+
+        assert TEST_DSN is not None
+        with LifecycleWorld(TEST_DSN, repository_root()) as world:
+            beets_config["paths"]["default"].set(
+                HISTORICAL_PASSENGER_PATH_TEMPLATE
+            )
+            violation_codes: set[str] = set()
+            try:
+                first_id, second_id = self._add_passenger_pressings(world)
+
+                world.import_request(first_id)
+                world.import_request(second_id)
+                violation_codes = {
+                    violation.code for violation in world.violations()
+                }
+            finally:
+                beets_config["paths"]["default"].set(
+                    world.beets.shipped.default_path_template
+                )
+
+            self.assertIn(
+                "folder_shared",
+                violation_codes,
+                "the world model did not detect the historical Passenger "
+                "folder collision",
             )
 
     def test_rejected_identical_retry_rebinds_current_evidence_path(self) -> None:


### PR DESCRIPTION
## Summary

- replace the synthetic two-pressing lifecycle pin with the exact Lisa Hannigan Passenger releases from the 2026-07-18 incident
- import the ATO Records pressing, then the same-key empty-label sibling, and carry the first pressing through an upgrade
- inject the exact historical path template from 76ad5a0d as a known-bad poison and require the real world invariant to report folder_shared
- share that historical poison with the existing exhaustive 512-world Beets contract so the two guards cannot drift

## Red/green evidence

With the historical template injected, the lifecycle world reports folder_shared (and the downstream evidence_fingerprint_mismatch). With the shipped never-empty path_disambig template, both exact Passenger pressings retain distinct folders through the upgrade.

The heavyweight lifecycle module remains outside standard discovery as agreed.

## Validation

- focused Passenger good and poisoned lifecycle pins: pass
- complete direct lifecycle world module: 8 tests pass
- TestAuniqueCollisionContract exhaustive 512-world sweep: pass
- docs audit: 46 tests pass
- pyright --threads 4: 0 errors
- scripts/run_tests.sh: 6,320 tests pass in 354.007s

Refs #743