### PR TITLE
Fix force-import evidence authority after relocation

### DIFF
--- a/lib/import_evidence.py
+++ b/lib/import_evidence.py
@@ -145,7 +145,15 @@ def ensure_candidate_evidence_for_action(
     download_log_id: int | None = None,
     import_job_id: int | None = None,
 ) -> CandidateEvidenceActionResult:
-    """Load valid candidate evidence for a mutating action or fail closed."""
+    """Load valid candidate evidence for a mutating action or fail closed.
+
+    Candidate evidence is addressed by release identity plus the audio
+    snapshot, not by its observed filesystem location.  Rejected downloads
+    are moved into ``failed_imports`` after preview, so refresh ``source_path``
+    when the same snapshot is consumed from its new action path.  This is the
+    shared action boundary for automation, force, and rescue imports; callers
+    must not grow a job-type-specific relocation exception.
+    """
 
     loaded = load_candidate_evidence_for_source(
         db,
@@ -154,8 +162,15 @@ def ensure_candidate_evidence_for_action(
         import_job_id=import_job_id,
     )
     if loaded.evidence is not None:
+        evidence = loaded.evidence
+        if evidence.source_path != source_path:
+            evidence = msgspec.structs.replace(
+                evidence,
+                source_path=source_path,
+            )
+            db.upsert_album_quality_evidence(evidence)
         return CandidateEvidenceActionResult(
-            evidence=loaded.evidence,
+            evidence=evidence,
             provenance=ActionEvidenceProvenance(
                 candidate_status=CANDIDATE_STATUS_REUSED,
                 snapshot_guard=SNAPSHOT_GUARD_MATCHED,

--- a/lib/pipeline_db/import_jobs.py
+++ b/lib/pipeline_db/import_jobs.py
@@ -280,9 +280,11 @@ class _ImportJobsMixin(_PipelineDBBase):
 
         This is the final authorization immediately before ``import_one.py``.
         It runs while the caller holds the release advisory lock.  The linked
-        candidate-evidence row is the content-addressed source snapshot; the
-        job-type-specific path predicate prevents a stale payload or request
-        staging path from reaching Beets.
+        candidate-evidence row binds the release and content fingerprint. Its
+        ``source_path`` is mutable observation metadata, so path authority
+        belongs exclusively to the job-type-specific predicate below. The
+        caller and harness verify the current files against the evidence
+        snapshot before Beets may mutate the library.
         """
         cur = self._execute("""
             UPDATE import_jobs AS job
@@ -306,7 +308,6 @@ class _ImportJobsMixin(_PipelineDBBase):
               AND request.mb_release_id = %s
               AND evidence.id = job.candidate_evidence_id
               AND evidence.mb_release_id = %s
-              AND evidence.source_path = %s
               AND evidence.snapshot_fingerprint IS NOT NULL
               AND evidence.snapshot_fingerprint != ''
               AND (
@@ -334,7 +335,6 @@ class _ImportJobsMixin(_PipelineDBBase):
             request_id,
             release_id,
             release_id,
-            source_path,
             source_path,
             source_path,
             source_path,

--- a/tests/fakes/pipeline_db.py
+++ b/tests/fakes/pipeline_db.py
@@ -1127,7 +1127,6 @@ class FakePipelineDB:
             if (
                 evidence is None
                 or evidence.mb_release_id != release_id
-                or evidence.source_path != source_path
                 or not evidence.snapshot_fingerprint
             ):
                 return None

--- a/tests/test_import_evidence.py
+++ b/tests/test_import_evidence.py
@@ -48,6 +48,7 @@ class TestImportEvidenceAcquisition(unittest.TestCase):
     def _candidate_evidence(self) -> AlbumQualityEvidence:
         return make_album_quality_evidence(
             mb_release_id="release-1",
+            source_path=self.root,
             files=snapshot_audio_files(self.root),
         )
 
@@ -120,6 +121,38 @@ class TestImportEvidenceAcquisition(unittest.TestCase):
         self.assertEqual(result.provenance.candidate_status, "reused")
         self.assertEqual(result.provenance.snapshot_guard, "matched")
         self.assertFalse(result.provenance.fail_closed)
+
+    def test_matching_candidate_is_rebound_to_current_action_path(self):
+        """Same bytes at a moved path refresh authority before Beets launch."""
+
+        evidence = make_album_quality_evidence(
+            mb_release_id="release-1",
+            source_path="/pre-quarantine/Artist - Album",
+            files=snapshot_audio_files(self.root),
+        )
+        self.db.upsert_album_quality_evidence(evidence)
+        persisted = self.db.find_album_quality_evidence(
+            mb_release_id=evidence.mb_release_id,
+            snapshot_fingerprint=evidence.snapshot_fingerprint,
+        )
+        assert persisted is not None and persisted.id is not None
+        self.db.set_download_log_candidate_evidence(
+            self.download_log_id,
+            persisted.id,
+        )
+
+        result = ensure_candidate_evidence_for_action(
+            self.db,
+            source_path=self.root,
+            download_log_id=self.download_log_id,
+        )
+
+        self.assertTrue(result.available)
+        assert result.evidence is not None
+        self.assertEqual(result.evidence.source_path, self.root)
+        rebound = self.db.load_album_quality_evidence_by_id(persisted.id)
+        assert rebound is not None
+        self.assertEqual(rebound.source_path, self.root)
 
     def test_stale_candidate_snapshot_fails_closed(self):
         self._persist_candidate()

--- a/tests/test_import_operation_fence.py
+++ b/tests/test_import_operation_fence.py
@@ -136,6 +136,49 @@ class TestImportOperationFence(unittest.TestCase):
         assert current is not None
         self.assertIsNone(current.beets_launch_authorized_at)
 
+    def test_relocated_evidence_uses_job_path_as_launch_authority(self) -> None:
+        """Evidence location is metadata; the owned job path is authority."""
+
+        db = FakePipelineDB()
+        source_path = "/failed_imports/operator-copy"
+        db.seed_request(make_request_row(
+            id=42,
+            mb_release_id="release-42",
+            status="wanted",
+        ))
+        job = db.enqueue_import_job(
+            IMPORT_JOB_FORCE,
+            request_id=42,
+            dedupe_key=force_import_dedupe_key(7004),
+            payload=force_import_payload(
+                download_log_id=7004,
+                failed_path=source_path,
+            ),
+        )
+        fingerprint = _seed_candidate(
+            db,
+            job.id,
+            release_id="release-42",
+            source_path="/pre-quarantine/operator-copy",
+        )
+        db.mark_import_job_preview_importable(job.id, preview_result={"ready": True})
+        claimed = db.claim_next_import_job(worker_id="worker")
+        assert claimed is not None
+
+        authorized = db.authorize_import_job_launch(
+            claimed.id,
+            request_id=42,
+            release_id="release-42",
+            source_path=source_path,
+        )
+
+        assert authorized is not None
+        self.assertEqual(authorized.beets_launch_source_path, source_path)
+        self.assertEqual(
+            authorized.beets_launch_snapshot_fingerprint,
+            fingerprint,
+        )
+
     def test_startup_requeues_only_jobs_proven_not_started(self) -> None:
         from scripts import importer
 
@@ -654,6 +697,52 @@ class TestImportOperationFence(unittest.TestCase):
 
 @requires_postgres
 class TestImportOperationFencePostgres(unittest.TestCase):
+    def test_relocated_evidence_path_does_not_override_job_authority(self) -> None:
+        db = make_db()
+        self.addCleanup(db.close)
+        source_path = "/failed_imports/postgres-force"
+        request_id = db.add_request(
+            artist_name="Fence",
+            album_title="Relocated PostgreSQL evidence",
+            source="request",
+            mb_release_id="release-pg-relocated",
+            status="wanted",
+        )
+        job = db.enqueue_import_job(
+            IMPORT_JOB_FORCE,
+            request_id=request_id,
+            dedupe_key="force:postgres-relocated",
+            payload={"failed_path": source_path},
+        )
+        evidence = make_album_quality_evidence(
+            mb_release_id="release-pg-relocated",
+            source_path="/pre-quarantine/postgres-force",
+        )
+        db.upsert_album_quality_evidence(evidence)
+        persisted = db.find_album_quality_evidence(
+            mb_release_id=evidence.mb_release_id,
+            snapshot_fingerprint=evidence.snapshot_fingerprint,
+        )
+        assert persisted is not None and persisted.id is not None
+        db.set_import_job_candidate_evidence(job.id, persisted.id)
+        db.mark_import_job_preview_importable(job.id, preview_result={"ready": True})
+        claimed = db.claim_next_import_job(worker_id="postgres-worker")
+        assert claimed is not None
+
+        launched = db.authorize_import_job_launch(
+            claimed.id,
+            request_id=request_id,
+            release_id="release-pg-relocated",
+            source_path=source_path,
+        )
+
+        assert launched is not None
+        self.assertEqual(launched.beets_launch_source_path, source_path)
+        self.assertEqual(
+            launched.beets_launch_snapshot_fingerprint,
+            evidence.snapshot_fingerprint,
+        )
+
     def test_launch_marker_survives_connection_loss_and_blocks_replay(self) -> None:
         db = make_db()
         self.addCleanup(db.close)

--- a/tests/world_model/state_machine.py
+++ b/tests/world_model/state_machine.py
@@ -205,6 +205,22 @@ class TestPinnedLifecycleWorld(unittest.TestCase):
             )
             self.assertEqual(world.beets.snapshots(), ())
 
+    def test_force_import_refreshes_relocated_candidate_authority(self) -> None:
+        """A rejected source move cannot create a force-only launch failure."""
+
+        assert TEST_DSN is not None
+        with LifecycleWorld(TEST_DSN, repository_root()) as world:
+            request_id = world.add_release(BeetsWorldRelease(
+                release_id="21000000-0000-4000-8000-000000000001",
+                artist="Relocated Evidence",
+                album="Distance Is The Only Override",
+                year=2000,
+                codec="mp3",
+            ))
+
+            self.assertTrue(world.force_import_request(request_id, codec="mp3"))
+            world.assert_invariants()
+
     def test_discogs_replace_preserves_pathway_and_exact_identity(self) -> None:
         assert TEST_DSN is not None
         with LifecycleWorld(TEST_DSN, repository_root()) as world:
@@ -694,6 +710,57 @@ TestGeneratedLifecycleWorld.settings = settings(
     print_blob=_RANDOMIZED,
     suppress_health_check=(HealthCheck.too_slow,),
 )
+
+
+class TestGeneratedRelocatedForceImportWorld(unittest.TestCase):
+    """D19: source relocation cannot make force diverge from automation."""
+
+    @given(
+        identity_source=st.sampled_from(("mb", "discogs")),
+        codec=st.sampled_from(("mp3", "flac")),
+        verified_lossless=st.booleans(),
+    )
+    def test_force_import_refreshes_relocated_candidate_authority(
+        self,
+        identity_source: str,
+        codec: str,
+        verified_lossless: bool,
+    ) -> None:
+        assert TEST_DSN is not None
+        release_id = (
+            "22000000-0000-4000-8000-000000000001"
+            if identity_source == "mb"
+            else "7220001"
+        )
+        with LifecycleWorld(TEST_DSN, repository_root()) as world:
+            request_id = world.add_release(BeetsWorldRelease(
+                release_id=release_id,
+                artist="Generated Relocation",
+                album="Same Pipeline",
+                year=2001,
+                codec=codec,
+            ))
+
+            self.assertTrue(world.force_import_request(
+                request_id,
+                codec=codec,
+                verified_lossless=(codec == "flac" and verified_lossless),
+            ))
+            world.assert_invariants()
+
+
+TestGeneratedRelocatedForceImportWorld \
+    .test_force_import_refreshes_relocated_candidate_authority = settings(
+        max_examples=int(os.environ.get("CRATEDIGGER_WORLD_EXAMPLES", "6")),
+        deadline=None,
+        derandomize=not _RANDOMIZED,
+        database=_DATABASE,
+        print_blob=_RANDOMIZED,
+        suppress_health_check=(HealthCheck.too_slow,),
+    )(
+        TestGeneratedRelocatedForceImportWorld
+        .test_force_import_refreshes_relocated_candidate_authority
+    )
 
 
 class TestGeneratedEvidenceDriftWorld(unittest.TestCase):

--- a/tests/world_model/support.py
+++ b/tests/world_model/support.py
@@ -710,13 +710,18 @@ class LifecycleWorld:
         attempt = replace(release, codec=codec or release.codec)
         before_album = self._album_for_release(release.release_id)
         self._dispatch_counter += 1
+        origin = (
+            self.beets.root
+            / "slskd"
+            / f"force-{request_id}-{self._dispatch_counter:04d}"
+        )
         source = (
             self.beets.root
             / "failed_imports"
             / f"force-{request_id}-{self._dispatch_counter:04d}"
         )
-        self.beets.stage_release(attempt, source_dir=source)
-        candidate_files = snapshot_audio_files(str(source))
+        self.beets.stage_release(attempt, source_dir=origin)
+        candidate_files = snapshot_audio_files(str(origin))
         min_bitrate = 900 if attempt.codec.casefold() == "flac" else 245
         measurement = AudioQualityMeasurement(
             min_bitrate_kbps=min_bitrate,
@@ -740,7 +745,7 @@ class LifecycleWorld:
         )
         candidate = make_album_quality_evidence(
             mb_release_id=attempt.release_id,
-            source_path=str(source),
+            source_path=str(origin),
             files=candidate_files,
             measurement=measurement,
             verified_lossless_proof=proof,
@@ -755,6 +760,8 @@ class LifecycleWorld:
         )
         if persisted is None or persisted.id is None:
             raise AssertionError("force candidate evidence did not persist")
+        source.parent.mkdir(parents=True, exist_ok=True)
+        origin.rename(source)
         download_log_id = self.db.log_download(
             request_id,
             soulseek_username=f"force-peer-{self._dispatch_counter}",


### PR DESCRIPTION
## Summary
- refresh content-matching candidate evidence at the shared import action boundary after source relocation
- keep launch path authority on the active import job instead of mutable evidence metadata
- model preview-to-failed_imports relocation in deterministic and generated real-storage worlds

## Validation
- nix-shell --run pyright --threads 4
- nix-shell --run bash scripts/run_tests.sh
- focused dispatch, import queue, evidence, operation-fence, PostgreSQL, and world-model tests