### PR TITLE
fix: single-source the denylisted decision field + live-candidate replay tier

### DIFF
--- a/docs/debugging-cli.md
+++ b/docs/debugging-cli.md
@@ -2,7 +2,7 @@
 
 ```bash
 pipeline-cli show <request_id>               # quality columns + download history with import decisions
-pipeline-cli quality <request_id>            # simulate gate for genuine FLAC / V0 / CBR 320 / suspect FLAC
+pipeline-cli quality <request_id>            # simulate gate for genuine FLAC / V0 / CBR 320 / suspect FLAC, PLUS a replay of the request's actual last download_log candidate evidence through the real decider
 pipeline-cli debug-download <download_log_id>  # raw JSONB audit for one attempt
 pipeline-cli search-plan show <request_id>   # active plan + cursor + per-slot usefulness stats (--json for machine output)
 pipeline-cli triage quarantine --json       # unreferenced immediate failed_imports album folders (read-only)
@@ -38,7 +38,7 @@ Note the escaped `\$` and `\"` — they are evaluated inside the inner
 `pipeline-cli query - <<'SQL' ... SQL` *inside* the `sudo bash -c` body, or
 write the query to a temp file and pass it as an argument.
 
-`pipeline-cli query` sets `default_transaction_read_only = on` — safe for diagnostics. When debugging pipeline behavior, start with the simulator (`pipeline-cli quality`) and add scenarios that expose the bug FIRST — see `.claude/rules/code-quality.md` § "Pipeline Decision Debugging — Simulator-First TDD".
+`pipeline-cli query` sets `default_transaction_read_only = on` — safe for diagnostics. When debugging pipeline behavior, start with the simulator (`pipeline-cli quality`) and add scenarios that expose the bug FIRST — see `.claude/rules/code-quality.md` § "Pipeline Decision Debugging — Simulator-First TDD". `pipeline-cli quality`'s synthetic scenarios are canned grade/bitrate combos that may not reproduce the exact live candidate; the trailing "What the last real candidate actually decided" section (issue #813 tooling tier) replays the request's actual last-candidate `album_quality_evidence` row (the newest `download_log.candidate_evidence_id` for the request) through the real production decider (`full_pipeline_decision_from_evidence`) — read-only, no offline decider run needed to verify a live album's quality decision.
 
 ## Beets operation recovery
 

--- a/lib/dispatch/core.py
+++ b/lib/dispatch/core.py
@@ -537,7 +537,6 @@ def dispatch_import_core(
                     file_list,
                 ) = _resolve_post_import_search_policy(
                     decision=decision,
-                    action=action,
                     files=files,
                     fallback_username=dl_info.username,
                 )

--- a/lib/dispatch/post_import.py
+++ b/lib/dispatch/post_import.py
@@ -23,7 +23,7 @@ from lib.quality.decisions import (
     PostImportSearchAction,
     post_import_search_action_if_known,
 )
-from lib.quality.dispatch_actions import DispatchAction
+from lib.quality.dispatch_actions import decision_denylists
 
 from lib.dispatch.quality_gate import QualityGatePlan
 from lib.dispatch.types import QualityGateFn
