### PR TITLE
Automate the daily unstable compatibility gate

### DIFF
--- a/.claude/rules/deploy.md
+++ b/.claude/rules/deploy.md
@@ -37,7 +37,7 @@
   owned by `scripts/verify_cratedigger_cycle.sh`.
 - Always derive the active cratedigger wrapper from `systemctl show cratedigger.service --property=ExecStart --value`, extract its exact `*-source` path from the wrapper, and verify the unique source string there; never glob historical store generations, which can produce a false positive. For module changes, inspect `systemctl cat cratedigger.service` and the rendered `/var/lib/cratedigger/config.ini`.
 - Before deploying changes to `nix/module.nix`, run the VM check: `nix build .#checks.x86_64-linux.moduleVm`.
-- **Every `nix flake update` in cratedigger must re-run the real-beets drift gate** (`tests/test_harness_beets2_contract.py` inside the re-pinned shell, plus the full suite): since tier-2 packaging, the flake.lock — not the consumer's nixpkgs — decides the beets version production runs. A lock bump is a beets upgrade until proven otherwise.
+- **Every `nix flake update` in cratedigger must re-run the real-beets drift gate** (`tests/test_harness_beets2_contract.py` inside the re-pinned shell, plus the full suite): the repository lock is Cratedigger's last verified standalone unstable snapshot. Fleet deliberately replaces that input edge through `cratedigger-src.inputs.nixpkgs.follows = "nixpkgs"`; there, nixosconfig's unstable pin is authoritative. `scripts/daily_flake_update.sh` automates the standalone lock update and all drift gates; no package override is permitted.
 - Before the first cratedigger branch push, the agent runs whole-repo threaded
   Pyright and the full suite once on the final committed tree. Do not replay
   those gates during deploy when the pushed revision is unchanged.

--- a/docs/generated-testing.md
+++ b/docs/generated-testing.md
@@ -4,9 +4,21 @@ Issue #548. Hypothesis-driven generated tests assert **policy invariants**
 over large generated state spaces instead of hand-picked examples. The normal
 pure/fake-backed modules are ordinary members of the unittest suite — no seed
 bookkeeping or standing service. The deterministic cross-engine world model is
-also part of the normal suite at its measured small budget. Deeper randomized,
-mirror-backed, long-fuzz, and live-audit runs remain separate scheduled work
-tracked by issue #498.
+also part of the normal suite at its measured small budget. The deeper
+randomized, mirror-backed, and long-fuzz runs execute together in the daily
+unstable compatibility gate tracked by issue #498. The read-only live audit
+joins that same run after issue #762 establishes current-path authority.
+
+## Daily unstable compatibility gate
+
+`scripts/daily_flake_update.sh` is the single unattended entry point. It
+checks out current `main`, advances `flake.lock` to current nixpkgs unstable,
+and runs whole-repository Pyright, the deterministic suite, `nix flake check`,
+the default lifecycle hammer, the full fuzz burst, and the mirror-harness
+smoke. Independent test stages all run so one notification contains the whole
+day's result. A completely green candidate commits and pushes only
+`flake.lock`; a red candidate pushes nothing. Scheduling, state paths, and
+notification belong to the downstream nixosconfig service.
 
 ## Bug hunting — the house method
 
@@ -196,7 +208,7 @@ all six module tests in 8.470 test-seconds (10 seconds wrapper wall time). The
 default 25 × 100 profile completed cleanly in 449.930 test-seconds (451 seconds
 wrapper wall time). That measured depth is not part of `scripts/run_tests.sh`.
 Its exact-revision doc1 schedule, alongside the long generated fuzz burst, is
-tracked by issue #498.
+the daily `scripts/daily_flake_update.sh` gate tracked by issue #498.
 
 The default hammer uses the in-process production adapter that performs real
 Beets model/database/filesystem mutations beneath the real dispatch services.
