### PR TITLE
chore: promote 17 already-clean strict rules into the production gate (#765 phase 7)

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -104,11 +104,21 @@ tests/_typing_ratchet_baseline.py`). Counting is lexical (stdlib
 tokenizer) — mentions inside strings and docstrings don't count, and the
 scanner is deliberately not a semantic analyzer.
 
-Phase 2 additionally enforces four mode-independent strict rules on
-production code — `reportUnnecessaryIsInstance`,
+Phases 2 and 7 enforce every strict-mode rule that production is already
+clean on — 21 rules as of phase 7 (`reportUnnecessaryIsInstance`,
 `reportUnnecessaryComparison`, `reportConstantRedefinition`,
-`reportDeprecated` — via `pyrightconfig.production.json`, gated in
-`scripts/run_tests.sh`. They are deliberately NOT in the main
+`reportDeprecated`, plus the 17 promoted wholesale after an empirical
+zero-error probe) — via `pyrightconfig.production.json`, gated in
+`scripts/run_tests.sh`. Deliberately NOT promoted, with reasons:
+`reportUninitializedInstanceVariable` (conflicts with the mixin
+forward-declaration idiom in `lib/pipeline_db/_core.py`),
+`reportCallInDefaultInitializer` (conflicts with the kwarg-DI
+production-default seam pattern), `reportImplicitOverride` (style, needs
+`@override` sprinkling), `reportUnusedFunction`/`Class` (incompatible
+with cross-module private imports — phase 5 finding), and the
+`reportUnknown*`/`reportMissingParameterType` family (the remaining
+~5,300-error annotation campaign that the typed-row rollout chips at
+per family). They are deliberately NOT in the main
 `pyrightconfig.json`: tests carry intentional protocol-conformance
 `issubclass` pins (the #430 parity-gate pattern) that the isinstance rule
 would flag, and a tests `executionEnvironments` split doesn't work here

--- a/pyrightconfig.production.json
+++ b/pyrightconfig.production.json
@@ -1,5 +1,7 @@
 {
-  "extraPaths": ["."],
+  "extraPaths": [
+    "."
+  ],
   "venvPath": ".",
   "venv": ".pyright-venv",
   "pythonVersion": "3.13",
@@ -9,6 +11,23 @@
   "reportUnnecessaryComparison": "error",
   "reportConstantRedefinition": "error",
   "reportDeprecated": "error",
+  "reportUntypedFunctionDecorator": "error",
+  "reportUntypedClassDecorator": "error",
+  "reportUntypedBaseClass": "error",
+  "reportUntypedNamedTuple": "error",
+  "reportPrivateImportUsage": "error",
+  "reportInvalidStringEscapeSequence": "error",
+  "reportSelfClsParameterName": "error",
+  "reportAssertAlwaysTrue": "error",
+  "reportUnusedExpression": "error",
+  "reportUnnecessaryContains": "error",
+  "reportRedeclaration": "error",
+  "reportInconsistentConstructor": "error",
+  "reportOverlappingOverload": "error",
+  "reportPropertyTypeMismatch": "error",
+  "reportTypeCommentUsage": "error",
+  "reportMatchNotExhaustive": "error",
+  "reportShadowedImports": "error",
   "exclude": [
     "build",
     "tools/vulture",


### PR DESCRIPTION
Phase 7 of #765 resolves as a **promotion, not a flip**: an empirical probe of 20 strict-mode rules against production found **17 already at zero errors** — those are now enforced in `pyrightconfig.production.json` (a config-level ratchet with zero code churn), bringing the production gate to 21 rules.

The three probe rules with findings are **declined with rationale** (documented in `code-quality.md`): `reportUninitializedInstanceVariable` (collides with the mixin forward-declaration idiom in `_core.py`), `reportCallInDefaultInitializer` (collides with the kwarg-DI production-default seam pattern), `reportImplicitOverride` (pure style). Also documented as deferred: the `reportUnknown*`/`reportMissingParameterType` family (~5,300 errors — the annotation campaign the typed-row rollout chips at per family, not a config change).

Verification: production gate 0 errors with all 21 rules; whole-repo pyright 0 errors; full suite green.

Refs #765

🤖 Generated with [Claude Code](https://claude.com/claude-code)