@@ -97,7 +97,6 @@ def _run_or_stage_quality_gate(
 def _resolve_post_import_search_policy(
     *,
     decision: str,
-    action: DispatchAction,
     files: Sequence[object] | None,
     fallback_username: str | None,
 ) -> tuple[PostImportSearchAction | None, bool, set[str], list[object]]:
@@ -109,11 +108,7 @@ def _resolve_post_import_search_policy(
     """
 
     search_action = post_import_search_action_if_known(decision)
-    should_denylist = (
-        search_action.denylist
-        if search_action is not None
-        else action.denylist
-    )
+    should_denylist = decision_denylists(decision)
     file_list = list(files or ())
     usernames = extract_usernames(file_list) if should_denylist else set[str]()
     if should_denylist and fallback_username:

--- a/lib/pipeline_db/evidence.py
+++ b/lib/pipeline_db/evidence.py
@@ -646,6 +646,32 @@ class _EvidenceMixin(_PipelineDBBase):
         return int(row["candidate_evidence_id"])
 
 
+    def get_latest_download_log_candidate_evidence_id(
+        self,
+        request_id: int,
+    ) -> int | None:
+        """Return the newest download_log candidate evidence id for this
+        request, or None if no download attempt left candidate evidence.
+
+        Candidate evidence is addressed per-attempt (``download_log_id``),
+        not per-request — this is the one place that walks attempt history
+        to find "the request's last candidate", for diagnostics
+        (``pipeline-cli quality <id>``'s live-candidate replay tier, issue
+        #813). Production dispatch never needs this: it always already
+        knows the exact ``download_log_id``/``import_job_id`` in flight.
+        """
+        cur = self._execute("""
+            SELECT candidate_evidence_id
+            FROM download_log
+            WHERE request_id = %s
+              AND candidate_evidence_id IS NOT NULL
+            ORDER BY id DESC
+            LIMIT 1
+        """, (int(request_id),))
+        row = cur.fetchone()
+        return int(row["candidate_evidence_id"]) if row else None
+
+
     def get_request_current_evidence_id(
         self,
         request_id: int,

--- a/lib/quality/__init__.py
+++ b/lib/quality/__init__.py
@@ -171,6 +171,7 @@ from lib.quality.dispatch_actions import (
     DispatchAction,
     RejectionSearchOverrideResolution,
     compute_effective_override_bitrate,
+    decision_denylists,
     dispatch_action,
     extract_usernames,
     narrow_override_on_downgrade,
@@ -198,6 +199,7 @@ from lib.quality.pipeline import (
     full_pipeline_decision,
     full_pipeline_decision_from_evidence,
     override_bitrate_from_current_evidence,
+    resolve_pipeline_decision_denylist,
 )
 
 __all__ = [
@@ -321,6 +323,7 @@ __all__ = [
     "comparison_format_hint",
     "compute_effective_override_bitrate",
     "decide_download_action",
+    "decision_denylists",
     "determine_verified_lossless",
     "mint_verified_lossless_proof",
     "dispatch_action",
@@ -353,6 +356,7 @@ __all__ = [
     "reduce_poll_cycle",
     "rejected_download_tier",
     "rejection_backfill_override",
+    "resolve_pipeline_decision_denylist",
     "resolve_rejection_search_override",
     "resolve_retained_search_override",
     "resolve_user_requeue_override",

--- a/lib/quality/dispatch_actions.py
+++ b/lib/quality/dispatch_actions.py
@@ -21,6 +21,7 @@ from lib.quality.decisions import (
     DECISION_SUSPECT_LOSSLESS_DOWNGRADE,
     DECISION_SUSPECT_LOSSLESS_PROBE_MISSING,
     DECISION_VERIFIED_LOSSLESS_LOCKED,
+    post_import_search_action_if_known,
 )
 
 
@@ -104,6 +105,31 @@ def dispatch_action(decision: str) -> DispatchAction:
                               cleanup=False)
     else:  # import_failed, conversion_failed, mbid_missing, crash, etc.
         return DispatchAction(record_rejection=True)
+
+
+def decision_denylists(decision: str) -> bool:
+    """Whether ``decision`` denylists its source — the ONE production policy.
+
+    Issue #813 Finding 2: the ``full_pipeline_decision``/
+    ``full_pipeline_decision_from_evidence`` decision dict used to carry a
+    hand-set ``denylisted`` bool that three separate branches independently
+    forgot to set (all three ``downgrade`` return sites), silently diverging
+    from what the real importer writes. This is the two-tier lookup
+    production actually applies to resolve denylist policy from a decision
+    string: a retained-import decision (``accept``/``requeue_upgrade``/
+    ``requeue_lossless``/``provisional_lossless_upgrade``/
+    ``transcode_upgrade``/``transcode_first``) is governed by
+    ``post_import_search_action``; every other decision falls back to
+    ``dispatch_action``. Both ``lib.dispatch.post_import.
+    _resolve_post_import_search_policy`` (the real write) and
+    ``lib.quality.pipeline.resolve_pipeline_decision_denylist`` (the
+    simulator/evidence-pipeline display) call this one function — no second
+    reimplementation.
+    """
+    search_action = post_import_search_action_if_known(decision)
+    if search_action is not None:
+        return search_action.denylist
+    return dispatch_action(decision).denylist
 
 
 def compute_effective_override_bitrate(

--- a/lib/quality/pipeline.py
+++ b/lib/quality/pipeline.py
@@ -51,7 +51,10 @@ from lib.quality.decisions import (
     transcode_detection,
     v0_probe_overrides_spectral,
 )
-from lib.quality.dispatch_actions import compute_effective_override_bitrate
+from lib.quality.dispatch_actions import (
+    compute_effective_override_bitrate,
+    decision_denylists,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -132,7 +135,12 @@ def full_pipeline_decision(
             "stage3_quality_gate": str,   # post-import quality gate decision
             "final_status": str,          # what the pipeline DB ends up as
             "imported": bool,             # whether files were imported to beets
-            "denylisted": bool,           # whether source user gets denylisted
+            "denylisted": bool,           # whether source user gets denylisted —
+                                           # single-sourced by _finalize_denylist
+                                           # (resolve_pipeline_decision_denylist),
+                                           # matching production's real
+                                           # dispatch_action/post_import_search_action
+                                           # write exactly (issue #813 Finding 2)
             "keep_searching": bool,       # whether the system keeps looking for better
             "comparison_basis": dict | None,  # QualityComparisonBasis builtins from stage 2
         }
@@ -182,7 +190,7 @@ def full_pipeline_decision(
     if current_verified_lossless_proof:
         result["stage2_import"] = DECISION_VERIFIED_LOSSLESS_LOCKED
         result["final_status"] = "imported"
-        return result
+        return _finalize_denylist(result)
 
     # --- Preimport gates (issue #91) ---
     # Ordering mirrors the live flow: lib.dispatch.dispatch_import_from_db
@@ -197,15 +205,14 @@ def full_pipeline_decision(
     if nested_outcome == "reject_nested":
         result["final_status"] = "wanted"
         result["keep_searching"] = True
-        return result
+        return _finalize_denylist(result)
 
     audio_outcome = preimport_audio_gate(audio_check_mode, audio_corrupt)
     result["preimport_audio"] = audio_outcome
     if audio_outcome == "reject_corrupt":
         result["final_status"] = "wanted"
         result["keep_searching"] = True
-        result["denylisted"] = True
-        return result
+        return _finalize_denylist(result)
 
     # --- Stage 0: Spectral gate trigger (issue #93) ---
     # Mirrors lib.measurement._needs_spectral_check. Tells the operator
@@ -249,9 +256,8 @@ def full_pipeline_decision(
                 and not (provisional_source_candidate
                          and has_provisional_probe_input)):
             result["final_status"] = "wanted"  # stays wanted, denylist user
-            result["denylisted"] = True
             result["keep_searching"] = True
-            return result
+            return _finalize_denylist(result)
 
     # --- Stage 2: Import decision ---
     # Existing measurement — carries format if the caller provided one,
@@ -357,16 +363,14 @@ def full_pipeline_decision(
             result["stage2_import"] = provisional.decision
             if provisional.confident_reject:
                 result["final_status"] = "wanted"
-                result["denylisted"] = True
                 result["keep_searching"] = True
-                return result
+                return _finalize_denylist(result)
             search_action = post_import_search_action(provisional.decision)
             result["imported"] = True
-            result["denylisted"] = search_action.denylist
             result["keep_searching"] = search_action.status == "wanted"
             result["final_status"] = search_action.status
             result["target_final_format"] = stage2_new_format
-            return result
+            return _finalize_denylist(result)
         measured = measured_import_decision(
             MeasuredImportDecisionInput(
                 new_m,
@@ -383,7 +387,7 @@ def full_pipeline_decision(
         if result["stage2_import"] == "downgrade":
             result["final_status"] = "imported"
             result["keep_searching"] = True
-            return result
+            return _finalize_denylist(result)
         result["imported"] = True
 
         # Genuine FLAC on disk is verified lossless (for quality gate). Route
@@ -483,17 +487,15 @@ def full_pipeline_decision(
             result["stage2_import"] = provisional.decision
             if provisional.confident_reject:
                 result["final_status"] = "wanted"
-                result["denylisted"] = True
                 result["keep_searching"] = True
-                return result
+                return _finalize_denylist(result)
             search_action = post_import_search_action(provisional.decision)
             result["imported"] = True
-            result["denylisted"] = search_action.denylist
             result["keep_searching"] = search_action.status == "wanted"
             result["final_status"] = search_action.status
             if verified_lossless_target:
                 result["target_final_format"] = verified_lossless_target
-            return result
+            return _finalize_denylist(result)
         target_contract = None
         if stage2_new_format is not None:
             target_contract = (
@@ -536,15 +538,13 @@ def full_pipeline_decision(
         if result["stage2_import"] == "downgrade":
             result["final_status"] = "imported"  # keeps existing
             result["keep_searching"] = True
-            return result
+            return _finalize_denylist(result)
         elif result["stage2_import"] == "transcode_downgrade":
             result["final_status"] = "wanted"
-            result["denylisted"] = True
             result["keep_searching"] = True
-            return result
+            return _finalize_denylist(result)
         elif result["stage2_import"] in ("transcode_upgrade", "transcode_first"):
             result["imported"] = True
-            result["denylisted"] = True
             result["keep_searching"] = True
             # Still runs quality gate after import
         else:
@@ -633,9 +633,8 @@ def full_pipeline_decision(
         if lossy_lock.decision == DECISION_LOSSLESS_SOURCE_LOCKED:
             result["stage2_import"] = lossy_lock.decision
             result["final_status"] = "wanted"
-            result["denylisted"] = True
             result["keep_searching"] = True
-            return result
+            return _finalize_denylist(result)
         measured = measured_import_decision(
             MeasuredImportDecisionInput(
                 new_m,
@@ -652,7 +651,7 @@ def full_pipeline_decision(
         if result["stage2_import"] == "downgrade":
             result["final_status"] = "imported"  # keeps existing
             result["keep_searching"] = True
-            return result
+            return _finalize_denylist(result)
 
         result["imported"] = True
         gate_bitrate = min_bitrate
@@ -703,10 +702,9 @@ def full_pipeline_decision(
     )
     search_action = post_import_search_action(result["stage3_quality_gate"])
     result["final_status"] = search_action.status
-    result["denylisted"] = search_action.denylist
     result["keep_searching"] = search_action.status == "wanted"
 
-    return result
+    return _finalize_denylist(result)
 
 
 class AlbumQualityEvidenceDecisionFacts(msgspec.Struct, frozen=True):
@@ -781,6 +779,43 @@ def evidence_decision_name(
     ):
         return "spectral_reject"
     return default
+
+
+def resolve_pipeline_decision_denylist(result: dict[str, object]) -> bool:
+    """Whether a decision dict's outcome denylists its source — single-
+    sourced from production's real write (issue #813 Finding 2).
+
+    Production resolves denylist policy from a decision string via
+    ``lib.quality.dispatch_actions.decision_denylists`` (the two-tier
+    ``post_import_search_action`` -> ``dispatch_action`` lookup shared with
+    ``lib.dispatch.post_import._resolve_post_import_search_policy``, the
+    real importer write). A decision dict can carry TWO governing decisions:
+    the stage2/early-exit decision that fires when the outcome never reaches
+    Stage 3 (``evidence_decision_name``), and — independently — the Stage-3
+    quality-gate decision when the import *does* reach that gate
+    (``lib.dispatch.quality_gate`` re-evaluates denylist policy fresh from
+    the post-import state, so an outcome can be denylisted by either stage).
+    """
+    denylisted = decision_denylists(evidence_decision_name(result))
+    stage3 = result.get("stage3_quality_gate")
+    if isinstance(stage3, str) and stage3:
+        denylisted = denylisted or decision_denylists(stage3)
+    return denylisted
+
+
+def _finalize_denylist(result: dict[str, object]) -> dict[str, object]:
+    """Single choke point every ``full_pipeline_decision``/
+    ``full_pipeline_decision_from_evidence`` return path funnels through.
+
+    Issue #813 Finding 2: three separate ``downgrade`` return sites each
+    independently forgot to set ``denylisted``, silently diverging from what
+    ``dispatch_action("downgrade").denylist`` (and the real importer) always
+    writes. Computing it here, once, from the decision(s) already recorded
+    on ``result`` makes that whole bug class structurally impossible — a new
+    branch cannot "forget" a step it never performs.
+    """
+    result["denylisted"] = resolve_pipeline_decision_denylist(result)
+    return result
 
 
 def comparison_basis_from_decision(
@@ -1042,7 +1077,7 @@ def full_pipeline_decision_from_evidence(
             "stage3_quality_gate": str | None,
             "final_status": str | None,
             "imported": bool,
-            "denylisted": bool,
+            "denylisted": bool,  # see resolve_pipeline_decision_denylist — #813
             "keep_searching": bool,
             "target_final_format": str | None,
             "verified_lossless": bool,
@@ -1085,7 +1120,7 @@ def full_pipeline_decision_from_evidence(
         current is not None
         and current.verified_lossless_proof is not None
     ):
-        return {
+        return _finalize_denylist({
             "preimport_audio": None,
             "preimport_nested": None,
             "preimport_bad_hash": None,
@@ -1102,7 +1137,7 @@ def full_pipeline_decision_from_evidence(
             "target_final_format": None,
             "verified_lossless": candidate.verified_lossless_proof is not None,
             "comparison_basis": None,
-        }
+        })
 
     # --- U11 folder/audio-integrity early-exit rejects ---
     # The four facts live directly on the persisted ``AlbumQualityEvidence``
@@ -1122,12 +1157,13 @@ def full_pipeline_decision_from_evidence(
         preimport_bad_hash: str | None = None,
         preimport_empty_fileset: str | None = None,
         preimport_mixed_source: str | None = None,
-        denylisted: bool,
     ) -> dict[str, Any]:
         # The acquisition verdict remains wanted. Caller identity is absent
         # from this reducer; the dispatch boundary decides whether that verdict
-        # may mutate an operator-owned request status.
-        return {
+        # may mutate an operator-owned request status. ``denylisted`` is
+        # derived by ``_finalize_denylist`` from the fact just recorded above
+        # (issue #813 Finding 2) — never a per-call literal.
+        return _finalize_denylist({
             "preimport_audio": preimport_audio,
             "preimport_nested": preimport_nested,
             "preimport_bad_hash": preimport_bad_hash,
@@ -1139,29 +1175,26 @@ def full_pipeline_decision_from_evidence(
             "stage3_quality_gate": None,
             "final_status": "wanted",
             "imported": False,
-            "denylisted": bool(denylisted),
+            "denylisted": False,
             "keep_searching": True,
             "target_final_format": None,
             "verified_lossless": False,
             "comparison_basis": None,
-        }
+        })
 
     if candidate.audio_corrupt:
         return _early_reject_result(
             preimport_audio="reject_corrupt",
-            denylisted=True,
         )
 
     if candidate.matched_bad_audio_hash_id is not None:
         return _early_reject_result(
             preimport_bad_hash="reject_bad_hash",
-            denylisted=True,
         )
 
     if candidate.folder_layout == "nested":
         return _early_reject_result(
             preimport_nested="reject_nested",
-            denylisted=False,
         )
 
     # Reconcile audio_file_count against snapshot files: legacy rows decode
@@ -1174,7 +1207,6 @@ def full_pipeline_decision_from_evidence(
     if effective_audio_file_count == 0:
         return _early_reject_result(
             preimport_empty_fileset="reject_empty",
-            denylisted=False,
         )
 
     # Mixed-source reject: lossless + lossy containers in the same folder.
@@ -1184,7 +1216,6 @@ def full_pipeline_decision_from_evidence(
     if has_mixed_lossless_and_lossy(candidate.files):
         return _early_reject_result(
             preimport_mixed_source="reject_mixed_source",
-            denylisted=True,
         )
 
     candidate_measurement = candidate.measurement

--- a/lib/world_invariants.py
+++ b/lib/world_invariants.py
@@ -15,8 +15,9 @@ from lib.beets_db import (
     CurrentBeetsMissing,
     CurrentBeetsResolution,
 )
-from lib.quality import ImportResult, dispatch_action
+from lib.quality import ImportResult
 from lib.quality.decisions import post_import_search_action_if_known
+from lib.quality.dispatch_actions import decision_denylists
 from lib.validation_envelope import decode_validation_envelope
 
 
@@ -429,11 +430,10 @@ _LEGACY_TRANSCODE_REASON = re.compile(r"transcode: \d+kbps\Z")
 
 
 def _decision_denylists(decision: str) -> bool:
-    search_action = post_import_search_action_if_known(decision)
-    return bool(
-        (search_action is not None and search_action.denylist)
-        or dispatch_action(decision).denylist
-    )
+    """Issue #813: delegates to the one production policy lookup shared with
+    ``lib.dispatch.post_import`` and the quality simulator/evidence-pipeline
+    display — no second reimplementation."""
+    return decision_denylists(decision)
 
 
 def _denylist_reason_authorities(reason: str) -> tuple[str, ...]:

--- a/scripts/pipeline_cli/quality.py
+++ b/scripts/pipeline_cli/quality.py
@@ -95,13 +95,139 @@ def _quality_preview_target_label(
     return "V0"
 
 
+def _print_decision_outcome(
+    name: str,
+    result: dict[str, object],
+    *,
+    q_override: str | None,
+    gate_unavailable_reason: str | None,
+) -> None:
+    """Print one decision-dict outcome in the shared ``cmd_quality`` format.
+
+    Shared by the synthetic scenario matrix and the live-candidate replay
+    tier (issue #813 tooling tier) — one display path, not two.
+    """
+    from lib.quality import search_tiers
+
+    imported = "IMPORT" if result["imported"] else "REJECT"
+    parts = [imported]
+    if result["denylisted"]:
+        parts.append("denylist")
+    if result["keep_searching"]:
+        parts.append("keep searching")
+    final = result["final_status"] or "?"
+    decision_chain = " → ".join(
+        f"{s}={result[s]}"
+        for s in ["preimport_audio", "preimport_nested", "preimport_bad_hash",
+                  "preimport_empty_fileset", "preimport_mixed_source",
+                  "stage0_spectral_gate", "stage1_spectral",
+                  "stage2_import", "stage3_quality_gate"]
+        if result[s] is not None)
+
+    print(f"    {name}:")
+    print(f"      → {', '.join(parts)} (final: {final})")
+    if decision_chain:
+        print(f"      chain: {decision_chain}")
+
+    # For rejections that keep searching: simulate what happens after
+    if not result["imported"] and result["keep_searching"]:
+        if q_override:
+            tiers, _ = search_tiers(q_override, [])
+            print(f"      next search: {', '.join(tiers)}")
+        elif gate_unavailable_reason is not None:
+            print("      no backfill simulation (linked evidence unavailable)")
+        else:
+            # Importer narrowing requires an independent attempt-local
+            # audit of the exact HAVE copy. Candidate spectral fields in
+            # this scenario are deliberately not substituted for it.
+            print("      no backfill simulation "
+                  "(attempt-local HAVE audit not modeled; keep all tiers)")
+
+
+def _print_live_candidate_replay(
+    db: "PipelineDB",
+    request_id: int,
+    *,
+    rank_cfg: "QualityRankConfig",
+    target_format: str | None,
+    verified_lossless_target: str | None,
+    runtime_audio_check: str,
+    q_override: str | None,
+    gate_unavailable_reason: str | None,
+) -> None:
+    """Replay the request's actual last-candidate evidence through the real
+    decider (issue #813 tooling tier).
+
+    Every synthetic scenario above is a canned grade/bitrate combo — none
+    reproduce the exact live candidate a real download produced, so live
+    verification of a quality-decision change previously needed an offline
+    decider run (PR #812's Mark DeNardo/request 1308 verification). This
+    replays the SAME persisted ``AlbumQualityEvidence`` the importer itself
+    would have decided from, through the SAME production decider
+    (``full_pipeline_decision_from_evidence``) — never a second reimplementation.
+
+    Read-only: loads persisted rows, decides, prints. No writes.
+    """
+    from lib.quality import (
+        AlbumQualityEvidenceDecisionFacts,
+        full_pipeline_decision_from_evidence,
+    )
+
+    print("\n  What the last real candidate actually decided:")
+
+    candidate_evidence_id = db.get_latest_download_log_candidate_evidence_id(
+        request_id)
+    if candidate_evidence_id is None:
+        print("    (no download attempt has left measured candidate "
+              "evidence yet)")
+        return
+    candidate = db.load_album_quality_evidence_by_id(candidate_evidence_id)
+    if candidate is None:
+        print(f"    (candidate evidence #{candidate_evidence_id} is "
+              "referenced but missing — data integrity issue)")
+        return
+
+    current_evidence_id = db.get_request_current_evidence_id(request_id)
+    current = (
+        db.load_album_quality_evidence_by_id(current_evidence_id)
+        if current_evidence_id is not None
+        else None
+    )
+
+    facts = AlbumQualityEvidenceDecisionFacts(
+        audio_check_mode=runtime_audio_check,
+        target_format=target_format,
+        verified_lossless_target=verified_lossless_target,
+    )
+    m = candidate.measurement
+    label = (
+        f"Candidate evidence #{candidate.id} "
+        f"(measured {m.format or '(unknown)'} "
+        f"{_fmt_br(m.min_bitrate_kbps)}, "
+        f"spectral={m.spectral_grade or 'n/a'}, "
+        f"measured_at={candidate.measured_at})"
+    )
+    try:
+        result = full_pipeline_decision_from_evidence(
+            candidate, current, facts=facts, cfg=rank_cfg)
+    except ValueError as exc:
+        print(f"    {label}:")
+        print(f"      → could not decide: {exc}")
+        return
+    _print_decision_outcome(
+        label, result,
+        q_override=q_override,
+        gate_unavailable_reason=gate_unavailable_reason,
+    )
+
+
 def cmd_quality(db: "PipelineDB", args: argparse.Namespace) -> None:
     """Show quality state and simulate decisions for common download scenarios."""
     from lib.dispatch import load_quality_gate_state
     from lib.quality import (full_pipeline_decision, quality_gate_decision,
                              gate_rank,
                              rejection_backfill_override,
-                             search_tiers, compute_effective_override_bitrate)
+                             compute_effective_override_bitrate)
 
     rank_cfg = _load_runtime_rank_config()
 
@@ -394,38 +520,21 @@ def cmd_quality(db: "PipelineDB", args: argparse.Namespace) -> None:
             ),
             **params_with_runtime)
 
-        imported = "IMPORT" if result["imported"] else "REJECT"
-        parts = [imported]
-        if result["denylisted"]:
-            parts.append("denylist")
-        if result["keep_searching"]:
-            parts.append("keep searching")
-        final = result["final_status"] or "?"
-        decision_chain = " → ".join(
-            f"{s}={result[s]}"
-            for s in ["preimport_audio", "preimport_nested",
-                      "stage0_spectral_gate", "stage1_spectral",
-                      "stage2_import", "stage3_quality_gate"]
-            if result[s] is not None)
+        _print_decision_outcome(
+            name, result,
+            q_override=q_override,
+            gate_unavailable_reason=gate_unavailable_reason,
+        )
 
-        print(f"    {name}:")
-        print(f"      → {', '.join(parts)} (final: {final})")
-        if decision_chain:
-            print(f"      chain: {decision_chain}")
-
-        # For rejections that keep searching: simulate what happens after
-        if not result["imported"] and result["keep_searching"]:
-            if q_override:
-                tiers, _ = search_tiers(q_override, [])
-                print(f"      next search: {', '.join(tiers)}")
-            elif gate_unavailable_reason is not None:
-                print("      no backfill simulation (linked evidence unavailable)")
-            else:
-                # Importer narrowing requires an independent attempt-local
-                # audit of the exact HAVE copy. Candidate spectral fields in
-                # this scenario are deliberately not substituted for it.
-                print("      no backfill simulation "
-                      "(attempt-local HAVE audit not modeled; keep all tiers)")
+    _print_live_candidate_replay(
+        db, args.id,
+        rank_cfg=rank_cfg,
+        target_format=target_format,
+        verified_lossless_target=verified_lossless_target,
+        runtime_audio_check=runtime_audio_check,
+        q_override=q_override,
+        gate_unavailable_reason=gate_unavailable_reason,
+    )
 
 
 def cmd_repair_spectral(

--- a/tests/fakes/pipeline_db.py
+++ b/tests/fakes/pipeline_db.py
@@ -3345,6 +3345,21 @@ class FakePipelineDB:
                 )
         return None
 
+    def get_latest_download_log_candidate_evidence_id(
+        self,
+        request_id: int,
+    ) -> int | None:
+        candidate_ids = [
+            (row.id, row.candidate_evidence_id)
+            for row in self.download_logs
+            if row.request_id == request_id
+            and row.candidate_evidence_id is not None
+        ]
+        if not candidate_ids:
+            return None
+        candidate_ids.sort(key=lambda pair: pair[0], reverse=True)
+        return int(candidate_ids[0][1])
+
     def get_request_current_evidence_id(
         self,
         request_id: int,

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -171,6 +171,63 @@ class TestFakePipelineDB(unittest.TestCase):
         assert loaded is not None
         self.assertEqual(loaded.mb_release_id, "mb-dl-fk-1")
 
+    def test_get_latest_download_log_candidate_evidence_id(self):
+        """Issue #813 tooling tier: replaying the request's real last
+        candidate needs the newest download_log candidate_evidence_id."""
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=42))
+        db.seed_request(make_request_row(id=99))
+
+        # No download attempts yet.
+        self.assertIsNone(db.get_latest_download_log_candidate_evidence_id(42))
+
+        older_log_id = db.log_download(request_id=42, outcome="rejected")
+        older_evidence = make_album_quality_evidence(mb_release_id="mb-older")
+        db.upsert_album_quality_evidence(older_evidence)
+        older_persisted = db.find_album_quality_evidence(
+            mb_release_id=older_evidence.mb_release_id,
+            snapshot_fingerprint=older_evidence.snapshot_fingerprint,
+        )
+        assert older_persisted is not None and older_persisted.id is not None
+        db.set_download_log_candidate_evidence(older_log_id, older_persisted.id)
+
+        # A download attempt with no candidate evidence (e.g. failed before
+        # measurement) must not shadow the older one, and must not win over
+        # the newer evidence-bearing row added below.
+        db.log_download(request_id=42, outcome="failed")
+
+        newer_log_id = db.log_download(request_id=42, outcome="rejected")
+        newer_evidence = make_album_quality_evidence(mb_release_id="mb-newer")
+        db.upsert_album_quality_evidence(newer_evidence)
+        newer_persisted = db.find_album_quality_evidence(
+            mb_release_id=newer_evidence.mb_release_id,
+            snapshot_fingerprint=newer_evidence.snapshot_fingerprint,
+        )
+        assert newer_persisted is not None and newer_persisted.id is not None
+        db.set_download_log_candidate_evidence(newer_log_id, newer_persisted.id)
+
+        # A row on a DIFFERENT request must never leak in.
+        other_log_id = db.log_download(request_id=99, outcome="rejected")
+        other_evidence = make_album_quality_evidence(mb_release_id="mb-other")
+        db.upsert_album_quality_evidence(other_evidence)
+        other_persisted = db.find_album_quality_evidence(
+            mb_release_id=other_evidence.mb_release_id,
+            snapshot_fingerprint=other_evidence.snapshot_fingerprint,
+        )
+        assert other_persisted is not None and other_persisted.id is not None
+        db.set_download_log_candidate_evidence(other_log_id, other_persisted.id)
+
+        self.assertEqual(
+            db.get_latest_download_log_candidate_evidence_id(42),
+            newer_persisted.id,
+        )
+        self.assertEqual(
+            db.get_latest_download_log_candidate_evidence_id(99),
+            other_persisted.id,
+        )
+        self.assertIsNone(
+            db.get_latest_download_log_candidate_evidence_id(12345))
+
     def test_album_quality_evidence_supports_import_job_addressing(self):
         from lib.import_queue import IMPORT_JOB_FORCE
 

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -2111,6 +2111,197 @@ class TestCmdQuality(unittest.TestCase):
         self.assertNotIn("(rank=EXCELLENT)", output)
 
 
+class TestCmdQualityLiveCandidateReplay(unittest.TestCase):
+    """pipeline-cli quality <id>'s live-candidate replay tier (issue #813
+    tooling tier). Every synthetic scenario in TestCmdQuality is a canned
+    grade/bitrate combo; this tier replays the request's actual last
+    download_log candidate evidence through the real production decider
+    (full_pipeline_decision_from_evidence) — PR #812's Mark DeNardo
+    verification needed an offline decider run because no tier reproduced
+    the exact live candidate; this one does.
+    """
+
+    def _run(self, db: FakePipelineDB, request_id: int) -> str:
+        from lib.quality import QualityRankConfig
+
+        stdout = io.StringIO()
+        with patch("scripts.pipeline_cli.quality._load_runtime_rank_config",
+                   return_value=QualityRankConfig.defaults()), \
+             patch("scripts.pipeline_cli.quality._load_runtime_verified_lossless_target",
+                   return_value=""), \
+             redirect_stdout(stdout):
+            pipeline_cli.cmd_quality(cast(Any, db), MagicMock(id=request_id))
+        return stdout.getvalue()
+
+    def test_no_candidate_evidence_shows_diagnostic(self):
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=5001, mb_release_id="mbid-no-candidate", status="wanted",
+        ))
+
+        output = self._run(db, 5001)
+
+        self.assertIn("What the last real candidate actually decided", output)
+        self.assertIn(
+            "no download attempt has left measured candidate evidence yet",
+            output,
+        )
+
+    def test_replays_the_actual_last_candidate_decision(self):
+        from lib.quality import AudioQualityMeasurement
+
+        db = FakePipelineDB()
+        request_row = make_request_row(
+            id=5002, mb_release_id="mbid-replay", status="wanted",
+            min_bitrate=320, current_spectral_grade="likely_transcode",
+            current_spectral_bitrate=160,
+        )
+        db.seed_request(request_row)
+
+        # The installed ("current") copy: MP3 320 CBR, likely_transcode/160.
+        current = make_album_quality_evidence(
+            mb_release_id="mbid-replay",
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=320, avg_bitrate_kbps=320,
+                format="MP3", is_cbr=True,
+                spectral_grade="likely_transcode", spectral_bitrate_kbps=160,
+            ),
+        )
+        db.upsert_album_quality_evidence(current)
+        current_persisted = db.find_album_quality_evidence(
+            mb_release_id=current.mb_release_id,
+            snapshot_fingerprint=current.snapshot_fingerprint,
+        )
+        assert current_persisted is not None and current_persisted.id is not None
+        db.set_request_current_evidence(5002, current_persisted.id)
+
+        # The actual last candidate: an identical-quality MP3 320 CBR
+        # transcode — a real downgrade (Tyler Lamberts / Deerhunter shape).
+        log_id = db.log_download(request_id=5002, outcome="rejected")
+        candidate = make_album_quality_evidence(
+            mb_release_id="mbid-replay",
+            source_path="/tmp/candidate-source",
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=320, avg_bitrate_kbps=320,
+                format="MP3", is_cbr=True,
+                spectral_grade="likely_transcode", spectral_bitrate_kbps=160,
+            ),
+        )
+        db.upsert_album_quality_evidence(candidate)
+        candidate_persisted = db.find_album_quality_evidence(
+            mb_release_id=candidate.mb_release_id,
+            snapshot_fingerprint=candidate.snapshot_fingerprint,
+        )
+        assert (
+            candidate_persisted is not None
+            and candidate_persisted.id is not None
+        )
+        db.set_download_log_candidate_evidence(log_id, candidate_persisted.id)
+
+        output = self._run(db, 5002)
+
+        self.assertIn("What the last real candidate actually decided", output)
+        self.assertIn(f"Candidate evidence #{candidate_persisted.id}", output)
+        # Real decision: an identical-rank transcode is a downgrade, and
+        # issue #813 Finding 2 requires the display to show the denylist
+        # production actually applies for that decision.
+        self.assertIn("REJECT, denylist", output)
+        self.assertIn("stage2_import=downgrade", output)
+
+    def test_uses_the_newest_candidate_when_several_exist(self):
+        from lib.quality import AudioQualityMeasurement
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=5003, mb_release_id="mbid-latest", status="wanted",
+        ))
+
+        # Distinct file snapshots (evidence is content-addressed by
+        # (mb_release_id, snapshot_fingerprint) — a shared default file
+        # list would collide the two rows into one).
+        from lib.quality import AlbumQualityEvidenceFile
+
+        older_log_id = db.log_download(request_id=5003, outcome="rejected")
+        older = make_album_quality_evidence(
+            mb_release_id="mbid-latest",
+            source_path="/tmp/older-source",
+            files=[AlbumQualityEvidenceFile(
+                relative_path="01 - older.mp3", size_bytes=111,
+                mtime_ns=1, extension="mp3", container="mp3", codec="mp3",
+            )],
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=128, format="MP3", is_cbr=True,
+            ),
+        )
+        db.upsert_album_quality_evidence(older)
+        older_persisted = db.find_album_quality_evidence(
+            mb_release_id=older.mb_release_id,
+            snapshot_fingerprint=older.snapshot_fingerprint,
+        )
+        assert older_persisted is not None and older_persisted.id is not None
+        db.set_download_log_candidate_evidence(
+            older_log_id, older_persisted.id)
+
+        newer_log_id = db.log_download(request_id=5003, outcome="success")
+        newer = make_album_quality_evidence(
+            mb_release_id="mbid-latest",
+            source_path="/tmp/newer-source",
+            files=[AlbumQualityEvidenceFile(
+                relative_path="01 - newer.mp3", size_bytes=222,
+                mtime_ns=2, extension="mp3", container="mp3", codec="mp3",
+            )],
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=320, format="MP3", is_cbr=True,
+            ),
+        )
+        db.upsert_album_quality_evidence(newer)
+        newer_persisted = db.find_album_quality_evidence(
+            mb_release_id=newer.mb_release_id,
+            snapshot_fingerprint=newer.snapshot_fingerprint,
+        )
+        assert newer_persisted is not None and newer_persisted.id is not None
+        db.set_download_log_candidate_evidence(
+            newer_log_id, newer_persisted.id)
+
+        output = self._run(db, 5003)
+
+        self.assertIn(f"Candidate evidence #{newer_persisted.id}", output)
+        self.assertNotIn(f"Candidate evidence #{older_persisted.id}", output)
+
+    def test_policy_incomplete_candidate_shows_diagnostic_not_a_crash(self):
+        """A legacy/partial evidence row (e.g. missing bitrate + format)
+        must not crash the CLI — full_pipeline_decision_from_evidence's
+        _require_evidence_ready raises ValueError; this is a read-only
+        diagnostic and must degrade gracefully."""
+        from lib.quality import AudioQualityMeasurement
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=5004, mb_release_id="mbid-incomplete", status="wanted",
+        ))
+        log_id = db.log_download(request_id=5004, outcome="rejected")
+        candidate = make_album_quality_evidence(
+            mb_release_id="mbid-incomplete",
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=None, avg_bitrate_kbps=None,
+                median_bitrate_kbps=None, format=None,
+            ),
+        )
+        db.upsert_album_quality_evidence(candidate)
+        persisted = db.find_album_quality_evidence(
+            mb_release_id=candidate.mb_release_id,
+            snapshot_fingerprint=candidate.snapshot_fingerprint,
+        )
+        assert persisted is not None and persisted.id is not None
+        db.set_download_log_candidate_evidence(log_id, persisted.id)
+
+        output = self._run(db, 5004)
+
+        self.assertIn(f"Candidate evidence #{persisted.id}", output)
+        self.assertIn("could not decide", output)
+        self.assertNotIn("Traceback", output)
+
+
 class _ForensicsDB(FakePipelineDB):
     """Minimal FakePipelineDB subclass that lets each test return a
     fixed list from ``get_search_history`` without forcing tests to

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -1643,6 +1643,29 @@ class TestCmdRepairSpectral(unittest.TestCase):
             os.unlink(cfg_path)
 
 
+def _invoke_cmd_quality(
+    db: "FakePipelineDB", request_id: int, *, runtime_target: str | None,
+) -> str:
+    """Shared ``cmd_quality`` invocation seam.
+
+    One ``cast(Any, db)`` call site for every test in this module that
+    drives ``cmd_quality`` (``TestCmdQuality`` and
+    ``TestCmdQualityLiveCandidateReplay``) — the tests escape-hatch freeze
+    (issue #784) counts lexical occurrences, so a second inline copy of this
+    same bridge would be a new escape hatch, not a reused one.
+    """
+    from lib.quality import QualityRankConfig
+
+    stdout = io.StringIO()
+    with patch("scripts.pipeline_cli.quality._load_runtime_rank_config",
+               return_value=QualityRankConfig.defaults()), \
+         patch("scripts.pipeline_cli.quality._load_runtime_verified_lossless_target",
+               return_value=runtime_target or ""), \
+         redirect_stdout(stdout):
+        pipeline_cli.cmd_quality(cast(Any, db), MagicMock(id=request_id))
+    return stdout.getvalue()
+
+
 class TestCmdQuality(unittest.TestCase):
     """Regression tests for pipeline-cli quality simulator parity.
 
@@ -1665,7 +1688,7 @@ class TestCmdQuality(unittest.TestCase):
         current_evidence: Any | None = None,
         auto_link: bool = True,
     ):
-        from lib.quality import AudioQualityMeasurement, QualityRankConfig
+        from lib.quality import AudioQualityMeasurement
 
         db = FakePipelineDB()
         db.seed_request(request_row)
@@ -1713,15 +1736,8 @@ class TestCmdQuality(unittest.TestCase):
             assert persisted is not None and persisted.id is not None
             db.set_request_current_evidence(request_row["id"], persisted.id)
 
-        stdout = io.StringIO()
-        with patch("scripts.pipeline_cli.quality._load_runtime_rank_config",
-                   return_value=QualityRankConfig.defaults()), \
-             patch("scripts.pipeline_cli.quality._load_runtime_verified_lossless_target",
-                   return_value=runtime_target or ""), \
-             redirect_stdout(stdout):
-            pipeline_cli.cmd_quality(cast(Any, db), MagicMock(id=request_row["id"]))
-
-        return stdout.getvalue()
+        return _invoke_cmd_quality(
+            db, request_row["id"], runtime_target=runtime_target)
 
     def _bare_mp3_request(self, *, request_id: int):
         return make_request_row(
@@ -2122,16 +2138,7 @@ class TestCmdQualityLiveCandidateReplay(unittest.TestCase):
     """
 
     def _run(self, db: FakePipelineDB, request_id: int) -> str:
-        from lib.quality import QualityRankConfig
-
-        stdout = io.StringIO()
-        with patch("scripts.pipeline_cli.quality._load_runtime_rank_config",
-                   return_value=QualityRankConfig.defaults()), \
-             patch("scripts.pipeline_cli.quality._load_runtime_verified_lossless_target",
-                   return_value=""), \
-             redirect_stdout(stdout):
-            pipeline_cli.cmd_quality(cast(Any, db), MagicMock(id=request_id))
-        return stdout.getvalue()
+        return _invoke_cmd_quality(db, request_id, runtime_target=None)
 
     def test_no_candidate_evidence_shows_diagnostic(self):
         db = FakePipelineDB()

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -4983,6 +4983,58 @@ class TestAlbumQualityEvidenceStorage(unittest.TestCase):
         evidence_id = self.db.get_download_log_candidate_evidence_id(log_id)
         self.assertEqual(evidence_id, persisted.id)
 
+    def test_get_latest_download_log_candidate_evidence_id(self):
+        """Issue #813 tooling tier: pipeline-cli quality's live-candidate
+        replay walks attempt history for the newest candidate evidence."""
+        self.assertIsNone(
+            self.db.get_latest_download_log_candidate_evidence_id(
+                self.req_id))
+
+        older_log_id = self.db.log_download(
+            request_id=self.req_id, outcome="rejected")
+        older = self._seed(mb_release_id="mbid-latest-older")
+        self.db.upsert_album_quality_evidence(older)
+        older_persisted = self.db.find_album_quality_evidence(
+            mb_release_id=older.mb_release_id,
+            snapshot_fingerprint=older.snapshot_fingerprint,
+        )
+        assert older_persisted is not None and older_persisted.id is not None
+        self.db.set_download_log_candidate_evidence(
+            older_log_id, older_persisted.id)
+
+        self.assertEqual(
+            self.db.get_latest_download_log_candidate_evidence_id(
+                self.req_id),
+            older_persisted.id,
+        )
+
+        # A later attempt with no candidate evidence must not shadow the
+        # older evidence-bearing row.
+        self.db.log_download(request_id=self.req_id, outcome="failed")
+        self.assertEqual(
+            self.db.get_latest_download_log_candidate_evidence_id(
+                self.req_id),
+            older_persisted.id,
+        )
+
+        newer_log_id = self.db.log_download(
+            request_id=self.req_id, outcome="rejected")
+        newer = self._seed(mb_release_id="mbid-latest-newer")
+        self.db.upsert_album_quality_evidence(newer)
+        newer_persisted = self.db.find_album_quality_evidence(
+            mb_release_id=newer.mb_release_id,
+            snapshot_fingerprint=newer.snapshot_fingerprint,
+        )
+        assert newer_persisted is not None and newer_persisted.id is not None
+        self.db.set_download_log_candidate_evidence(
+            newer_log_id, newer_persisted.id)
+
+        self.assertEqual(
+            self.db.get_latest_download_log_candidate_evidence_id(
+                self.req_id),
+            newer_persisted.id,
+        )
+
     def test_fk_chain_resolves_import_job_candidate_evidence(self):
         job = self.db.enqueue_import_job(
             "force_import",

--- a/tests/test_quality_classification.py
+++ b/tests/test_quality_classification.py
@@ -45,10 +45,15 @@ class TestLiveBugReproductions(unittest.TestCase):
         rejects — it defers to Stage 2, which rejects this equal-rank
         candidate as a ``downgrade``. The bug this guards is *acceptance* of a
         320 transcode from a 160k source; that is still prevented — the
-        candidate is never imported and the search continues. (Denylist is a
-        production-side ``dispatch_action("downgrade")`` concern, not reflected
-        in the simulator dict for the native-lossy downgrade branch; out of
-        scope for this quality assertion.)
+        candidate is never imported and the search continues.
+
+        Issue #813 Finding 2: the native-lossy ``downgrade`` return site used
+        to leave the decision dict's ``denylisted`` field at its default
+        ``False`` — a lie, since ``dispatch_action("downgrade").denylist``
+        is ``True`` in production (the offering peer never gets a better
+        candidate from re-grabbing the same source). Now single-sourced via
+        ``resolve_pipeline_decision_denylist``, so the display matches the
+        real write.
         """
         r = full_pipeline_decision(
             is_flac=False,
@@ -65,6 +70,10 @@ class TestLiveBugReproductions(unittest.TestCase):
         self.assertEqual(r["stage2_import"], "downgrade")
         self.assertFalse(r["imported"])
         self.assertTrue(r["keep_searching"])
+        # Issue #813 Finding 2 pin: the display must match production exactly.
+        from lib.quality import dispatch_action
+        self.assertTrue(r["denylisted"])
+        self.assertEqual(r["denylisted"], dispatch_action("downgrade").denylist)
 
     def test_tyler_lamberts_grave_no_spectral_bitrate(self):
         """Same bug but when spectral_bitrate is None (HF deficit only, no cliff).
@@ -194,6 +203,8 @@ class TestLiveBugReproductions(unittest.TestCase):
         self.assertFalse(r["imported"])
         # Never stop searching: the installed copy is still a transcode.
         self.assertTrue(r["keep_searching"])
+        # Issue #813 Finding 2: downgrade always denylists in production.
+        self.assertTrue(r["denylisted"])
 
     def test_taboo_vi_fake_flac_192_accepted(self):
         """Fake FLAC (192k source) converted to V0 at 224kbps is provisional.
@@ -646,9 +657,15 @@ class TestLiveBugReproductionsThroughEvidencePipeline(unittest.TestCase):
 
     def test_heretic_pride_downgrade_via_evidence(self):
         """test_heretic_pride second-pass downgrade case via the evidence
-        pipeline — MP3 192 vs existing MP3 192."""
+        pipeline — MP3 192 vs existing MP3 192.
+
+        Issue #813 Finding 2 pin: this is the production decider (the
+        function the real importer calls) — proves the fix through the
+        actual entry point, not just the flat-kwargs simulator twin.
+        """
         from lib.quality import (
             AlbumQualityEvidenceDecisionFacts,
+            dispatch_action,
             full_pipeline_decision_from_evidence,
         )
 
@@ -668,6 +685,8 @@ class TestLiveBugReproductionsThroughEvidencePipeline(unittest.TestCase):
 
         self.assertEqual(r["stage2_import"], "downgrade")
         self.assertFalse(r["imported"])
+        self.assertTrue(r["denylisted"])
+        self.assertEqual(r["denylisted"], dispatch_action("downgrade").denylist)
 
     def test_mark_denardo_equal_spectral_higher_bitrate_imports_via_evidence(self):
         """Mark DeNardo request 1308 through the production evidence decider.
@@ -745,6 +764,8 @@ class TestLiveBugReproductionsThroughEvidencePipeline(unittest.TestCase):
         self.assertEqual(r["comparison_basis"]["existing_value_kbps"], 256)
         self.assertFalse(r["imported"])
         self.assertTrue(r["keep_searching"])
+        # Issue #813 Finding 2: downgrade always denylists in production.
+        self.assertTrue(r["denylisted"])
 
     def test_lil_wayne_da_drought_3_transcoded_flac_rejects_duplicate_via_evidence(self):
         """Parity sibling of

--- a/tests/test_quality_decisions.py
+++ b/tests/test_quality_decisions.py
@@ -2238,6 +2238,90 @@ class TestDispatchAction(unittest.TestCase):
 
 
 # ============================================================================
+# decision_denylists (issue #813 Finding 2) — single-source denylist policy
+# ============================================================================
+
+class TestDecisionDenylists(unittest.TestCase):
+    """decision_denylists: the two-tier lookup (``post_import_search_action``
+    for retained-import decisions, else ``dispatch_action``) production
+    applies to resolve denylist policy from a decision string. Both the real
+    write (``lib.dispatch.post_import._resolve_post_import_search_policy``)
+    and the simulator/evidence-pipeline display
+    (``lib.quality.pipeline.resolve_pipeline_decision_denylist``) call this
+    ONE function — no second reimplementation.
+
+    Deterministic pin for the exact issue #813 Finding 2 lie: ``"downgrade"``
+    -> True. The decision dict used to leave ``denylisted=False`` for this
+    decision (three separate return sites forgot to set it) while
+    ``dispatch_action("downgrade").denylist`` was always True in production.
+    """
+
+    # (decision, expected denylist)
+    CASES = [
+        # --- stage2/early-exit decisions: resolved via dispatch_action
+        # fallback (not in _POST_IMPORT_SEARCH_ACTIONS) ---
+        ("import", False),
+        ("preflight_existing", False),
+        ("downgrade", True),  # <- issue #813 Finding 2 pin
+        ("transcode_downgrade", True),
+        ("suspect_lossless_downgrade", True),
+        ("suspect_lossless_probe_missing", True),
+        ("lossless_source_locked", True),
+        ("verified_lossless_locked", False),
+        ("spectral_reject", True),
+        ("audio_corrupt", True),
+        ("bad_audio_hash", True),
+        ("nested_layout", False),
+        ("empty_fileset", False),
+        ("mixed_source", True),
+        ("duplicate_remove_guard_failed", True),
+        ("import_failed", False),
+        ("unknown_decision_not_in_any_table", False),
+        # --- stage3/retained-import decisions: resolved via
+        # post_import_search_action_if_known ---
+        ("accept", False),
+        ("requeue_upgrade", True),
+        ("requeue_lossless", True),
+        ("provisional_lossless_upgrade", True),
+        ("transcode_upgrade", True),
+        ("transcode_first", True),
+    ]
+
+    def test_matches_production_two_tier_policy(self):
+        from lib.quality.dispatch_actions import decision_denylists
+        for decision, expected in self.CASES:
+            with self.subTest(decision=decision):
+                self.assertEqual(
+                    decision_denylists(decision), expected,
+                    f"decision_denylists({decision!r}): expected {expected!r}")
+
+    def test_matches_dispatch_action_exactly_when_no_search_action(self):
+        """Issue #813's literal invariant: for every decision NOT in the
+        retained-import policy table, decision_denylists(...) must equal
+        dispatch_action(...).denylist exactly — this is the comparison the
+        pre-fix decision dict silently violated for ``downgrade``."""
+        from lib.quality import dispatch_action
+        from lib.quality.decisions import post_import_search_action_if_known
+        from lib.quality.dispatch_actions import decision_denylists
+        for decision, _expected in self.CASES:
+            if post_import_search_action_if_known(decision) is not None:
+                continue
+            with self.subTest(decision=decision):
+                self.assertEqual(
+                    decision_denylists(decision),
+                    dispatch_action(decision).denylist,
+                )
+
+    def test_known_bad_downgrade_lie_would_have_failed_pre_fix(self):
+        """Known-bad self-test: the pre-#813 shape (decision dict hardcodes
+        denylisted=False for downgrade) disagrees with decision_denylists —
+        proves this table is not vacuously true."""
+        from lib.quality.dispatch_actions import decision_denylists
+        pre_fix_lie = False
+        self.assertNotEqual(decision_denylists("downgrade"), pre_fix_lie)
+
+
+# ============================================================================
 # extract_usernames
 # ============================================================================
 

--- a/tests/test_quality_generated.py
+++ b/tests/test_quality_generated.py
@@ -76,6 +76,7 @@ from tests.test_simulator_scenarios import (
     AlbumState,
     DownloadScenario,
     SimResult,
+    assert_denylist_has_valid_cause,
     simulate,
 )
 
@@ -617,6 +618,20 @@ class TestGeneratedSimulatorInvariants(unittest.TestCase):
     def test_generated_decisions_are_definitive(self, album, download):
         result = simulate(album, download)
         assert_decision_is_definitive(result)
+
+    @given(album=album_states(), download=download_scenarios())
+    def test_generated_denylist_always_has_valid_cause(self, album, download):
+        """Issue #813 Finding 2, generated half of the PAIR: over randomly
+        generated (album, download) worlds driven through the real decider
+        (``full_pipeline_decision`` via ``simulate()``), a denylisted
+        outcome must always trace to a real reject/retained-nonterminal
+        decision. Deterministic pin:
+        ``TestLiveBugReproductions.test_tyler_lamberts_grave_cbr320_transcode_accepted``
+        (``tests/test_quality_classification.py``) and
+        ``TestSimulatorInvariants.test_denylist_requires_cause`` (fixture
+        matrix, same module as this checker)."""
+        result = simulate(album, download)
+        assert_denylist_has_valid_cause(result)
 
     @given(album=raw_verified_lossless_albums(), download=lossy_downloads())
     def test_raw_verified_lossless_never_imports_lossy_candidate(

--- a/tests/test_simulator_scenarios.py
+++ b/tests/test_simulator_scenarios.py
@@ -437,6 +437,86 @@ def simulate(
     )
 
 
+# Stage2/early-exit decisions that denylist their source (issue #813 Finding
+# 2). Deliberately hardcoded here rather than delegated to
+# ``lib.quality.dispatch_actions.decision_denylists`` — this independent
+# oracle must keep catching drift in every consumer, same rationale as the
+# post-import ``expected_actions`` table inside ``simulate()`` above
+# ("Deliberately do not call post_import_search_action() here"). Before the
+# #813 fix, ``"downgrade"`` was missing from this list — the simulator's
+# decision dict silently stayed ``denylisted=False`` for a decision
+# production always denylists (``dispatch_action("downgrade").denylist``),
+# so this checker would NOT have caught the live lie. It is included now
+# and the known-bad self-test below proves the checker trips on its absence.
+_REJECT_DENYLIST_CAUSES = (
+    "downgrade",
+    "transcode_upgrade",
+    "transcode_downgrade",
+    "transcode_first",
+    "provisional_lossless_upgrade",
+    "suspect_lossless_downgrade",
+    "suspect_lossless_probe_missing",
+    "lossless_source_locked",
+)
+
+
+def assert_denylist_has_valid_cause(r: "SimResult") -> None:
+    """A denylisted outcome must trace to a real reject/retained-nonterminal
+    decision — never a bare default with no decision behind it."""
+    if not r.denylisted:
+        return
+    causes = (
+        r.stage1_spectral == "reject",
+        r.stage2_import in _REJECT_DENYLIST_CAUSES,
+        r.stage3_quality_gate in ("requeue_upgrade", "requeue_lossless"),
+    )
+    if not any(causes):
+        raise AssertionError(f"Denylisted without valid cause: {r!r}")
+
+
+class TestAssertDenylistHasValidCauseTripsOnViolations(unittest.TestCase):
+    """Known-bad self-test (issue #813): proves the checker actually trips."""
+
+    def _result(self, **overrides: object) -> "SimResult":
+        base = SimResult(
+            imported=False,
+            keep_searching=True,
+            denylisted=True,
+            final_status="wanted",
+            stage0_spectral_gate=None,
+            stage1_spectral=None,
+            stage2_import=None,
+            stage3_quality_gate=None,
+            backfill_override=None,
+            search_filetype_override_after=None,
+        )
+        return replace(base, **overrides)
+
+    def test_trips_on_denylisted_with_no_decision_at_all(self):
+        """A denylisted outcome with no stage decision anywhere is the
+        planted violation this checker exists to catch."""
+        with self.assertRaises(AssertionError):
+            assert_denylist_has_valid_cause(self._result())
+
+    def test_passes_on_downgrade(self):
+        """The exact issue #813 Finding 2 shape: production always
+        denylists a downgrade — must NOT trip."""
+        assert_denylist_has_valid_cause(
+            self._result(stage2_import="downgrade", final_status="imported")
+        )
+
+    def test_passes_when_not_denylisted(self):
+        assert_denylist_has_valid_cause(self._result(denylisted=False))
+
+    def test_passes_on_requeue_upgrade(self):
+        assert_denylist_has_valid_cause(
+            self._result(
+                imported=True, final_status="wanted",
+                stage2_import="import", stage3_quality_gate="requeue_upgrade",
+            )
+        )
+
+
 # ============================================================================
 # Invariant tests — properties that hold across the full matrix
 # ============================================================================
@@ -525,23 +605,7 @@ class TestSimulatorInvariants(unittest.TestCase):
         for album in ALBUM_STATES:
             for dl in DOWNLOAD_SCENARIOS:
                 with self.subTest(album=album.name, dl=dl.name):
-                    r = simulate(album, dl)
-                    if r.denylisted:
-                        causes = (
-                            r.stage1_spectral == "reject",
-                            r.stage2_import in ("transcode_upgrade",
-                                                "transcode_downgrade",
-                                                "transcode_first",
-                                                "provisional_lossless_upgrade",
-                                                "suspect_lossless_downgrade",
-                                                "suspect_lossless_probe_missing",
-                                                "lossless_source_locked"),
-                            r.stage3_quality_gate in (
-                                "requeue_upgrade", "requeue_lossless"
-                            ),
-                        )
-                        self.assertTrue(any(causes),
-                                        f"Denylisted without valid cause: {r}")
+                    assert_denylist_has_valid_cause(simulate(album, dl))
 
     def test_provisional_locked_album_rejects_all_lossy_candidates(self):
         """When existing has a recorded lossless-source V0 probe, every lossy


### PR DESCRIPTION
## Summary

PR A of issue #813 (Finding 2 + the minor tooling tier — Finding 1 is scoped to a separate later PR and is untouched here).

- **Finding 2 fix**: `full_pipeline_decision`/`full_pipeline_decision_from_evidence` hand-set a `denylisted` bool per branch. Three separate `downgrade` return sites independently forgot to set it, leaving `denylisted=False` while `dispatch_action("downgrade").denylist` is always `True` in production — the exact lie that bit PR #812's Tyler-Lamberts repoint. Added `decision_denylists()` as the single production policy lookup (the two-tier `post_import_search_action` → `dispatch_action` fallback the real write already applied inline) and reused it from three call sites: the real write (`lib/dispatch/post_import.py`), world-invariant cross-checks (`lib/world_invariants.py`, dropping its own duplicate reimplementation), and a new `resolve_pipeline_decision_denylist()` that every decision-dict return path now funnels through via one `_finalize_denylist()` choke point — closing the "forgot a branch" bug class structurally instead of patching the three known sites by hand.
- **Tooling tier**: `pipeline-cli quality <id>`'s scenarios were all synthetic canned grade/bitrate combos — none reproduced the exact live candidate, so PR #812's verification needed an offline decider run. Added a trailing "What the last real candidate actually decided" section that loads the request's actual last `download_log` candidate evidence (new `PipelineDB.get_latest_download_log_candidate_evidence_id`) plus its current evidence, and replays them through the real production decider (`full_pipeline_decision_from_evidence`) — read-only, CLI-only (existing diagnostic with no API twin).

## Test plan

- [x] Deterministic pins: Tyler Lamberts / Deerhunter / Heretic-Pride downgrade scenarios (simulator + evidence-pipeline decider) assert `denylisted` matches `dispatch_action("downgrade").denylist` exactly; exhaustive `TestDecisionDenylists` table covers every decision string.
- [x] Generated property: fuzzed `(album, download)` worlds through the real simulator must never denylist without a valid cause (`assert_denylist_has_valid_cause`, with a known-bad self-test proving it trips).
- [x] Mutant check (manual, not committed): reverting `_finalize_denylist`'s body made all of the above RED; restored, all GREEN.
- [x] New `PipelineDB` read method mirrored on `FakePipelineDB` with a self-test (`tests/test_fakes.py`) plus a real-PG round-trip test (`tests/test_pipeline_db.py`).
- [x] CLI tests for the replay tier: no-candidate diagnostic, actual-decision replay, newest-candidate selection, policy-incomplete graceful degradation.
- [x] `nix-shell --run "pyright --threads 4"` — 0 errors (whole repo).
- [x] `nix-shell --run "bash scripts/run_tests.sh"` — full suite green (6709 tests).
- [x] `nix-shell --run "bash scripts/fuzz_burst.sh"` — the two directly-relevant modules (`test_quality_generated`, `test_world_invariants_generated`) passed under the randomized profile.
- [x] Docs: `docs/debugging-cli.md` updated for the new replay tier.

Part of #813.

🤖 Generated with [Claude Code](https://claude.com/claude-code)