### PR TITLE
Reuse candidate evidence for unchanged imports

### DIFF
--- a/docs/generated-testing.md
+++ b/docs/generated-testing.md
@@ -55,6 +55,7 @@ Hunting — Generated-First".
 | `tests/test_quality_lineage_generated.py` | target-quality contracts and measurement/evidence projection | `from_explicit_label` rejects bare MP3 across case/whitespace variants; `from_projection` requires a CBR/VBR boolean and preserves it for bare MP3; explicit V/numeric labels own their mode and gate policy even when the measured boolean contradicts them; exact single/equal/differing-track projections preserve mode; measurement-only early rejects never claim target policy |
 | `tests/test_evidence_generated.py` | `ensure_current_evidence_for_action` | converted current evidence requires a linked source V0 fact (fix `6cf26a4`): never `loaded` without it, request scalar mutations cannot change the result, and missing evidence fails closed; fingerprint rebuilds carry only source-subject facts with `carried` provenance |
 | `tests/test_preview_failure_evidence_generated.py` | `process_claimed_preview_job` plus failure-point current-evidence preparation/enrichment | every producer stage that terminates as `measurement_failed` reaches one lifecycle owner: request-owned failures always persist their job/audit and diagnostic; an exact readable installed release links a complete pre-attempt HAVE snapshot regardless of stage or job type; missing identity, absent/unreadable HAVE, and preparation/enrichment faults stay fail-soft without fabricating evidence |
+| `tests/test_spectral_attempt_audit_generated.py` | both attempt-audit adapters plus `process_claimed_preview_job` | candidate measurement is once per content snapshot across automation and force jobs: a matching snapshot projects the persisted spectral fact without another candidate scan, a changed snapshot runs full preview exactly once, and the installed HAVE scan remains an independent authority boundary |
 | `tests/test_lossless_lineage_check_generated.py` | migration 057's real PostgreSQL CHECK plus same-address FakePipelineDB upsert worlds | v4 installed-subject spectral is rejected exactly when source V0, verified-lossless proof, or a case-normalized lossless conversion source establishes lossless lineage; native installed facts, source-subject facts, M4A-container-only rows, and legacy v1/v3 rows remain valid; failures name the exact constraint; a same-key merge clears stale installed spectral when new lineage arrives while preserving a source-subject fact |
 | `tests/test_slskd_events_generated.py` | `ingest_download_file_events` (event stamping — the ONLY source of completed-file locations) | stamping oracle (newest decodable event per key in the new-events window, nothing else); totality + exactly-once over wild feeds (dup ids, garbage timestamps, undecodable payloads, pruned/absent cursors, rows leaving `downloading` mid-ingest); duplicate-id invariance (mid-pagination shape) |
 | `tests/test_completed_purge_generated.py` | `purge_completed_transfers` | a write-ahead intent becomes ownership only after POST acceptance; pending and foreign keys are never mutated; 1-N successor IDs for each confirmed `(username, filename)` key remain owned across every terminal state; terminal accounting conserves every row through successful removals, false returns, and exceptions (`removed + removal_failed + foreign`); failed removals remain resident, a successful second pass is idempotent, and every removal uses `remove=true` |
@@ -142,6 +143,14 @@ exact new snapshot without allowing an unenriched retry to become
 authoritative. Ordinary and force-import pins then prove installed-only facts
 produce the expected `have_analysis_error`, keep the request wanted, and
 converge after the production enrichment path measures the exact new snapshot.
+
+Candidate evidence reuse is also crossed through the real PostgreSQL preview
+queue for both automation and force jobs. Generated worlds vary provider
+identity, codec, spectral grade, and whether the candidate snapshot changes.
+An unchanged snapshot must reach `candidate_status=reused` with no full preview
+and no candidate analyzer call; a changed snapshot must run full preview once.
+The explicit unchanged force example uses the Rolling Stones incident identity;
+the exact 12-FLAC detail is pinned in the faster generated module.
 
 The expanded lifecycle generator also shrank a separate counterexample from a
 live-census seed: a successful unverified retained FLAC import widened an

--- a/docs/quality-verification.md
+++ b/docs/quality-verification.md
@@ -492,11 +492,14 @@ another observation of that address. If the files have changed since capture,
 backfill writes
 a fresh row, repoints the FK, and persists the changed-snapshot enrichment
 gate described above. Either way enrichment can then complete the surviving
-row. The candidate-reuse preview fast path also
-persists its attempt-time HAVE scan through
+row. The candidate-reuse preview fast path first verifies the content
+snapshot, then projects the candidate spectral fact from that content-addressed
+evidence without scanning those bytes again. It separately persists any
+required attempt-time HAVE scan through
 `persist_exact_current_spectral_from_attempt` before marking the job
-importable, so a reused-evidence force import decides against the same
-completed HAVE the full measurement path would see.
+importable, so reused-evidence force and automation imports decide against the
+same completed HAVE the full measurement path would see. A changed candidate
+snapshot misses the front gate and runs full preview measurement again.
 
 **Search narrowing companion.** When `lossless_source_locked` fires —
 in the importer (`lib/dispatch/core.py`) or wrong-match cleanup

--- a/scripts/import_preview_worker.py
+++ b/scripts/import_preview_worker.py
@@ -674,6 +674,15 @@ def process_claimed_preview_job(
                 spectral_detail_analyzer or analyze_spectral_audit_path
             ),
             existing_resolver=audit_resolver,