@@ -221,8 +233,9 @@ loads the shipped path template, exact-ID duplicate keys, inline field, match
 policy, and MusicBrainz plugin; unrelated production fetchart/lyrics/scrub hooks
 stay disabled so the boundary test cannot make external content requests. A
 2-world × 5-step mirror smoke completed cleanly in 5 seconds on doc1 on
-2026-07-19. It remains outside the normal suite; exact-revision scheduled
-execution and separate mirror-failure reporting are tracked by issue #498.
+2026-07-19. It remains outside the normal suite and runs as a separately named
+stage inside the daily issue-#498 gate, so mirror availability stays distinct
+in the combined result.
 
 When the hammer finds a defect:
 
@@ -257,9 +270,11 @@ nix-shell --run "bash scripts/fuzz_burst.sh tests.test_quality_generated"  # sub
 `scripts/fuzz_burst.sh` runs each generated module in its own process,
 parallelised to the host's core count (`nproc`) — Hypothesis is
 single-threaded, so a serial burst pegs one core and leaves the rest of
-whatever machine you are on idle. Per-module logs surface only on failure;
-the 20k-example budget is unchanged. The serial equivalent, when you need
-one module's live output:
+whatever machine you are on idle. Per-module logs surface only on failure.
+Set `HYPOTHESIS_STORAGE_DIRECTORY` for a persistent replay database and
+`CRATEDIGGER_FUZZ_OUTPUT_DIR` to retain a failed run's complete module logs;
+green-run logs are removed. The 20k-example budget is unchanged. The serial
+equivalent, when you need one module's live output:
 
 ```bash
 nix-shell --run "CRATEDIGGER_HYPOTHESIS_PROFILE=fuzz \

--- a/scripts/daily_flake_update.sh
+++ b/scripts/daily_flake_update.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# Daily nixpkgs-unstable compatibility gate for issue #498.
+#
+# This script owns repository semantics only: clone current main, update the
+# lock, run every candidate gate, and push one lock-only commit when green.
+# The caller owns scheduling, persistent state, and failure notification.
+set -euo pipefail
+
+repository="${CRATEDIGGER_UPDATE_REPOSITORY:-https://github.com/abl030/cratedigger.git}"
+branch="${CRATEDIGGER_UPDATE_BRANCH:-main}"
+state_dir="${CRATEDIGGER_AUTOMATION_STATE_DIR:?CRATEDIGGER_AUTOMATION_STATE_DIR is required}"
+mirror_url="${CRATEDIGGER_MIRROR_URL:?CRATEDIGGER_MIRROR_URL is required}"
+
+world_database="$state_dir/hypothesis/world-model"
+mirror_database="$state_dir/hypothesis/mirror-world"
+fuzz_database="$state_dir/hypothesis/fuzz"
+fuzz_output_dir="$state_dir/fuzz-failures"
+
+mkdir -p \
+    "$world_database" \
+    "$mirror_database" \
+    "$fuzz_database" \
+    "$fuzz_output_dir"
+
+work_root=$(mktemp -d "${TMPDIR:-/tmp}/cratedigger-daily-update.XXXXXX")
+checkout="$work_root/repo"
+
+cleanup() {
+    if [[ -n "${work_root:-}" && -d "$work_root" ]]; then
+        rm -rf -- "$work_root"
+    fi
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+echo "daily unstable gate: cloning $repository branch $branch"
+if ! git clone --quiet --branch "$branch" --single-branch "$repository" "$checkout"; then
+    echo "daily unstable gate: clone failed" >&2
+    exit 1
+fi
+cd "$checkout"
+
+# No unattended test may inherit authority to connect to an ambient database.
+# The world wrappers repeat this guard, but the normal suite must be protected
+# too because its conftest accepts TEST_DB_DSN for explicit developer use.
+unset TEST_DB_DSN
+
+echo "daily unstable gate: updating flake.lock"
+if ! nix flake update; then
+    echo "daily unstable gate: flake update failed" >&2
+    exit 1
+fi
+
+declare -a stage_names=()
+declare -a stage_statuses=()
+
+run_stage() {
+    local name="$1"
+    shift
+    local status
+
+    echo ""
+    echo "=== $name ==="
+    if "$@"; then
+        status=0
+    else
+        status=$?
+    fi
+    stage_names+=("$name")
+    stage_statuses+=("$status")
+}
+
+run_stage "whole-repository Pyright" \
+    nix-shell --run "pyright --threads 4"
+run_stage "deterministic full suite" \
+    nix-shell --run "bash scripts/run_tests.sh"
+run_stage "Nix flake checks" \
+    nix flake check --print-build-logs
+run_stage "world-model burst" \
+    env CRATEDIGGER_WORLD_DATABASE="$world_database" \
+    nix-shell --run "bash scripts/world_model_burst.sh"
+run_stage "generated fuzz burst" \
+    env HYPOTHESIS_STORAGE_DIRECTORY="$fuzz_database" \
+        CRATEDIGGER_FUZZ_OUTPUT_DIR="$fuzz_output_dir" \
+    nix-shell --run "bash scripts/fuzz_burst.sh"
+run_stage "mirror-harness smoke" \
+    env CRATEDIGGER_WORLD_DATABASE="$mirror_database" \
+        CRATEDIGGER_WORLD_ENGINE="mirror-harness" \
+        CRATEDIGGER_WORLD_MIRROR_URL="$mirror_url" \
+        CRATEDIGGER_WORLD_EXAMPLES="2" \
+        CRATEDIGGER_WORLD_STEPS="5" \
+    nix-shell --run "bash scripts/world_model_burst.sh"
+
+echo ""
+echo "=== daily candidate summary ==="
+candidate_failed=0
+for ((i = 0; i < ${#stage_names[@]}; i++)); do
+    if [[ "${stage_statuses[$i]}" -eq 0 ]]; then
+        echo "PASS ${stage_names[$i]}"
+    else
+        echo "FAIL ${stage_names[$i]} (exit ${stage_statuses[$i]})"
+        candidate_failed=1
+    fi
+done
+
+if [[ "$candidate_failed" -ne 0 ]]; then
+    echo "daily unstable gate: candidate failed; flake.lock was not committed" >&2
+    exit 1
+fi
+
+echo "ALL CANDIDATE GATES GREEN"
+if git diff --quiet -- flake.lock; then
+    echo "daily unstable gate: flake.lock already current"
+    exit 0
+fi
+
+if ! git commit --only \
+    -m "chore(nix): refresh unstable lock" \
+    -m "Refs #498" \
+    -- flake.lock; then
+    echo "daily unstable gate: lock commit failed" >&2
+    exit 1
+fi
+if ! git push origin "HEAD:refs/heads/$branch"; then
+    echo "daily unstable gate: push failed; verify the remote branch state" >&2
+    exit 1
+fi
+
+echo "daily unstable gate: pushed updated flake.lock"

--- a/scripts/fuzz_burst.sh
+++ b/scripts/fuzz_burst.sh
@@ -16,6 +16,8 @@
 #
 # FUZZ_PROFILE overrides the Hypothesis profile (default: fuzz) — used by the
 # script's own smoke test; real bursts never pass it.
+# CRATEDIGGER_FUZZ_OUTPUT_DIR retains a failed run's complete per-module logs
+# below a unique run.* directory. Successful run logs are always removed.
 set -u
 
 cd "$(dirname "$0")/.."
@@ -31,8 +33,21 @@ fi
 
 jobs=$(nproc)
 profile="${FUZZ_PROFILE:-fuzz}"
-outdir=$(mktemp -d)
-trap 'rm -rf "$outdir"' EXIT
+persistent_output=false
+if [ -n "${CRATEDIGGER_FUZZ_OUTPUT_DIR:-}" ]; then
+    mkdir -p "$CRATEDIGGER_FUZZ_OUTPUT_DIR"
+    outdir=$(mktemp -d "$CRATEDIGGER_FUZZ_OUTPUT_DIR/run.XXXXXX")
+    persistent_output=true
+else
+    outdir=$(mktemp -d)
+fi
+
+cleanup_output() {
+    if [ -d "$outdir" ]; then
+        rm -rf -- "$outdir"
+    fi
+}
+trap cleanup_output EXIT
 export _FUZZ_OUTDIR="$outdir"
 export _FUZZ_PROFILE="$profile"
 
@@ -53,6 +68,10 @@ status=$?
 
 if [ "$status" -ne 0 ]; then
     echo "fuzz burst: FAILURES (see above)"
+    if [ "$persistent_output" = true ]; then
+        trap - EXIT
+        echo "fuzz burst: complete module logs retained at $outdir"
+    fi
     exit 1
 fi
 echo "fuzz burst: ALL GREEN (${#modules[@]} modules)"

--- a/tests/fakes/daily_flake_update.py
+++ b/tests/fakes/daily_flake_update.py
@@ -1,0 +1,198 @@
+"""Process-level fakes for the unattended flake-update runner."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+_FAKE_COMMAND = r'''#!/usr/bin/env python3
+import fcntl
+import json
+import os
+import sys
+from pathlib import Path
+
+state_path = Path(os.environ["DAILY_UPDATE_FAKE_STATE"])
+with state_path.with_suffix(".lock").open("a+", encoding="utf-8") as lock:
+    fcntl.flock(lock, fcntl.LOCK_EX)
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    command = Path(sys.argv[0]).name
+    args = sys.argv[1:]
+
+    def save():
+        state_path.write_text(json.dumps(state, sort_keys=True), encoding="utf-8")
+
+    def fail(message):
+        print(message, file=sys.stderr)
+        save()
+        raise SystemExit(1)
+
+    state["events"].append([command, *args])
+
+    if command == "git":
+        if args[:1] == ["clone"]:
+            clone_path = Path(args[-1])
+            clone_path.mkdir(parents=True)
+            clone_path.joinpath(".git").mkdir()
+            clone_path.joinpath("flake.lock").write_text("old lock\n", encoding="utf-8")
+            state["clone_path"] = str(clone_path)
+        elif args == ["diff", "--quiet", "--", "flake.lock"]:
+            save()
+            raise SystemExit(1 if state["lock_changed"] else 0)
+        elif args[:2] == ["commit", "--only"]:
+            if state.get("fault") == "commit":
+                fail("fake commit failed")
+            state["commit_count"] += 1
+            state["commit_args"] = args
+        elif args[:2] == ["push", "origin"]:
+            if state.get("fault") == "push":
+                fail("fake push failed")
+            state["push_count"] += 1
+            state["push_ref"] = args[2]
+        else:
+            fail(f"unexpected git argv: {args!r}")
+        save()
+        raise SystemExit(0)
+
+    if command == "nix":
+        if args == ["flake", "update"]:
+            if state.get("fault") == "update":
+                fail("fake flake update failed")
+            if state["lock_changed"]:
+                Path.cwd().joinpath("flake.lock").write_text(
+                    "new lock\n", encoding="utf-8"
+                )
+            save()
+            raise SystemExit(0)
+        if args == ["flake", "check", "--print-build-logs"]:
+            stage = "flake-check"
+        else:
+            fail(f"unexpected nix argv: {args!r}")
+    elif command == "nix-shell":
+        if args[:1] != ["--run"] or len(args) != 2:
+            fail(f"unexpected nix-shell argv: {args!r}")
+        shell_command = args[1]
+        if shell_command == "pyright --threads 4":
+            stage = "pyright"
+        elif shell_command == "bash scripts/run_tests.sh":
+            stage = "suite"
+        elif shell_command == "bash scripts/fuzz_burst.sh":
+            stage = "fuzz"
+        elif shell_command == "bash scripts/world_model_burst.sh":
+            stage = (
+                "mirror"
+                if os.environ.get("CRATEDIGGER_WORLD_ENGINE") == "mirror-harness"
+                else "world"
+            )
+        else:
+            fail(f"unexpected nix-shell command: {shell_command!r}")
+    else:
+        fail(f"unexpected fake command: {command}")
+
+    state["stages"].append(stage)
+    state["stage_env"][stage] = {
+        "TEST_DB_DSN": os.environ.get("TEST_DB_DSN"),
+        "CRATEDIGGER_WORLD_DATABASE": os.environ.get(
+            "CRATEDIGGER_WORLD_DATABASE"
+        ),
+        "CRATEDIGGER_WORLD_ENGINE": os.environ.get("CRATEDIGGER_WORLD_ENGINE"),
+        "CRATEDIGGER_WORLD_MIRROR_URL": os.environ.get(
+            "CRATEDIGGER_WORLD_MIRROR_URL"
+        ),
+        "CRATEDIGGER_WORLD_EXAMPLES": os.environ.get(
+            "CRATEDIGGER_WORLD_EXAMPLES"
+        ),
+        "CRATEDIGGER_WORLD_STEPS": os.environ.get("CRATEDIGGER_WORLD_STEPS"),
+        "HYPOTHESIS_STORAGE_DIRECTORY": os.environ.get(
+            "HYPOTHESIS_STORAGE_DIRECTORY"
+        ),
+        "CRATEDIGGER_FUZZ_OUTPUT_DIR": os.environ.get(
+            "CRATEDIGGER_FUZZ_OUTPUT_DIR"
+        ),
+    }
+    if state.get("fault") == stage:
+        fail(f"fake {stage} failed")
+    save()
+'''
+
+
+class FakeDailyFlakeUpdateCommands:
+    """Fake git/Nix commands while the real Bash runner owns orchestration."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+        self.fake_bin = root / "fake-bin"
+        self.fake_bin.mkdir()
+        self.state_path = root / "state.json"
+        self.automation_state = root / "automation-state"
+        self.tmpdir = root / "tmp"
+        self.tmpdir.mkdir()
+        command = self.fake_bin / "command"
+        command.write_text(_FAKE_COMMAND, encoding="utf-8")
+        command.chmod(0o755)
+        for name in ("git", "nix", "nix-shell"):
+            (self.fake_bin / name).symlink_to(command)
+        self._write_state(
+            {
+                "fault": None,
+                "lock_changed": True,
+                "events": [],
+                "stages": [],
+                "stage_env": {},
+                "clone_path": None,
+                "commit_count": 0,
+                "commit_args": [],
+                "push_count": 0,
+                "push_ref": None,
+            }
+        )
+
+    @property
+    def state(self) -> dict[str, Any]:
+        return json.loads(self.state_path.read_text(encoding="utf-8"))
+
+    def _write_state(self, state: dict[str, Any]) -> None:
+        self.state_path.write_text(
+            json.dumps(state, sort_keys=True), encoding="utf-8"
+        )
+
+    def update_state(self, **changes: Any) -> None:
+        state = self.state
+        state.update(changes)
+        self._write_state(state)
+
+    def run(
+        self,
+        script: Path,
+        *,
+        extra_env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{self.fake_bin}:{env['PATH']}",
+                "DAILY_UPDATE_FAKE_STATE": str(self.state_path),
+                "CRATEDIGGER_AUTOMATION_STATE_DIR": str(self.automation_state),
+                "CRATEDIGGER_MIRROR_URL": "http://mirror.example.test/ws/2",
+                "CRATEDIGGER_UPDATE_REPOSITORY": (
+                    "https://github.com/abl030/cratedigger.git"
+                ),
+                "CRATEDIGGER_UPDATE_BRANCH": "main",
+                "TMPDIR": str(self.tmpdir),
+                "TEST_DB_DSN": "postgresql://production-must-not-leak",
+            }
+        )
+        if extra_env:
+            env.update(extra_env)
+        return subprocess.run(
+            ["bash", str(script)],
+            cwd=self.root,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )

--- a/tests/test_daily_flake_update.py
+++ b/tests/test_daily_flake_update.py
@@ -1,0 +1,147 @@
+"""Contract tests for the unattended unstable lock-update runner."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from tests.fakes.daily_flake_update import FakeDailyFlakeUpdateCommands
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "daily_flake_update.sh"
+
+
+class TestDailyFlakeUpdateScript(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.fake = FakeDailyFlakeUpdateCommands(Path(self.tempdir.name))
+
+    def test_green_candidate_runs_every_gate_and_pushes_only_lock(self) -> None:
+        proc = self.fake.run(SCRIPT)
+        state = self.fake.state
+
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(
+            state["stages"],
+            ["pyright", "suite", "flake-check", "world", "fuzz", "mirror"],
+        )
+        self.assertEqual(state["commit_count"], 1)
+        self.assertEqual(state["push_count"], 1)
+        self.assertEqual(state["push_ref"], "HEAD:refs/heads/main")
+        self.assertIn("--only", state["commit_args"])
+        self.assertEqual(state["commit_args"][-2:], ["--", "flake.lock"])
+        self.assertIn("Refs #498", state["commit_args"])
+        self.assertIn("ALL CANDIDATE GATES GREEN", proc.stdout)
+        self.assertIn("pushed updated flake.lock", proc.stdout)
+
+        clone_path = Path(state["clone_path"])
+        self.assertFalse(clone_path.exists())
+        for stage, stage_env in state["stage_env"].items():
+            self.assertIsNone(stage_env["TEST_DB_DSN"], stage)
+
+    def test_failed_gate_runs_later_gates_and_pushes_nothing(self) -> None:
+        self.fake.update_state(fault="world")
+
+        proc = self.fake.run(SCRIPT)
+        state = self.fake.state
+
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertEqual(
+            state["stages"],
+            ["pyright", "suite", "flake-check", "world", "fuzz", "mirror"],
+        )
+        self.assertEqual(state["commit_count"], 0)
+        self.assertEqual(state["push_count"], 0)
+        self.assertIn("FAIL world-model burst", proc.stdout)
+        self.assertIn("PASS mirror-harness smoke", proc.stdout)
+        self.assertIn("candidate failed; flake.lock was not committed", proc.stderr)
+
+    def test_unchanged_lock_still_runs_gates_without_commit(self) -> None:
+        self.fake.update_state(lock_changed=False)
+
+        proc = self.fake.run(SCRIPT)
+        state = self.fake.state
+
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(len(state["stages"]), 6)
+        self.assertEqual(state["commit_count"], 0)
+        self.assertEqual(state["push_count"], 0)
+        self.assertIn("flake.lock already current", proc.stdout)
+
+    def test_update_failure_stops_before_candidate_gates_or_push(self) -> None:
+        self.fake.update_state(fault="update")
+
+        proc = self.fake.run(SCRIPT)
+        state = self.fake.state
+
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertEqual(state["stages"], [])
+        self.assertEqual(state["push_count"], 0)
+        self.assertIn("flake update failed", proc.stderr)
+
+    def test_push_failure_is_reported_as_the_single_run_failure(self) -> None:
+        self.fake.update_state(fault="push")
+
+        proc = self.fake.run(SCRIPT)
+        state = self.fake.state
+
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertEqual(state["commit_count"], 1)
+        self.assertEqual(state["push_count"], 0)
+        self.assertIn("push failed", proc.stderr)
+
+    def test_commit_failure_never_attempts_a_push(self) -> None:
+        self.fake.update_state(fault="commit")
+
+        proc = self.fake.run(SCRIPT)
+        state = self.fake.state
+
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertEqual(state["commit_count"], 0)
+        self.assertEqual(state["push_count"], 0)
+        self.assertIn("lock commit failed", proc.stderr)
+
+    def test_state_paths_and_mirror_budget_are_explicit(self) -> None:
+        proc = self.fake.run(SCRIPT)
+        state = self.fake.state
+
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        world = state["stage_env"]["world"]
+        fuzz = state["stage_env"]["fuzz"]
+        mirror = state["stage_env"]["mirror"]
+        self.assertEqual(
+            world["CRATEDIGGER_WORLD_DATABASE"],
+            str(self.fake.automation_state / "hypothesis" / "world-model"),
+        )
+        self.assertEqual(
+            fuzz["HYPOTHESIS_STORAGE_DIRECTORY"],
+            str(self.fake.automation_state / "hypothesis" / "fuzz"),
+        )
+        self.assertEqual(
+            fuzz["CRATEDIGGER_FUZZ_OUTPUT_DIR"],
+            str(self.fake.automation_state / "fuzz-failures"),
+        )
+        self.assertEqual(mirror["CRATEDIGGER_WORLD_ENGINE"], "mirror-harness")
+        self.assertEqual(
+            mirror["CRATEDIGGER_WORLD_MIRROR_URL"],
+            "http://mirror.example.test/ws/2",
+        )
+        self.assertEqual(mirror["CRATEDIGGER_WORLD_EXAMPLES"], "2")
+        self.assertEqual(mirror["CRATEDIGGER_WORLD_STEPS"], "5")
+
+    def test_missing_required_configuration_fails_before_clone(self) -> None:
+        proc = self.fake.run(
+            SCRIPT,
+            extra_env={"CRATEDIGGER_MIRROR_URL": ""},
+        )
+
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIsNone(self.fake.state["clone_path"])
+        self.assertIn("CRATEDIGGER_MIRROR_URL", proc.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fuzz_burst.py
+++ b/tests/test_fuzz_burst.py
@@ -1,0 +1,70 @@
+"""Persistence contract for unattended generated fuzz bursts."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "fuzz_burst.sh"
+
+
+class TestFuzzBurstOutput(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.root = Path(self.tempdir.name)
+        self.fake_bin = self.root / "bin"
+        self.fake_bin.mkdir()
+        python = self.fake_bin / "python3"
+        python.write_text(
+            "#!/usr/bin/env bash\n"
+            "echo fuzz-log-marker\n"
+            "echo 'Ran 1 test in 0.001s'\n"
+            "exit \"${FAKE_FUZZ_EXIT:-0}\"\n",
+            encoding="utf-8",
+        )
+        python.chmod(0o755)
+        self.output_dir = self.root / "failures"
+
+    def run_burst(self, status: int) -> subprocess.CompletedProcess[str]:
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{self.fake_bin}:{env['PATH']}",
+                "FAKE_FUZZ_EXIT": str(status),
+                "FUZZ_PROFILE": "suite",
+                "CRATEDIGGER_FUZZ_OUTPUT_DIR": str(self.output_dir),
+            }
+        )
+        return subprocess.run(
+            ["bash", str(SCRIPT), "tests.test_example_generated"],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_failed_module_log_is_retained_in_supplied_directory(self) -> None:
+        proc = self.run_burst(1)
+
+        self.assertNotEqual(proc.returncode, 0)
+        logs = list(self.output_dir.glob("run.*/tests.test_example_generated.log"))
+        self.assertEqual(len(logs), 1)
+        self.assertIn("fuzz-log-marker", logs[0].read_text(encoding="utf-8"))
+        self.assertIn(str(logs[0].parent), proc.stdout)
+
+    def test_green_run_removes_transient_module_logs(self) -> None:
+        proc = self.run_burst(0)
+
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(list(self.output_dir.glob("run.*")), [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add one unattended runner that updates the standalone unstable lock and runs every compatibility gate
- keep all package versions owned by nixpkgs, with no dependency overrides and no yt-dlp or ffmpeg ownership
- persist Hypothesis replay state and complete failed fuzz logs through caller-owned paths
- commit and push only `flake.lock` when every candidate gate is green; push nothing when any gate fails
- leave scheduling, notification, fleet rollout, and the post-#762 live world audit outside this repository boundary

## Validation

- `nix-shell --run \"pyright --threads 4\"`
- `nix-shell --run \"bash scripts/run_tests.sh\"` (6519 tests plus deterministic world model; no skips)

Refs #498