### PR TITLE
Run deterministic world model in the standard suite

### DIFF
--- a/docs/generated-testing.md
+++ b/docs/generated-testing.md
@@ -3,9 +3,10 @@
 Issue #548. Hypothesis-driven generated tests assert **policy invariants**
 over large generated state spaces instead of hand-picked examples. The normal
 pure/fake-backed modules are ordinary members of the unittest suite — no seed
-bookkeeping or standing service. The heavyweight cross-engine world model has
-its own direct runner while issue #743 measures its cost; suite and scheduled
-placement are deliberately separate follow-up decisions.
+bookkeeping or standing service. The deterministic cross-engine world model is
+also part of the normal suite at its measured small budget. Deeper randomized,
+mirror-backed, long-fuzz, and live-audit runs remain separate scheduled work
+tracked by issue #498.
 
 ## Bug hunting — the house method
 
@@ -135,8 +136,11 @@ Fault injection qualifies the retry property: temporarily removing the durable
 gate makes the pinned installed/installed world become authoritative on its
 first touch, and the generated test fails on that explicit example.
 
-It is intentionally named outside unittest's `test*.py` discovery pattern.
-Run the deterministic pin and generated state machine directly:
+It is intentionally named outside unittest's `test*.py` discovery pattern so
+raw discovery cannot accidentally inherit a randomized hammer environment.
+The canonical `scripts/run_tests.sh` explicitly fixes the six-example,
+eight-step deterministic budget, scrubs `TEST_DB_DSN`, and runs the module as
+part of every normal suite. It can also be run directly while iterating:
 
 ```bash
 nix-shell --run "python3 -m unittest tests.world_model.state_machine -v"
@@ -158,9 +162,10 @@ CRATEDIGGER_WORLD_EXAMPLES=20 CRATEDIGGER_WORLD_STEPS=20 \
   nix-shell --run "python3 -m unittest tests.world_model.state_machine -v"
 ```
 
-Do not add this runner to `scripts/run_tests.sh` or schedule it merely because
-the core exists. Issue #743 records runtime and fault-injection evidence first;
-standard-suite and scheduled-depth choices belong to a follow-up PR.
+The 20.396-second measured cost is about six percent of the 355-second normal
+suite and was accepted for standard-suite coverage after issue #743 completed
+its runtime qualification. Do not raise this deterministic budget in the
+normal suite; deeper exploration belongs to the scheduled runners below.
 
 ### Randomized lifecycle hammer
 
@@ -184,9 +189,9 @@ failures print a reproduction blob and shrink to a minimal operation sequence.
 On doc1 on 2026-07-19, the initial 3-world × 20-step randomized smoke completed
 all six module tests in 8.470 test-seconds (10 seconds wrapper wall time). The
 default 25 × 100 profile completed cleanly in 449.930 test-seconds (451 seconds
-wrapper wall time). That measured depth remains operator-only and is not part of
-`scripts/run_tests.sh`; suite/nightly placement is still the explicit follow-up
-decision recorded on issue #743.
+wrapper wall time). That measured depth is not part of `scripts/run_tests.sh`.
+Its exact-revision doc1 schedule, alongside the long generated fuzz burst, is
+tracked by issue #498.
 
 The default hammer uses the in-process production adapter that performs real
 Beets model/database/filesystem mutations beneath the real dispatch services.
@@ -211,8 +216,8 @@ loads the shipped path template, exact-ID duplicate keys, inline field, match
 policy, and MusicBrainz plugin; unrelated production fetchart/lyrics/scrub hooks
 stay disabled so the boundary test cannot make external content requests. A
 2-world × 5-step mirror smoke completed cleanly in 5 seconds on doc1 on
-2026-07-19. It remains operator-only: neither this profile nor the in-process
-hammer has been added to standard discovery or a schedule.
+2026-07-19. It remains outside the normal suite; exact-revision scheduled
+execution and separate mirror-failure reporting are tracked by issue #498.
 
 When the hammer finds a defect:
 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -30,3 +30,15 @@ echo ""
 
 echo "=== Python tests ==="
 python3 -m unittest discover -s tests -t . -p 'test*.py' -v
+
+echo ""
+echo "=== Deterministic cross-engine world model ==="
+(
+  # The normal suite owns the small reproducible budget only. Never inherit
+  # the randomized hammer's depth, replay database, or an external PG target.
+  unset TEST_DB_DSN
+  export CRATEDIGGER_WORLD_RANDOMIZED=0
+  export CRATEDIGGER_WORLD_EXAMPLES=6
+  export CRATEDIGGER_WORLD_STEPS=8
+  python3 -m unittest tests.world_model.state_machine -v
+)

--- a/tests/test_world_model_burst.py
+++ b/tests/test_world_model_burst.py
@@ -10,6 +10,7 @@ import unittest
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SCRIPT = REPO_ROOT / "scripts" / "world_model_burst.sh"
+RUN_TESTS_SCRIPT = REPO_ROOT / "scripts" / "run_tests.sh"
 
 
 class TestWorldModelBurstScript(unittest.TestCase):
@@ -90,6 +91,20 @@ class TestWorldModelBurstScript(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("randomized real-storage lifecycle hammer", result.stdout)
+
+    def test_standard_suite_runs_only_the_deterministic_world_budget(self) -> None:
+        script = RUN_TESTS_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertIn(
+            "python3 -m unittest tests.world_model.state_machine -v",
+            script,
+        )
+        self.assertIn("CRATEDIGGER_WORLD_RANDOMIZED=0", script)
+        self.assertIn("CRATEDIGGER_WORLD_EXAMPLES=6", script)
+        self.assertIn("CRATEDIGGER_WORLD_STEPS=8", script)
+        self.assertIn("unset TEST_DB_DSN", script)
+        self.assertNotIn("scripts/world_model_burst.sh", script)
+        self.assertNotIn("scripts/fuzz_burst.sh", script)
 
 
 if __name__ == "__main__":

--- a/tests/world_model/state_machine.py
+++ b/tests/world_model/state_machine.py
@@ -1,10 +1,14 @@
 """Heavy real-PostgreSQL/real-Beets lifecycle world model (#743).
 
-This module is intentionally outside unittest discovery. Run it directly:
+The normal suite invokes this module explicitly after unittest discovery:
+
+    nix-shell --run "bash scripts/run_tests.sh"
+
+It can also be run directly while working on the world model:
 
     nix-shell --run "python3 -m unittest tests.world_model.state_machine -v"
 
-Direct invocation uses a small deterministic budget. The operator-only
+Normal-suite and direct invocation use a small deterministic budget. The
 ``scripts/world_model_burst.sh`` switches the same machine to randomized
 generation with a replay database and a much deeper lifecycle budget.
 """


### PR DESCRIPTION
## Summary

- run the cross-engine lifecycle world model explicitly in the normal test suite
- fix its standard-suite budget at 6 examples × 8 steps and scrub external DB/randomized settings
- keep the deep world hammer, long fuzz burst, mirror harness, and live audit outside the normal suite under #498
- document the split and pin it with a runner contract test

## Validation

- `nix-shell --run "pyright --threads 4"` — 0 errors
- `nix-shell --run "bash scripts/run_tests.sh"` — 6,337 ordinary tests passed in 347.264s; 14 deterministic world-model tests passed in 22.040s

Refs #743