+            # The front-gate already proved this exact content snapshot owns
+            # complete candidate evidence. Re-project its persisted spectral
+            # fact into the attempt audit instead of analyzing the same bytes
+            # again. HAVE remains separate below: ordinary installed bytes
+            # are still freshly analyzed for this replacement attempt.
+            candidate_detail=spectral_detail_from_persisted_source(
+                front_gate_result.evidence.measurement.spectral_grade,
+                front_gate_result.evidence.measurement.spectral_bitrate_kbps,
+            ),
         )
         # The reuse fast path skips measurement but must still make its
         # HAVE scan durable BEFORE the importer decides — an audit-only

--- a/tests/test_import_queue.py
+++ b/tests/test_import_queue.py
@@ -2264,8 +2264,11 @@ class TestImportPreviewWorkerFrontGate(unittest.TestCase):
 
         preview.assert_not_called()
         preimport.assert_not_called()
-        self.assertEqual(len(audit_calls), 1)
-        self.assertEqual(audit_calls[0], source)
+        self.assertEqual(
+            audit_calls,
+            [],
+            "matching candidate evidence must not trigger another source scan",
+        )
         assert updated is not None
         self.assertEqual(updated.status, "queued")
         self.assertEqual(updated.preview_status, "evidence_ready")
@@ -2449,7 +2452,11 @@ class TestImportPreviewWorkerFrontGate(unittest.TestCase):
                     ),
                 )
 
-        self.assertEqual(calls, [source, existing])
+        self.assertEqual(
+            calls,
+            [existing],
+            "candidate reuse must not suppress the separate HAVE scan",
+        )
         assert updated is not None and updated.preview_result is not None
         import_result = ImportResult.from_dict(cast(
             dict[str, Any],
@@ -2629,8 +2636,8 @@ class TestImportPreviewWorkerFrontGate(unittest.TestCase):
         self.assertEqual(linked.measurement.spectral_grade, "genuine")
         self.assertIsNone(linked.measurement.spectral_bitrate_kbps)
 
-    def test_have_lookup_failure_still_analyzes_candidate(self):
-        """A DB failure on HAVE provenance must not suppress the WANT scan."""
+    def test_have_lookup_failure_does_not_reanalyze_reused_candidate(self):
+        """A HAVE lookup failure cannot revoke matching candidate evidence."""
         from scripts import import_preview_worker
         from lib.measurement import ExistingSpectralAuditLookup
         from lib.quality import SpectralAnalysisDetail
@@ -2677,7 +2684,7 @@ class TestImportPreviewWorkerFrontGate(unittest.TestCase):
                 ),
             )
 
