### PR TITLE
chore: phase 5 finding — the 'unused' cohort is not dead code (#765)

### DIFF
--- a/lib/world_audit_service.py
+++ b/lib/world_audit_service.py
@@ -158,7 +158,6 @@ def audit_world(
             ))
 
     requests = pipeline_db.list_non_replaced_requests()
-    request_ids = [int(row["id"]) for row in requests]
     denylist_rows = pipeline_db.list_denylist_rows()
     denylist_request_ids = sorted({
         int(row["request_id"])


### PR DESCRIPTION
Phase 5 of #765 — resolved by a finding rather than a sweep.

The issue's phase-5 premise ("54 unused functions / 14 unused classes to delete") turns out to be a misread of the strict-mode output: **every single flagged name has a production reference outside its defining file.** Pyright's `reportUnusedFunction`/`reportUnusedClass` simply don't credit cross-module private imports — which are a deliberate house convention here (`_server()`, the `PipelineDB` `_*Mixin` composition, the dispatch helper seams, `_fanout_browse_users`, …). The vulture sweep — which IS cross-module aware — has been right all along: production carries no dead-function cohort.

The one genuinely dead item the strict run surfaced (`reportUnusedVariable`) is deleted here: an unused `request_ids` local in `lib/world_audit_service.py`.

**Recorded consequence for phase 7**: the strict flip must keep `reportUnusedFunction`/`reportUnusedClass` disabled (or the shared-private convention gets renamed public first) — they are structurally incompatible with cross-module private imports.

Verification: whole-repo pyright 0 errors, full suite green (6,374 tests).

Part of #765 (phase 6: typed-row exemplar; phase 7: strict flip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)