### PR TITLE
Unify quality and spectral colours across the UI

### DIFF
--- a/tests/test_js_badges.mjs
+++ b/tests/test_js_badges.mjs
@@ -66,6 +66,8 @@ console.log('renderStatusBadges() marks a verified lossless install');
     pipeline_provisional: false,
   });
   assertContains(html, 'badge-verified', 'verified install renders chip');
+  assertContains(html, 'badge-rank-lossless',
+    'verified identity reuses the brightest lossless bucket colour');
   assertContains(html, '>verified<', 'chip label reads verified');
   assertExcludes(html, 'badge-provisional', 'verified never doubles as provisional');
 }

--- a/tests/test_js_history.mjs
+++ b/tests/test_js_history.mjs
@@ -387,13 +387,21 @@ console.log('withWas() helper appends the existing comparison inline');
 
 console.log('formatSpectral() helper colors grades and prefixes the floor');
 {
-  if (!formatSpectral('genuine').includes('#6d6')) {
+  if (!formatSpectral('genuine').includes('quality-tone-lossless')) {
     failed++;
-    console.error('  FAIL: genuine should be green (#6d6)');
+    console.error('  FAIL: genuine should use the brightest shared green');
   } else { passed++; }
-  if (!formatSpectral('suspect').includes('#d66')) {
+  if (!formatSpectral('marginal').includes('quality-tone-good')) {
     failed++;
-    console.error('  FAIL: suspect should be red (#d66)');
+    console.error('  FAIL: marginal should use the shared yellow tone');
+  } else { passed++; }
+  if (!formatSpectral('suspect').includes('quality-tone-acceptable')) {
+    failed++;
+    console.error('  FAIL: suspect should use the shared orange tone');
+  } else { passed++; }
+  if (!formatSpectral('likely_transcode').includes('quality-tone-poor')) {
+    failed++;
+    console.error('  FAIL: likely transcode should use the shared red tone');
   } else { passed++; }
   if (!formatSpectral('genuine', 96).includes('~96kbps')) {
     failed++;

--- a/tests/test_js_long_tail_console.mjs
+++ b/tests/test_js_long_tail_console.mjs
@@ -31,6 +31,7 @@ const {
   consoleYoutubeResult,
   consoleSetYoutubeResult,
   consoleOpenIds,
+  renderSpectralFragment,
 } = __test__;
 
 let passed = 0;
@@ -52,6 +53,22 @@ function assertEqual(actual, expected, msg) {
     failed++;
     console.error(`  FAIL: ${msg} — expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
   }
+}
+
+console.log('long-tail current quality uses the shared ordered spectral palette');
+for (const [grade, tone] of [
+  ['likely_transcode', 'poor'],
+  ['suspect', 'acceptable'],
+  ['marginal', 'good'],
+  ['genuine', 'lossless'],
+]) {
+  const html = renderSpectralFragment({
+    current_spectral_grade: grade,
+    current_spectral_bitrate: 128,
+  });
+  assert(html.includes(`quality-tone-${tone}`), `${grade} uses shared ${tone} tone`);
+  assert(html.includes(grade.replaceAll('_', ' ')), `${grade} is humanized`);
+  if (grade.includes('_')) assert(!html.includes(grade), `${grade} raw token stays hidden`);
 }
 
 // --- consoleOpen / consoleClose / consoleIsOpen / consoleToken ---

--- a/tests/test_js_pipeline.mjs
+++ b/tests/test_js_pipeline.mjs
@@ -110,5 +110,28 @@ console.log('request 6039 current Quality uses average positive track bitrate');
   assertExcludes(html, 'MP3 V2', 'min 194 never paints current quality');
 }
 
+console.log('current Quality uses the shared ordered spectral palette');
+for (const [grade, tone] of [
+  ['likely_transcode', 'poor'],
+  ['suspect', 'acceptable'],
+  ['marginal', 'good'],
+  ['genuine', 'lossless'],
+]) {
+  const html = __test__.renderCurrentQualityRow(
+    {
+      current_spectral_bitrate: 128,
+      last_download_spectral_bitrate: null,
+      current_spectral_grade: grade,
+      last_download_spectral_grade: null,
+      verified_lossless: false,
+    },
+    [{ format: 'MP3', bitrate: 192000 }],
+  );
+  assertContains(html, `quality-tone-${tone}`, `${grade} uses shared ${tone} tone`);
+  assertContains(html, grade.replaceAll('_', ' '), `${grade} is humanized`);
+  assertExcludes(html, grade.includes('_') ? grade : '__never__',
+    `${grade} never leaks a raw token`);
+}
+
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/tests/test_js_quality_palette.mjs
+++ b/tests/test_js_quality_palette.mjs
@@ -1,0 +1,122 @@
+/** Shared quality/spectral palette contract tests. */
+
+import fs from 'node:fs';
+import {
+  QUALITY_RANK_ORDER,
+  SPECTRAL_GRADE_ORDER,
+  SPECTRAL_GRADE_TONES,
+  qualityRankBadgeClass,
+  qualityToneClass,
+  spectralGradeBadgeClass,
+  spectralGradeClass,
+  spectralGradeLabel,
+  spectralGradeTone,
+} from '../web/js/quality_palette.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, message) {
+  if (condition) passed++;
+  else {
+    failed++;
+    console.error(`  FAIL: ${message}`);
+  }
+}
+
+function assertEqual(actual, expected, message) {
+  assert(actual === expected,
+    `${message} — expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+}
+
+const expectedRanks = [
+  'unknown', 'poor', 'acceptable', 'good', 'excellent', 'transparent', 'lossless',
+];
+const expectedSpectral = [
+  'likely_transcode', 'suspect', 'marginal', 'genuine',
+];
+
+console.log('quality bucket palette spans unknown through bright-green lossless');
+assertEqual(JSON.stringify(QUALITY_RANK_ORDER), JSON.stringify(expectedRanks),
+  'quality ranks stay ordered from least evidence/quality to best');
+for (const rank of expectedRanks) {
+  assertEqual(qualityToneClass(rank), `quality-tone-${rank}`,
+    `${rank} gets its canonical text-tone class`);
+  assertEqual(qualityRankBadgeClass(rank), `badge-rank-${rank}`,
+    `${rank} gets its canonical badge class`);
+}
+assertEqual(qualityToneClass('future_rank'), 'quality-tone-unknown',
+  'unknown rank tokens fail closed to the neutral tone');
+assertEqual(qualityRankBadgeClass('future_rank'), 'badge-rank-unknown',
+  'unknown rank badge tokens fail closed to the neutral badge');
+
+console.log('spectral grades reuse ordered bucket colours from red to bright green');
+assertEqual(JSON.stringify(SPECTRAL_GRADE_ORDER), JSON.stringify(expectedSpectral),
+  'spectral grades stay ordered from likely transcode to genuine');
+assertEqual(SPECTRAL_GRADE_TONES.likely_transcode, 'poor',
+  'likely transcode reuses the red poor tone');
+assertEqual(SPECTRAL_GRADE_TONES.suspect, 'acceptable',
+  'suspect reuses the orange acceptable tone');
+assertEqual(SPECTRAL_GRADE_TONES.marginal, 'good',
+  'marginal reuses the yellow good tone');
+assertEqual(SPECTRAL_GRADE_TONES.genuine, 'lossless',
+  'genuine reuses the bright-green lossless tone');
+
+for (const grade of expectedSpectral) {
+  const tone = SPECTRAL_GRADE_TONES[grade];
+  assertEqual(spectralGradeTone(grade), tone, `${grade} resolves to ${tone}`);
+  assertEqual(spectralGradeClass(grade), `spectral-grade quality-tone-${tone}`,
+    `${grade} inline text uses the shared ${tone} colour`);
+  assertEqual(spectralGradeBadgeClass(grade),
+    `badge spectral-grade badge-rank-${tone}`,
+    `${grade} badges use the shared ${tone} foreground and background`);
+}
+assertEqual(spectralGradeTone('future_grade'), 'unknown',
+  'unknown spectral tokens fail closed to neutral');
+assertEqual(spectralGradeTone('constructor'), 'unknown',
+  'inherited object keys cannot escape the neutral fallback');
+assertEqual(spectralGradeLabel('likely_transcode'), 'likely transcode',
+  'spectral tokens are humanized consistently');
+
+console.log('generated spectral ordering property covers every ordered grade pair');
+const rankIndex = new Map(QUALITY_RANK_ORDER.map((rank, index) => [rank, index]));
+for (let low = 0; low < SPECTRAL_GRADE_ORDER.length; low++) {
+  for (let high = low + 1; high < SPECTRAL_GRADE_ORDER.length; high++) {
+    const lowGrade = SPECTRAL_GRADE_ORDER[low];
+    const highGrade = SPECTRAL_GRADE_ORDER[high];
+    assert(rankIndex.get(spectralGradeTone(lowGrade))
+      < rankIndex.get(spectralGradeTone(highGrade)),
+    `${lowGrade} stays visually below ${highGrade}`);
+  }
+}
+
+console.log('known-bad swapped spectral mapping violates the ordering property');
+const badTones = { ...SPECTRAL_GRADE_TONES, likely_transcode: 'good', suspect: 'poor' };
+const badOrdered = SPECTRAL_GRADE_ORDER.every((grade, index) => index === 0
+  || rankIndex.get(badTones[SPECTRAL_GRADE_ORDER[index - 1]])
+    < rankIndex.get(badTones[grade]));
+assert(!badOrdered, 'the checker rejects a likely-transcode/suspect colour reversal');
+
+console.log('CSS owns one red-to-green palette for text and badges');
+const css = fs.readFileSync(new URL('../web/index.html', import.meta.url), 'utf8');
+for (const [rank, foreground] of Object.entries({
+  unknown: '#888',
+  poor: '#d66',
+  acceptable: '#d96',
+  good: '#ec6',
+  excellent: '#cd6',
+  transparent: '#6d6',
+  lossless: '#8f8',
+})) {
+  assert(css.includes(`--quality-${rank}-fg: ${foreground};`),
+    `${rank} foreground is declared once as ${foreground}`);
+  assert(css.includes(`.quality-tone-${rank} { color: var(--quality-${rank}-fg); }`),
+    `${rank} inline text consumes its shared foreground token`);
+  assert(css.includes(`.badge-rank-${rank} { background: var(--quality-${rank}-bg); color: var(--quality-${rank}-fg); }`),
+    `${rank} badges consume both shared palette tokens`);
+}
+assert(css.includes('.badge-quality-outline { border: 1px solid currentColor; }'),
+  'quality badge outlines preserve their canonical rank background');
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/tests/test_js_wrong_matches.mjs
+++ b/tests/test_js_wrong_matches.mjs
@@ -747,6 +747,47 @@ console.log('renderQualityBadges() labels current average and retained floor fal
   );
 }
 
+console.log('wrong-match headers use the shared ordered spectral badge palette');
+for (const [grade, tone] of [
+  ['likely_transcode', 'poor'],
+  ['suspect', 'acceptable'],
+  ['marginal', 'good'],
+]) {
+  const html = __test__.renderQualityBadges({
+    in_library: true,
+    quality_label: 'MP3 V2',
+    quality_rank: 'excellent',
+    current_spectral_grade: grade,
+    current_spectral_bitrate: 128,
+  });
+  assert(html.includes(`badge-rank-${tone}`), `${grade} uses shared ${tone} badge`);
+  assert(html.includes(grade.replaceAll('_', ' ')), `${grade} is humanized`);
+  if (grade.includes('_')) assert(!html.includes(grade), `${grade} raw token stays hidden`);
+}
+
+console.log('wrong-match bucket badges use the same canonical classes as every other view');
+for (const rank of ['poor', 'acceptable', 'good', 'excellent', 'transparent', 'lossless']) {
+  const html = __test__.renderQualityBadges({
+    in_library: true,
+    quality_label: rank,
+    quality_rank: rank,
+  });
+  assert(html.includes(`badge-rank-${rank}`), `${rank} uses its canonical rank class`);
+}
+
+console.log('wrong-match verified-lossless identity reuses the lossless bucket colour');
+{
+  const html = __test__.renderQualityBadges({
+    in_library: true,
+    quality_label: 'FLAC',
+    quality_rank: 'lossless',
+    verified_lossless: true,
+  });
+  assert(html.includes('verified lossless'), 'verified identity remains explicit');
+  assert(countOccurrences(html, 'badge-rank-lossless') === 3,
+    'quality label, verified identity, and rank label share lossless colour');
+}
+
 console.log('renderEntry() embeds evidence cells without preview hooks');
 {
   installStorage();
@@ -759,6 +800,8 @@ console.log('renderEntry() embeds evidence cells without preview hooks');
   __test__.renderWrongMatches(data, dom.wrongMatches);
   const html = dom.wrongMatches.innerHTML;
   assert(html.includes('suspect'), 'rendered HTML carries the spectral grade');
+  assert(html.includes('quality-tone-acceptable'),
+    'candidate spectral metadata uses the same orange suspect tone');
   assert(html.includes('265'), 'rendered HTML carries the lossless-source V0 average');
   assert(html.includes('Downloaded as'), 'rendered HTML surfaces preserved source folders');
   assert(html.includes('wm-explorer-100'), 'rendered HTML includes an explorer mount');

--- a/web/index.html
+++ b/web/index.html
@@ -9,6 +9,22 @@
 <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
 <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
 <style>
+  :root {
+    --quality-unknown-fg: #888;
+    --quality-unknown-bg: #2a2a2a;
+    --quality-poor-fg: #d66;
+    --quality-poor-bg: #4a1a1a;
+    --quality-acceptable-fg: #d96;
+    --quality-acceptable-bg: #4a2a1a;
+    --quality-good-fg: #ec6;
+    --quality-good-bg: #4a3a1a;
+    --quality-excellent-fg: #cd6;
+    --quality-excellent-bg: #2a4a1a;
+    --quality-transparent-fg: #6d6;
+    --quality-transparent-bg: #1a4a2a;
+    --quality-lossless-fg: #8f8;
+    --quality-lossless-bg: #164a24;
+  }
   * { box-sizing: border-box; margin: 0; padding: 0; }
   body { font-family: -apple-system, system-ui, sans-serif; background: #111; color: #eee; padding: 16px; max-width: 800px; margin: 0 auto; }
   h1 { font-size: 1.4em; margin-bottom: 16px; color: #aaa; }
@@ -76,22 +92,29 @@
   .badge-rejected { background: #4a1a1a; color: #d66; }
   .badge-transcode { background: #3a3a1a; color: #da6; }
   .badge-provisional { background: #1f3a24; color: #9d8; }
-  .badge-verified { background: #1a4a2a; color: #6d6; }
+  .badge-verified { background: var(--quality-lossless-bg); color: var(--quality-lossless-fg); }
   .badge-force { background: #1a2a4a; color: #6af; }
   .badge-failed { background: #4a1a1a; color: #d66; }
   .badge-warn { background: #3a3a1a; color: #ec6; }
   .badge-library { background: #1a3a5a; color: #6af; }
-  /* Codec-aware rank tiers — same colour scheme as the rest of the
-     status badges. Used for the "in library" badge when the backend
-     supplies library_rank (computed via lib.quality.quality_rank, which
-     is what the import gate uses — single source of truth). */
-  .badge-rank-lossless    { background: #1a3a5a; color: #6cf; }
-  .badge-rank-transparent { background: #1a4a2a; color: #6d6; }
-  .badge-rank-excellent   { background: #2a4a1a; color: #cd6; }
-  .badge-rank-good        { background: #4a3a1a; color: #ec6; }
-  .badge-rank-acceptable  { background: #4a2a1a; color: #d96; }
-  .badge-rank-poor        { background: #4a1a1a; color: #d66; }
-  .badge-rank-unknown     { background: #2a2a2a; color: #888; }
+  /* Codec-aware ranks and spectral grades share this one red-to-green
+     palette. Inline evidence uses quality-tone-*; badges consume the same
+     foreground plus its matching dark background. */
+  .quality-tone-unknown { color: var(--quality-unknown-fg); }
+  .quality-tone-poor { color: var(--quality-poor-fg); }
+  .quality-tone-acceptable { color: var(--quality-acceptable-fg); }
+  .quality-tone-good { color: var(--quality-good-fg); }
+  .quality-tone-excellent { color: var(--quality-excellent-fg); }
+  .quality-tone-transparent { color: var(--quality-transparent-fg); }
+  .quality-tone-lossless { color: var(--quality-lossless-fg); }
+  .badge-rank-lossless { background: var(--quality-lossless-bg); color: var(--quality-lossless-fg); }
+  .badge-rank-transparent { background: var(--quality-transparent-bg); color: var(--quality-transparent-fg); }
+  .badge-rank-excellent { background: var(--quality-excellent-bg); color: var(--quality-excellent-fg); }
+  .badge-rank-good { background: var(--quality-good-bg); color: var(--quality-good-fg); }
+  .badge-rank-acceptable { background: var(--quality-acceptable-bg); color: var(--quality-acceptable-fg); }
+  .badge-rank-poor { background: var(--quality-poor-bg); color: var(--quality-poor-fg); }
+  .badge-rank-unknown { background: var(--quality-unknown-bg); color: var(--quality-unknown-fg); }
+  .badge-quality-outline { border: 1px solid currentColor; }
   .badge-wanted { background: #5a3a1a; color: #fa6; }
   .badge-downloading { background: #1a3a5a; color: #6cf; }
   .badge-imported { background: #1a4a2a; color: #6d6; }

--- a/web/js/badges.js
+++ b/web/js/badges.js
@@ -17,6 +17,7 @@
 
 import { pipelineStore, pipelineStoreKey } from './state.js';
 import { qualityLabelShort } from './util.js';
+import { qualityRankBadgeClass } from './quality_palette.js';
 
 /**
  * @typedef {Object} BadgeItem
@@ -62,14 +63,14 @@ export function renderStatusBadges(item) {
     // Rank colour overrides the default blue when the backend supplied
     // a codec-aware tier. Falls back to badge-library blue when not.
     const rank = (item.library_rank || '').toLowerCase();
-    const cls = rank ? `badge-rank-${rank}` : 'badge-library';
+    const cls = rank ? qualityRankBadgeClass(rank) : 'badge-library';
     html += `<span class="badge ${cls}">in library${suffix}</span>`;
   }
   // Quality identity of the tracked install (issue #711 provisional
   // surfacing): verified is terminal; provisional means an unverified
   // lossless-source conversion the pipeline is still trying to verify.
   if (item.pipeline_verified_lossless) {
-    html += '<span class="badge badge-verified" title="verified lossless source — search complete">verified</span>';
+    html += '<span class="badge badge-verified badge-rank-lossless" title="verified lossless source — search complete">verified</span>';
   } else if (item.pipeline_provisional) {
     html += '<span class="badge badge-provisional" title="unverified lossless-source conversion — still hunting a verified lossless copy">provisional</span>';
   }

--- a/web/js/history.js
+++ b/web/js/history.js
@@ -1,5 +1,10 @@
 // @ts-check
 import { awstDateTime, esc } from './util.js';
+import {
+  qualityToneClass,
+  spectralGradeClass,
+  spectralGradeLabel,
+} from './quality_palette.js';
 
 /**
  * Render a single V0 probe value with its provenance suffix.
@@ -54,20 +59,15 @@ function stripV0Phrase(avg, min = undefined) {
  * @param {string} grade
  * @param {number|string|undefined} bitrate
  */
-function spectralGradeLabel(grade) {
-  return esc(String(grade || '').replace(/_/g, ' '));
-}
-
 function formatSpectral(grade, bitrate) {
-  const sgColor = grade === 'genuine' ? '#6d6' : grade === 'suspect' ? '#d66' : '#aa8';
   // Show the spectral floor whenever it's present — even when the album's
   // rollup grade is `genuine`, a non-null spectral_bitrate means at least
   // one track triggered a cliff and the min-across-tracks is this value
   // (Eno case, download_log 3291).
   const label = bitrate
-    ? `${spectralGradeLabel(grade)} (~${esc(bitrate)}kbps)`
-    : spectralGradeLabel(grade);
-  return `<span style="color:${sgColor};">${label}</span>`;
+    ? `${esc(spectralGradeLabel(grade))} (~${esc(bitrate)}kbps)`
+    : esc(spectralGradeLabel(grade));
+  return `<span class="${spectralGradeClass(grade)}">${label}</span>`;
 }
 
 /**
@@ -267,11 +267,9 @@ function buildEvidenceCardModel(h) {
     );
     const floor = (h.spectral_bitrate && !basisAlreadyHasFloor)
       ? `~${esc(h.spectral_bitrate)}k ` : '';
-    const sgColor = h.spectral_grade === 'genuine' ? '#6d6'
-      : h.spectral_grade === 'suspect' ? '#d66' : '#aa8';
-    inCells.spectral = `<span style="color:${sgColor};">${floor}${spectralGradeLabel(h.spectral_grade)}</span>`;
+    inCells.spectral = `<span class="${spectralGradeClass(h.spectral_grade)}">${floor}${esc(spectralGradeLabel(h.spectral_grade))}</span>`;
   } else if (h.spectral_attempted && h.spectral_error) {
-    inCells.spectral = `<span style="color:#d66;" title="${esc(h.spectral_error)}">spectral failed</span>`;
+    inCells.spectral = `<span class="${qualityToneClass('poor')}" title="${esc(h.spectral_error)}">spectral failed</span>`;
   }
   // V0 on every candidate: keep the compact comparison numeric and bounded.
   // Probe-kind provenance remains in the expanded V0 probe row.
@@ -308,11 +306,9 @@ function buildEvidenceCardModel(h) {
   }
   if (h.existing_spectral_grade) {
     const floor = h.existing_spectral_bitrate ? `~${esc(h.existing_spectral_bitrate)}k ` : '';
-    const color = h.existing_spectral_grade === 'genuine' ? '#6d6'
-      : h.existing_spectral_grade === 'suspect' ? '#d66' : '#aa8';
-    haveCells.spectral = `<span style="color:${color};">${floor}${spectralGradeLabel(h.existing_spectral_grade)}</span>`;
+    haveCells.spectral = `<span class="${spectralGradeClass(h.existing_spectral_grade)}">${floor}${esc(spectralGradeLabel(h.existing_spectral_grade))}</span>`;
   } else if (h.existing_spectral_attempted && h.existing_spectral_error) {
-    haveCells.spectral = `<span style="color:#d66;" title="${esc(h.existing_spectral_error)}">spectral failed</span>`;
+    haveCells.spectral = `<span class="${qualityToneClass('poor')}" title="${esc(h.existing_spectral_error)}">spectral failed</span>`;
   } else if (h.existing_spectral_bitrate) {
     // Historical attempts measured only the existing floor, not its grade.
     haveCells.spectral = `ungraded (~${esc(h.existing_spectral_bitrate)}k)`;
@@ -497,16 +493,16 @@ export function renderDownloadHistoryItem(h) {
   if (h.spectral_grade || h.existing_spectral_grade || h.existing_spectral_bitrate
       || h.spectral_error || h.existing_spectral_error) {
     const candidate = h.spectral_error
-      ? `<span style="color:#d66;" title="${esc(h.spectral_error)}">analysis failed</span>`
+      ? `<span class="${qualityToneClass('poor')}" title="${esc(h.spectral_error)}">analysis failed</span>`
       : h.spectral_grade
       ? formatSpectral(h.spectral_grade, h.spectral_bitrate)
       : 'unmeasured';
     const existing = h.existing_spectral_error
-      ? `<span style="color:#d66;" title="${esc(h.existing_spectral_error)}">analysis failed</span>`
+      ? `<span class="${qualityToneClass('poor')}" title="${esc(h.existing_spectral_error)}">analysis failed</span>`
       : h.existing_spectral_grade
       ? formatSpectral(h.existing_spectral_grade, h.existing_spectral_bitrate)
       : h.existing_spectral_bitrate
-        ? `<span style="color:#aa8;">ungraded (~${esc(h.existing_spectral_bitrate)}kbps)</span>`
+        ? `<span class="${qualityToneClass('unknown')}">ungraded (~${esc(h.existing_spectral_bitrate)}kbps)</span>`
         : 'unmeasured';
     rows.push(['Spectral', `<span class="r-ev-tag">IN</span> ${candidate} `
       + `<span class="r-ev-tag">HAVE</span> ${existing}`]);

--- a/web/js/long_tail.js
+++ b/web/js/long_tail.js
@@ -31,6 +31,7 @@
  */
 
 import { state, API } from './state.js';
+import { qualityRankBadgeClass } from './quality_palette.js';
 import {
   esc,
   sourceLabel,
@@ -284,7 +285,7 @@ export function renderLongTailRow(row) {
   // mislabel the actual file. The band name + colour is the honest
   // signal; the console (U4) surfaces the exact on-disk format.
   const band = String(row.band || '').toLowerCase();
-  const bandCls = band === MISSING_BAND ? 'badge-wanted' : `badge-rank-${esc(band)}`;
+  const bandCls = band === MISSING_BAND ? 'badge-wanted' : qualityRankBadgeClass(band);
   const bandBadge = `<span class="badge ${bandCls}">${esc(bandLabel(band))}</span>`;
   const flight = row.in_flight_rescue
     ? '<span class="badge badge-new">rescue running</span>'

--- a/web/js/long_tail_console.js
+++ b/web/js/long_tail_console.js
@@ -141,6 +141,11 @@ import {
 } from './util.js';
 import { openReplacePicker, pressingMeta } from './replace_picker.js';
 import { bandLabel, renderLongTail, loadLongTail } from './long_tail.js';
+import {
+  qualityRankBadgeClass,
+  spectralGradeClass,
+  spectralGradeLabel,
+} from './quality_palette.js';
 
 // --- Action console (U4) --------------------------------------------
 //
@@ -662,7 +667,7 @@ function renderSiblingRow(rel) {
   // panel and the picker render the same "country · year · format · Nt".
   const meta = pressingMeta(rel);
   const inLib = rel.in_library
-    ? `<span class="badge badge-rank-${esc(String(rel.library_rank || 'library').toLowerCase())}">in library</span>`
+    ? `<span class="badge ${rel.library_rank ? qualityRankBadgeClass(rel.library_rank) : 'badge-library'}">in library</span>`
     : '';
   const pStatus = rel.pipeline_status
     ? `<span class="badge badge-${esc(String(rel.pipeline_status))}">${esc(String(rel.pipeline_status))}</span>`
@@ -830,8 +835,8 @@ function renderYoutubeBody(result, id) {
 
 /**
  * Inline "spectral: <grade> ~<kbps>kbps" fragment for the on-disk quality
- * line, coloured by grade (green genuine / red suspect-or-transcode /
- * neutral otherwise — matching `pipeline.js`). Returns '' when the grade is
+ * line, coloured through the shared red→orange→yellow→bright-green
+ * spectral palette used by every other view. Returns '' when the grade is
  * unknown (NULL `current_spectral_grade` — pre-2026-05-17 imports or
  * lossy-source transcodes): "if known". Pure.
  *
@@ -844,10 +849,7 @@ function renderSpectralFragment(row) {
   if (!grade) return '';
   const br = (row.current_spectral_bitrate != null)
     ? ` ~${Number(row.current_spectral_bitrate)}kbps` : '';
-  const color = (grade === 'genuine') ? '#6d6'
-    : (grade === 'suspect' || grade === 'likely_transcode') ? '#d88'
-    : '#caa';
-  return ` · <span style="color:${color};">spectral: ${esc(grade)}${esc(br)}</span>`;
+  return ` · <span class="${spectralGradeClass(grade)}">spectral: ${esc(spectralGradeLabel(grade))}${esc(br)}</span>`;
 }
 
 /**
@@ -1957,4 +1959,5 @@ export const __test__ = {
   intentToggleTarget,
   buildAcceptSiblingOptions,
   renderActionsBar,
+  renderSpectralFragment,
 };

--- a/web/js/pipeline.js
+++ b/web/js/pipeline.js
@@ -10,6 +10,7 @@ import { renderSearchPlanDetail } from './search_plan.js';
 import { loadLongTail, renderLongTailBody } from './long_tail.js';
 import { restoreLongTailConsoles } from './long_tail_console.js';
 import { renderPipelineDashboard as renderDashboardCards } from './pipeline_dashboard.js';
+import { qualityToneClass, spectralGradeClass, spectralGradeLabel } from './quality_palette.js';
 
 const VISIBLE_HISTORY_ATTEMPTS = 10;
 
@@ -306,18 +307,14 @@ function renderCurrentQualityRow(req, beetsTracks) {
   const verified = req.verified_lossless === true || req.verified_lossless === 'True';
   let qualitySummary = nominal;
   if (verified) {
-    qualitySummary += ' <span style="color:#6d6;">verified lossless</span>';
-  } else if (spectralGrade === 'suspect' || spectralGrade === 'likely_transcode') {
+    qualitySummary += ` <span class="${qualityToneClass('lossless')}">verified lossless</span>`;
+  } else if (spectralGrade) {
+    // Show every measured grade through the shared palette. Keep the spectral
+    // floor even on a genuine rollup: a non-null bitrate there means some
+    // tracks tripped the cliff detector below the album suspect threshold,
+    // and the shared-spectral clamp still consults that floor (Eno case).
     const brStr = spectralBr ? ` ~${spectralBr}kbps` : '';
-    qualitySummary += ` <span style="color:#d88;">spectral: ${spectralGrade}${brStr}</span>`;
-  } else if (spectralGrade === 'genuine') {
-    // Show the spectral floor even on a genuine rollup. A non-null
-    // spectral_bitrate under genuine means some tracks tripped the
-    // cliff detector but the album-level grade stayed below the
-    // suspect-pct threshold — the 96k signal is what the shared-
-    // spectral clamp in compare_quality now consults (Eno case).
-    const brStr = spectralBr ? ` ~${spectralBr}kbps` : '';
-    qualitySummary += ` <span style="color:#6d6;">spectral: genuine${brStr}</span>`;
+    qualitySummary += ` <span class="${spectralGradeClass(spectralGrade)}">spectral: ${esc(spectralGradeLabel(spectralGrade))}${brStr}</span>`;
   }
   return renderDetailRow('Quality', qualitySummary);
 }

--- a/web/js/quality_palette.js
+++ b/web/js/quality_palette.js
@@ -1,0 +1,84 @@
+// @ts-check
+
+/**
+ * Shared visual ordering for codec-quality ranks and spectral grades.
+ *
+ * CSS owns the actual foreground/background values in `web/index.html`.
+ * Renderers consume only the semantic classes returned here, so the same
+ * rank or spectral grade cannot silently acquire a different colour in a
+ * different view.
+ */
+
+export const QUALITY_RANK_ORDER = Object.freeze([
+  'unknown',
+  'poor',
+  'acceptable',
+  'good',
+  'excellent',
+  'transparent',
+  'lossless',
+]);
+
+export const SPECTRAL_GRADE_ORDER = Object.freeze([
+  'likely_transcode',
+  'suspect',
+  'marginal',
+  'genuine',
+]);
+
+/**
+ * Four spectral grades reuse four stops from the larger quality-rank scale:
+ * red (worst), orange, yellow, and bright green (best).
+ */
+export const SPECTRAL_GRADE_TONES = Object.freeze({
+  likely_transcode: 'poor',
+  suspect: 'acceptable',
+  marginal: 'good',
+  genuine: 'lossless',
+});
+
+const QUALITY_RANKS = new Set(QUALITY_RANK_ORDER);
+
+/** @param {unknown} value */
+function token(value) {
+  return String(value ?? '').trim().toLowerCase();
+}
+
+/** @param {unknown} rank */
+export function qualityRankTone(rank) {
+  const normalized = token(rank);
+  return QUALITY_RANKS.has(normalized) ? normalized : 'unknown';
+}
+
+/** @param {unknown} rank */
+export function qualityToneClass(rank) {
+  return `quality-tone-${qualityRankTone(rank)}`;
+}
+
+/** @param {unknown} rank */
+export function qualityRankBadgeClass(rank) {
+  return `badge-rank-${qualityRankTone(rank)}`;
+}
+
+/** @param {unknown} grade */
+export function spectralGradeTone(grade) {
+  const normalized = token(grade);
+  return Object.hasOwn(SPECTRAL_GRADE_TONES, normalized)
+    ? SPECTRAL_GRADE_TONES[normalized]
+    : 'unknown';
+}
+
+/** @param {unknown} grade */
+export function spectralGradeClass(grade) {
+  return `spectral-grade ${qualityToneClass(spectralGradeTone(grade))}`;
+}
+
+/** @param {unknown} grade */
+export function spectralGradeBadgeClass(grade) {
+  return `badge spectral-grade ${qualityRankBadgeClass(spectralGradeTone(grade))}`;
+}
+
+/** @param {unknown} grade */
+export function spectralGradeLabel(grade) {
+  return token(grade).replace(/_/g, ' ');
+}

--- a/web/js/wrong-matches.js
+++ b/web/js/wrong-matches.js
@@ -2,6 +2,13 @@
 import { API, toast } from './state.js';
 import { esc, externalReleaseUrl, sourceLabel } from './util.js';
 import { renderReplaceButton } from './release_actions.js';
+import {
+  qualityRankBadgeClass,
+  qualityToneClass,
+  spectralGradeBadgeClass,
+  spectralGradeClass,
+  spectralGradeLabel,
+} from './quality_palette.js';
 
 /** @type {boolean} */
 let _loaded = false;
@@ -506,8 +513,8 @@ function formatEntryEvidence(entry) {
   const bitrate = entry && Number.isFinite(entry.spectral_bitrate)
     ? entry.spectral_bitrate : null;
   let spectral = '—';
-  if (grade && bitrate != null) spectral = `${grade} · ${bitrate} kbps`;
-  else if (grade) spectral = grade;
+  if (grade && bitrate != null) spectral = `${spectralGradeLabel(grade)} · ${bitrate} kbps`;
+  else if (grade) spectral = spectralGradeLabel(grade);
   else if (bitrate != null) spectral = `${bitrate} kbps`;
 
   const kind = entry && typeof entry.v0_probe_kind === 'string'
@@ -792,23 +799,6 @@ function renderWrongMatches(data, el) {
 }
 
 /**
- * Return a tier color for a quality_rank name (matches library tab palette).
- * @param {string} rank
- * @returns {string}
- */
-function rankColor(rank) {
-  switch (rank) {
-    case 'lossless':     return '#7cf';
-    case 'transparent':  return '#6d6';
-    case 'excellent':    return '#6d6';
-    case 'good':         return '#da6';
-    case 'acceptable':   return '#da6';
-    case 'poor':         return '#f88';
-    default:             return '#888';
-  }
-}
-
-/**
  * Build the quality badge strip for a group header. Shows format + bitrate,
  * verified-lossless marker, spectral grade (when suspect/likely_transcode),
  * and the rank tier — so the user can tell at a glance whether there's
@@ -849,8 +839,7 @@ function renderQualityBadges(g) {
   const parts = [];
   const label = g.quality_label || (g.format ? String(g.format).toUpperCase() : null);
   if (label) {
-    const color = rankColor(g.quality_rank || '');
-    parts.push(`<span class="badge" style="background:#222;color:${color};border:1px solid ${color};">${esc(label)}</span>`);
+    parts.push(`<span class="badge badge-quality-outline ${qualityRankBadgeClass(g.quality_rank)}">${esc(label)}</span>`);
   } else if (avgBr !== null || minBr !== null) {
     const fallback = [];
     if (avgBr !== null) fallback.push(`avg ${avgBr}k`);
@@ -858,18 +847,15 @@ function renderQualityBadges(g) {
     parts.push(`<span class="badge" style="background:#222;color:#aaa;">${fallback.join(' · ')}</span>`);
   }
   if (g.verified_lossless) {
-    parts.push('<span class="badge" style="background:#1a3a4a;color:#7cf;">verified lossless</span>');
+    parts.push('<span class="badge badge-verified badge-rank-lossless">verified lossless</span>');
   }
   // Spectral badge only when it's worth flagging.
   if (g.current_spectral_grade && g.current_spectral_grade !== 'genuine') {
-    const sColor = g.current_spectral_grade === 'suspect' || g.current_spectral_grade === 'likely_transcode'
-      ? '#f88' : '#da6';
     const suffix = g.current_spectral_bitrate ? ` (${g.current_spectral_bitrate}k)` : '';
-    parts.push(`<span class="badge" style="background:#2a1a1a;color:${sColor};">${esc(g.current_spectral_grade)}${suffix}</span>`);
+    parts.push(`<span class="${spectralGradeBadgeClass(g.current_spectral_grade)}">${esc(spectralGradeLabel(g.current_spectral_grade))}${suffix}</span>`);
   }
   if (g.quality_rank) {
-    const rColor = rankColor(g.quality_rank);
-    parts.push(`<span class="badge" style="background:#1a1a1a;color:${rColor};font-family:monospace;font-size:0.72em;">${esc(g.quality_rank)}</span>`);
+    parts.push(`<span class="badge ${qualityRankBadgeClass(g.quality_rank)}" style="font-family:monospace;font-size:0.72em;">${esc(g.quality_rank)}</span>`);
   }
   return parts.join(' ');
 }
@@ -1036,10 +1022,10 @@ function renderEntry(e, thresholdMilli, requestId) {
   // since FLAC can show up before/after we know it's actually lossless.
   const rank = typeof e.quality_rank === 'string' ? e.quality_rank : '';
   const rankBadge = rank && rank !== 'unknown'
-    ? `<span class="badge" style="background:#1a1a1a;color:${rankColor(rank)};font-family:monospace;font-size:0.72em;margin-left:6px;">${esc(rank)}</span>`
+    ? `<span class="badge ${qualityRankBadgeClass(rank)}" style="font-family:monospace;font-size:0.72em;margin-left:6px;">${esc(rank)}</span>`
     : '';
   const verifiedBadge = e.verified_lossless
-    ? '<span class="badge" style="background:#1a2a1a;color:#6d6;margin-left:6px;">verified lossless</span>'
+    ? '<span class="badge badge-verified badge-rank-lossless" style="margin-left:6px;">verified lossless</span>'
     : '';
 
   const header = `
@@ -1056,7 +1042,7 @@ function renderEntry(e, thresholdMilli, requestId) {
         <span id="wm-entry-dist-${e.download_log_id}" style="color:${distColor};">dist: ${dist}</span>
         <span>${esc(e.scenario || '')}</span>
         <span style="color:#bbb;">${esc(evidence.format)}</span>
-        <span style="color:#888;">spectral: ${esc(evidence.spectral)}</span>
+        <span class="${e.spectral_grade ? spectralGradeClass(e.spectral_grade) : qualityToneClass('unknown')}">spectral: ${esc(evidence.spectral)}</span>
         <span style="color:#888;">${esc(evidence.v0)}</span>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- define one ordered red-to-bright-green palette for codec quality ranks
- map spectral grades onto ordered colours from that same palette
- use the shared classes across Recents, Pipeline, Long Tail, Wrong Matches, and common badges
- humanize spectral labels consistently and remove duplicated inline colour decisions

## Validation

- independent read-only sub-agent review: clean after one inconsistency was fixed
- `nix-shell --run "pyright --threads 4"`
- `nix-shell --run "bash scripts/run_tests.sh"`
- focused palette and UI-renderer tests
- mobile and Wrong Matches browser visual checks