-        self.assertEqual(calls, [source])
+        self.assertEqual(calls, [])
         assert updated is not None
         assert updated.preview_result is not None
         import_result = ImportResult.from_dict(cast(
@@ -2687,13 +2694,13 @@ class TestImportPreviewWorkerFrontGate(unittest.TestCase):
         assert import_result.spectral.candidate is not None
         self.assertEqual(
             import_result.spectral.candidate.grade,
-            "likely_transcode",
+            "genuine",
         )
         self.assertEqual(updated.status, "queued")
         self.assertEqual(updated.preview_status, "evidence_ready")
         self.assertIsNotNone(updated.importable_at)
 
-    def test_reused_evidence_audit_failure_is_fail_soft(self):
+    def test_reused_evidence_does_not_call_candidate_analyzer(self):
         from scripts import import_preview_worker
 
         with tempfile.TemporaryDirectory() as source:
@@ -2716,8 +2723,10 @@ class TestImportPreviewWorkerFrontGate(unittest.TestCase):
             assert claimed is not None
             self._seed_evidence_for_download_log(db, download_log_id, source)
 
+            analyzer_calls: list[str] = []
+
             def raising_analyzer(path: str):
-                del path
+                analyzer_calls.append(path)
                 raise RuntimeError("spectral backend unavailable")
 
             updated = import_preview_worker.process_claimed_preview_job(
@@ -2735,11 +2744,10 @@ class TestImportPreviewWorkerFrontGate(unittest.TestCase):
         )
         assert result.spectral.candidate is not None
         assert result.spectral.existing is not None
+        self.assertEqual(analyzer_calls, [])
         self.assertTrue(result.spectral.candidate.attempted)
-        self.assertIn(
-            "spectral backend unavailable",
-            result.spectral.candidate.error or "",
-        )
+        self.assertEqual(result.spectral.candidate.grade, "genuine")
+        self.assertIsNone(result.spectral.candidate.error)
         self.assertFalse(result.spectral.existing.attempted)
         self.assertIsNone(result.spectral.existing.error)
 
@@ -2750,6 +2758,7 @@ class TestImportPreviewWorkerFrontGate(unittest.TestCase):
         not invoke _materialize_processing_dir.
         """
         from scripts import import_preview_worker
+        from lib.quality import SpectralAnalysisDetail
 
         with tempfile.TemporaryDirectory() as staged:
             with open(os.path.join(staged, "01.flac"), "wb") as handle:
@@ -2780,6 +2789,15 @@ class TestImportPreviewWorkerFrontGate(unittest.TestCase):
             assert claimed is not None
             self._seed_evidence_for_job(db, claimed.id, staged)
 
+            candidate_audit_calls: list[str] = []
+
+            def analyze(path: str):
+                candidate_audit_calls.append(path)
+                return SpectralAnalysisDetail(
+                    attempted=True,
+                    grade="genuine",
+                )
+
             with patch(
                 "scripts.import_preview_worker.measure_and_persist_candidate_evidence",
             ) as preview, patch(
@@ -2790,11 +2808,13 @@ class TestImportPreviewWorkerFrontGate(unittest.TestCase):
                 updated = import_preview_worker.process_claimed_preview_job(
                     db,
                     claimed,
+                    spectral_detail_analyzer=analyze,
                 )
 
         preview.assert_not_called()
         preimport.assert_not_called()
         materialize.assert_not_called()
+        self.assertEqual(candidate_audit_calls, [])
         assert updated is not None
         self.assertEqual(updated.preview_status, "evidence_ready")
         assert updated.preview_result is not None
@@ -2947,6 +2967,97 @@ class TestImportPreviewWorkerFrontGate(unittest.TestCase):
         assert evidence is not None
         self.assertEqual(len(evidence.files), 1)
         self.assertEqual(evidence.files[0].relative_path, "01.mp3")
+
+    def test_rolling_stones_force_reuses_all_twelve_unchanged_flacs(self):
+        """Live dl 37709: unchanged force-import candidate is measured once."""
+        from lib.quality_evidence import EvidenceBuildResult
+        from lib.measurement import ExistingSpectralAuditLookup
+        from lib.quality import SpectralAnalysisDetail
+        from scripts import import_preview_worker
+
+        with tempfile.TemporaryDirectory() as source:
+            for track in range(1, 13):
+                with open(
+                    os.path.join(source, f"{track:02d}.flac"),
+                    "wb",
+                ) as handle:
+                    handle.write(f"rolling-stones-track-{track}".encode())
+
+            db = FakePipelineDB()
+            db.seed_request(make_request_row(
+                id=8883,
+                status="wanted",
+                mb_release_id="1f9fdeeb-59b4-4751-91b6-be38fb76c380",
+                artist_name="The Rolling Stones",
+                album_title="The Rolling Stones No. 2",
+            ))
+            download_log_id = db.log_download(8883, outcome="rejected")
+            db.enqueue_import_job(
+                IMPORT_JOB_FORCE,
+                request_id=8883,
+                dedupe_key=force_import_dedupe_key(download_log_id),
+                payload=force_import_payload(
+                    download_log_id=download_log_id,
+                    failed_path=source,
+                    source_username="buckwheat8404",
+                ),
+            )
+            claimed = db.claim_next_import_preview_job(worker_id="preview")
+            assert claimed is not None
+            _seed_candidate_for_download_log(
+                db,
+                download_log_id,
+                mb_release_id="1f9fdeeb-59b4-4751-91b6-be38fb76c380",
+                source_path=source,
+                files=snapshot_audio_files(source),
+                measurement=AudioQualityMeasurement(
+                    min_bitrate_kbps=3301,
+                    avg_bitrate_kbps=3505,
+                    median_bitrate_kbps=3515,
+                    format="FLAC",
+                    spectral_grade="genuine",
+                    spectral_subject="source",
+                    spectral_provenance="measured",
+                ),
+                codec="flac",
+                container="flac",
+                storage_format="FLAC",
+                target_format="opus 128",
+            )
+            candidate_scans: list[str] = []
+            preview_calls = 0
+
+            def analyze(path: str) -> SpectralAnalysisDetail:
+                candidate_scans.append(path)
+                return SpectralAnalysisDetail(attempted=True, grade="genuine")
+
+            def full_preview(*_args: Any, **_kwargs: Any):
+                nonlocal preview_calls
+                preview_calls += 1
+                raise AssertionError("matching evidence must skip full preview")
+
+            updated = import_preview_worker.process_claimed_preview_job(
+                db,
+                claimed,
+                spectral_detail_analyzer=analyze,
+                existing_spectral_resolver=(
+                    lambda _release_id: ExistingSpectralAuditLookup()
+                ),
+                preview_fn=full_preview,
+                current_evidence_loader=(
+                    lambda *_args, **_kwargs: EvidenceBuildResult(
+                        None,
+                        "empty_current",
+                        "exact album not in beets",
+                    )
+                ),
+            )
+
+        self.assertEqual(preview_calls, 0)
+        self.assertEqual(candidate_scans, [])
+        assert updated is not None and updated.preview_result is not None
+        self.assertEqual(updated.preview_status, "evidence_ready")
+        self.assertEqual(updated.preview_result["candidate_status"], "reused")
 
 
 class TestYoutubeImportJobType(unittest.TestCase):

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -6038,7 +6038,7 @@ class TestPreviewFrontGateSlice(unittest.TestCase):
             }
             audit = SpectralDetail(
                 candidate=SpectralAnalysisDetail(
-                    attempted=True, grade="suspect", bitrate_kbps=160),
+                    attempted=True, grade="genuine", bitrate_kbps=None),
                 existing=SpectralAnalysisDetail(
                     attempted=True, grade="genuine", bitrate_kbps=None),
             )
@@ -6079,7 +6079,11 @@ class TestPreviewFrontGateSlice(unittest.TestCase):
                     ),
                 )
 
-            self.assertEqual(audit_calls, [source, "existing"])
+            self.assertEqual(
+                audit_calls,
+                ["existing"],
+                "candidate reuse must preserve the separate HAVE scan",
+            )
             assert updated is not None
             assert updated.preview_result is not None
             preview_ir = ImportResult.from_dict(
@@ -6214,7 +6218,11 @@ class TestPreviewFrontGateSlice(unittest.TestCase):
                     spectral_detail_analyzer=analyze,
                 )
 
-            self.assertEqual(len(audit_calls), 1)
+            self.assertEqual(
+                audit_calls,
+                [],
+                "automation must not reanalyze a matching candidate snapshot",
+            )
 
         self.assertFalse(sentinels["preview_called"])
         self.assertFalse(sentinels["measure_called"])

--- a/tests/test_spectral_attempt_audit_generated.py
+++ b/tests/test_spectral_attempt_audit_generated.py
@@ -1,5 +1,6 @@
 """Generated invariant for independent two-sided spectral attempt audit."""
 
+import configparser
 from contextlib import contextmanager
 import logging
 import os
@@ -8,12 +9,12 @@ import subprocess as sp
 import tempfile
 import unittest
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, Literal
 from unittest.mock import patch
 
 import msgspec
 
-from hypothesis import given, strategies as st
+from hypothesis import example, given, strategies as st
 
 import tests._hypothesis_profiles  # noqa: F401  (loads active profile)
 
@@ -56,10 +57,11 @@ def _have_scan_boundary_holds(
     analyzer_calls: list[str],
     *,
     preserve_existing_source: bool,
+    candidate_reused: bool,
 ) -> bool:
-    expected = ["candidate"] if preserve_existing_source else [
-        "candidate", "existing",
-    ]
+    expected = [] if candidate_reused else ["candidate"]
+    if not preserve_existing_source:
+        expected.append("existing")
     return analyzer_calls == expected
 
 
@@ -265,6 +267,284 @@ def _run_have_boundary_through_both_adapters(
         measured.spectral_audit,
         reused,
     )
+
+
+PreviewJobMode = Literal["automation", "force"]
+
+
+def assert_candidate_snapshot_reuse(
+    *,
+    snapshot_changed: bool,
+    has_have: bool,
+    full_preview_calls: int,
+    analyzer_roles: list[str],
+    candidate_status: str | None,
+    persisted_candidate_grade: str | None,
+    expected_candidate_grade: str,
+) -> None:
+    """Candidate work is once per snapshot; HAVE authority stays separate."""
+
+    if snapshot_changed:
+        if full_preview_calls != 1:
+            raise AssertionError("changed candidate snapshot did not remeasure")
+        if candidate_status == "reused":
+            raise AssertionError("changed candidate snapshot was marked reused")
+        return
+
+    if full_preview_calls:
+        raise AssertionError("matching candidate snapshot ran full preview")
+    if "candidate" in analyzer_roles:
+        raise AssertionError("matching candidate evidence was analyzed again")
+    expected_roles = ["existing"] if has_have else []
+    if analyzer_roles != expected_roles:
+        raise AssertionError(
+            "candidate reuse changed the independent HAVE scan boundary"
+        )
+    if candidate_status != "reused":
+        raise AssertionError("matching candidate snapshot lost reuse provenance")
+    if persisted_candidate_grade != expected_candidate_grade:
+        raise AssertionError("reused preview dropped persisted candidate spectral")
+
+
+def _run_candidate_snapshot_reuse_world(
+    *,
+    job_mode: PreviewJobMode,
+    snapshot_changed: bool,
+    has_have: bool,
+    candidate_grade: str,
+    track_count: int,
+) -> tuple[int, list[str], str | None, str | None]:
+    from lib.config import CratediggerConfig
+    from lib.import_queue import (
+        IMPORT_JOB_AUTOMATION,
+        IMPORT_JOB_FORCE,
+        automation_import_dedupe_key,
+        force_import_dedupe_key,
+        force_import_payload,
+    )
+    from lib.import_preview import ImportPreviewResult
+    from lib.measurement import ExistingSpectralAuditLookup
+    from lib.quality import (
+        AudioQualityMeasurement,
+        ImportResult,
+        SpectralAnalysisDetail,
+    )
+    from lib.quality_evidence import EvidenceBuildResult, snapshot_audio_files
+    from scripts.import_preview_worker import process_claimed_preview_job
+    from tests.fakes import FakePipelineDB
+    from tests.helpers import make_album_quality_evidence, make_request_row
+
+    request_id = 8883
+    mbid = "generated-candidate-reuse-mbid"
+    with tempfile.TemporaryDirectory() as candidate, \
+         tempfile.TemporaryDirectory() as existing:
+        for track in range(1, track_count + 1):
+            Path(candidate, f"{track:02d}.mp3").write_bytes(
+                f"candidate-{track}".encode()
+            )
+        Path(existing, "01.mp3").write_bytes(b"installed-have")
+
+        db = FakePipelineDB()
+        active_state = {
+            "filetype": "mp3",
+            "enqueued_at": "2026-07-21T00:00:00+00:00",
+            "current_path": candidate,
+            "files": [
+                {
+                    "username": "generated-peer",
+                    "filename": f"Artist\\Album\\{track:02d}.mp3",
+                    "file_dir": "Artist\\Album",
+                    "size": track,
+                }
+                for track in range(1, track_count + 1)
+            ],
+        }
+        db.seed_request(make_request_row(
+            id=request_id,
+            mb_release_id=mbid,
+            status="downloading" if job_mode == "automation" else "wanted",
+            active_download_state=(
+                active_state if job_mode == "automation" else None
+            ),
+        ))
+
+        current = None
+        if has_have:
+            current = make_album_quality_evidence(
+                mb_release_id=mbid,
+                source_path=existing,
+                files=snapshot_audio_files(existing),
+                measurement=AudioQualityMeasurement(
+                    min_bitrate_kbps=192,
+                    avg_bitrate_kbps=196,
+                    median_bitrate_kbps=195,
+                    format="MP3",
+                    spectral_grade="genuine",
+                    spectral_subject="installed",
+                    spectral_provenance="measured",
+                ),
+            )
+            db.upsert_album_quality_evidence(current)
+            current = db.find_album_quality_evidence(
+                mb_release_id=mbid,
+                snapshot_fingerprint=current.snapshot_fingerprint,
+            )
+            assert current is not None and current.id is not None
+            db.set_request_current_evidence(request_id, current.id)
+
+        download_log_id: int | None = None
+        if job_mode == "force":
+            download_log_id = db.log_download(request_id, outcome="rejected")
+            job = db.enqueue_import_job(
+                IMPORT_JOB_FORCE,
+                request_id=request_id,
+                dedupe_key=force_import_dedupe_key(download_log_id),
+                payload=force_import_payload(
+                    download_log_id=download_log_id,
+                    failed_path=candidate,
+                    source_username="generated-peer",
+                ),
+            )
+        else:
+            job = db.enqueue_import_job(
+                IMPORT_JOB_AUTOMATION,
+                request_id=request_id,
+                dedupe_key=automation_import_dedupe_key(request_id),
+                payload={},
+            )
+
+        candidate_evidence = make_album_quality_evidence(
+            mb_release_id=mbid,
+            source_path=candidate,
+            files=snapshot_audio_files(candidate),
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=245,
+                avg_bitrate_kbps=256,
+                median_bitrate_kbps=252,
+                format="MP3",
+                spectral_grade=candidate_grade,
+                spectral_subject="source",
+                spectral_provenance="measured",
+            ),
+        )
+        db.upsert_album_quality_evidence(candidate_evidence)
+        stored_candidate = db.find_album_quality_evidence(
+            mb_release_id=mbid,
+            snapshot_fingerprint=candidate_evidence.snapshot_fingerprint,
+        )
+        assert stored_candidate is not None and stored_candidate.id is not None
+        if download_log_id is not None:
+            db.set_download_log_candidate_evidence(
+                download_log_id,
+                stored_candidate.id,
+            )
+        else:
+            db.set_import_job_candidate_evidence(job.id, stored_candidate.id)
+
+        if snapshot_changed:
+            Path(candidate, f"{track_count:02d}.mp3").write_bytes(
+                b"changed-candidate-snapshot"
+            )
+
+        claimed = db.claim_next_import_preview_job(worker_id="generated")
+        assert claimed is not None and claimed.id == job.id
+        full_preview_calls = 0
+        analyzer_roles: list[str] = []
+
+        def analyze(path: str):
+            role = "existing" if path == existing else "candidate"
+            analyzer_roles.append(role)
+            return SpectralAnalysisDetail(
+                attempted=True,
+                grade="suspect" if role == "existing" else candidate_grade,
+                bitrate_kbps=128 if role == "existing" else None,
+            )
+
+        def full_preview(db_arg: Any, _job: Any) -> ImportPreviewResult:
+            nonlocal full_preview_calls
+            full_preview_calls += 1
+            fresh = make_album_quality_evidence(
+                mb_release_id=mbid,
+                source_path=candidate,
+                files=snapshot_audio_files(candidate),
+                measurement=AudioQualityMeasurement(
+                    min_bitrate_kbps=245,
+                    avg_bitrate_kbps=256,
+                    median_bitrate_kbps=252,
+                    format="MP3",
+                    spectral_grade=candidate_grade,
+                    spectral_subject="source",
+                    spectral_provenance="measured",
+                ),
+            )
+            db_arg.upsert_album_quality_evidence(fresh)
+            persisted = db_arg.find_album_quality_evidence(
+                mb_release_id=mbid,
+                snapshot_fingerprint=fresh.snapshot_fingerprint,
+            )
+            assert persisted is not None and persisted.id is not None
+            if download_log_id is not None:
+                db_arg.set_download_log_candidate_evidence(
+                    download_log_id,
+                    persisted.id,
+                )
+            else:
+                db_arg.set_import_job_candidate_evidence(job.id, persisted.id)
+            return ImportPreviewResult(
+                mode="path",
+                verdict="evidence_ready",
+                decision="import",
+                reason="import",
+                source_path=candidate,
+            )
+
+        def load_current(*_args: Any, **_kwargs: Any) -> EvidenceBuildResult:
+            if current is None:
+                return EvidenceBuildResult(
+                    None,
+                    "empty_current",
+                    "exact album not in beets",
+                )
+            return EvidenceBuildResult(current, "ready")
+
+        ini = configparser.ConfigParser()
+        ini["Beets Validation"] = {
+            "harness_path": "/fake/harness/run_beets_harness.sh",
+            "audio_check": "off",
+        }
+        ini["Pipeline DB"] = {"enabled": "true"}
+        cfg = CratediggerConfig.from_ini(ini)
+        with patch(
+            "scripts.import_preview_worker.read_runtime_config",
+            return_value=cfg,
+        ):
+            updated = process_claimed_preview_job(
+                db,
+                claimed,
+                spectral_detail_analyzer=analyze,
+                existing_spectral_resolver=lambda _release_id: (
+                    ExistingSpectralAuditLookup(
+                        path=existing if has_have else None,
+                    )
+                ),
+                preview_fn=full_preview,
+                current_evidence_loader=load_current,
+            )
+        assert updated is not None
+        preview_result = updated.preview_result or {}
+        candidate_status = preview_result.get("candidate_status")
+        persisted_grade = None
+        import_result_raw = preview_result.get("import_result")
+        if isinstance(import_result_raw, dict):
+            import_result = ImportResult.from_dict(import_result_raw)
+            if import_result.spectral.candidate is not None:
+                persisted_grade = import_result.spectral.candidate.grade
+        return (
+            full_preview_calls,
+            analyzer_roles,
+            candidate_status if isinstance(candidate_status, str) else None,
+            persisted_grade,
+        )
 
 
 def _authoritative_have_matches(detail, grade, bitrate) -> bool:
@@ -509,16 +789,105 @@ class TestAttemptAuditCheckerQualification(unittest.TestCase):
         self.assertFalse(_have_scan_boundary_holds(
             ["candidate"],
             preserve_existing_source=False,
+            candidate_reused=False,
         ))
 
     def test_have_boundary_checker_rejects_blanket_scan_mutant(self):
         self.assertFalse(_have_scan_boundary_holds(
             ["candidate", "existing"],
             preserve_existing_source=True,
+            candidate_reused=True,
         ))
+
+    def test_have_boundary_checker_rejects_reused_candidate_rescan(self):
+        self.assertFalse(_have_scan_boundary_holds(
+            ["candidate", "existing"],
+            preserve_existing_source=False,
+            candidate_reused=True,
+        ))
+
+    def test_candidate_reuse_checker_rejects_matching_snapshot_rescan(self):
+        with self.assertRaises(AssertionError):
+            assert_candidate_snapshot_reuse(
+                snapshot_changed=False,
+                has_have=False,
+                full_preview_calls=0,
+                analyzer_roles=["candidate"],
+                candidate_status="reused",
+                persisted_candidate_grade="genuine",
+                expected_candidate_grade="genuine",
+            )
+
+    def test_candidate_reuse_checker_rejects_changed_snapshot_skip(self):
+        with self.assertRaises(AssertionError):
+            assert_candidate_snapshot_reuse(
+                snapshot_changed=True,
+                has_have=False,
+                full_preview_calls=0,
+                analyzer_roles=[],
+                candidate_status="reused",
+                persisted_candidate_grade="genuine",
+                expected_candidate_grade="genuine",
+            )
 
 
 class TestAttemptAuditGenerated(unittest.TestCase):
+    @given(
+        job_mode=st.sampled_from(("automation", "force")),
+        snapshot_changed=st.booleans(),
+        has_have=st.booleans(),
+        candidate_grade=st.sampled_from((
+            "genuine",
+            "marginal",
+            "suspect",
+            "likely_transcode",
+        )),
+        track_count=st.integers(min_value=1, max_value=12),
+    )
+    @example(
+        job_mode="force",
+        snapshot_changed=False,
+        has_have=False,
+        candidate_grade="genuine",
+        track_count=12,
+    )
+    @example(
+        job_mode="automation",
+        snapshot_changed=False,
+        has_have=True,
+        candidate_grade="suspect",
+        track_count=1,
+    )
+    def test_candidate_measurement_is_once_per_snapshot_across_job_modes(
+        self,
+        job_mode: PreviewJobMode,
+        snapshot_changed: bool,
+        has_have: bool,
+        candidate_grade: str,
+        track_count: int,
+    ):
+        (
+            full_preview_calls,
+            analyzer_roles,
+            candidate_status,
+            persisted_candidate_grade,
+        ) = _run_candidate_snapshot_reuse_world(
+            job_mode=job_mode,
+            snapshot_changed=snapshot_changed,
+            has_have=has_have,
+            candidate_grade=candidate_grade,
+            track_count=track_count,
+        )
+        assert_candidate_snapshot_reuse(
+            snapshot_changed=snapshot_changed,
+            has_have=has_have,
+            full_preview_calls=full_preview_calls,
+            analyzer_roles=analyzer_roles,
+            candidate_status=candidate_status,
+            persisted_candidate_grade=persisted_candidate_grade,
+            expected_candidate_grade=candidate_grade,
+        )
+
     def test_gespenst_mp3_scans_exact_have_through_both_adapters(self):
         (
             preserve_source,
@@ -537,7 +906,7 @@ class TestAttemptAuditGenerated(unittest.TestCase):
 
         self.assertFalse(preserve_source)
         self.assertEqual(normal_calls, ["candidate", "existing"])
-        self.assertEqual(reused_calls, ["candidate", "existing"])
+        self.assertEqual(reused_calls, ["existing"])
         for audit in (normal_audit, reused_audit):
             assert audit.existing is not None
             self.assertEqual(audit.existing.grade, "suspect")
@@ -684,11 +1053,16 @@ class TestAttemptAuditGenerated(unittest.TestCase):
                 or lossless_v0_lineage
             ),
         )
-        for calls in (normal_calls, reused_calls):
-            self.assertTrue(_have_scan_boundary_holds(
-                calls,
-                preserve_existing_source=preserve_existing_source,
-            ))
+        self.assertTrue(_have_scan_boundary_holds(
+            normal_calls,
+            preserve_existing_source=preserve_existing_source,
+            candidate_reused=False,
+        ))
+        self.assertTrue(_have_scan_boundary_holds(
+            reused_calls,
+            preserve_existing_source=preserve_existing_source,
+            candidate_reused=True,
+        ))
         for audit in (normal_audit, reused_audit):
             assert audit.existing is not None
             if preserve_existing_source:

--- a/tests/world_model/state_machine.py
+++ b/tests/world_model/state_machine.py
@@ -862,6 +862,90 @@ TestGeneratedRelocatedForceImportWorld \
     )
 
 
+class TestGeneratedCandidateEvidenceReuseWorld(unittest.TestCase):
+    """Candidate measurement is once per content snapshot in both job modes."""
+
+    @given(
+        identity_source=st.sampled_from(("mb", "discogs")),
+        job_mode=st.sampled_from(("automation", "force")),
+        snapshot_changed=st.booleans(),
+        codec=st.sampled_from(("mp3", "flac")),
+        spectral_grade=st.sampled_from((
+            "genuine",
+            "marginal",
+            "suspect",
+            "likely_transcode",
+        )),
+    )
+    @example(
+        identity_source="mb",
+        job_mode="force",
+        snapshot_changed=False,
+        codec="flac",
+        spectral_grade="genuine",
+    )
+    def test_candidate_measurement_is_once_per_snapshot(
+        self,
+        identity_source: str,
+        job_mode: str,
+        snapshot_changed: bool,
+        codec: str,
+        spectral_grade: str,
+    ) -> None:
+        assert TEST_DSN is not None
+        release_id = (
+            "1f9fdeeb-59b4-4751-91b6-be38fb76c380"
+            if identity_source == "mb"
+            else "7220808"
+        )
+        with LifecycleWorld(TEST_DSN, repository_root()) as world:
+            request_id = world.add_release(BeetsWorldRelease(
+                release_id=release_id,
+                artist="The Rolling Stones",
+                album="The Rolling Stones No. 2",
+                year=1965,
+                codec=codec,
+            ))
+            (
+                full_preview_calls,
+                analyzer_paths,
+                candidate_status,
+            ) = world.exercise_candidate_preview_boundary(
+                request_id,
+                job_mode=job_mode,
+                snapshot_changed=snapshot_changed,
+                codec=codec,
+                spectral_grade=spectral_grade,
+            )
+
+            if snapshot_changed:
+                self.assertEqual(full_preview_calls, 1)
+                self.assertNotEqual(candidate_status, "reused")
+            else:
+                self.assertEqual(full_preview_calls, 0)
+                self.assertEqual(
+                    analyzer_paths,
+                    [],
+                    "matching candidate evidence was analyzed again",
+                )
+                self.assertEqual(candidate_status, "reused")
+            world.assert_invariants()
+
+
+TestGeneratedCandidateEvidenceReuseWorld \
+    .test_candidate_measurement_is_once_per_snapshot = settings(
+        max_examples=int(os.environ.get("CRATEDIGGER_WORLD_EXAMPLES", "6")),
+        deadline=None,
+        derandomize=not _RANDOMIZED,
+        database=_DATABASE,
+        print_blob=_RANDOMIZED,
+        suppress_health_check=(HealthCheck.too_slow,),
+    )(
+        TestGeneratedCandidateEvidenceReuseWorld
+        .test_candidate_measurement_is_once_per_snapshot
+    )
+
+
 class TestGeneratedEvidenceDriftWorld(unittest.TestCase):
     """Cross the live mutation and evidence-fact vocabularies in real stores."""
 

--- a/tests/world_model/support.py
+++ b/tests/world_model/support.py
@@ -6,6 +6,7 @@ import os
 from dataclasses import replace
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 import msgspec
 
@@ -35,7 +36,10 @@ from lib.import_evidence import (
     CurrentEvidenceActionResult,
     load_current_evidence_for_action,
 )
-from lib.import_preview import enrich_incomplete_current_evidence_for_request
+from lib.import_preview import (
+    ImportPreviewResult,
+    enrich_incomplete_current_evidence_for_request,
+)
 from lib.import_queue import (
     IMPORT_JOB_AUTOMATION,
     IMPORT_JOB_FORCE,
@@ -56,7 +60,12 @@ from lib.quality import (
     VerifiedLosslessProof,
     resolve_user_requeue_override,
 )
-from lib.quality_evidence import snapshot_audio_files, snapshot_fingerprint
+from lib.measurement import ExistingSpectralAuditLookup
+from lib.quality_evidence import (
+    EvidenceBuildResult,
+    snapshot_audio_files,
+    snapshot_fingerprint,
+)
 from lib.mbid_replace_service import (
     MbidReplaceService,
     REPLACE_REASON_SOURCE_IDENTITY_INVALID,
@@ -105,6 +114,7 @@ from tests.world_model.census_seeds import (
     EvidenceDriftMutationSeed,
     WorldCensusSeed,
 )
+from scripts.import_preview_worker import process_claimed_preview_job
 
 
 class LifecycleWorld:
@@ -465,6 +475,185 @@ class LifecycleWorld:
                 outcome = row.get("outcome")
                 return str(outcome) if outcome is not None else None
         return None
+
+    def exercise_candidate_preview_boundary(
+        self,
+        request_id: int,
+        *,
+        job_mode: str,
+        snapshot_changed: bool,
+        codec: str,
+        spectral_grade: str,
+    ) -> tuple[int, list[str], str | None]:
+        """Drive the real preview front gate over one disposable candidate."""
+
+        if job_mode not in {"automation", "force"}:
+            raise ValueError(f"unknown preview job mode: {job_mode!r}")
+        row = self._require_request(request_id)
+        if row["status"] != "wanted":
+            raise AssertionError("preview boundary world requires a wanted row")
+        release = replace(self._release_by_request[request_id], codec=codec)
+        self._dispatch_counter += 1
+        source = (
+            self.beets.incoming_root
+            / f"preview-{job_mode}-{request_id}-{self._dispatch_counter:04d}"
+        )
+        self.beets.stage_release(release, source_dir=source)
+        candidate_files = snapshot_audio_files(str(source))
+        measurement = AudioQualityMeasurement(
+            min_bitrate_kbps=900 if codec == "flac" else 245,
+            avg_bitrate_kbps=900 if codec == "flac" else 256,
+            median_bitrate_kbps=900 if codec == "flac" else 252,
+            format=codec.upper(),
+            is_cbr=False,
+            spectral_grade=spectral_grade,
+            spectral_subject=EVIDENCE_SUBJECT_SOURCE,
+            spectral_provenance=EVIDENCE_PROVENANCE_MEASURED,
+        )
+        candidate = make_album_quality_evidence(
+            mb_release_id=release.release_id,
+            source_path=str(source),
+            files=candidate_files,
+            measurement=measurement,
+            codec=codec,
+            container=codec,
+            storage_format=codec.upper(),
+        )
+        self.db.upsert_album_quality_evidence(candidate)
+        persisted = self.db.find_album_quality_evidence(
+            mb_release_id=release.release_id,
+            snapshot_fingerprint=candidate.snapshot_fingerprint,
+        )
+        if persisted is None or persisted.id is None:
+            raise AssertionError("preview boundary candidate did not persist")
+
+        download_log_id: int | None = None
+        if job_mode == "automation":
+            require_transition_applied(finalize_request(
+                self.db,
+                request_id,
+                RequestTransition.to_downloading(
+                    from_status="wanted",
+                    state_json=make_active_download_state_json([]),
+                ),
+            ))
+            self.db.update_download_state_current_path(request_id, str(source))
+            import_job = self.db.enqueue_import_job(
+                IMPORT_JOB_AUTOMATION,
+                request_id=request_id,
+                dedupe_key=automation_import_dedupe_key(request_id),
+                payload=automation_import_payload(),
+                message="World-model preview boundary",
+            )
+        else:
+            download_log_id = self.db.log_download(
+                request_id,
+                soulseek_username="world-preview-peer",
+                outcome="rejected",
+                validation_result=msgspec.json.encode({
+                    "scenario": "high_distance",
+                    "failed_path": str(source),
+                }).decode(),
+            )
+            self.db.set_download_log_candidate_evidence(
+                download_log_id,
+                persisted.id,
+            )
+            import_job = self.db.enqueue_import_job(
+                IMPORT_JOB_FORCE,
+                request_id=request_id,
+                dedupe_key=force_import_dedupe_key(download_log_id),
+                payload=force_import_payload(
+                    download_log_id=download_log_id,
+                    failed_path=str(source),
+                    source_username="world-preview-peer",
+                ),
+                message="World-model preview boundary",
+            )
+        self.db.set_import_job_candidate_evidence(import_job.id, persisted.id)
+
+        if snapshot_changed:
+            changed_file = source / candidate_files[-1].relative_path
+            changed_file.write_bytes(changed_file.read_bytes() + b"snapshot-drift")
+
+        claimed = self.db.claim_next_import_preview_job(worker_id="world-preview")
+        if claimed is None or claimed.id != import_job.id:
+            raise AssertionError("world preview job was not claimable")
+        full_preview_calls = 0
+        analyzer_paths: list[str] = []
+
+        def analyze(path: str) -> SpectralAnalysisDetail:
+            analyzer_paths.append(path)
+            return SpectralAnalysisDetail(
+                attempted=True,
+                grade=spectral_grade,
+            )
+
+        def full_preview(db: Any, _job: Any) -> ImportPreviewResult:
+            nonlocal full_preview_calls
+            full_preview_calls += 1
+            fresh = make_album_quality_evidence(
+                mb_release_id=release.release_id,
+                source_path=str(source),
+                files=snapshot_audio_files(str(source)),
+                measurement=measurement,
+                codec=codec,
+                container=codec,
+                storage_format=codec.upper(),
+            )
+            db.upsert_album_quality_evidence(fresh)
+            linked = db.find_album_quality_evidence(
+                mb_release_id=release.release_id,
+                snapshot_fingerprint=fresh.snapshot_fingerprint,
+            )
+            if linked is None or linked.id is None:
+                raise AssertionError("fresh preview evidence did not persist")
+            db.set_import_job_candidate_evidence(import_job.id, linked.id)
+            if download_log_id is not None:
+                db.set_download_log_candidate_evidence(
+                    download_log_id,
+                    linked.id,
+                )
+            return ImportPreviewResult(
+                mode="path",
+                verdict="evidence_ready",
+                decision="import",
+                reason="import",
+                source_path=str(source),
+                request_id=request_id,
+                download_log_id=download_log_id,
+            )
+
+        cfg = CratediggerConfig(
+            pipeline_db_enabled=True,
+            beets_directory=str(self.beets.library_root),
+            beets_library_db=str(self.beets.library_db),
+        )
+        with patch(
+            "scripts.import_preview_worker.read_runtime_config",
+            return_value=cfg,
+        ):
+            updated = process_claimed_preview_job(
+                self.db,
+                claimed,
+                spectral_detail_analyzer=analyze,
+                existing_spectral_resolver=(
+                    lambda _release_id: ExistingSpectralAuditLookup()
+                ),
+                preview_fn=full_preview,
+                current_evidence_loader=(
+                    lambda *_args, **_kwargs: EvidenceBuildResult(
+                        None,
+                        "empty_current",
+                        "exact album not in beets",
+                    )
+                ),
+            )
+        if updated is None:
+            raise AssertionError("preview boundary lost its claimed job")
+        raw_status = (updated.preview_result or {}).get("candidate_status")
+        candidate_status = raw_status if isinstance(raw_status, str) else None
+        return full_preview_calls, analyzer_paths, candidate_status
 
     def import_request(
         self,


### PR DESCRIPTION
## Summary

- reuse the persisted candidate spectral fact after the content snapshot front gate matches, avoiding a second scan of unchanged source files
- keep the installed-library HAVE scan independent for replacement decisions
- remeasure when the candidate snapshot changes
- lock the invariant into a deterministic 12-FLAC Rolling Stones pin, generated automation/force worker worlds, and the real-PostgreSQL cross-engine world model

## Live reproduction

The Rolling Stones No. 2 request 8883 reused candidate evidence 33377 during force import, but spent about 44 seconds rescanning the same 12 FLACs before logging that reuse. The front gate called the shared two-sided audit without passing the already-authoritative candidate detail, so the audit analyzed the candidate path again.

## Generated invariant

Across automation and force jobs:

- matching content snapshot: no full preview and no candidate analyzer call; project the persisted candidate fact
- changed content snapshot: run full preview exactly once
- installed HAVE: retain its independent scan boundary

The cross-engine world varies MB/Discogs identity, codec, spectral grade, and snapshot drift against throwaway PostgreSQL.

## Validation

- `python3 -m unittest tests.test_import_queue -v` — 76 passed
- `python3 -m unittest tests.test_spectral_attempt_audit_generated -v` — 15 passed
- `python3 -m unittest tests.test_integration_slices.TestPreviewFrontGateSlice -v` — 2 passed
- `python3 -m unittest tests.world_model.state_machine -v` — 19 passed
- full Pyright — 0 errors
- full suite — 6,565 Python tests plus JS/static checks, no skips
- deterministic cross-engine world model — 19 passed
