### PR TITLE
fix: bail on absent HAVE spectral + fresh-audit-wins persistence (#815)

### DIFF
--- a/docs/quality-verification.md
+++ b/docs/quality-verification.md
@@ -457,9 +457,13 @@ both still match, the immutable evidence row is reused without rewriting it.
 After the download log and request-state reset are safely persisted,
 `enrich_incomplete_current_evidence_for_request`
 plans exactly the missing pieces (`plan_current_evidence_enrichment`, pure),
-measures the on-disk copy directly, and persists through the same
-preview-owned once-only helpers — never overwriting present evidence, never
-re-probing an attempted snapshot, and refusing stale on-disk state. Adapter
+measures the on-disk copy directly, and persists through the
+preview-owned helpers — measuring only the pieces the plan reports missing,
+never re-probing an already-attempted V0 snapshot (the V0 research marker is
+once-only), and refusing stale on-disk state. (The HAVE spectral helper is
+*not* once-only — a fresh audit overwrites a disagreeing grade; see the
+fresh-audit-wins policy below.)
+Adapter
 or backfill failures and actual measurement work consume the per-cycle
 `CratediggerContext.evidence_enrichment_budget`; complete or authoritatively
 absent library copies cost nothing. Over time the failed-download cohort's
@@ -494,12 +498,45 @@ a fresh row, repoints the FK, and persists the changed-snapshot enrichment
 gate described above. Either way enrichment can then complete the surviving
 row. The candidate-reuse preview fast path first verifies the content
 snapshot, then projects the candidate spectral fact from that content-addressed
-evidence without scanning those bytes again. It separately persists any
-required attempt-time HAVE scan through
+evidence without scanning those bytes again. It separately persists the
+attempt-time HAVE scan through
 `persist_exact_current_spectral_from_attempt` before marking the job
 importable, so reused-evidence force and automation imports decide against the
 same completed HAVE the full measurement path would see. A changed candidate
 snapshot misses the front gate and runs full preview measurement again.
+
+**HAVE spectral persistence is fail-closed on absence and fresh-audit-wins on
+disagreement (issue #815).** Two rules govern how the request's on-disk (HAVE)
+spectral fact is written:
+
+- **Bail, never infer.** The candidate download's spectral is NEVER adopted as
+  the request's on-disk state. When the on-disk audit of the installed files
+  yields no measurement — a stale/missing Beets path, an analyzer error — the
+  measurement helper (`lib/measurement.py::_persist_spectral_state`) writes
+  nothing; the container bitrate remains the HAVE comparison fallback. The old
+  "reasonable proxy" branch that adopted a candidate's grade is deleted: on
+  2026-05-12 it wrote a rejected fake-320's `likely_transcode`/128 as the HAVE
+  state of a genuine 192 copy, the evidence seeder froze it, and on 2026-07-21
+  it drove a real library downgrade (request 4351, dl 37742). Same fail-closed
+  doctrine as #762/#723 — if we cannot ascertain evidence of the on-disk files,
+  we surface the absence rather than infer.
+- **Fresh-audit-wins.** A SUCCESSFUL fresh on-disk HAVE audit of matched-
+  fingerprint bytes (grade non-null, no error) re-persists grade + bitrate over
+  a disagreeing persisted installed-subject value, with
+  `spectral_provenance='measured'` (`persist_current_spectral_measurement` and
+  `persist_exact_current_spectral_from_attempt`). This replaced the old
+  fill-only-if-NULL policy, which silently discarded a fresh genuine/160 audit
+  and let the frozen 128 landmine keep deciding. The class self-heals at the
+  next preview, which always re-scans the installed bytes. Guards preserved: a
+  FAILED fresh audit never clears a persisted grade (fail-soft `incomplete`),
+  and an R19 lossless-sourced row keeps its source spectral — an installed-
+  derivative scan is never persisted as its grade (`preserve_existing_source_spectral`
+  plus the DB CHECK `album_quality_evidence_lossless_lineage_spectral_subject`).
+
+`spectral_provenance='measured'` means the analyzer ran over the exact bytes the
+snapshot fingerprint identifies; anything else is `'carried'` (a source-lineage
+fact propagated across a byte change) and is never authoritative against a fresh
+audit of the installed bytes.
 
 **Search narrowing companion.** When `lossless_source_locked` fires —
 in the importer (`lib/dispatch/core.py`) or wrong-match cleanup

--- a/lib/import_preview.py
+++ b/lib/import_preview.py
@@ -220,13 +220,21 @@ def persist_exact_current_spectral_from_attempt(
     measured_existing: SpectralAnalysisDetail | None,
     measured_existing_path: str | None,
 ) -> EvidenceBuildResult:
-    """Fill missing HAVE spectral fields from its exact attempt-time scan.
+    """Persist the exact attempt-time HAVE scan onto current evidence.
 
     ``measure_preimport_state`` independently scans the exact installed
     release before an import decision. This helper makes that successful scan
-    durable on the already-linked, content-addressed current evidence row. It
-    never rescans, never overwrites spectral provenance, and refuses a Beets
-    path that is not the path snapshotted by the evidence row.
+    durable on the already-linked, content-addressed current evidence row.
+
+    A successful fresh audit of the matched-fingerprint bytes is authoritative
+    (issue #815 fresh-audit-wins): it re-persists grade + bitrate over a
+    disagreeing persisted installed-subject value with
+    ``spectral_provenance='measured'``, so a stale legacy grade cannot survive a
+    fresh scan of the same bytes. It still refuses a Beets path that is not the
+    path snapshotted by the evidence row; a FAILED fresh audit never clears a
+    persisted grade (fail-soft ``incomplete``); and a lossless-sourced row keeps
+    its source spectral (R19) — an installed-derivative scan is never persisted
+    as its grade, whatever the caller's preserve flag said.
     """
     if current_evidence is None or current_evidence.id is None:
         return EvidenceBuildResult(None, "missing", "current evidence is missing")
@@ -301,12 +309,11 @@ def persist_exact_current_spectral_from_attempt(
             "skipped",
             "lossless-sourced copy keeps its source spectral (R19)",
         )
-    refreshed_measurement = refreshed.measurement
-    if (
-        refreshed_measurement.spectral_grade is not None
-        or refreshed_measurement.spectral_bitrate_kbps is not None
-    ):
-        return EvidenceBuildResult(refreshed, "ready")
+    # Fresh-audit-wins (issue #815): a successful fresh audit of the
+    # matched-fingerprint bytes re-persists over ANY disagreeing persisted
+    # installed-subject grade. The fill-only-if-NULL early return that used to
+    # sit here silently discarded a fresh genuine/160 audit and let a stale
+    # likely_transcode/128 landmine drive a real library downgrade.
     try:
         persisted = db.persist_current_spectral_measurement(
             request_id=request_id,
@@ -1620,14 +1627,13 @@ def measure_and_persist_candidate_evidence(
                 download_min_bitrate_bps=inspection.min_bitrate_bps,
                 download_is_vbr=inspection.is_vbr,
                 cfg=cfg,
-                # db=None / request_id=None: spectral propagation happens
-                # later via the persisted AlbumQualityEvidence row that the
-                # importer reads. Preview is now a pure measurement surface.
+                # db=None / request_id=None: HAVE spectral state is persisted
+                # later via the content-addressed AlbumQualityEvidence row that
+                # the importer reads. Preview is a pure measurement surface.
                 db=None,
                 request_id=None,
                 existing_spectral_evidence=existing_spectral_evidence,
                 preserve_existing_source_spectral=preserve_have_source,
-                propagate_download_to_existing=False,
                 precomputed_inspection=inspection,
                 spectral_detail_analyzer=spectral_detail_analyzer,
                 existing_spectral_resolver=existing_spectral_resolver,
@@ -2127,10 +2133,9 @@ def preview_import_from_path(
         # pattern: collect facts via ``measure_preimport_state`` (no denylist
         # writes, no decision branches), then surface the five folder/audio-
         # integrity facts as a confident reject for the CLI/triage UI.
-        # ``db=None`` / ``request_id=None`` / ``propagate_download_to_existing=False``:
-        # spectral propagation belongs to the persisted ``AlbumQualityEvidence``
-        # row that the importer reads — preview is now a pure measurement
-        # surface.
+        # ``db=None`` / ``request_id=None``: HAVE spectral state belongs to the
+        # persisted ``AlbumQualityEvidence`` row that the importer reads —
+        # preview is a pure measurement surface.
         try:
             measurement = measure_preimport_state(
                 path=preview_path,
@@ -2146,7 +2151,6 @@ def preview_import_from_path(
                     existing_spectral_evidence
                 ),
                 preserve_existing_source_spectral=preserve_have_source,
-                propagate_download_to_existing=False,
                 precomputed_inspection=inspection,
             )
             spectral_result = persist_exact_current_spectral_from_attempt(

--- a/lib/measurement.py
+++ b/lib/measurement.py
@@ -496,57 +496,42 @@ def _persist_spectral_state(
     *,
     db: "PipelineDB",
     request_id: int,
-    download_spectral: SpectralMeasurement | None,
     existing_spectral: SpectralMeasurement | None,
-    existing_min_bitrate: int | None,
-    label: str,
-    propagate_download_to_existing: bool = True,
 ) -> SpectralMeasurement | None:
-    """Write the on-disk spectral state to album_requests.
+    """Persist a real measured on-disk (HAVE) spectral state to album_requests.
 
-    When ``propagate_download_to_existing`` is True and there's no measured
-    existing spectral but there IS an existing album on disk
-    (existing_min_bitrate set), adopt the download's spectral as the current
-    on-disk measurement. This helps same-tier downgrade detection for
-    subsequent imports — the download and on-disk characterize the same
-    quality tier, so reusing the download's spectral is a reasonable proxy.
+    Writes ONLY a spectral measurement that was actually taken from the
+    existing installed files. When ``existing_spectral`` is None the on-disk
+    audit produced nothing, so this bails and writes nothing — the candidate
+    download's spectral is NEVER adopted as the request's on-disk state.
 
-    Pass ``propagate_download_to_existing=False`` from the force-import
-    import path: that path evaluates the gate *before* the subprocess import
-    runs, so propagating a download's spectral into on-disk state would be
-    speculative. If the downstream import fails (downgrade, no JSON,
-    timeout) the DB would otherwise be left claiming that the failed
-    download is on-disk, skewing later ``compute_effective_override_bitrate``
-    and quality-gate decisions.
+    Issue #815 (fail-closed doctrine, same as #762/#723): the old "reasonable
+    proxy" branch adopted a rejected fake-320 candidate's likely_transcode/128
+    as the HAVE grade of a genuine 192 copy; the evidence seeder froze it, and
+    fill-only-if-NULL persistence kept it until it drove a real library
+    downgrade (request 4351, dl 37742). If we cannot ascertain evidence of the
+    on-disk files, we bail — we never infer HAVE state from the candidate.
 
     Returns the measurement actually written (or None if nothing to write).
     """
-    to_write = existing_spectral
-    if (to_write is None
-            and propagate_download_to_existing
-            and download_spectral is not None
-            and existing_min_bitrate is not None):
-        to_write = download_spectral
-        logger.info(
-            f"SPECTRAL PROPAGATE: {label} on-disk spectral=NULL, "
-            f"adopting download spectral grade={to_write.grade}")
-    if to_write is not None:
-        try:
-            applied = db.update_spectral_state(
+    if existing_spectral is None:
+        return None
+    try:
+        applied = db.update_spectral_state(
+            request_id,
+            RequestSpectralStateUpdate(current=existing_spectral),
+        )
+        if not applied:
+            logger.warning(
+                "Skipped on-disk spectral update for frozen/missing "
+                "request %s",
                 request_id,
-                RequestSpectralStateUpdate(current=to_write),
             )
-            if not applied:
-                logger.warning(
-                    "Skipped on-disk spectral update for frozen/missing "
-                    "request %s",
-                    request_id,
-                )
-                return None
-        except Exception:
-            logger.exception("Failed to update on-disk spectral data")
             return None
-    return to_write
+    except Exception:
+        logger.exception("Failed to update on-disk spectral data")
+        return None
+    return existing_spectral
 
 
 @dataclass(frozen=True)
@@ -635,7 +620,6 @@ def measure_preimport_state(
     request_id: int | None = None,
     existing_spectral_evidence: SpectralAnalysisDetail | None = None,
     preserve_existing_source_spectral: bool = False,
-    propagate_download_to_existing: bool = True,
     precomputed_inspection: "LocalFileInspection | None" = None,
     spectral_detail_analyzer: SpectralDetailAnalyzer | None = None,
     existing_spectral_resolver: ExistingSpectralResolver | None = None,
@@ -644,10 +628,10 @@ def measure_preimport_state(
 
     This is the pure measurement helper introduced in U3. It has NO decision
     fields, no denylist writes, no requeue decisions. It DOES persist on-disk
-    spectral state to ``album_requests`` via ``_persist_spectral_state`` when
-    a DB is wired — that propagation is part of "we measured this candidate"
-    and must fire whether or not the downstream decision is accept or reject
-    (issue #90).
+    (HAVE) spectral state to ``album_requests`` via ``_persist_spectral_state``
+    when a DB is wired — but ONLY a real measured existing spectral. The
+    candidate download's spectral is never adopted as HAVE state; when the
+    on-disk audit produces nothing, nothing is written (issue #815 bail).
 
     As of U11 there is exactly one decision function: persisted evidence
     flows into ``lib.quality.full_pipeline_decision_from_evidence``, whose
@@ -912,24 +896,20 @@ def measure_preimport_state(
         )
         existing_spectral_path = existing_lookup.path
 
-    # --- Persist spectral state to DB (issue #90 propagation) ---
-    # This MUST fire on every measurement where spectral was collected,
-    # regardless of whether the downstream decision accepts or rejects. The
-    # request stamps remain accurate for audit and rendering. Persists AFTER
-    # the existing_spectral snapshot
-    # used by the decision is taken — propagation can't poison the comparison
-    # because the decision runs in ``full_pipeline_decision_from_evidence``
-    # on the *persisted* candidate evidence row (or the returned Struct for
-    # legacy callers), neither of which reads the request stamps.
-    if download_spectral is not None and db is not None and request_id is not None:
+    # --- Persist on-disk (HAVE) spectral state to DB ---
+    # Only a real measured existing spectral is written. The candidate's
+    # ``download_spectral`` is NEVER adopted as the request's on-disk state
+    # (issue #815): inferring HAVE from the candidate froze a rejected
+    # fake-320's grade onto a genuine copy and drove a real downgrade. When the
+    # on-disk audit yields nothing, ``existing_spectral`` is None and nothing is
+    # written (bail). The request stamps stay accurate for audit and rendering;
+    # the decision runs in ``full_pipeline_decision_from_evidence`` on the
+    # persisted candidate evidence row, which never reads the request stamps.
+    if existing_spectral is not None and db is not None and request_id is not None:
         try:
             _persist_spectral_state(
                 db=db, request_id=request_id,
-                download_spectral=download_spectral,
                 existing_spectral=existing_spectral,
-                existing_min_bitrate=existing_min_bitrate,
-                label=label,
-                propagate_download_to_existing=propagate_download_to_existing,
             )
         except Exception:
             logger.exception("failed to persist spectral state")

--- a/lib/pipeline_db/evidence.py
+++ b/lib/pipeline_db/evidence.py
@@ -448,7 +448,16 @@ class _EvidenceMixin(_PipelineDBBase):
         grade: str,
         bitrate_kbps: int | None,
     ) -> bool:
-        """Fill spectral fields on one exact, still-current empty snapshot."""
+        """Persist a fresh measured installed-subject spectral on one exact snapshot.
+
+        Fresh-audit-wins (issue #815): the caller only reaches here with a
+        successful fresh audit of the exact matched-fingerprint bytes, so this
+        re-persists ``grade``/``bitrate`` as ``installed``/``measured`` over ANY
+        disagreeing persisted value on the still-current row — the old
+        fill-only-if-NULL guard let a stale legacy grade survive a fresh scan.
+        The lossless-lineage R19 CHECK still fires against the hardcoded
+        ``installed`` subject, so a source-lineage row is never written here.
+        """
         cur = self._execute(
             """
             UPDATE album_quality_evidence AS evidence
@@ -462,8 +471,6 @@ class _EvidenceMixin(_PipelineDBBase):
               AND request.current_evidence_id = evidence.id
               AND evidence.id = %s
               AND evidence.snapshot_fingerprint = %s
-              AND evidence.spectral_grade IS NULL
-              AND evidence.spectral_bitrate_kbps IS NULL
             RETURNING evidence.id
             """,
             (

--- a/tests/fakes/pipeline_db.py
+++ b/tests/fakes/pipeline_db.py
@@ -3213,10 +3213,12 @@ class FakePipelineDB:
             or request.get("current_evidence_id") != int(expected_evidence_id)
             or evidence is None
             or evidence.snapshot_fingerprint != expected_snapshot_fingerprint
-            or evidence.measurement.spectral_grade is not None
-            or evidence.measurement.spectral_bitrate_kbps is not None
         ):
             return False
+        # Fresh-audit-wins (issue #815): overwrite ANY disagreeing persisted
+        # spectral with the fresh measured installed-subject audit. The old
+        # fill-only-if-NULL guard is gone; mirrors the production SQL. The R19
+        # lossless-lineage CHECK still fires in _store_album_quality_evidence.
         measurement = msgspec.structs.replace(
             evidence.measurement,
             spectral_grade=grade,

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -278,6 +278,9 @@ class TestFakePipelineDB(unittest.TestCase):
             grade="genuine",
             bitrate_kbps=96,
         )
+        # Issue #815 fresh-audit-wins: a disagreeing fresh measured audit of
+        # the SAME snapshot overwrites (mirrors the production SQL, which
+        # dropped the fill-only-if-NULL guard).
         overwrite = db.persist_current_spectral_measurement(
             request_id=42,
             expected_evidence_id=persisted.id,
@@ -285,15 +288,16 @@ class TestFakePipelineDB(unittest.TestCase):
             grade="likely_transcode",
             bitrate_kbps=160,
         )
-        db.upsert_album_quality_evidence(evidence)
 
         self.assertFalse(wrong_fingerprint)
         self.assertTrue(exact)
-        self.assertFalse(overwrite)
+        self.assertTrue(overwrite)
         stored = db.load_album_quality_evidence_by_id(persisted.id)
         assert stored is not None
-        self.assertEqual(stored.measurement.spectral_grade, "genuine")
-        self.assertEqual(stored.measurement.spectral_bitrate_kbps, 96)
+        self.assertEqual(stored.measurement.spectral_grade, "likely_transcode")
+        self.assertEqual(stored.measurement.spectral_bitrate_kbps, 160)
+        self.assertEqual(stored.measurement.spectral_subject, "installed")
+        self.assertEqual(stored.measurement.spectral_provenance, "measured")
 
     def test_album_quality_evidence_attempt_marker_is_monotonic(self):
         db = FakePipelineDB()

--- a/tests/test_force_import_gates.py
+++ b/tests/test_force_import_gates.py
@@ -38,11 +38,40 @@ from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from hypothesis import example, given, strategies as st
+
+import tests._hypothesis_profiles  # noqa: F401  (loads active profile)
 from lib.beets_db import AlbumInfo
 from lib.config import CratediggerConfig
+from lib.measurement import (
+    ExistingSpectralAuditLookup,
+    ExistingSpectralResolver,
+    LocalFileInspection,
+    PreimportMeasurement,
+    measure_preimport_state,
+)
+from lib.quality import SpectralAnalysisDetail, SpectralMeasurement
 from tests.fakes import FakePipelineDB
 from tests.helpers import make_request_row
 from tests.test_integration_slices import _mock_beets_db
+
+
+def _have_state_is_never_candidate(
+    *,
+    persisted_current_grade: str | None,
+    existing_spectral: SpectralMeasurement | None,
+    download_spectral: SpectralMeasurement | None,
+) -> bool:
+    """Invariant A checker: the request's on-disk grade is never the candidate's.
+
+    Holds iff: when there is no real existing measurement, NO on-disk grade is
+    written at all; when there is one, the on-disk grade equals it. The
+    candidate's ``download_spectral`` is never adopted as HAVE state (#815).
+    """
+    del download_spectral  # named to make the anti-adoption contrast explicit
+    if existing_spectral is None:
+        return persisted_current_grade is None
+    return persisted_current_grade == existing_spectral.grade
 
 
 def _analyze_result(grade: str, bitrate: int | None, suspect_pct: float = 0.0,
@@ -354,47 +383,164 @@ class TestInspectLocalFilesRecursive(unittest.TestCase):
             shutil.rmtree(tmpdir, ignore_errors=True)
 
 
-class TestAutoPathPreservesSpectralPropagation(unittest.TestCase):
-    """The auto path still propagates: measure_preimport_state with
-    propagate_download_to_existing=True (the default) adopts the download's
-    spectral as current when min_bitrate is set but spectral is unmeasured.
+class TestNoCandidateSpectralAdoptedAsHave(unittest.TestCase):
+    """Issue #815 Invariant A (bail): when the on-disk HAVE audit yields no
+    measurement, the candidate download's spectral is NEVER adopted as the
+    request's on-disk (``current_spectral_*``) state.
+
+    The May-12 world (dl 11380): a rejected fake-320 candidate measured
+    ``likely_transcode``/128 while the genuine 192 copy's on-disk audit
+    produced nothing (stale ``album_path`` / analyzer error). Pre-#815 the
+    ``_persist_spectral_state`` "reasonable proxy" branch adopted the
+    candidate's grade; the evidence seeder froze it and it later drove a real
+    library downgrade. The prior ``TestAutoPathPreservesSpectralPropagation``
+    asserted the OPPOSITE (``current_spectral_grade == "suspect"``); that
+    adoption behaviour is deliberately removed, so this pin flips it: nothing
+    is written and the container bitrate remains the HAVE fallback.
     """
 
-    def test_auto_path_propagates_download_spectral(self):
-        from lib.measurement import measure_preimport_state
+    CANDIDATE = "/tmp/candidate-815"
+    EXISTING = "/tmp/existing-815"
 
+    def _measure(
+        self,
+        *,
+        candidate_grade: str = "likely_transcode",
+        existing_outcome: str,  # "measured" | "none" | "raises"
+        existing_grade: str = "genuine",
+    ) -> tuple[FakePipelineDB, PreimportMeasurement]:
         db = FakePipelineDB()
         db.seed_request(make_request_row(
-            id=1, min_bitrate=256,
+            id=42, min_bitrate=192,
             current_spectral_grade=None, current_spectral_bitrate=None,
         ))
-        beets_info = AlbumInfo(
-            album_id=1, track_count=10, min_bitrate_kbps=256,
-            avg_bitrate_kbps=256, format="MP3", is_cbr=True,
-            album_path="/Beets/NonexistentPath")
         cfg = CratediggerConfig(audio_check_mode="off")
 
-        with patch("lib.measurement.spectral_analyze",
-                   return_value=_analyze_result("suspect", 192, 80.0, 5)), \
-             patch("lib.beets_db.BeetsDB", _mock_beets_db(beets_info)):
-            measure_preimport_state(
-                path="/tmp/dl",
-                mb_release_id="mbid-123",
-                label="Test",
-                download_filetype="mp3",
-                download_min_bitrate_bps=320_000,
-                download_is_vbr=False,
-                cfg=cfg,
-                db=db,  # type: ignore[arg-type]
-                request_id=1,
-                # Default propagate=True — auto path preserves propagation.
-            )
+        def analyze(path: str) -> SpectralAnalysisDetail:
+            if path == self.EXISTING:
+                if existing_outcome == "raises":
+                    raise RuntimeError("stale album_path: sox found nothing")
+                return SpectralAnalysisDetail(
+                    attempted=True, grade=existing_grade, bitrate_kbps=160)
+            return SpectralAnalysisDetail(
+                attempted=True, grade=candidate_grade, bitrate_kbps=128)
 
-        row = db.request(1)
-        self.assertEqual(
-            row["current_spectral_grade"], "suspect",
-            "auto path must propagate download spectral when existing unmeasured")
-        self.assertEqual(row["current_spectral_bitrate"], 192)
+        def resolver(_mbid: str) -> ExistingSpectralAuditLookup:
+            if existing_outcome == "none":
+                return ExistingSpectralAuditLookup(
+                    path=None, min_bitrate_kbps=192)
+            return ExistingSpectralAuditLookup(
+                path=self.EXISTING, min_bitrate_kbps=192)
+
+        typed_resolver: ExistingSpectralResolver = resolver
+        measurement = measure_preimport_state(
+            path=self.CANDIDATE,
+            mb_release_id="mbid-123",
+            label="Mark DeNardo - Fake 320",
+            download_filetype="mp3",
+            download_min_bitrate_bps=320_000,
+            download_is_vbr=False,
+            cfg=cfg,
+            db=db,  # type: ignore[arg-type]
+            request_id=42,
+            precomputed_inspection=LocalFileInspection(
+                filetype="mp3", min_bitrate_bps=320_000, is_vbr=False),
+            spectral_detail_analyzer=analyze,
+            existing_spectral_resolver=typed_resolver,
+        )
+        return db, measurement
+
+    def _assert_no_adoption(
+        self, db: FakePipelineDB, measurement: PreimportMeasurement,
+    ) -> None:
+        # The candidate WAS measured — candidate state is unaffected.
+        assert measurement.download_spectral is not None
+        self.assertEqual(measurement.download_spectral.grade, "likely_transcode")
+        self.assertEqual(measurement.download_spectral.bitrate_kbps, 128)
+        # The on-disk audit produced nothing → no HAVE measurement.
+        self.assertIsNone(measurement.existing_spectral)
+        # BAIL: the candidate's grade is NEVER written as on-disk state.
+        row = db.request(42)
+        self.assertIsNone(row.get("current_spectral_grade"))
+        self.assertIsNone(row.get("current_spectral_bitrate"))
+        # The container bitrate (192) remains the HAVE fallback for the decision.
+        self.assertEqual(measurement.existing_min_bitrate, 192)
+
+    def test_path_missing_shape_writes_no_have_state(self):
+        # Beets reports a 192 copy but its files are not on disk → no path.
+        db, measurement = self._measure(existing_outcome="none")
+        self._assert_no_adoption(db, measurement)
+
+    def test_analyzer_exception_shape_writes_no_have_state(self):
+        # The existing files resolve but the HAVE audit raises → no measurement.
+        db, measurement = self._measure(existing_outcome="raises")
+        self._assert_no_adoption(db, measurement)
+
+    @given(
+        candidate_grade=st.sampled_from((
+            "genuine", "marginal", "suspect", "likely_transcode",
+        )),
+        existing_outcome=st.sampled_from(("measured", "none", "raises")),
+        existing_grade=st.sampled_from(
+            ("genuine", "suspect", "likely_transcode")),
+    )
+    @example(
+        candidate_grade="likely_transcode",
+        existing_outcome="none",
+        existing_grade="genuine",
+    )
+    @example(
+        candidate_grade="likely_transcode",
+        existing_outcome="raises",
+        existing_grade="genuine",
+    )
+    def test_candidate_spectral_never_becomes_have_state(
+        self,
+        candidate_grade: str,
+        existing_outcome: str,
+        existing_grade: str,
+    ) -> None:
+        """Issue #815 Invariant A (bail) property: across candidate grades ×
+        existing-audit outcomes, the request's on-disk (HAVE) spectral state,
+        when written, always equals a REAL existing measurement — never the
+        candidate's. When the on-disk audit yields nothing, no HAVE state is
+        written at all."""
+        db, measurement = self._measure(
+            candidate_grade=candidate_grade,
+            existing_outcome=existing_outcome,
+            existing_grade=existing_grade,
+        )
+        persisted = db.request(42).get("current_spectral_grade")
+        persisted_grade = persisted if isinstance(persisted, str) else None
+        # The candidate WAS measured — candidate state is unaffected.
+        assert measurement.download_spectral is not None
+        self.assertEqual(measurement.download_spectral.grade, candidate_grade)
+        # The on-disk state is never the candidate's.
+        self.assertTrue(_have_state_is_never_candidate(
+            persisted_current_grade=persisted_grade,
+            existing_spectral=measurement.existing_spectral,
+            download_spectral=measurement.download_spectral,
+        ))
+        # Explicit anti-adoption: no existing measurement → nothing written.
+        if measurement.existing_spectral is None:
+            self.assertIsNone(persisted_grade)
+
+    def test_have_state_checker_trips_on_adopted_candidate(self):
+        # Known-bad self-test: a request whose on-disk grade was adopted from
+        # the candidate (no existing measurement) must trip the checker.
+        self.assertFalse(_have_state_is_never_candidate(
+            persisted_current_grade="likely_transcode",
+            existing_spectral=None,
+            download_spectral=SpectralMeasurement(
+                grade="likely_transcode", bitrate_kbps=128),
+        ))
+        # ...and it holds on the correct bail case.
+        self.assertTrue(_have_state_is_never_candidate(
+            persisted_current_grade=None,
+            existing_spectral=None,
+            download_spectral=SpectralMeasurement(
+                grade="likely_transcode", bitrate_kbps=128),
+        ))
 
 
 class TestRepairMp3HeadersRecurses(unittest.TestCase):
@@ -469,8 +615,6 @@ class TestPreimportDoesNotReadRequestSpectral(unittest.TestCase):
     """Missing HAVE analysis cannot be replaced by request-row stamps."""
 
     def test_stored_spectral_ignored_when_beets_lookup_empty(self):
-        from lib.measurement import measure_preimport_state
-
         db = FakePipelineDB()
         # Request row has stored spectral: on-disk is actually a 128 transcode,
         # even though beets reports 320 as the container min_bitrate.
@@ -502,7 +646,6 @@ class TestPreimportDoesNotReadRequestSpectral(unittest.TestCase):
                 cfg=cfg,
                 db=db,  # type: ignore[arg-type]
                 request_id=42,
-                propagate_download_to_existing=False,
             )
 
         self.assertIsNone(measurement.existing_spectral)
@@ -809,7 +952,6 @@ class TestFallbackSkippedWhenBeetsFindsNoAlbum(unittest.TestCase):
                 cfg=cfg,
                 db=db,  # type: ignore[arg-type]
                 request_id=42,
-                propagate_download_to_existing=False,
             )
 
         self.assertIsNone(

--- a/tests/test_force_import_gates.py
+++ b/tests/test_force_import_gates.py
@@ -59,19 +59,27 @@ from tests.test_integration_slices import _mock_beets_db
 def _have_state_is_never_candidate(
     *,
     persisted_current_grade: str | None,
+    persisted_current_bitrate: int | None,
     existing_spectral: SpectralMeasurement | None,
     download_spectral: SpectralMeasurement | None,
 ) -> bool:
-    """Invariant A checker: the request's on-disk grade is never the candidate's.
+    """Invariant A checker: on-disk state is never adopted from the candidate.
 
-    Holds iff: when there is no real existing measurement, NO on-disk grade is
-    written at all; when there is one, the on-disk grade equals it. The
+    Holds iff: when there is no real existing measurement, NO on-disk state is
+    written at all (grade AND bitrate stay None); when there is one, the on-disk
+    state equals that REAL existing measurement — grade AND bitrate. The
     candidate's ``download_spectral`` is never adopted as HAVE state (#815).
     """
     del download_spectral  # named to make the anti-adoption contrast explicit
     if existing_spectral is None:
-        return persisted_current_grade is None
-    return persisted_current_grade == existing_spectral.grade
+        return (
+            persisted_current_grade is None
+            and persisted_current_bitrate is None
+        )
+    return (
+        persisted_current_grade == existing_spectral.grade
+        and persisted_current_bitrate == existing_spectral.bitrate_kbps
+    )
 
 
 def _analyze_result(grade: str, bitrate: int | None, suspect_pct: float = 0.0,
@@ -406,8 +414,10 @@ class TestNoCandidateSpectralAdoptedAsHave(unittest.TestCase):
         self,
         *,
         candidate_grade: str = "likely_transcode",
+        candidate_bitrate: int | None = 128,
         existing_outcome: str,  # "measured" | "none" | "raises"
         existing_grade: str = "genuine",
+        existing_bitrate: int | None = 160,
     ) -> tuple[FakePipelineDB, PreimportMeasurement]:
         db = FakePipelineDB()
         db.seed_request(make_request_row(
@@ -421,9 +431,11 @@ class TestNoCandidateSpectralAdoptedAsHave(unittest.TestCase):
                 if existing_outcome == "raises":
                     raise RuntimeError("stale album_path: sox found nothing")
                 return SpectralAnalysisDetail(
-                    attempted=True, grade=existing_grade, bitrate_kbps=160)
+                    attempted=True, grade=existing_grade,
+                    bitrate_kbps=existing_bitrate)
             return SpectralAnalysisDetail(
-                attempted=True, grade=candidate_grade, bitrate_kbps=128)
+                attempted=True, grade=candidate_grade,
+                bitrate_kbps=candidate_bitrate)
 
         def resolver(_mbid: str) -> ExistingSpectralAuditLookup:
             if existing_outcome == "none":
@@ -480,55 +492,77 @@ class TestNoCandidateSpectralAdoptedAsHave(unittest.TestCase):
         candidate_grade=st.sampled_from((
             "genuine", "marginal", "suspect", "likely_transcode",
         )),
+        candidate_bitrate=st.one_of(
+            st.none(), st.integers(min_value=32, max_value=500)),
         existing_outcome=st.sampled_from(("measured", "none", "raises")),
         existing_grade=st.sampled_from(
             ("genuine", "suspect", "likely_transcode")),
+        existing_bitrate=st.one_of(
+            st.none(), st.integers(min_value=32, max_value=500)),
     )
     @example(
         candidate_grade="likely_transcode",
+        candidate_bitrate=128,
         existing_outcome="none",
         existing_grade="genuine",
+        existing_bitrate=None,
     )
     @example(
         candidate_grade="likely_transcode",
+        candidate_bitrate=128,
         existing_outcome="raises",
         existing_grade="genuine",
+        existing_bitrate=160,
     )
     def test_candidate_spectral_never_becomes_have_state(
         self,
         candidate_grade: str,
+        candidate_bitrate: int | None,
         existing_outcome: str,
         existing_grade: str,
+        existing_bitrate: int | None,
     ) -> None:
-        """Issue #815 Invariant A (bail) property: across candidate grades ×
-        existing-audit outcomes, the request's on-disk (HAVE) spectral state,
-        when written, always equals a REAL existing measurement — never the
-        candidate's. When the on-disk audit yields nothing, no HAVE state is
-        written at all."""
+        """Issue #815 Invariant A (bail) property. Across generated candidate
+        grade × bitrate × existing-audit outcome (measured / none / raises)
+        worlds driving the real ``measure_preimport_state``, the request's
+        on-disk (HAVE) spectral state, when present, always equals a REAL
+        existing measurement — grade AND bitrate — and never the candidate's.
+        When the on-disk audit yields nothing, no HAVE state is written."""
         db, measurement = self._measure(
             candidate_grade=candidate_grade,
+            candidate_bitrate=candidate_bitrate,
             existing_outcome=existing_outcome,
             existing_grade=existing_grade,
+            existing_bitrate=existing_bitrate,
         )
-        persisted = db.request(42).get("current_spectral_grade")
-        persisted_grade = persisted if isinstance(persisted, str) else None
+        row = db.request(42)
+        raw_grade = row.get("current_spectral_grade")
+        persisted_grade = raw_grade if isinstance(raw_grade, str) else None
+        raw_bitrate = row.get("current_spectral_bitrate")
+        persisted_bitrate = raw_bitrate if isinstance(raw_bitrate, int) else None
         # The candidate WAS measured — candidate state is unaffected.
         assert measurement.download_spectral is not None
         self.assertEqual(measurement.download_spectral.grade, candidate_grade)
-        # The on-disk state is never the candidate's.
+        self.assertEqual(
+            measurement.download_spectral.bitrate_kbps, candidate_bitrate)
+        # The on-disk state is never the candidate's — it equals the real
+        # existing measurement (grade + bitrate), or is absent entirely.
         self.assertTrue(_have_state_is_never_candidate(
             persisted_current_grade=persisted_grade,
+            persisted_current_bitrate=persisted_bitrate,
             existing_spectral=measurement.existing_spectral,
             download_spectral=measurement.download_spectral,
         ))
         # Explicit anti-adoption: no existing measurement → nothing written.
         if measurement.existing_spectral is None:
             self.assertIsNone(persisted_grade)
+            self.assertIsNone(persisted_bitrate)
 
     def test_have_state_checker_trips_on_adopted_candidate(self):
         # Known-bad self-test: a request whose on-disk grade was adopted from
         # the candidate (no existing measurement) must trip the checker.
         self.assertFalse(_have_state_is_never_candidate(
+            persisted_current_bitrate=128,
             persisted_current_grade="likely_transcode",
             existing_spectral=None,
             download_spectral=SpectralMeasurement(
@@ -537,6 +571,15 @@ class TestNoCandidateSpectralAdoptedAsHave(unittest.TestCase):
         # ...and it holds on the correct bail case.
         self.assertTrue(_have_state_is_never_candidate(
             persisted_current_grade=None,
+            persisted_current_bitrate=None,
+            existing_spectral=None,
+            download_spectral=SpectralMeasurement(
+                grade="likely_transcode", bitrate_kbps=128),
+        ))
+        # It also trips when only the bitrate leaked from the candidate.
+        self.assertFalse(_have_state_is_never_candidate(
+            persisted_current_grade=None,
+            persisted_current_bitrate=128,
             existing_spectral=None,
             download_spectral=SpectralMeasurement(
                 grade="likely_transcode", bitrate_kbps=128),

--- a/tests/test_import_preview.py
+++ b/tests/test_import_preview.py
@@ -932,6 +932,138 @@ class TestImportPreviewPath(unittest.TestCase):
             import shutil
             shutil.rmtree(source, ignore_errors=True)
 
+    def test_fresh_have_audit_overwrites_stale_installed_grade(self):
+        """Issue #815 fresh-audit-wins pin (Shugo Tokumaru EXIT, request 4351).
+
+        An installed-subject evidence row carrying a STALE likely_transcode/128
+        (a legacy landmine seeded on a matched fingerprint — a state a clean
+        forward run can never produce) is re-persisted to the fresh genuine/160
+        audit of the exact same bytes. Pre-#815 the fill-only-if-NULL early
+        return discarded the fresh audit; the stale 128 then decided the
+        dl 37742 import and a fake-320 replaced the genuine 192 copy.
+        """
+        db = self._db()
+        source = self._source_dir()
+        try:
+            evidence = make_album_quality_evidence(
+                mb_release_id="mbid-42",
+                source_path=source,
+                files=snapshot_audio_files(source),
+                measurement=AudioQualityMeasurement(
+                    min_bitrate_kbps=192,
+                    avg_bitrate_kbps=192,
+                    median_bitrate_kbps=192,
+                    format="MP3",
+                    spectral_grade="likely_transcode",
+                    spectral_bitrate_kbps=128,
+                    spectral_subject="installed",
+                    spectral_provenance="measured",
+                ),
+            )
+            db.upsert_album_quality_evidence(evidence)
+            stored = db.find_album_quality_evidence(
+                mb_release_id=evidence.mb_release_id,
+                snapshot_fingerprint=evidence.snapshot_fingerprint,
+            )
+            assert stored is not None and stored.id is not None
+            db.set_request_current_evidence(42, stored.id)
+
+            result = persist_exact_current_spectral_from_attempt(
+                db,
+                request_id=42,
+                current_evidence=stored,
+                measured_existing=SpectralAnalysisDetail(
+                    attempted=True,
+                    grade="genuine",
+                    bitrate_kbps=160,
+                    suspect_pct=30.0,
+                ),
+                measured_existing_path=source,
+            )
+
+            self.assertEqual(result.status, "ready")
+            assert result.evidence is not None
+            self.assertEqual(
+                result.evidence.measurement.spectral_grade, "genuine")
+            self.assertEqual(
+                result.evidence.measurement.spectral_bitrate_kbps, 160)
+            # The overwrite is durable and stamped measured/installed.
+            reloaded = db.load_album_quality_evidence_by_id(stored.id)
+            assert reloaded is not None
+            self.assertEqual(reloaded.measurement.spectral_grade, "genuine")
+            self.assertEqual(reloaded.measurement.spectral_bitrate_kbps, 160)
+            self.assertEqual(
+                reloaded.measurement.spectral_subject, "installed")
+            self.assertEqual(
+                reloaded.measurement.spectral_provenance, "measured")
+        finally:
+            import shutil
+            shutil.rmtree(source, ignore_errors=True)
+
+    def test_fresh_audit_never_overwrites_lossless_source_carried_grade(self):
+        """R19 must-still-work: a lossless-sourced row that already carries a
+        source-subject grade is NEVER overwritten by an installed-derivative
+        fresh audit, even under #815 fresh-audit-wins."""
+        from lib.quality import EVIDENCE_SUBJECT_SOURCE, AlbumQualityV0Metric
+
+        db = self._db()
+        source = self._source_dir()
+        try:
+            evidence = make_album_quality_evidence(
+                mb_release_id="mbid-42",
+                source_path=source,
+                files=snapshot_audio_files(source),
+                measurement=AudioQualityMeasurement(
+                    min_bitrate_kbps=129,
+                    avg_bitrate_kbps=129,
+                    median_bitrate_kbps=129,
+                    format="Opus",
+                    spectral_grade="suspect",
+                    spectral_bitrate_kbps=140,
+                    spectral_subject=EVIDENCE_SUBJECT_SOURCE,
+                    spectral_provenance="carried",
+                ),
+                v0_metric=AlbumQualityV0Metric(
+                    min_bitrate_kbps=187,
+                    avg_bitrate_kbps=213,
+                    median_bitrate_kbps=210,
+                    subject=EVIDENCE_SUBJECT_SOURCE,
+                    provenance="carried",
+                ),
+                codec="opus",
+                container="opus",
+                storage_format="Opus",
+            )
+            db.upsert_album_quality_evidence(evidence)
+            stored = db.find_album_quality_evidence(
+                mb_release_id=evidence.mb_release_id,
+                snapshot_fingerprint=evidence.snapshot_fingerprint,
+            )
+            assert stored is not None and stored.id is not None
+            db.set_request_current_evidence(42, stored.id)
+
+            result = persist_exact_current_spectral_from_attempt(
+                db,
+                request_id=42,
+                current_evidence=stored,
+                measured_existing=SpectralAnalysisDetail(
+                    attempted=True,
+                    grade="genuine",
+                    bitrate_kbps=200,
+                ),
+                measured_existing_path=source,
+            )
+
+            self.assertEqual(result.status, "skipped")
+            reloaded = db.load_album_quality_evidence_by_id(stored.id)
+            assert reloaded is not None
+            self.assertEqual(reloaded.measurement.spectral_grade, "suspect")
+            self.assertEqual(
+                reloaded.measurement.spectral_subject, EVIDENCE_SUBJECT_SOURCE)
+        finally:
+            import shutil
+            shutil.rmtree(source, ignore_errors=True)
+
     def test_attempt_scan_never_persists_onto_lossless_sourced_row(self):
         """R19 guard: a lossless-sourced row (source anchor, empty spectral)
         must refuse the installed-derivative scan — the source grade

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -1222,27 +1222,20 @@ class TestSpectralPropagationSlice(unittest.TestCase):
         self.assertEqual(row["current_spectral_grade"], "genuine")
         self.assertEqual(row["current_spectral_bitrate"], 320)
 
-    def test_stale_album_path_does_not_self_compare(self):
-        """Issue #90: when BeetsDB returns an album whose on-disk path has
-        gone stale (``os.path.isdir`` returns False), propagation must not
-        mutate ``existing_spectral`` *before* ``spectral_import_decision``
-        runs — otherwise the download is compared against itself and
-        legitimate suspect-grade downloads get rejected by their own
-        spectral estimate.
+    def test_stale_album_path_bails_without_adopting_candidate(self):
+        """Issue #815 (supersedes the #90 self-compare pin): when BeetsDB
+        returns an album whose on-disk path has gone stale (``os.path.isdir``
+        False), the candidate's spectral must NOT be adopted as the request's
+        on-disk state.
 
         Setup: beets says the album exists (min_bitrate=320) but
         isdir(album_path) is False. Download is suspect at 128kbps.
 
-        With the bug: propagation writes download's 128kbps into
-        existing_spectral, then decision sees new=128 vs existing=128 →
-        reject (self-compare).
-
-        Correct behavior: decision compares download's 128 against the
-        container's 320 (fallback via existing_min_bitrate) → reject with a
-        legitimate comparison; OR if existing_min_bitrate also isn't
-        trustworthy (e.g. caller treats stale path as no-existing),
-        import_no_exist. The key invariant: the reject reason must NOT
-        read ``spectral {x}kbps <= existing {x}kbps`` with equal numbers.
+        Pre-#815 the ``_persist_spectral_state`` "reasonable proxy" branch
+        copied the download's 128kbps into ``current_spectral_*`` (and the old
+        self-compare bug then read 128<=128). Now the on-disk audit yields no
+        measurement, so nothing is written; the importer compares the
+        candidate against the container bitrate (via existing_min_bitrate).
         """
         from lib.config import CratediggerConfig
         from lib.measurement import measure_preimport_state
@@ -1281,29 +1274,25 @@ class TestSpectralPropagationSlice(unittest.TestCase):
                 cfg=cfg,
                 db=db,  # type: ignore[arg-type]
                 request_id=42,
-                propagate_download_to_existing=True,
             )
 
-        # The self-compare bug — propagation must not have copied the
-        # download's spectral into existing_spectral. existing_spectral
-        # may stay None (stale path on disk) or come from beets, but it
-        # must NOT equal the download's spectral exactly.
-        if measurement.download_spectral and measurement.existing_spectral:
-            self.assertNotEqual(
-                measurement.existing_spectral,
-                measurement.download_spectral,
-                "self-compare bug: existing_spectral propagated from download",
-            )
+        # No on-disk (HAVE) measurement, and the candidate's spectral is never
+        # adopted as the request's current on-disk state.
+        self.assertIsNone(measurement.existing_spectral)
+        row = db.request(42)
+        self.assertIsNone(row.get("current_spectral_grade"))
+        self.assertIsNone(row.get("current_spectral_bitrate"))
+        # The container bitrate remains the HAVE comparison fallback.
+        self.assertEqual(measurement.existing_min_bitrate, 320)
 
-    def test_stale_album_path_imports_when_download_beats_container(self):
-        """Issue #90 correctness: a suspect download above the container
-        bitrate must persist its spectral state to album_requests for the
-        importer's evidence pipeline to consume.
+    def test_stale_album_path_leaves_have_state_unwritten(self):
+        """Issue #815: a suspect download above the container bitrate on a
+        stale album path leaves the request's on-disk spectral UNWRITTEN.
 
-        Pre-fix: propagation wrote 280 into existing_spectral, decision saw
-        280 <= 280 → reject. After the fix the measurement keeps
-        existing_spectral disjoint from the download's; the importer's
-        full pipeline then sees 280 vs container 256 and imports.
+        Pre-#815 propagation wrote 280 into ``current_spectral_*`` (and the
+        old self-compare bug read 280<=280 → reject). Now the importer's full
+        pipeline compares the candidate 280 against the container 256; the
+        candidate's spectral is never frozen as HAVE state.
         """
         from lib.config import CratediggerConfig
         from lib.measurement import measure_preimport_state
@@ -1341,15 +1330,17 @@ class TestSpectralPropagationSlice(unittest.TestCase):
                 cfg=cfg,
                 db=db,  # type: ignore[arg-type]
                 request_id=42,
-                propagate_download_to_existing=True,
             )
 
         # Measurement is fact-only — accept/reject lives in the importer.
         self.assertFalse(measurement.audio_corrupt)
-        # Propagation still persisted the download's spectral for future runs.
+        self.assertIsNone(measurement.existing_spectral)
+        # BAIL: the candidate's spectral is never written as on-disk state.
         row = db.request(42)
-        self.assertEqual(row["current_spectral_grade"], "suspect")
-        self.assertEqual(row["current_spectral_bitrate"], 280)
+        self.assertIsNone(row.get("current_spectral_grade"))
+        self.assertIsNone(row.get("current_spectral_bitrate"))
+        # The container bitrate remains the HAVE comparison fallback.
+        self.assertEqual(measurement.existing_min_bitrate, 256)
 
 
 class TestSpectralPropagationOnAccept(unittest.TestCase):
@@ -1383,20 +1374,20 @@ class TestSpectralPropagationOnAccept(unittest.TestCase):
         persisted = _persist_spectral_state(
             db=db,  # type: ignore[arg-type]
             request_id=42,
-            download_spectral=None,
             existing_spectral=SpectralMeasurement(
                 grade="genuine",
                 bitrate_kbps=320,
             ),
-            existing_min_bitrate=320,
-            label="Frozen Artist - Frozen Album",
         )
 
         self.assertIsNone(persisted)
         self.assertEqual(db.request(42), before)
 
     def test_accept_suspect_upgrade_still_persists_spectral(self):
-        """Accept (suspect grade but bitrate upgrades existing) → spectral state still propagates."""
+        """Accept (suspect grade but bitrate upgrades existing) → the REAL
+        measured existing spectral state is still persisted (must-still-work
+        for #815: a genuine on-disk measurement IS written; only candidate
+        adoption is removed)."""
         from lib.config import CratediggerConfig
         from lib.measurement import measure_preimport_state
         from lib.quality import SpectralAnalysisDetail
@@ -1462,8 +1453,9 @@ class TestSpectralPropagationOnAccept(unittest.TestCase):
         # Measurement never writes denylist.
         self.assertEqual(len(db.denylist), 0)
 
-    def test_accept_import_no_exist_still_persists_spectral(self):
-        """Accept (suspect grade, no existing on disk) → spectral state propagates the download's spectral."""
+    def test_accept_import_no_exist_writes_no_have_state(self):
+        """Accept (suspect grade, no existing on disk) → no on-disk spectral is
+        written; the candidate's spectral is never adopted as HAVE state (#815)."""
         from lib.config import CratediggerConfig
         from lib.measurement import measure_preimport_state
 
@@ -1496,10 +1488,10 @@ class TestSpectralPropagationOnAccept(unittest.TestCase):
                 request_id=42,
             )
 
-        # Measurement is fact-only; no existing album means no
-        # existing-spectral propagation. Per ``_persist_spectral_state``
-        # semantics, when existing_spectral is None AND existing_min_bitrate
-        # is None, nothing is persisted.
+        # Measurement is fact-only; no existing album means no on-disk
+        # measurement. Per ``_persist_spectral_state`` semantics, when
+        # existing_spectral is None nothing is persisted — the candidate's
+        # spectral is never adopted (#815).
         self.assertFalse(measurement.audio_corrupt)
         row = db.request(42)
         self.assertIsNone(row.get("current_spectral_grade"))

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -4467,7 +4467,11 @@ class TestAlbumQualityEvidenceStorage(unittest.TestCase):
         self.assertTrue(claimed.on_disk_v0_research_attempted)
         self.assertIsNone(claimed.v0_metric)
 
-    def test_current_spectral_write_requires_exact_empty_current_snapshot(self):
+    def test_current_spectral_write_overwrites_with_fresh_measured_audit(self):
+        """Issue #815 fresh-audit-wins (real-PG round-trip). A fresh measured
+        installed-subject audit of the exact snapshot re-persists over ANY
+        disagreeing persisted grade; only the identity guards (request FK,
+        evidence id, snapshot fingerprint) still gate the write."""
         evidence = self._seed(
             mb_release_id="evidence-uuid",
             measurement=AudioQualityMeasurement(
@@ -4488,6 +4492,7 @@ class TestAlbumQualityEvidenceStorage(unittest.TestCase):
         self.assertTrue(self.db.set_request_current_evidence(
             self.req_id, stored.id))
 
+        # A wrong fingerprint is still refused.
         self.assertFalse(self.db.persist_current_spectral_measurement(
             request_id=self.req_id,
             expected_evidence_id=stored.id,
@@ -4495,6 +4500,7 @@ class TestAlbumQualityEvidenceStorage(unittest.TestCase):
             grade="genuine",
             bitrate_kbps=96,
         ))
+        # First exact write fills the empty slot.
         self.assertTrue(self.db.persist_current_spectral_measurement(
             request_id=self.req_id,
             expected_evidence_id=stored.id,
@@ -4502,19 +4508,22 @@ class TestAlbumQualityEvidenceStorage(unittest.TestCase):
             grade="genuine",
             bitrate_kbps=96,
         ))
-        self.assertFalse(self.db.persist_current_spectral_measurement(
+        # A disagreeing fresh measured audit of the SAME snapshot now WINS
+        # (pre-#815 this was fill-only-if-NULL and returned False).
+        self.assertTrue(self.db.persist_current_spectral_measurement(
             request_id=self.req_id,
             expected_evidence_id=stored.id,
             expected_snapshot_fingerprint=stored.snapshot_fingerprint,
             grade="likely_transcode",
             bitrate_kbps=160,
         ))
-        self.db.upsert_album_quality_evidence(evidence)
 
         loaded = self.db.load_album_quality_evidence_by_id(stored.id)
         assert loaded is not None
-        self.assertEqual(loaded.measurement.spectral_grade, "genuine")
-        self.assertEqual(loaded.measurement.spectral_bitrate_kbps, 96)
+        self.assertEqual(loaded.measurement.spectral_grade, "likely_transcode")
+        self.assertEqual(loaded.measurement.spectral_bitrate_kbps, 160)
+        self.assertEqual(loaded.measurement.spectral_subject, "installed")
+        self.assertEqual(loaded.measurement.spectral_provenance, "measured")
 
     def test_current_spectral_write_rejects_lossless_lineage(self):
         from lib.quality import AlbumQualityV0Metric

--- a/tests/test_quality_classification.py
+++ b/tests/test_quality_classification.py
@@ -501,6 +501,54 @@ class TestLiveBugReproductions(unittest.TestCase):
         self.assertEqual(basis["existing_value_kbps"], 256)
 
 
+class TestSpectralLandmineDecisionConsequence(unittest.TestCase):
+    """Issue #815: the persisted HAVE spectral grade is decision-load-bearing.
+
+    Shugo Tokumaru EXIT (request 4351, dl 37742). The installed genuine 192
+    copy carried a STALE ``likely_transcode``/128 landmine (a rejected fake-320
+    candidate's grade adopted in May-2026 and frozen into evidence). Fresh
+    audit of the installed bytes says ``genuine`` — and #815 fresh-audit-wins
+    now re-persists it. This pins the downstream consequence through the REAL
+    production decider (``full_pipeline_decision_from_evidence``): the stale
+    landmine drags the installed copy's rank down from its true ``good`` to a
+    degraded ``acceptable``, making the genuine copy far easier for a lossy
+    candidate to displace. With the fresh genuine grade the installed rank is
+    honest again.
+    """
+
+    def _existing_rank(self, have_grade: str | None, have_bitrate: int | None):
+        from lib.quality import full_pipeline_decision_from_evidence
+        candidate = build_parity_candidate_evidence(
+            is_flac=False, min_bitrate=320, is_cbr=True, avg_bitrate=320,
+            spectral_grade="likely_transcode", spectral_bitrate=128,
+        )
+        current = build_parity_current_evidence(
+            min_bitrate=192, avg_bitrate=192, format="MP3", is_cbr=True,
+            spectral_grade=have_grade, spectral_bitrate=have_bitrate,
+        )
+        r = full_pipeline_decision_from_evidence(candidate, current)
+        return r["comparison_basis"]["existing_rank"]
+
+    def test_fresh_genuine_have_ranks_installed_copy_honestly(self):
+        # Fresh-audit-wins: the installed 192 copy ranks by its true genuine
+        # grade — ``good``.
+        self.assertEqual(self._existing_rank("genuine", None), "good")
+
+    def test_stale_transcode_landmine_degrades_installed_rank(self):
+        # The pre-#815 landmine (frozen likely_transcode/128) drags the very
+        # same installed copy down to ``acceptable`` — a strictly weaker rank
+        # than the honest ``good`` above, which is what let a fake-320 displace
+        # the genuine copy on dl 37742.
+        self.assertEqual(self._existing_rank("likely_transcode", 128),
+                         "acceptable")
+        self.assertNotEqual(
+            self._existing_rank("likely_transcode", 128),
+            self._existing_rank("genuine", None),
+            "the persisted HAVE grade must change the installed copy's rank — "
+            "otherwise the fresh-audit-wins fix would be inert",
+        )
+
+
 class TestLiveBugReproductionsThroughEvidencePipeline(unittest.TestCase):
     """Every TestLiveBugReproductions scenario must produce the same outcome
     when run through ``full_pipeline_decision_from_evidence`` — the function

--- a/tests/test_quality_classification.py
+++ b/tests/test_quality_classification.py
@@ -502,21 +502,29 @@ class TestLiveBugReproductions(unittest.TestCase):
 
 
 class TestSpectralLandmineDecisionConsequence(unittest.TestCase):
-    """Issue #815: the persisted HAVE spectral grade is decision-load-bearing.
+    """Issue #815 dl-37742 counterfactual: the persisted HAVE spectral grade
+    flips the import decision through the REAL production decider.
 
     Shugo Tokumaru EXIT (request 4351, dl 37742). The installed genuine 192
     copy carried a STALE ``likely_transcode``/128 landmine (a rejected fake-320
-    candidate's grade adopted in May-2026 and frozen into evidence). Fresh
-    audit of the installed bytes says ``genuine`` — and #815 fresh-audit-wins
-    now re-persists it. This pins the downstream consequence through the REAL
-    production decider (``full_pipeline_decision_from_evidence``): the stale
-    landmine drags the installed copy's rank down from its true ``good`` to a
-    degraded ``acceptable``, making the genuine copy far easier for a lossy
-    candidate to displace. With the fresh genuine grade the installed rank is
-    honest again.
+    candidate's grade adopted in May-2026 and frozen into evidence). The fresh
+    audit of the installed bytes says ``genuine``/160, and #815 fresh-audit-wins
+    now re-persists it. Fed the exact fake-320 candidate
+    (``likely_transcode``/128) against that installed 192 copy,
+    ``full_pipeline_decision_from_evidence`` (the function the importer actually
+    calls) reverses outcome on the HAVE grade alone:
+
+    - fresh genuine/160  -> Stage 1 REJECTS the fake-320, imported=False
+      (the genuine copy is protected).
+    - stale lt/128 landmine -> Stage 1 imports, imported=True — the actual
+      data-loss path that replaced the genuine 192 with the fake-320.
+
+    (Note the missing-bitrate shape genuine/None routes through
+    ``import_no_exist`` and imports — which is why the HAVE bitrate is part of
+    what fresh-audit-wins re-persists, not just the grade.)
     """
 
-    def _existing_rank(self, have_grade: str | None, have_bitrate: int | None):
+    def _decide(self, have_grade: str | None, have_bitrate: int | None):
         from lib.quality import full_pipeline_decision_from_evidence
         candidate = build_parity_candidate_evidence(
             is_flac=False, min_bitrate=320, is_cbr=True, avg_bitrate=320,
@@ -526,27 +534,30 @@ class TestSpectralLandmineDecisionConsequence(unittest.TestCase):
             min_bitrate=192, avg_bitrate=192, format="MP3", is_cbr=True,
             spectral_grade=have_grade, spectral_bitrate=have_bitrate,
         )
-        r = full_pipeline_decision_from_evidence(candidate, current)
-        return r["comparison_basis"]["existing_rank"]
+        return full_pipeline_decision_from_evidence(candidate, current)
 
-    def test_fresh_genuine_have_ranks_installed_copy_honestly(self):
-        # Fresh-audit-wins: the installed 192 copy ranks by its true genuine
-        # grade — ``good``.
-        self.assertEqual(self._existing_rank("genuine", None), "good")
+    def test_fresh_genuine_have_rejects_the_fake_320(self):
+        # Fresh-audit-wins value (genuine/160): the fake-320 candidate is
+        # rejected at Stage 1 (which short-circuits before Stage 2's
+        # comparison), so the genuine 192 copy is protected.
+        r = self._decide("genuine", 160)
+        self.assertEqual(r["stage1_spectral"], "reject")
+        self.assertFalse(r["imported"])
+        self.assertTrue(r["keep_searching"])
 
-    def test_stale_transcode_landmine_degrades_installed_rank(self):
-        # The pre-#815 landmine (frozen likely_transcode/128) drags the very
-        # same installed copy down to ``acceptable`` — a strictly weaker rank
-        # than the honest ``good`` above, which is what let a fake-320 displace
-        # the genuine copy on dl 37742.
-        self.assertEqual(self._existing_rank("likely_transcode", 128),
-                         "acceptable")
-        self.assertNotEqual(
-            self._existing_rank("likely_transcode", 128),
-            self._existing_rank("genuine", None),
-            "the persisted HAVE grade must change the installed copy's rank — "
-            "otherwise the fresh-audit-wins fix would be inert",
-        )
+    def test_stale_transcode_landmine_imports_the_fake_320(self):
+        # The pre-#815 landmine (frozen likely_transcode/128) is the actual
+        # dl-37742 displacement: the fake-320 imports over the genuine copy.
+        r = self._decide("likely_transcode", 128)
+        self.assertEqual(r["stage1_spectral"], "import")
+        self.assertTrue(r["imported"])
+        # The landmine degrades the installed copy's rank to acceptable.
+        self.assertEqual(r["comparison_basis"]["existing_rank"], "acceptable")
+
+    def test_have_grade_flips_the_import_outcome(self):
+        # The load-bearing pin: the persisted HAVE grade alone flips imported.
+        self.assertFalse(self._decide("genuine", 160)["imported"])
+        self.assertTrue(self._decide("likely_transcode", 128)["imported"])
 
 
 class TestLiveBugReproductionsThroughEvidencePipeline(unittest.TestCase):

--- a/tests/test_quality_lineage_generated.py
+++ b/tests/test_quality_lineage_generated.py
@@ -1375,6 +1375,92 @@ class TestQualityLineageGenerated(unittest.TestCase):
             )
 
     @given(
+        stale_grade=st.sampled_from(("genuine", "suspect", "likely_transcode")),
+        stale_bitrate=st.one_of(
+            st.none(), st.integers(min_value=32, max_value=500)),
+        fresh_grade=st.sampled_from(("genuine", "suspect", "likely_transcode")),
+        fresh_bitrate=st.one_of(
+            st.none(), st.integers(min_value=32, max_value=500)),
+        payload_size=st.integers(min_value=1, max_value=128),
+    )
+    @example(
+        stale_grade="likely_transcode", stale_bitrate=128,
+        fresh_grade="genuine", fresh_bitrate=160, payload_size=27,
+    )
+    def test_fresh_audit_overwrites_stale_landmine_grade(
+        self,
+        stale_grade: str,
+        stale_bitrate: int | None,
+        fresh_grade: str,
+        fresh_bitrate: int | None,
+        payload_size: int,
+    ) -> None:
+        """Issue #815 fresh-audit-wins property. A legacy landmine — an
+        installed-subject evidence row whose spectral grade disagrees with a
+        fresh audit of its matched-fingerprint bytes (a state a clean forward
+        run can never produce) — is always overwritten by a successful fresh
+        measured audit; the stale grade never survives."""
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=42, mb_release_id="landmine-have"))
+        with tempfile.TemporaryDirectory() as source:
+            with open(os.path.join(source, "01.mp3"), "wb") as handle:
+                handle.write(b"y" * payload_size)
+            evidence = make_album_quality_evidence(
+                mb_release_id="landmine-have",
+                source_path=source,
+                files=snapshot_audio_files(source),
+                measurement=AudioQualityMeasurement(
+                    min_bitrate_kbps=192,
+                    avg_bitrate_kbps=192,
+                    median_bitrate_kbps=192,
+                    format="MP3",
+                    spectral_grade=stale_grade,
+                    spectral_bitrate_kbps=stale_bitrate,
+                    spectral_subject="installed",
+                    spectral_provenance="measured",
+                ),
+            )
+            db.upsert_album_quality_evidence(evidence)
+            stored = db.find_album_quality_evidence(
+                mb_release_id=evidence.mb_release_id,
+                snapshot_fingerprint=evidence.snapshot_fingerprint,
+            )
+            assert stored is not None and stored.id is not None
+            db.set_request_current_evidence(42, stored.id)
+
+            result = persist_exact_current_spectral_from_attempt(
+                db,
+                request_id=42,
+                current_evidence=stored,
+                measured_existing=SpectralAnalysisDetail(
+                    attempted=True,
+                    grade=fresh_grade,
+                    bitrate_kbps=fresh_bitrate,
+                ),
+                measured_existing_path=source,
+            )
+
+            assert result.evidence is not None
+            # The fresh audit wins on the returned row...
+            assert_exact_current_spectral_persisted(
+                expected_grade=fresh_grade,
+                expected_bitrate=fresh_bitrate,
+                actual_grade=result.evidence.measurement.spectral_grade,
+                actual_bitrate=(
+                    result.evidence.measurement.spectral_bitrate_kbps
+                ),
+            )
+            # ...and durably, not just in the returned struct.
+            reloaded = db.load_album_quality_evidence_by_id(stored.id)
+            assert reloaded is not None
+            assert_exact_current_spectral_persisted(
+                expected_grade=fresh_grade,
+                expected_bitrate=fresh_bitrate,
+                actual_grade=reloaded.measurement.spectral_grade,
+                actual_bitrate=reloaded.measurement.spectral_bitrate_kbps,
+            )
+
+    @given(
         label=st.sampled_from(("mp3 v0", "MP3 V0", "mp3 320", " MP3 320 ")),
         supplied_mode=st.booleans(),
     )
@@ -1906,6 +1992,17 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
                 expected_bitrate=96,
                 actual_grade=None,
                 actual_bitrate=None,
+            )
+
+    def test_exact_current_spectral_checker_rejects_surviving_landmine(self):
+        # #815 fresh-audit-wins: a stale likely_transcode/128 grade that
+        # survived a fresh genuine/160 audit must trip the checker.
+        with self.assertRaisesRegex(AssertionError, "exact current evidence"):
+            assert_exact_current_spectral_persisted(
+                expected_grade="genuine",
+                expected_bitrate=160,
+                actual_grade="likely_transcode",
+                actual_bitrate=128,
             )
 
     def test_source_target_checker_rejects_target_labelled_proxy(self):

--- a/tests/world_model/state_machine.py
+++ b/tests/world_model/state_machine.py
@@ -1025,5 +1025,79 @@ TestGeneratedEvidenceDriftWorld.test_live_drift_worlds_relink_without_retry_bypa
 )
 
 
+class TestGeneratedSpectralLandmineWorld(unittest.TestCase):
+    """Issue #815: a legacy spectral landmine on real installed evidence is
+    overwritten by a fresh audit of the exact same real Beets bytes.
+
+    A stale installed/measured spectral grade that disagrees with a fresh audit
+    of its matched-fingerprint bytes is a state a clean forward run can never
+    produce (the May-2026 adoption + fill-only-if-NULL freeze). Fresh-audit-wins
+    must overwrite it; the stale grade must never survive. Driven end-to-end
+    against real PostgreSQL and a real Beets album so the persist path's
+    fingerprint guard is exercised against genuine installed bytes."""
+
+    @given(
+        identity_source=st.sampled_from(("mb", "discogs")),
+        stale_grade=st.sampled_from(("suspect", "likely_transcode")),
+        fresh_grade=st.sampled_from(("genuine", "marginal")),
+    )
+    @example(
+        identity_source="mb",
+        stale_grade="likely_transcode",
+        fresh_grade="genuine",
+    )
+    def test_fresh_audit_overwrites_installed_spectral_landmine(
+        self,
+        identity_source: str,
+        stale_grade: str,
+        fresh_grade: str,
+    ) -> None:
+        assert TEST_DSN is not None
+        release_id = (
+            "33000000-0000-4000-8000-000000000815"
+            if identity_source == "mb"
+            else "7330815"
+        )
+        with LifecycleWorld(TEST_DSN, repository_root()) as world:
+            request_id = world.add_release(BeetsWorldRelease(
+                release_id=release_id,
+                artist="Shugo Tokumaru",
+                album="Exit",
+                year=2007,
+                codec="mp3",
+            ))
+            self.assertTrue(world.import_request(request_id, codec="mp3"))
+
+            grade, bitrate, status = world.drive_spectral_landmine_heal(
+                request_id,
+                stale_grade=stale_grade,
+                stale_bitrate=128,
+                fresh_grade=fresh_grade,
+                fresh_bitrate=160,
+            )
+
+            self.assertEqual(status, "ready")
+            self.assertEqual(
+                grade, fresh_grade,
+                "fresh-audit-wins: the stale landmine grade must not survive",
+            )
+            self.assertEqual(bitrate, 160)
+            world.assert_invariants()
+
+
+TestGeneratedSpectralLandmineWorld \
+    .test_fresh_audit_overwrites_installed_spectral_landmine = settings(
+        max_examples=int(os.environ.get("CRATEDIGGER_WORLD_EXAMPLES", "6")),
+        deadline=None,
+        derandomize=not _RANDOMIZED,
+        database=_DATABASE,
+        print_blob=_RANDOMIZED,
+        suppress_health_check=(HealthCheck.too_slow,),
+    )(
+        TestGeneratedSpectralLandmineWorld
+        .test_fresh_audit_overwrites_installed_spectral_landmine
+    )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/world_model/support.py
+++ b/tests/world_model/support.py
@@ -39,6 +39,7 @@ from lib.import_evidence import (
 from lib.import_preview import (
     ImportPreviewResult,
     enrich_incomplete_current_evidence_for_request,
+    persist_exact_current_spectral_from_attempt,
 )
 from lib.import_queue import (
     IMPORT_JOB_AUTOMATION,
@@ -466,6 +467,70 @@ class LifecycleWorld:
                 f"reason={current.provenance.fallback_reason!r}"
             )
         return outcome
+
+    def drive_spectral_landmine_heal(
+        self,
+        request_id: int,
+        *,
+        stale_grade: str,
+        stale_bitrate: int | None,
+        fresh_grade: str,
+        fresh_bitrate: int | None,
+    ) -> tuple[str | None, int | None, str]:
+        """Seed a legacy spectral landmine on the linked HAVE evidence, then run
+        the REAL fresh-audit-wins persist over the real installed beets bytes.
+
+        The landmine — a stale installed/measured spectral grade that disagrees
+        with a fresh audit of the exact same bytes — is a state a clean forward
+        run can never produce (issue #815). Returns
+        ``(reloaded_grade, reloaded_bitrate, persist_status)``.
+        """
+        release = self._release_by_request[request_id]
+        album = self._album_for_release(release.release_id)
+        if album is None:
+            raise AssertionError("landmine heal requires an installed album")
+        evidence_id = self.db.get_request_current_evidence_id(request_id)
+        evidence = self.db.load_album_quality_evidence_by_id(evidence_id)
+        if evidence is None or evidence.id is None:
+            raise AssertionError(
+                "landmine heal requires linked current evidence"
+            )
+        self.db._execute(
+            """
+            UPDATE album_quality_evidence
+            SET spectral_grade = %s,
+                spectral_bitrate_kbps = %s,
+                spectral_subject = 'installed',
+                spectral_provenance = 'measured'
+            WHERE id = %s
+            """,
+            (stale_grade, stale_bitrate, evidence.id),
+        )
+        self.db.conn.commit()
+        seeded = self.db.load_album_quality_evidence_by_id(evidence.id)
+        if seeded is None:
+            raise AssertionError("landmine seed disappeared")
+        if seeded.measurement.spectral_grade != stale_grade:
+            raise AssertionError("landmine seed did not persist")
+        result = persist_exact_current_spectral_from_attempt(
+            self.db,
+            request_id=request_id,
+            current_evidence=seeded,
+            measured_existing=SpectralAnalysisDetail(
+                attempted=True,
+                grade=fresh_grade,
+                bitrate_kbps=fresh_bitrate,
+            ),
+            measured_existing_path=album.album_path,
+        )
+        reloaded = self.db.load_album_quality_evidence_by_id(evidence.id)
+        if reloaded is None:
+            raise AssertionError("current evidence disappeared during heal")
+        return (
+            reloaded.measurement.spectral_grade,
+            reloaded.measurement.spectral_bitrate_kbps,
+            result.status,
+        )
 
     def latest_download_outcome(self, request_id: int) -> str | None:
         """Return the newest audit outcome for one generated request."""


### PR DESCRIPTION
Fixes #815 (code half; the historical-row repair is a post-deploy operator one-shot per scope.md).

## What

Two policy changes, per the corrected RCA (https://github.com/abl030/cratedigger/issues/815#issuecomment-5040518013) and the operator's fail-closed directive (#762/#723 doctrine):

1. **Bail on absent HAVE spectral.** The `_persist_spectral_state` adoption branch is deleted with all its plumbing (`propagate_download_to_existing`): the candidate download's spectral is NEVER written as the request's on-disk (HAVE) state. When the on-disk audit yields nothing, nothing is written — the absence stays visible instead of being papered over with the "reasonable proxy" that froze a rejected fake-320's `likely_transcode/128` onto a genuine 192 copy and drove the dl-37742 library downgrade.
2. **Fresh-audit-wins.** `persist_current_spectral_measurement` drops the fill-only-if-NULL guard and `persist_exact_current_spectral_from_attempt` drops the already-has-grade early return: a SUCCESSFUL fresh on-disk audit of the exact matched-fingerprint bytes re-persists grade+bitrate (`installed`/`measured`) over any disagreeing persisted value. A FAILED audit still never clears anything (fail-soft `incomplete`), and R19 lossless-source rows keep their source spectral (Python preserve guard + migration-057 CHECK, both intact).

## Invariants (pin + property + known-bad, per the PAIR rule)

- **A (bail):** pins for the path-missing and analyzer-exception shapes (the May-12 world) + a Hypothesis property over candidate grade/bitrate × existing-audit outcome worlds driving the real `measure_preimport_state` + checker self-test (`tests/test_force_import_gates.py::TestNoCandidateSpectralAdoptedAsHave`).
- **B (fresh-audit-wins):** Shugo Tokumaru EXIT pin (stale `likely_transcode/128` overwritten by fresh `genuine/160`), real-PG round-trip (Rule A), fake parity self-test, generated property + known-bad (`tests/test_quality_lineage_generated.py`), end-to-end world-model landmine world over real PG + real beets (`TestGeneratedSpectralLandmineWorld`), and the decision-consequence pins proving the import outcome flips on the HAVE grade (`genuine/160 → reject` vs stale `128 → import` — the dl-37742 counterfactual).
- Must-still-work guards: R19 preserve, failed-audit fail-soft, real-existing-measurement persistence.

## Review

Opus adversarial review: production hunts (surviving adoption paths, overwrite widenings, R19 bypasses, failed-audit semantics) all came back empty; two test-strength findings (under-strength decision pin with an empirically false rationale; missing generated half of the bail invariant) fixed in the follow-up commit.

## Gates (on the final merged tree)

- `pyright --threads 4` whole repo: 0 errors
- `bash scripts/run_tests.sh`: 6675 tests OK
- `bash scripts/fuzz_burst.sh`: ALL GREEN (incl. `test_spectral_attempt_audit_generated` at 20k-example depth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
