### PR TITLE
docs: generalize masked-pipe rule + add outcome-flip pin rule

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -196,6 +196,20 @@ Any type that **crosses JSON** — harness stdout, an HTTP response, a JSONB blo
   a single-point mutant immediately proved was the load-bearing half).
   Subagent implementation briefs state the pair requirement verbatim and
   never offer a deterministic-only alternative.
+- **A decision-consequence pin must assert the decided outcome, not a proxy
+  field.** If a pin claims "this world changes what the pipeline decides,"
+  it must drive the real decider and assert the *decided outcome*
+  (import/reject/requeue) flipping between the bug world and the fixed
+  world — a rank, grade, or other intermediate field is not the
+  consequence, however plausible-looking. When the flip doesn't reproduce,
+  the probe world is wrong (check missing-value routing such as
+  `import_no_exist`) — verify empirically before writing a rationale that
+  it "can't flip". Lesson (#815 review): an implementer pinned a proxy
+  metric (`existing_rank` good→acceptable) because their probe world used
+  `genuine/None`, which routed through `import_no_exist` and hid the flip;
+  the real fresh-audit value (`genuine/160`) flips `imported` False↔True
+  through `full_pipeline_decision_from_evidence` — the actual consequence
+  and the strictly stronger regression guard.
 - **Every invariant checker owes a known-bad self-test**: a planted
   violating decision/state proving the checker trips. A property that has
   never failed anything is unfalsifiable until proven otherwise. Keep

--- a/.claude/rules/deploy.md
+++ b/.claude/rules/deploy.md
@@ -3,11 +3,18 @@
 - All code deploys via Nix flake: push cratedigger (GitHub) → `nix flake update cratedigger-src` on doc1 → commit (SSH-signed) + push nixosconfig to **Forgejo** → from doc1 run `fleet-deploy doc2` through the locked-sibling forced-command boundary, then poll and verify the asynchronous update.
 - **Since the Forgejo cutover (2026-06-10), nixosconfig deploys come from Forgejo (`git.ablz.au`), NEVER `github:abl030/nixosconfig` — GitHub is a frozen, stale fallback.** The cratedigger repo itself still lives on GitHub; only the nixosconfig leg changed.
 - The Forgejo push needs a token header (gh's credential helper is github.com-only). Configure it through `GIT_CONFIG_COUNT`, `GIT_CONFIG_KEY_0`, and `GIT_CONFIG_VALUE_0` in the environment, never a `git -c` argv value or remote URL. Never echo the token. The exact example is in `.claude/skills/deploy/SKILL.md`.
-- Check each push's exit status directly. Never pipe `git push` output through
-  `tail` (or any other command) inside an `&&` chain unless `pipefail` is
-  explicitly active: the downstream command's success can mask a failed push.
-  After a successful push, verify the expected remote ref resolves to the
-  pushed commit before any dependent action such as `gh pr merge` or
+- **Never pipe a result-bearing command through `tail`/`head`/`grep` inside an
+  `&&` chain unless `pipefail` is explicitly active** — this covers gate
+  commands (test suites, fuzz bursts), pushes, deploy triggers, and one-shots
+  alike: the downstream command's success can mask the real exit status.
+  Long-running commands redirect output to a file and echo `$?` explicitly,
+  then the file is tailed separately, as a distinct step. Incident:
+  `fuzz_burst.sh 2>&1 | tail -12` run in the background masked the script's
+  exit code behind `tail`'s AND buffered all output until EOF, so the
+  monitoring surface read "completed, exit 0, empty output" — triggering a
+  redundant second burst mid-deploy. For pushes specifically: check each
+  push's exit status directly, then verify the expected remote ref resolves
+  to the pushed commit before any dependent action such as `gh pr merge` or
   `fleet-deploy`.
 - `fleet-deploy doc2` asynchronously triggers doc2's `nixos-upgrade.service`; the underlying verified update checks every commit in range against the SSH signing keys in `hosts.nix`, then builds from its root-owned clone at `/var/lib/fleet-update/repo`. Capture `InvocationID` before triggering, wait within a bounded timeout for a different nonempty invocation, poll that same invocation's keyed `ActiveState`/`SubState`/`Result` to inactive/dead/success, and require `/var/lib/fleet-update/last-verified-rev` to equal the signed Forgejo commit before declaring success. Direct `fleet-update` on doc2 is not the normal deployment path.
 - The NixOS module lives in this repo at `nix/module.nix` (exposed as `nixosModules.default`). The downstream wrapper at `~/nixosconfig/modules/nixos/services/cratedigger.nix` imports it via `inputs.cratedigger-src.nixosModules.default`.


### PR DESCRIPTION
## Summary
- `deploy.md`: generalize the `git push | tail` masked-exit-code rule to any result-bearing command (gate commands, pushes, deploy triggers, one-shots) piped through `tail`/`head`/`grep` without `pipefail`; cites the `fuzz_burst.sh 2>&1 | tail -12` incident that masked exit code + buffered output until EOF and triggered a redundant second burst mid-deploy. Push-specific remote-ref verification guidance is kept intact.
- `code-quality.md`: adds a testing rule that a decision-consequence pin must drive the real decider and assert the *decided outcome* flipping (import/reject/requeue) between bug world and fixed world — a rank/grade/intermediate field is not the consequence. Cites the #815 review finding where a pinned `existing_rank` proxy flip masked that the probe world (`genuine/None`) routed through `import_no_exist`, hiding the real `imported` False↔True flip on `genuine/160`.

Both edits are the two items from the #815 post-ship reflection issue.

Part of #819.

## Test plan
- [x] `nix-shell --run "pyright --threads 4"` — 0 errors, 0 warnings, 0 informations
- [x] `nix-shell --run "bash scripts/run_tests.sh"` — OK, 6695 tests across 4 workers