### PR TITLE
Make issue orchestration outcome-driven

### DIFF
--- a/.claude/skills/orchestrate-issue/SKILL.md
+++ b/.claude/skills/orchestrate-issue/SKILL.md
@@ -1,84 +1,73 @@
 ---
 name: orchestrate-issue
-description: Orchestrate a substantial Cratedigger issue through scoped PRs, independent review, final validation, merge, deployment, live verification, and closure. Use for whole-issue delivery, especially when several workstreams can run concurrently. Do not use for a small patch, diagnosis-only request, or ordinary review.
+description: Orchestrate a substantial Cratedigger issue end to end: understand the scope, coordinate the work, converge efficiently, ship, verify live, and close. Use for issue-sized delivery, not small patches, diagnosis-only work, or ordinary review.
 ---
 
 # Orchestrate Issue
 
-Own the outcome, not every keystroke. Keep scope and architecture coherent while
-agents implement and review bounded pieces. Repository instructions remain the
-authority; load the deploy skill when it is time to ship instead of repeating
-its runbook here.
+You are the orchestrator. Own the issue outcome and keep the whole problem in
+view. This skill defines the broad lifecycle and safety boundaries; use your
+judgment for the route through them.
 
-## Shape the work
+Repository instructions remain authoritative. Do not use Compound Engineering.
+Load the deploy skill when it is time to ship instead of duplicating its
+runbook here.
 
-Read the issue and comments, inspect the relevant code and live state, then make
-a compact coverage ledger: requested outcome, PR, dependency, and evidence.
-Use it to prevent forgotten edge items, not to rewrite the issue as bureaucracy.
+## Own the issue
 
-Prefer small, coherent PRs in isolated worktrees. Use available agent slots for
-independent work when it shortens the critical path; an idle slot is cheaper
-than a duplicate agent. Serialize only for a concrete dependency, overlapping
-ownership, or required merge order. Independent PRs may start from the same
-current `main`; refresh it before final review.
+Understand the issue, its comments, the relevant code, and any live state that
+can change the diagnosis. Keep enough lightweight coverage tracking to know
+that every requested outcome and invariant has an owner and convincing
+evidence. The format does not matter.
 
-## Implement and review
+Choose the delivery shape that best fits the work: one PR or several,
+sequential or parallel, direct implementation or delegation. Agents,
+worktrees, exact SHAs, detailed ledgers, and extra validation passes are tools
+to use when they reduce a concrete risk or shorten the critical path. They are
+not required ceremony.
 
-Compose agents around bounded jobs, not a fixed per-PR template. Implementation
-may stay local, be delegated, or be split across disjoint surfaces. Review may
-be broad or specialist, but must be independent of the code it assesses. Use
-the fewest agents that give real coverage. Do not spend tokens on duplicate
-generalist reviews or send several agents to answer the same question.
+The orchestrator retains responsibility for scope, architecture, integration,
+merge decisions, deployment, and live proof even when work is delegated.
 
-Treat tokens and context length as budgets. Brief agents with the issue slice,
-worktree, exact SHA, and only the relevant rules; point to durable files instead
-of pasting conversation history. Keep handoffs compact. Replace an agent whose
-context is getting long at a coherent boundary. Never carry a subagent into the
-next PR.
+## Converge efficiently
 
-Let useful implementations and reviews overlap when safe. Agents should run
-autonomously without reassurance pings or routine polling.
+Batch implementation failures, test failures, and review findings. During
+development, use focused tests and relevant generated or world-model fuzzing,
+let useful runs reveal the failure set, and fix related problems together.
 
-Keep work local through review. Implementers use focused tests while converging
-and follow the repository's rules for tests, docs, and generated properties.
-The orchestrator understands the diff and scope before handing the exact signed
-local SHA over for independent review.
+Do not stop for a fresh review or full-suite replay after every small test fix.
+Get the implementation and focused checks to a coherent state, then review the
+meaningful converged tree as a whole. Review again only when corrections
+materially change behavior or risk.
 
-Review returns either one consolidated finding batch or `CLEAN`. Fix findings
-locally and repeat on the new SHA. An independent `CLEAN` verdict is final. If
-current `main` changes the reviewed tree, integrate it and review the new SHA.
+Integrate current `main` at sensible boundaries rather than continuously
+chasing it. Once the tree is stable and reviewed, run the repository-required
+whole-tree gates on the final tree. If they find problems, reconverge with
+focused checks and repeat final validation only for the changed tree.
 
-On the reviewed committed SHA, run the check skill once: whole-repo threaded
-Pyright followed by the full suite. Push that validated SHA with one ordinary
-branch push, then open the PR. If final validation requires a code change,
-reconverge with focused tests and review the new SHA before restarting the final
-validation sequence. Do not add post-push review, duplicate suites, Nix replays,
-or post-merge code audits.
+Review should challenge the issue contract and real production path, not just
+confirm that tests are green. Stop when the issue is covered, required checks
+pass, and there is no concrete remaining counterexample.
 
-## Merge and advance
+## Ship and prove it
 
-Confirm the PR head is the reviewed SHA and the coverage ledger is satisfied.
-The PR body and every branch commit message must use canonical `Refs #N` or a
-plain issue URL, never an auto-closing keyword; audit both with
-`python3 scripts/audit_issue_references.py`.
+Keep issue references non-closing while deployment and live proof remain. Use
+the repository's merge method, the deploy skill, and current downstream
+instructions.
 
-Use the repository's merge method and expected-head guard. Confirm the merge
-tree equals the reviewed PR-head tree, update the ledger, and keep independent
-work moving. Do not rerun code gates after an unchanged reviewed tree merges.
+Verify the deployed system rather than only the deployment command. Exercise
+the real CLI, API, or user-facing path and account for the service lifecycle
+that loads the new code. Close the issue deliberately only after its scope is
+covered and live evidence supports the result. Record unrelated follow-up work
+separately, and clean up temporary worktrees when they are no longer useful.
 
-## Ship
+## Communicate like an orchestrator
 
-When the ledger is complete, use the deploy skill. Verify the exact deployed
-source and the real user-facing behavior, including the post-switch successor
-cycle where the service lifecycle requires it. Screenshots or live data should
-prove the reported symptom, not merely that deployment commands succeeded.
+Lead with outcomes, decisions, material milestones, and blockers. Do not make
+the operator follow routine agent pings, exact-SHA churn, or every intermediate
+test failure. When evidence changes the diagnosis, say so and adjust.
 
-Record the PR, review, deploy, and live evidence. Only after the coverage ledger
-is complete and live verification succeeds, close the issue deliberately.
-
-## Keep perspective
-
-The orchestrator owns scope, architectural judgment, merge authority, and live
-evidence. Agents own bounded execution and independent challenge. Keep useful
-slots busy, communicate only material milestones or blockers, and lead the
-handoff with what shipped and how it was proven.
+Completion means the issue is covered, the converged change has been reviewed
+in proportion to its risk, required final checks pass, the work is merged and
+deployed, live behavior is verified, and the issue is closed with the evidence
+that matters.


### PR DESCRIPTION
## Summary

- make the orchestrator explicitly accountable for the whole issue outcome
- replace fixed agent, SHA, PR, and review choreography with risk-based judgment
- batch test failures and review the converged tree instead of every micro-fix
- keep deployment and live verification as the completion boundary

## Validation

- `nix-shell --run "pyright --threads 4"`
- `nix-shell --run "bash scripts/run_tests.sh"`
- AI adapter generation/check and focused portability/reference-contract tests