### PR TITLE
fix(audit): recover denylist decision provenance

### DIFF
--- a/lib/world_invariants.py
+++ b/lib/world_invariants.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from typing import Any
@@ -421,6 +422,59 @@ def check_denylist_authority(
     )
 
 
+_DENYLIST_REASON_DECISIONS: dict[str, str] = {
+    "quality downgrade prevented": "downgrade",
+    "lossless source locked": "lossless_source_locked",
+    "audio decode failures": "audio_corrupt",
+    "matched curated bad audio hash": "bad_audio_hash",
+    "spectral analysis rejected the source": "spectral_reject",
+    "mixed lossless+lossy source": "mixed_source",
+    "duplicate remove guard failed": "duplicate_remove_guard_failed",
+    "provisional lossless source imported": "provisional_lossless_upgrade",
+}
+_IMPORT_PREVIEW_REASON_PREFIX = "import preview rejected: "
+_REJECTED_REASON_PREFIX = "rejected: "
+_LEGACY_SPECTRAL_REASON = re.compile(
+    r"spectral: \d+kbps <= existing \d+kbps\Z"
+)
+_LEGACY_TRANSCODE_REASON = re.compile(r"transcode: \d+kbps\Z")
+
+
+def _decision_denylists(decision: str) -> bool:
+    search_action = post_import_search_action_if_known(decision)
+    return bool(
+        (search_action is not None and search_action.denylist)
+        or dispatch_action(decision).denylist
+    )
+
+
+def _denylist_reason_authorities(reason: str) -> tuple[str, ...]:
+    """Decode stable decision-bearing reasons across producer generations."""
+
+    if reason == "suspect lossless source not an upgrade":
+        return ("suspect_lossless_reject",)
+
+    decision = _DENYLIST_REASON_DECISIONS.get(reason)
+    if decision is not None and _decision_denylists(decision):
+        return (decision,)
+
+    if reason.startswith(_IMPORT_PREVIEW_REASON_PREFIX):
+        decision = reason.removeprefix(_IMPORT_PREVIEW_REASON_PREFIX)
+        if _decision_denylists(decision):
+            return (decision,)
+
+    if reason.startswith(_REJECTED_REASON_PREFIX):
+        decision = reason.removeprefix(_REJECTED_REASON_PREFIX)
+        if _decision_denylists(decision):
+            return (decision,)
+
+    if _LEGACY_SPECTRAL_REASON.fullmatch(reason):
+        return ("spectral_reject",)
+    if reason == "transcode detected" or _LEGACY_TRANSCODE_REASON.fullmatch(reason):
+        return ("legacy_transcode",)
+    return ()
+
+
 def derive_denylist_authorities(
     *,
     username: str,
@@ -428,7 +482,7 @@ def derive_denylist_authorities(
     history: Sequence[Mapping[str, Any]],
 ) -> tuple[str, ...]:
     """Find persisted decisions that authorize one source-denylist row."""
-    decisions: set[str] = set()
+    decisions = set(_denylist_reason_authorities(reason))
     if any(
         entry.get("outcome") == "curator_ban"
         and entry.get("soulseek_username") == username
@@ -447,8 +501,7 @@ def derive_denylist_authorities(
             decisions.add(decision)
 
     for entry in history:
-        if entry.get("soulseek_username") != username:
-            continue
+        exact_peer = entry.get("soulseek_username") == username
         try:
             validation = decode_validation_envelope(
                 entry.get("validation_result")
@@ -462,10 +515,22 @@ def derive_denylist_authorities(
         if (
             entry.get("outcome") == "rejected"
             and validation is not None
-            and validation.valid is False
+            and (
+                (exact_peer and validation.valid is False)
+                or (
+                    reason == "beets validation rejected"
+                    and validation.valid is not True
+                )
+            )
         ):
             decisions.add("validation_reject")
 
+        # One import/validation decision owns every peer that contributed to
+        # a multi-peer folder, while download_log retains only its primary
+        # username. The canonical Beets-reject reason is the binding from each
+        # secondary source_denylist row back to that request-level decision.
+        if not exact_peer and reason != "beets validation rejected":
+            continue
         raw_result = entry.get("import_result")
         if isinstance(raw_result, str):
             encoded_result = raw_result
@@ -479,11 +544,7 @@ def derive_denylist_authorities(
             continue
         if decision is None:
             continue
-        search_action = post_import_search_action_if_known(decision)
-        if (
-            (search_action is not None and search_action.denylist)
-            or dispatch_action(decision).denylist
-        ):
+        if _decision_denylists(decision):
             decisions.add(decision)
     return tuple(sorted(decisions))
 

--- a/tests/test_world_invariants.py
+++ b/tests/test_world_invariants.py
@@ -8,7 +8,7 @@ import unittest
 
 import msgspec
 
-from lib.quality import ValidationResult
+from lib.quality import ImportResult, ValidationResult
 from lib.world_invariants import (
     DenylistAuthoritySnapshot,
     EvidenceDiskSnapshot,
@@ -126,7 +126,7 @@ class TestWorldInvariantPins(unittest.TestCase):
             ("requeue_lossless",),
         )
 
-    def test_invalid_validation_authorizes_only_its_exact_source_peer(self) -> None:
+    def test_multi_peer_validation_authorizes_every_rejected_source(self) -> None:
         validation = msgspec.to_builtins(ValidationResult(
             valid=False,
             scenario="high_distance",
@@ -151,6 +151,26 @@ class TestWorldInvariantPins(unittest.TestCase):
             derive_denylist_authorities(
                 username="different-peer",
                 reason="beets validation rejected",
+                history=history,
+            ),
+            ("validation_reject",),
+        )
+        self.assertEqual(
+            derive_denylist_authorities(
+                username="legacy-secondary-peer",
+                reason="beets validation rejected",
+                history=[{
+                    "outcome": "rejected",
+                    "soulseek_username": "legacy-primary-peer",
+                    "validation_result": None,
+                }],
+            ),
+            ("validation_reject",),
+        )
+        self.assertEqual(
+            derive_denylist_authorities(
+                username="different-peer",
+                reason="manual note",
                 history=history,
             ),
             (),
@@ -189,6 +209,62 @@ class TestWorldInvariantPins(unittest.TestCase):
             ),
             (),
         )
+
+    def test_historical_denylist_reasons_decode_only_denylisting_policy(self) -> None:
+        cases = (
+            ("quality downgrade prevented", ("downgrade",)),
+            ("lossless source locked", ("lossless_source_locked",)),
+            ("audio decode failures", ("audio_corrupt",)),
+            ("matched curated bad audio hash", ("bad_audio_hash",)),
+            ("spectral analysis rejected the source", ("spectral_reject",)),
+            ("mixed lossless+lossy source", ("mixed_source",)),
+            (
+                "suspect lossless source not an upgrade",
+                ("suspect_lossless_reject",),
+            ),
+            (
+                "provisional lossless source imported",
+                ("provisional_lossless_upgrade",),
+            ),
+            ("import preview rejected: audio_corrupt", ("audio_corrupt",)),
+            ("import preview rejected: spectral_reject", ("spectral_reject",)),
+            ("import preview rejected: downgrade", ("downgrade",)),
+            ("spectral: 96kbps <= existing 96kbps", ("spectral_reject",)),
+            ("transcode: 202kbps", ("legacy_transcode",)),
+            ("rejected: bad_audio_hash", ("bad_audio_hash",)),
+            ("import preview rejected: nested_layout", ()),
+            ("rejected: nested_layout", ()),
+            ("transcode: unknown", ()),
+            ("manual note", ()),
+        )
+
+        for reason, expected in cases:
+            with self.subTest(reason=reason):
+                self.assertEqual(
+                    derive_denylist_authorities(
+                        username="historical-peer",
+                        reason=reason,
+                        history=[],
+                    ),
+                    expected,
+                )
+
+    def test_multi_peer_beets_reject_uses_the_persisted_import_decision(self) -> None:
+        authorities = derive_denylist_authorities(
+            username="secondary-peer",
+            reason="beets validation rejected",
+            history=[{
+                "outcome": "rejected",
+                "soulseek_username": "primary-peer",
+                "validation_result": msgspec.to_builtins(ValidationResult(
+                    valid=True,
+                    scenario="strong_match",
+                )),
+                "import_result": ImportResult(decision="downgrade").to_json(),
+            }],
+        )
+
+        self.assertEqual(authorities, ("downgrade",))
 
 
 class TestWorldInvariantCheckersTripOnKnownBad(unittest.TestCase):

--- a/tests/test_world_invariants_generated.py
+++ b/tests/test_world_invariants_generated.py
@@ -6,10 +6,12 @@ import os
 import tempfile
 import unittest
 
+import msgspec
 from hypothesis import given, strategies as st
 
 import tests._hypothesis_profiles  # noqa: F401  (loads active profile)
-from lib.quality import ValidationResult
+from lib.quality import dispatch_action
+from lib.quality.decisions import post_import_search_action_if_known
 from lib.world_invariants import (
     DenylistAuthoritySnapshot,
     EvidenceDiskSnapshot,
@@ -35,6 +37,14 @@ _SEGMENT = st.text(
     min_size=1,
     max_size=20,
 )
+
+
+def _decision_denylists_for_test(decision: str) -> bool:
+    search_action = post_import_search_action_if_known(decision)
+    return bool(
+        (search_action is not None and search_action.denylist)
+        or dispatch_action(decision).denylist
+    )
 
 
 class TestWorldInvariantGenerated(unittest.TestCase):
@@ -244,41 +254,119 @@ class TestWorldInvariantGenerated(unittest.TestCase):
         self.assertIn("denylist_without_authority", {v.code for v in violations})
 
     @given(
-        username=_SEGMENT,
-        reason=_SEGMENT,
+        denied_username=_SEGMENT,
+        history_username=_SEGMENT,
         scenario=_SEGMENT,
         as_jsonb=st.booleans(),
-        valid=st.booleans(),
+        valid=st.one_of(st.none(), st.booleans()),
+        canonical_reason=st.booleans(),
     )
-    def test_only_exact_peer_invalid_validation_authorizes_the_denylist(
+    def test_multi_peer_validation_authority_requires_rejection_provenance(
         self,
-        username: str,
-        reason: str,
+        denied_username: str,
+        history_username: str,
         scenario: str,
         as_jsonb: bool,
-        valid: bool,
+        valid: bool | None,
+        canonical_reason: bool,
     ) -> None:
-        result = ValidationResult(valid=valid, scenario=scenario)
+        payload = {"valid": valid, "scenario": scenario}
         validation_result: object = (
-            result.to_json()
+            msgspec.json.encode(payload).decode()
             if not as_jsonb
-            else {
-                "valid": valid,
-                "scenario": scenario,
-            }
+            else payload
         )
 
         authorities = derive_denylist_authorities(
-            username=username,
-            reason=reason,
+            username=denied_username,
+            reason=(
+                "beets validation rejected"
+                if canonical_reason
+                else "manual note"
+            ),
             history=[{
                 "outcome": "rejected",
-                "soulseek_username": username,
+                "soulseek_username": history_username,
                 "validation_result": validation_result,
             }],
         )
 
-        self.assertEqual("validation_reject" in authorities, not valid)
+        expected = (
+            valid is False and denied_username == history_username
+        ) or (
+            canonical_reason and valid is not True
+        )
+        self.assertEqual("validation_reject" in authorities, expected)
+
+    @given(
+        username=_SEGMENT,
+        decision=st.sampled_from((
+            "downgrade",
+            "audio_corrupt",
+            "bad_audio_hash",
+            "spectral_reject",
+            "mixed_source",
+            "nested_layout",
+            "empty_fileset",
+            "requeue_lossless",
+            "requeue_upgrade",
+            "transcode_upgrade",
+        )),
+    )
+    def test_preview_reason_authority_follows_current_denylist_policy(
+        self,
+        username: str,
+        decision: str,
+    ) -> None:
+        expected = _decision_denylists_for_test(decision)
+
+        authorities = derive_denylist_authorities(
+            username=username,
+            reason=f"import preview rejected: {decision}",
+            history=[],
+        )
+
+        self.assertEqual(decision in authorities, expected)
+
+    @given(
+        denied_username=_SEGMENT,
+        history_username=_SEGMENT,
+        decision=st.sampled_from((
+            "downgrade",
+            "audio_corrupt",
+            "spectral_reject",
+            "mixed_source",
+            "nested_layout",
+            "empty_fileset",
+        )),
+        canonical_reason=st.booleans(),
+    )
+    def test_multi_peer_import_authority_requires_canonical_source_reason(
+        self,
+        denied_username: str,
+        history_username: str,
+        decision: str,
+        canonical_reason: bool,
+    ) -> None:
+        authorities = derive_denylist_authorities(
+            username=denied_username,
+            reason=(
+                "beets validation rejected"
+                if canonical_reason
+                else "manual note"
+            ),
+            history=[{
+                "outcome": "rejected",
+                "soulseek_username": history_username,
+                "validation_result": {"valid": True},
+                "import_result": {"version": 4, "decision": decision},
+            }],
+        )
+        expected = _decision_denylists_for_test(decision) and (
+            canonical_reason or denied_username == history_username
+        )
+
+        self.assertEqual(decision in authorities, expected)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- recognize canonical decision-bearing denylist reasons across current and historical producer generations
- bind multi-peer Beets rejection rows to their request-level validation/import decision even when `download_log` retains only the primary username
- keep arbitrary reasons, malformed legacy reasons, and non-denylisting decisions fail-closed

## Live evidence

A read-only replay against doc2 classified all 17,897 current `source_denylist` rows. The merged checker reported 180 unexplained rows on the current world; this change reports zero. The cohort consisted of legitimate multi-peer rejections plus stable preview/transcode/spectral reason vocabulary. No production row, file, service, or library item was changed.

## Validation

- deterministic live pins plus generated multi-peer/reason properties: pass
- focused world invariant and audit service modules: pass
- whole-repository Pyright: clean
- full standard suite: pass, no skips

Refs #743
