### PR TITLE
fix: close Stage1/Stage2 disagreement inside the shared spectral clamp

### DIFF
--- a/docs/quality-ranks.md
+++ b/docs/quality-ranks.md
@@ -222,6 +222,19 @@ Unverifiable CBR only reaches TRANSPARENT at 320 because the pipeline can't
 prove a CBR file came from lossless source. Spectral cliff detection may
 clamp it down further.
 
+**Spectral-bound values always classify via this table.** The spectral cliff
+estimate (`lib/spectral_check.py`'s `LAME_LOWPASS` table: 96/112/128/160/
+192/224/256/320) is calibrated to these exact CBR thresholds, not the more
+generous MP3 VBR ones — a cliff-detected 192 IS a `good`-band reading, by
+construction. When `compare_quality`'s shared spectral clamp
+(`_shared_spectral_bitrates`) binds on a side (`spectral <= that side's raw
+metric`), that side's clamped value classifies through this table
+regardless of the file's own `is_cbr` — a VBR-tagged file's spectral-bound
+clamp does NOT get the more generous VBR bands (issue #813 Finding 1's
+second sub-finding; `docs/quality-verification.md` § "Stage 1 / Stage 2
+parity"). A side whose clamp did NOT bind (raw is the tighter value) still
+classifies with its own encoding mode.
+
 ### AAC
 
 | Band | Threshold (kbps) |

--- a/docs/quality-ranks.md
+++ b/docs/quality-ranks.md
@@ -222,18 +222,23 @@ Unverifiable CBR only reaches TRANSPARENT at 320 because the pipeline can't
 prove a CBR file came from lossless source. Spectral cliff detection may
 clamp it down further.
 
-**Spectral-bound values always classify via this table.** The spectral cliff
-estimate (`lib/spectral_check.py`'s `LAME_LOWPASS` table: 96/112/128/160/
-192/224/256/320) is calibrated to these exact CBR thresholds, not the more
-generous MP3 VBR ones — a cliff-detected 192 IS a `good`-band reading, by
-construction. When `compare_quality`'s shared spectral clamp
-(`_shared_spectral_bitrates`) binds on a side (`spectral <= that side's raw
-metric`), that side's clamped value classifies through this table
-regardless of the file's own `is_cbr` — a VBR-tagged file's spectral-bound
-clamp does NOT get the more generous VBR bands (issue #813 Finding 1's
-second sub-finding; `docs/quality-verification.md` § "Stage 1 / Stage 2
-parity"). A side whose clamp did NOT bind (raw is the tighter value) still
-classifies with its own encoding mode.
+**A spectral-bound value classifies via this table only when BOTH sides are
+bound.** The spectral cliff estimate (`lib/spectral_check.py`'s
+`LAME_LOWPASS` table: 96/112/128/160/192/224/256/320) is calibrated to
+these exact CBR thresholds, not the more generous MP3 VBR ones — a
+cliff-detected 192 IS a `good`-band reading, by construction. When
+`compare_quality`'s shared spectral clamp (`_shared_spectral_bitrates`)
+binds on BOTH sides (`spectral <= raw metric`, each side individually),
+both clamped values classify through this table regardless of either
+file's own `is_cbr` — a VBR-tagged file's spectral-bound clamp does NOT get
+the more generous VBR bands (issue #813 Finding 1's second sub-finding;
+`docs/quality-verification.md` § "Stage 1 / Stage 2 parity"). This is
+symmetric: forcing CBR bands on only one bound side while an unbound side
+keeps its own (possibly more generous VBR) table would mix a spectral-
+calibrated number against a raw-metric number under two different band
+tables, which can itself invert the ordering (a PR #827 review finding). A
+side whose clamp did NOT bind (raw is the tighter value) always classifies
+with its own encoding mode.
 
 ### AAC
 

--- a/docs/quality-verification.md
+++ b/docs/quality-verification.md
@@ -279,16 +279,17 @@ bitrate alone is not proof in the current policy.
 
 Every `compare_quality()` call returns a `QualityComparisonBasis`
 (`lib/quality/evidence_types.py`): the verdict plus which branch fired
-(`rank`, `metric_tiebreak`, `label_contract_same_rank`,
+(`rank`, `spectral_tiebreak`, `metric_tiebreak`, `label_contract_same_rank`,
 `cross_family_same_rank`, `lossless_same_rank`, `metric_missing`,
 `transcode_rank_regression`), the per-side ranks, the values that decided
-that branch (spectral-clamped values on a clamped rank comparison, raw
-configured-metric values on a tiebreak), and the per-side statistic actually
-classified (`min`/`avg`/`median` — the configured metric falls back to min
-when unmeasured). An explicit codec label such as `opus 128` is instead
-persisted as `contract`: the label's declared bitrate is policy, not a measured
-statistic. A temporary V0 probe may still inform source quality, but it never
-becomes an `OPUS` measurement. `import_quality_decision()` stamps
+that branch (spectral-clamped values on a clamped rank comparison or
+`spectral_tiebreak`, raw configured-metric values on `metric_tiebreak`), and
+the per-side statistic actually classified (`min`/`avg`/`median` — the
+configured metric falls back to min when unmeasured). An explicit codec
+label such as `opus 128` is instead persisted as `contract`: the label's
+declared bitrate is policy, not a measured statistic. A temporary V0 probe
+may still inform source quality, but it never becomes an `OPUS`
+measurement. `import_quality_decision()` stamps
 `verified_lossless_bypass=True` only when the bypass changed the outcome
 (an "equivalent" verdict imported).
 
@@ -299,6 +300,54 @@ plain dict — the dict crosses json.dumps'd API responses), the evidence
 action file, and the dispatch-synthesized reject `ImportResult`. Re-typing
 back from the dict goes through `comparison_basis_from_decision()` — the one
 converter.
+
+### Stage 1 / Stage 2 parity (issue #813 Finding 1)
+
+`spectral_import_decision` (Stage 1, pre-import spectral gate,
+`lib/quality/decisions.py`) and `compare_quality` (Stage 2, the full
+codec-aware comparison this section documents) are two separate decision
+surfaces over the same evidence. Stage 1's only operative effect is its
+`"reject"` verdict, which short-circuits `full_pipeline_decision` /
+`full_pipeline_decision_from_evidence` before Stage 2 ever runs — every
+other Stage 1 verdict defers unconditionally. A generated property
+(`tests/test_quality_generated.py::TestGeneratedSimulatorInvariants
+::test_stage1_never_contradicts_stage2`) drives both deciders directly over
+the same evidence and asserts Stage 1 never rejects a candidate Stage 2
+would score `"better"` — the audit found and fixed two independent gaps,
+both inside the shared spectral clamp (`_shared_spectral_bitrates`, fires
+when BOTH sides carry `spectral_bitrate_kbps`):
+
+1. **Same-rank tiebreak** (`spectral_tiebreak` branch). The coarse
+   `QualityRank` band can bucket two genuinely UNEQUAL clamped spectral
+   values together; before this fix the same-rank tiebreak fell through to
+   the fully-unclamped raw metric, which can reverse a real spectral
+   ordering (a worse-spectral candidate winning purely on a higher declared
+   container). A TRUE spectral tie (clamped values EQUAL) still defers to
+   the raw metric exactly as before — this is what lets Mark DeNardo
+   (request 1308, tied spectral 128==128) still import on its higher raw
+   container.
+2. **CBR/VBR band-table mismatch** (`rank` branch). The spectral bucket
+   values (`lib/spectral_check.py`'s `LAME_LOWPASS` table — 96/128/160/192/
+   256/320) are calibrated to `QualityRankConfig.mp3_cbr`'s thresholds
+   (128=acceptable, 192=good, 256=excellent, 320=transparent), not
+   `mp3_vbr`'s more generous ones. A side whose clamp is spectral-bound
+   (`spectral <= raw`) now always classifies via CBR bands regardless of
+   that side's own `is_cbr` — otherwise a VBR-tagged candidate's
+   spectral-bound clamp could outrank a CBR-tagged existing's purely from
+   table choice. A side whose clamp did NOT bind (raw is the tighter value)
+   still classifies with its own encoding mode, unaffected.
+
+Stage 1 remains load-bearing and was NOT folded into Stage 2: the property
+is deliberately scoped to internally-consistent evidence (`spectral <=` the
+side's own raw metric, the domain `_shared_spectral_bitrates` assumes — see
+`StageParityWorld`'s docstring). A self-inconsistent existing measurement
+(raw container measured LOWER than its own spectral estimate — reachable
+via evidence carried forward across snapshots, not a single fresh
+measurement) is outside that domain and is a residual case only Stage 1's
+coarse spectral-vs-spectral comparison protects; likewise a candidate with
+no existing spectral estimate at all (`spectral_import_decision` returns
+`"import_no_exist"`, deferring by design — absence of a measurement is not
+evidence the installed copy is genuine).
 
 Version 4 import results persist five disjoint concerns:
 

--- a/docs/quality-verification.md
+++ b/docs/quality-verification.md
@@ -325,27 +325,40 @@ when BOTH sides carry `spectral_bitrate_kbps`):
    container). A TRUE spectral tie (clamped values EQUAL) still defers to
    the raw metric exactly as before — this is what lets Mark DeNardo
    (request 1308, tied spectral 128==128) still import on its higher raw
-   container.
+   container. **Requires BOTH sides spectral-bound** (`spectral <= raw` on
+   each side individually) — a PR #827 review finding: gating on only
+   `rank_new_value != rank_existing_value` without consulting which side is
+   actually bound turns the branch into a stealth `metric_tiebreak` with no
+   `±5kbps` tolerance whenever one (or neither) side is bound, since the
+   "clamped" value on an unbound side is just its raw metric.
 2. **CBR/VBR band-table mismatch** (`rank` branch). The spectral bucket
    values (`lib/spectral_check.py`'s `LAME_LOWPASS` table — 96/128/160/192/
    256/320) are calibrated to `QualityRankConfig.mp3_cbr`'s thresholds
    (128=acceptable, 192=good, 256=excellent, 320=transparent), not
-   `mp3_vbr`'s more generous ones. A side whose clamp is spectral-bound
-   (`spectral <= raw`) now always classifies via CBR bands regardless of
-   that side's own `is_cbr` — otherwise a VBR-tagged candidate's
-   spectral-bound clamp could outrank a CBR-tagged existing's purely from
-   table choice. A side whose clamp did NOT bind (raw is the tighter value)
-   still classifies with its own encoding mode, unaffected.
+   `mp3_vbr`'s more generous ones. A side whose clamp is spectral-bound now
+   classifies via CBR bands regardless of that side's own `is_cbr` — but
+   **only when BOTH sides are bound** (another PR #827 review finding):
+   forcing CBR on one bound side while an unbound side keeps its own
+   (possibly more generous VBR) table mixes a spectral-calibrated number
+   against a raw-metric number under two different band tables, which can
+   itself invert the ordering. A side whose clamp did NOT bind (raw is the
+   tighter value) always classifies with its own encoding mode.
 
 Stage 1 remains load-bearing and was NOT folded into Stage 2: the property
 is deliberately scoped to internally-consistent evidence (`spectral <=` the
 side's own raw metric, the domain `_shared_spectral_bitrates` assumes — see
 `StageParityWorld`'s docstring). A self-inconsistent existing measurement
-(raw container measured LOWER than its own spectral estimate — reachable
-via evidence carried forward across snapshots, not a single fresh
-measurement) is outside that domain and is a residual case only Stage 1's
-coarse spectral-vs-spectral comparison protects; likewise a candidate with
-no existing spectral estimate at all (`spectral_import_decision` returns
+(raw container measured LOWER than its own spectral estimate) is outside
+that domain and is a residual case only Stage 1's coarse spectral-vs-
+spectral comparison protects — this shape is reachable from an ORDINARY
+FRESH measurement, not only cross-snapshot carry-forward: `analyze_album`
+(`lib/spectral_check.py`) aggregates the album-level spectral estimate as
+`min()` over only the tracks with a detected cliff (container-independent
+per-track buckets), computed independently of the album's overall grade
+threshold, so a single outlier track's cliff can produce a spectral
+estimate well above the album's real average container bitrate even while
+the album's overall grade stays "genuine". Likewise a candidate with no
+existing spectral estimate at all (`spectral_import_decision` returns
 `"import_no_exist"`, deferring by design — absence of a measurement is not
 evidence the installed copy is genuine).
 

--- a/lib/quality/compare.py
+++ b/lib/quality/compare.py
@@ -165,7 +165,11 @@ def _shared_spectral_bitrates(
     (128=acceptable, 192=good, 256=excellent, 320=transparent), not
     ``mp3_vbr``'s more generous ones. Classifying a spectral-bound value
     through a VBR-tagged side's own ``is_cbr=False`` inflates its rank
-    purely from table choice, not real content — see the caller.
+    purely from table choice, not real content. The caller only forces CBR
+    bands when BOTH sides are bound (symmetric) — forcing it on one bound
+    side while an unbound side keeps its own (possibly more generous VBR)
+    table mixes a spectral-calibrated number against a raw-metric number
+    under two different band tables, which can itself invert the ordering.
     """
     if (new.spectral_bitrate_kbps is None
             or existing.spectral_bitrate_kbps is None):
@@ -236,22 +240,29 @@ def compare_quality(
 
     Shared-spectral bucket: when BOTH measurements carry ``spectral_bitrate_kbps``,
     clamp each side's classified bitrate to ``min(selected_metric, spectral)``
-    for rank. When the clamped values land in the SAME rank but still differ
-    from each other, that difference decides the same-rank tiebreak directly
-    (branch ``spectral_tiebreak``) — otherwise the coarse rank band could
-    bucket two genuinely unequal spectral readings together and the fully
+    for rank. When the clamp binds on BOTH sides (the clamped value on each
+    side IS its spectral estimate, not its raw metric) and the clamped
+    values land in the SAME rank but still differ from each other, that
+    difference decides the same-rank tiebreak directly (branch
+    ``spectral_tiebreak``) — otherwise the coarse rank band could bucket
+    two genuinely unequal spectral readings together and the fully
     unclamped raw metric would decide instead, which can reverse a real
-    spectral ordering (issue #813 Finding 1). Only a TRUE spectral tie
-    (clamped values EQUAL) falls through to the raw configured metric, so
-    higher-average files can still replace lower-average files within an
-    identical spectral bucket — this keeps spectral as a demotion signal
-    without letting a pessimistic estimate permanently freeze the album at
-    the first source that happened to land in that bucket (Mark DeNardo
-    request 1308). See ``_shared_spectral_bitrates`` for the narrow guard
-    that keeps the Springsteen case (single stale estimate) on the
-    container path. A transcode-grade candidate over a non-transcode-grade
-    existing album has one extra guard before any of this: if its real
-    selected-metric rank is lower before the spectral clamp, it is worse.
+    spectral ordering (issue #813 Finding 1). When only one (or neither)
+    side is spectral-bound, that "both bound" requirement intentionally
+    withholds this tiebreak — comparing a spectral estimate against a raw
+    configured metric with no tolerance is not a like-for-like comparison,
+    and it falls through to the raw-metric tiebreak below instead. Only a
+    TRUE spectral tie (clamped values EQUAL, both bound) also falls through
+    to the raw configured metric, so higher-average files can still replace
+    lower-average files within an identical spectral bucket — this keeps
+    spectral as a demotion signal without letting a pessimistic estimate
+    permanently freeze the album at the first source that happened to land
+    in that bucket (Mark DeNardo request 1308). See
+    ``_shared_spectral_bitrates`` for the narrow guard that keeps the
+    Springsteen case (single stale estimate) on the container path. A
+    transcode-grade candidate over a non-transcode-grade existing album has
+    one extra guard before any of this: if its real selected-metric rank is
+    lower before the spectral clamp, it is worse.
 
     Returns a ``QualityComparisonBasis`` — the verdict plus the branch that
     fired and the values that decided it, emitted HERE per-branch so the
@@ -362,16 +373,23 @@ def compare_quality(
         # A spectral-bound side's clamped value is the spectral estimate,
         # calibrated to the CBR band thresholds regardless of that side's
         # own encoding mode (see ``_shared_spectral_bitrates``'s docstring)
-        # — classify it with CBR bands. A side whose clamp did NOT bind
-        # still carries its own genuine raw metric, classified with its own
-        # encoding mode as before.
+        # — classify it with CBR bands. This only applies when BOTH sides
+        # are spectral-bound: forcing CBR on a bound side while an UNBOUND
+        # side keeps its own (possibly more generous VBR) bands mixes a
+        # spectral-calibrated number against a raw-metric number under two
+        # different band tables, which can itself invert the ordering (a
+        # bound side demoted into CBR's stricter table while an unbound
+        # side keeps VBR's more generous one). A side whose clamp did NOT
+        # bind still carries its own genuine raw metric, classified with
+        # its own encoding mode as before.
+        both_spectral_bound = new_bound and existing_bound
         new_rank = quality_rank(
             new_format, clamped_new_br,
-            True if new_bound else projected_is_cbr, cfg,
+            True if both_spectral_bound else projected_is_cbr, cfg,
         )
         existing_rank = quality_rank(
             existing.format, clamped_existing_br,
-            True if existing_bound else existing.is_cbr, cfg,
+            True if both_spectral_bound else existing.is_cbr, cfg,
         )
         rank_new_value, rank_existing_value = clamped_new_br, clamped_existing_br
         spectral_clamped = True
@@ -385,6 +403,7 @@ def compare_quality(
         existing_rank = measurement_rank(existing, cfg)
         rank_new_value, rank_existing_value = new_br, existing_br
         spectral_clamped = False
+        both_spectral_bound = False
 
     if new_rank > existing_rank:
         return _basis(
@@ -438,23 +457,32 @@ def compare_quality(
             spectral_clamped=spectral_clamped,
         )
 
-    # When the shared-spectral clamp fired AND the clamped values themselves
-    # still differ, that difference decides the tiebreak directly — issue
-    # #813 Finding 1's remaining Stage1/Stage2 disagreement. The coarse
-    # QualityRank band can bucket two genuinely UNEQUAL spectral estimates
-    # into the same rank (e.g. spectral 287 and 317 both land in
-    # "transparent"); falling through to the fully-unclamped raw metric at
-    # that point lets a worse-spectral candidate win purely because its
-    # (already known-unreliable, that's why spectral exists) declared
-    # container happens to be higher. The clamped values are the more
-    # direct evidence and decide with the same strict (no-tolerance)
-    # comparison Stage 1 (``spectral_import_decision``) already uses — this
-    # is what makes the two stages agree instead of disagree. A TRUE
-    # spectral tie (clamped values EQUAL) carries no differentiating signal
-    # and still falls through to the raw-metric tiebreak below, exactly as
-    # before (Mark DeNardo request 1308: tied spectral 128==128, raw 192
-    # beats 128 must still import).
+    # When the shared-spectral clamp fired, BOTH sides are spectral-bound
+    # (the clamped value on each side IS the spectral estimate, not the raw
+    # metric — see ``_shared_spectral_bitrates``), AND the clamped values
+    # themselves still differ, that difference decides the tiebreak
+    # directly — issue #813 Finding 1's remaining Stage1/Stage2
+    # disagreement. The coarse QualityRank band can bucket two genuinely
+    # UNEQUAL spectral estimates into the same rank (e.g. spectral 287 and
+    # 317 both land in "transparent"); falling through to the fully-
+    # unclamped raw metric at that point lets a worse-spectral candidate
+    # win purely because its (already known-unreliable, that's why spectral
+    # exists) declared container happens to be higher. The clamped values
+    # are the more direct evidence and decide with the same strict
+    # (no-tolerance) comparison Stage 1 (``spectral_import_decision``)
+    # already uses — this is what makes the two stages agree instead of
+    # disagree. Requiring BOTH bound is essential: when only one (or
+    # neither) side is spectral-bound, the "clamped value" on the unbound
+    # side is just its raw configured metric, and comparing a spectral
+    # estimate against a raw metric with no tolerance is not a like-for-
+    # like tiebreak — it silently becomes the ``metric_tiebreak`` below
+    # minus its ±5 kbps tolerance. A TRUE spectral tie (clamped values
+    # EQUAL) carries no differentiating signal and still falls through to
+    # the raw-metric tiebreak below, exactly as before (Mark DeNardo
+    # request 1308: tied spectral 128==128, raw 192 beats 128 must still
+    # import).
     if (spectral_clamped
+            and both_spectral_bound
             and rank_new_value is not None
             and rank_existing_value is not None
             and rank_new_value != rank_existing_value):

--- a/lib/quality/compare.py
+++ b/lib/quality/compare.py
@@ -129,7 +129,7 @@ def _shared_spectral_bitrates(
     cfg: QualityRankConfig,
     *,
     new_v0_probe: V0ProbeEvidence | None = None,
-) -> "tuple[Optional[int], Optional[int]] | None":
+) -> "tuple[Optional[int], Optional[int], bool, bool] | None":
     """Return rank-bucket bitrates when BOTH sides carry spectral estimates.
 
     The clamp takes ``min(selected_metric, spectral_bitrate)`` per side — the
@@ -153,18 +153,34 @@ def _shared_spectral_bitrates(
     asymmetric case where a transcode-grade candidate would otherwise use a
     higher spectral floor to replace a non-transcode-grade existing album with
     a higher real quality rank.
+
+    Returns ``(new_value, existing_value, new_spectral_bound,
+    existing_spectral_bound)`` — the two ``*_spectral_bound`` flags tell the
+    caller which side's returned value IS the spectral estimate (clamp
+    bound, ``spectral <= raw``) versus which is still the untouched raw
+    metric (clamp did not bind, ``spectral > raw``). This matters for rank
+    classification (issue #813 Finding 1): the spectral bucket values
+    (``lib/spectral_check.py``'s ``LAME_LOWPASS`` table — 96/128/160/192/
+    256/320) are calibrated to ``QualityRankConfig.mp3_cbr``'s thresholds
+    (128=acceptable, 192=good, 256=excellent, 320=transparent), not
+    ``mp3_vbr``'s more generous ones. Classifying a spectral-bound value
+    through a VBR-tagged side's own ``is_cbr=False`` inflates its rank
+    purely from table choice, not real content — see the caller.
     """
     if (new.spectral_bitrate_kbps is None
             or existing.spectral_bitrate_kbps is None):
         return None
     new_br = _selected_quality_bitrate_with_source(new, cfg, new_v0_probe)[0]
     existing_br = _selected_bitrate(existing, cfg)
-    new_br = (min(new_br, new.spectral_bitrate_kbps)
-              if new_br is not None else new.spectral_bitrate_kbps)
-    existing_br = (min(existing_br, existing.spectral_bitrate_kbps)
-                   if existing_br is not None
-                   else existing.spectral_bitrate_kbps)
-    return new_br, existing_br
+    new_bound = new_br is None or new.spectral_bitrate_kbps <= new_br
+    existing_bound = (
+        existing_br is None or existing.spectral_bitrate_kbps <= existing_br
+    )
+    new_value = new.spectral_bitrate_kbps if new_bound else new_br
+    existing_value = (
+        existing.spectral_bitrate_kbps if existing_bound else existing_br
+    )
+    return new_value, existing_value, new_bound, existing_bound
 
 
 def _transcode_candidate_real_rank_regresses(
@@ -220,14 +236,21 @@ def compare_quality(
 
     Shared-spectral bucket: when BOTH measurements carry ``spectral_bitrate_kbps``,
     clamp each side's classified bitrate to ``min(selected_metric, spectral)``
-    for rank only. Same-rank tie-breaks still use the raw configured metric
-    so higher-average files can replace lower-average files within the same
-    spectral bucket. This keeps spectral as a demotion signal without letting
-    a pessimistic estimate permanently freeze the album at the first source
-    that happened to land in that bucket. See ``_shared_spectral_bitrates``
-    for the narrow guard that keeps the Springsteen case (single stale
-    estimate) on the container path. A transcode-grade candidate over a
-    non-transcode-grade existing album has one extra guard: if its real
+    for rank. When the clamped values land in the SAME rank but still differ
+    from each other, that difference decides the same-rank tiebreak directly
+    (branch ``spectral_tiebreak``) — otherwise the coarse rank band could
+    bucket two genuinely unequal spectral readings together and the fully
+    unclamped raw metric would decide instead, which can reverse a real
+    spectral ordering (issue #813 Finding 1). Only a TRUE spectral tie
+    (clamped values EQUAL) falls through to the raw configured metric, so
+    higher-average files can still replace lower-average files within an
+    identical spectral bucket — this keeps spectral as a demotion signal
+    without letting a pessimistic estimate permanently freeze the album at
+    the first source that happened to land in that bucket (Mark DeNardo
+    request 1308). See ``_shared_spectral_bitrates`` for the narrow guard
+    that keeps the Springsteen case (single stale estimate) on the
+    container path. A transcode-grade candidate over a non-transcode-grade
+    existing album has one extra guard before any of this: if its real
     selected-metric rank is lower before the spectral clamp, it is worse.
 
     Returns a ``QualityComparisonBasis`` — the verdict plus the branch that
@@ -330,17 +353,26 @@ def compare_quality(
         new, existing, cfg, new_v0_probe=new_v0_probe
     )
     if shared is not None:
-        clamped_new_br, clamped_existing_br = shared
+        clamped_new_br, clamped_existing_br, new_bound, existing_bound = shared
         projected_is_cbr = (
             new_target_contract.is_cbr
             if new_target_contract is not None
             else new.is_cbr
         )
+        # A spectral-bound side's clamped value is the spectral estimate,
+        # calibrated to the CBR band thresholds regardless of that side's
+        # own encoding mode (see ``_shared_spectral_bitrates``'s docstring)
+        # — classify it with CBR bands. A side whose clamp did NOT bind
+        # still carries its own genuine raw metric, classified with its own
+        # encoding mode as before.
         new_rank = quality_rank(
-            new_format, clamped_new_br, projected_is_cbr, cfg
+            new_format, clamped_new_br,
+            True if new_bound else projected_is_cbr, cfg,
         )
         existing_rank = quality_rank(
-            existing.format, clamped_existing_br, existing.is_cbr, cfg)
+            existing.format, clamped_existing_br,
+            True if existing_bound else existing.is_cbr, cfg,
+        )
         rank_new_value, rank_existing_value = clamped_new_br, clamped_existing_br
         spectral_clamped = True
     else:
@@ -403,6 +435,33 @@ def compare_quality(
         return _basis(
             "equivalent", "label_contract_same_rank", new_rank, existing_rank,
             new_value=new_br, existing_value=existing_br,
+            spectral_clamped=spectral_clamped,
+        )
+
+    # When the shared-spectral clamp fired AND the clamped values themselves
+    # still differ, that difference decides the tiebreak directly — issue
+    # #813 Finding 1's remaining Stage1/Stage2 disagreement. The coarse
+    # QualityRank band can bucket two genuinely UNEQUAL spectral estimates
+    # into the same rank (e.g. spectral 287 and 317 both land in
+    # "transparent"); falling through to the fully-unclamped raw metric at
+    # that point lets a worse-spectral candidate win purely because its
+    # (already known-unreliable, that's why spectral exists) declared
+    # container happens to be higher. The clamped values are the more
+    # direct evidence and decide with the same strict (no-tolerance)
+    # comparison Stage 1 (``spectral_import_decision``) already uses — this
+    # is what makes the two stages agree instead of disagree. A TRUE
+    # spectral tie (clamped values EQUAL) carries no differentiating signal
+    # and still falls through to the raw-metric tiebreak below, exactly as
+    # before (Mark DeNardo request 1308: tied spectral 128==128, raw 192
+    # beats 128 must still import).
+    if (spectral_clamped
+            and rank_new_value is not None
+            and rank_existing_value is not None
+            and rank_new_value != rank_existing_value):
+        verdict = "better" if rank_new_value > rank_existing_value else "worse"
+        return _basis(
+            verdict, "spectral_tiebreak", new_rank, existing_rank,
+            new_value=rank_new_value, existing_value=rank_existing_value,
             spectral_clamped=spectral_clamped,
         )
 

--- a/lib/quality/evidence_types.py
+++ b/lib/quality/evidence_types.py
@@ -502,8 +502,9 @@ class QualityComparisonBasis(msgspec.Struct, frozen=True):
     numbers that DECIDED that branch (spectral-clamped values on a clamped
     rank comparison, raw configured-metric values on a same-rank tiebreak).
     Consumers reading ``(metric, value)`` pairs must suppress the metric
-    label when ``branch == "rank" and spectral_clamped`` — the value there
-    is ``min(metric, spectral floor)``, not the named statistic.
+    label when ``spectral_clamped and branch in ("rank", "spectral_tiebreak")``
+    — the value there is ``min(metric, spectral floor)``, not the named
+    statistic.
     ``new_metric`` / ``existing_metric`` name the per-side statistic actually
     classified — ``measurement_rank()`` falls back to min when the configured
     metric is unmeasured, and a basis claiming "avg" for a min value would be
@@ -544,6 +545,7 @@ COMPARISON_BASIS_BRANCHES: frozenset[str] = frozenset({
     "lossless_same_rank",          # both LOSSLESS: equivalent by identity
     "cross_family_same_rank",      # same rank, different codec family
     "label_contract_same_rank",    # same rank, explicit label is authoritative
+    "spectral_tiebreak",           # same rank, differing clamped spectral values decide
     "metric_tiebreak",             # same rank, raw metric delta vs tolerance
     "metric_missing",              # same rank, a side has no classifiable value
     "transcode_rank_regression",   # transcode-grade candidate regresses real rank

--- a/tests/test_js_history.mjs
+++ b/tests/test_js_history.mjs
@@ -1385,6 +1385,27 @@ console.log('renderEvidenceStrip() marks spectral-clamped rank values with ~');
   assertExcludes(strip, 'avg 250k', 'clamped value must not claim a metric');
 }
 
+console.log('renderEvidenceStrip() marks spectral_tiebreak values with ~ too (issue #813)');
+{
+  // Same clamped-value display rule as the rank branch — the coarse
+  // rank band bucketed differing spectral estimates together, so the
+  // same-rank tiebreak decided directly on the clamped values.
+  const strip = renderEvidenceFixture({
+    actual_min_bitrate: 1000,
+    comparison_basis: {
+      verdict: 'worse', branch: 'spectral_tiebreak',
+      new_rank: 'good', existing_rank: 'good',
+      new_metric: 'avg', existing_metric: 'avg',
+      new_value_kbps: 200, existing_value_kbps: 230,
+      new_format: 'MP3', existing_format: 'MP3',
+      spectral_clamped: true, tolerance_kbps: null,
+      verified_lossless_bypass: false,
+    },
+  });
+  assertContains(strip, '~200k', 'clamped value gets the ~ prefix, no metric label');
+  assertExcludes(strip, 'avg 200k', 'clamped value must not claim a metric');
+}
+
 console.log('renderEvidenceStrip() escapes basis strings');
 {
   const strip = renderEvidenceFixture({

--- a/tests/test_quality_classification.py
+++ b/tests/test_quality_classification.py
@@ -206,6 +206,72 @@ class TestLiveBugReproductions(unittest.TestCase):
         # Issue #813 Finding 2: downgrade always denylists in production.
         self.assertTrue(r["denylisted"])
 
+    def test_stage_parity_review_f1_unbound_tied_spectral_stays_equivalent(self):
+        """PR #827 review finding F1: neither side is spectral-bound here
+        (both containers are LOWER than their own tied 256 spectral
+        estimate), so the compared values are the raw avg metrics — a
+        stealth ``metric_tiebreak`` with no tolerance, not a genuine
+        ``spectral_tiebreak``. Before the fix (gating the tiebreak on
+        ``new_bound and existing_bound``), the tied 256/256 spectral values
+        made both sides classify identically (rank ties), and the
+        UNGATED spectral_tiebreak branch then compared the RAW avg values
+        (250 vs 247) with NO tolerance, flipping this into a phantom
+        "better"/imported=True. With the ±5kbps tolerance restored via the
+        raw ``metric_tiebreak`` fallback, delta=3 stays "equivalent" —
+        not imported.
+        """
+        r = full_pipeline_decision(
+            is_flac=False,
+            min_bitrate=250,
+            is_cbr=False,
+            avg_bitrate=250,
+            new_format="MP3",
+            spectral_grade="genuine",
+            spectral_bitrate=256,
+            existing_min_bitrate=247,
+            existing_avg_bitrate=247,
+            existing_format="MP3",
+            existing_is_cbr=False,
+            existing_spectral_grade="genuine",
+            existing_spectral_bitrate=256,
+        )
+        self.assertEqual(r["comparison_basis"]["verdict"], "equivalent")
+        self.assertEqual(r["comparison_basis"]["branch"], "metric_tiebreak")
+        self.assertFalse(r["imported"])
+
+    def test_stage_parity_review_f2_asymmetric_cbr_forcing_stays_worse(self):
+        """PR #827 review finding F2: existing's spectral (256) IS bound
+        (256 <= its own 260 container) but candidate's spectral (320)
+        is NOT bound (320 > its own 246 container) — an asymmetric case.
+        Before the fix (requiring BOTH sides bound before forcing CBR
+        bands), existing alone got demoted from VBR "transparent" to CBR
+        "excellent" while candidate kept VBR "transparent" unforced,
+        letting a lower-container V0 candidate (246) outrank a
+        higher-container V0 existing (260) purely from an asymmetric
+        table swap driven by cliff-bucket noise at the V0 lowpass
+        boundary. With CBR-forcing withheld unless both sides are bound,
+        both classify under their own (matching) VBR table and the raw
+        containers correctly decide: candidate 246 stays worse than
+        existing 260 — not imported.
+        """
+        r = full_pipeline_decision(
+            is_flac=False,
+            min_bitrate=246,
+            is_cbr=False,
+            avg_bitrate=246,
+            new_format="MP3",
+            spectral_grade="genuine",
+            spectral_bitrate=320,
+            existing_min_bitrate=260,
+            existing_avg_bitrate=260,
+            existing_format="MP3",
+            existing_is_cbr=False,
+            existing_spectral_grade="genuine",
+            existing_spectral_bitrate=256,
+        )
+        self.assertEqual(r["comparison_basis"]["verdict"], "worse")
+        self.assertFalse(r["imported"])
+
     def test_taboo_vi_fake_flac_192_accepted(self):
         """Fake FLAC (192k source) converted to V0 at 224kbps is provisional.
 

--- a/tests/test_quality_comparison_basis.py
+++ b/tests/test_quality_comparison_basis.py
@@ -122,25 +122,100 @@ class TestCompareQualityBasisBranches(unittest.TestCase):
                  new_value_kbps=180, existing_value_kbps=250),
         ),
         (
-            "shared-spectral clamp deciding rank shows the clamped values",
-            _m(avg_bitrate_kbps=288, format="MP3",
-               spectral_grade="genuine", spectral_bitrate_kbps=250),
-            _m(avg_bitrate_kbps=196, format="MP3",
-               spectral_grade="genuine", spectral_bitrate_kbps=250),
+            # Issue #813 Finding 1 line-189 audit: when BOTH sides are
+            # transcode-grade, ``_transcode_candidate_real_rank_regresses``
+            # deliberately skips (its line-189 early-out) and routes to the
+            # shared spectral clamp instead. This is load-bearing, not
+            # redundant: the candidate's RAW rank (150, "acceptable") is
+            # LOWER than existing's raw rank (200, "good") — a raw-only
+            # pre-check would wrongly reject this as a rank regression. But
+            # existing's own spectral (100) reveals it is actually much
+            # worse real content than its raw container claims, while the
+            # candidate's spectral (300) does not even bind its own clamp
+            # (300 > 150, so 150 stands). The clamp correctly scores this a
+            # genuine upgrade — removing the early-out would silently
+            # regress this case back to a wrong "worse".
+            "transcode-over-transcode routes to the shared clamp, not the "
+            "raw pre-check (line-189 audit)",
+            _m(avg_bitrate_kbps=150, format="MP3", is_cbr=True,
+               spectral_grade="likely_transcode", spectral_bitrate_kbps=300),
+            _m(avg_bitrate_kbps=200, format="MP3", is_cbr=True,
+               spectral_grade="likely_transcode", spectral_bitrate_kbps=100),
             dict(verdict="better", branch="rank",
-                 new_rank="transparent", existing_rank="good",
-                 new_value_kbps=250, existing_value_kbps=196,
+                 new_rank="acceptable", existing_rank="poor",
+                 new_value_kbps=150, existing_value_kbps=100,
                  spectral_clamped=True),
         ),
         (
-            "shared-spectral clamp landing same-rank tie-breaks on RAW metric",
+            # Both sides' spectral estimates are the binding clamp (below
+            # their own raw container), so both classify via the CBR bands
+            # the spectral bucket values are calibrated to (issue #813
+            # Finding 1) — regardless of either side's own is_cbr.
+            "shared-spectral clamp deciding rank shows the clamped values",
+            _m(avg_bitrate_kbps=1000, format="MP3",
+               spectral_grade="genuine", spectral_bitrate_kbps=300),
+            _m(avg_bitrate_kbps=500, format="MP3",
+               spectral_grade="genuine", spectral_bitrate_kbps=150),
+            dict(verdict="better", branch="rank",
+                 new_rank="excellent", existing_rank="acceptable",
+                 new_value_kbps=300, existing_value_kbps=150,
+                 spectral_clamped=True),
+        ),
+        (
+            # Issue #813 Finding 1: the coarse "good" band buckets spectral
+            # 200 and 240 together, but they are NOT a spectral tie — the
+            # clamped values (200 vs 196, since existing's raw 196 is
+            # already below its own 240 spectral floor) decide directly
+            # instead of falling through to the fully-unclamped raw metric
+            # (288 vs 196), which would launder the worse-spectral candidate
+            # in purely on its higher declared container.
+            "shared-spectral clamp: differing clamped values decide the "
+            "same-rank tiebreak directly",
             _m(avg_bitrate_kbps=288, format="MP3",
                spectral_grade="genuine", spectral_bitrate_kbps=200),
             _m(avg_bitrate_kbps=196, format="MP3",
                spectral_grade="genuine", spectral_bitrate_kbps=240),
-            dict(verdict="better", branch="metric_tiebreak",
+            dict(verdict="better", branch="spectral_tiebreak",
                  new_rank="good", existing_rank="good",
+                 new_value_kbps=200, existing_value_kbps=196,
+                 spectral_clamped=True),
+        ),
+        (
+            # A TRUE spectral tie (both sides clamp to the identical 190
+            # value) carries no differentiating signal — Stage 2 still
+            # falls through to the raw configured metric, exactly as before
+            # (Mark DeNardo request 1308: a tied spectral floor must not
+            # block a genuine raw-bitrate upgrade).
+            "shared-spectral clamp: a TRUE spectral tie still defers to "
+            "the raw metric",
+            _m(avg_bitrate_kbps=288, format="MP3",
+               spectral_grade="genuine", spectral_bitrate_kbps=190),
+            _m(avg_bitrate_kbps=196, format="MP3",
+               spectral_grade="genuine", spectral_bitrate_kbps=190),
+            dict(verdict="better", branch="metric_tiebreak",
+                 new_rank="acceptable", existing_rank="acceptable",
                  new_value_kbps=288, existing_value_kbps=196,
+                 spectral_clamped=True, tolerance_kbps=5),
+        ),
+        (
+            # Issue #813 Finding 1 (second sub-finding): the spectral
+            # bucket values (LAME_LOWPASS) are calibrated to the CBR band
+            # thresholds, not the more generous VBR ones. A spectral-bound
+            # clamped value classifies via CBR bands regardless of that
+            # side's own is_cbr — otherwise a VBR-tagged 245 (VBR
+            # "transparent") would outrank a CBR-tagged 300 (CBR
+            # "excellent") purely from table choice, despite 245 < 300
+            # (worse real content, per spectral evidence both sides agree
+            # is the direct signal).
+            "shared-spectral clamp: CBR bands classify a spectral-bound "
+            "value even when that side is VBR",
+            _m(avg_bitrate_kbps=1000, format="MP3", is_cbr=False,
+               spectral_grade="likely_transcode", spectral_bitrate_kbps=245),
+            _m(avg_bitrate_kbps=1000, format="MP3", is_cbr=True,
+               spectral_grade="likely_transcode", spectral_bitrate_kbps=300),
+            dict(verdict="worse", branch="rank",
+                 new_rank="good", existing_rank="excellent",
+                 new_value_kbps=245, existing_value_kbps=300,
                  spectral_clamped=True),
         ),
         (

--- a/tests/test_quality_comparison_basis.py
+++ b/tests/test_quality_comparison_basis.py
@@ -162,19 +162,23 @@ class TestCompareQualityBasisBranches(unittest.TestCase):
                  spectral_clamped=True),
         ),
         (
-            # Issue #813 Finding 1: the coarse "good" band buckets spectral
-            # 200 and 240 together, but they are NOT a spectral tie — the
-            # clamped values (200 vs 196, since existing's raw 196 is
-            # already below its own 240 spectral floor) decide directly
-            # instead of falling through to the fully-unclamped raw metric
-            # (288 vs 196), which would launder the worse-spectral candidate
-            # in purely on its higher declared container.
+            # Issue #813 Finding 1: BOTH sides are spectral-bound (each raw
+            # container of 1000 is far above its own spectral estimate),
+            # and the coarse "good" band buckets spectral 200 and 196
+            # together, but they are NOT a spectral tie — the clamped
+            # (spectral) values decide directly instead of falling through
+            # to the fully-unclamped raw metric (1000 vs 1000, which would
+            # be an uninformative wash and mask the real spectral signal).
+            # PR #827 review (F1): the spectral_tiebreak branch requires
+            # BOTH sides bound, or this degenerates into comparing raw
+            # metrics with no tolerance — this case is deliberately
+            # constructed so both sides genuinely are bound.
             "shared-spectral clamp: differing clamped values decide the "
             "same-rank tiebreak directly",
-            _m(avg_bitrate_kbps=288, format="MP3",
+            _m(avg_bitrate_kbps=1000, format="MP3",
                spectral_grade="genuine", spectral_bitrate_kbps=200),
-            _m(avg_bitrate_kbps=196, format="MP3",
-               spectral_grade="genuine", spectral_bitrate_kbps=240),
+            _m(avg_bitrate_kbps=1000, format="MP3",
+               spectral_grade="genuine", spectral_bitrate_kbps=196),
             dict(verdict="better", branch="spectral_tiebreak",
                  new_rank="good", existing_rank="good",
                  new_value_kbps=200, existing_value_kbps=196,

--- a/tests/test_quality_decisions.py
+++ b/tests/test_quality_decisions.py
@@ -3408,7 +3408,13 @@ class TestCompareQualitySharedSpectralBucket(unittest.TestCase):
                          "downgrade")
 
     def test_transcode_guard_requires_known_non_transcode_existing_grade(self):
-        """Unknown existing grade keeps the backward-compatible shared bucket."""
+        """Unknown existing grade keeps the backward-compatible shared bucket.
+
+        Issue #813 Finding 1: both clamped values (160, 128) land in the
+        same CBR-calibrated "acceptable" band, so the ``spectral_tiebreak``
+        branch decides directly on the differing clamped values — not the
+        raw ``rank`` branch, and not the fully-unclamped raw metric.
+        """
         new = self._m(
             format="MP3",
             avg_bitrate_kbps=196,
@@ -3421,10 +3427,19 @@ class TestCompareQualitySharedSpectralBucket(unittest.TestCase):
             spectral_bitrate_kbps=128,
         )
 
-        self.assertEqual(compare_quality(new, existing, CFG).verdict, "better")
+        basis = compare_quality(new, existing, CFG)
+        self.assertEqual(basis.verdict, "better")
+        self.assertEqual(basis.branch, "spectral_tiebreak")
+        self.assertEqual(basis.new_rank, "acceptable")
+        self.assertEqual(basis.existing_rank, "acceptable")
 
     def test_transcode_candidate_can_still_import_when_real_rank_does_not_regress(self):
-        """Bay of Biscay shape: spectral and actual selected metric both improve."""
+        """Bay of Biscay shape: spectral and actual selected metric both improve.
+
+        Issue #813 Finding 1: both clamped values (160, 128) land in the
+        same CBR-calibrated "acceptable" band — ``spectral_tiebreak``, not
+        the ``rank`` branch, decides.
+        """
         new = self._m(
             format="MP3",
             min_bitrate_kbps=119,
@@ -3444,12 +3459,20 @@ class TestCompareQualitySharedSpectralBucket(unittest.TestCase):
             spectral_bitrate_kbps=128,
         )
 
-        self.assertEqual(compare_quality(new, existing, CFG).verdict, "better")
+        basis = compare_quality(new, existing, CFG)
+        self.assertEqual(basis.verdict, "better")
+        self.assertEqual(basis.branch, "spectral_tiebreak")
         self.assertEqual(import_quality_decision(new, existing, cfg=CFG).decision,
                          "import")
 
     def test_transcode_over_transcode_still_uses_shared_spectral_floor(self):
-        """The guard only covers transcode-grade over known non-transcode."""
+        """The guard only covers transcode-grade over known non-transcode.
+
+        Issue #813 Finding 1 line-189 audit: transcode-over-transcode
+        routes to the shared clamp (never the raw pre-check), and both
+        clamped values (160, 128) land in the same CBR-calibrated
+        "acceptable" band — ``spectral_tiebreak`` decides directly.
+        """
         new = self._m(
             format="MP3",
             avg_bitrate_kbps=196,
@@ -3463,7 +3486,11 @@ class TestCompareQualitySharedSpectralBucket(unittest.TestCase):
             spectral_bitrate_kbps=128,
         )
 
-        self.assertEqual(compare_quality(new, existing, CFG).verdict, "better")
+        basis = compare_quality(new, existing, CFG)
+        self.assertEqual(basis.verdict, "better")
+        self.assertEqual(basis.branch, "spectral_tiebreak")
+        self.assertEqual(basis.new_rank, "acceptable")
+        self.assertEqual(basis.existing_rank, "acceptable")
 
     def test_equal_spectral_bucket_keeps_raw_avg_tiebreaker(self):
         """Grouper live case: equal spectral floor must not erase avg upgrade."""

--- a/tests/test_quality_generated.py
+++ b/tests/test_quality_generated.py
@@ -374,25 +374,43 @@ class StageParityWorld:
     is the same established convention as
     ``test_existing_spectral_override_is_noop_when_candidate_has_spectral``
     (which clamps ``candidate_spectral``/``existing_spectral`` to their own
-    containers). A stale/mismatched spectral estimate that legitimately
-    EXCEEDS a fresher container reading is real (evidence carry-forward
-    across snapshots, not a fresh single measurement) but is a data-hygiene
-    gap in a different subsystem, not a Stage1/Stage2 decision disagreement
-    — out of scope here, and precisely the domain this property does NOT
-    reach, which is why Stage 1 remains load-bearing (issue #813 Finding 1
-    audit conclusion) even though this property finds zero disagreement
-    inside its own (consistent-evidence) domain.
+    containers).
+
+    ``spectral > own container`` IS reachable from an ordinary FRESH single
+    measurement, not only via evidence carried forward across snapshots
+    (correction, PR #827 review F3 — the original text here overclaimed
+    cross-snapshot carry-forward as the only path). ``estimate_bitrate_from_
+    cliff`` (``lib/spectral_check.py``) maps a per-track cliff frequency to
+    a fixed, container-INDEPENDENT bucket (96/128/.../320), and
+    ``analyze_album`` aggregates the album-level estimate as
+    ``min(track estimates)`` over ONLY the tracks that had a cliff detected
+    at all — tracks with no cliff are excluded from that ``min``, and the
+    album's overall grade classification (``classify_album``'s 60%/75%
+    suspect-percentage thresholds) is computed independently of this
+    aggregation. So a single outlier track with a cliff at or above the
+    highest lowpass bucket (≥19,550 Hz) yields an album spectral estimate
+    of 320 even when the album's overall grade stays "genuine" (too few
+    suspect tracks to cross the percentage threshold) and its real average
+    container bitrate is much lower (e.g. 246). This domain remains a data-
+    hygiene/aggregation-policy question in a different subsystem
+    (``lib/spectral_check.py::analyze_album``'s own min-over-cliffed-tracks
+    policy), not a Stage1/Stage2 decision disagreement — out of scope here,
+    and precisely the domain this property does NOT reach, which is why
+    Stage 1 remains load-bearing (issue #813 Finding 1 audit conclusion)
+    even though this property finds zero disagreement inside its own
+    (consistent-evidence) domain.
 
     ``new_format``/``existing_format`` are deliberately the SAME codec
     family on both sides (see ``stage_parity_worlds``). Random probing
     (millions of iterations, outside this property) found the shared
     spectral clamp ALSO disagrees when the two sides are DIFFERENT codec
     families — but the spectral bucket table (``LAME_LOWPASS``) is
-    calibrated to MP3/LAME specifically, so a cross-codec spectral pairing
-    is itself evidence of the SAME carry-forward mismatch this docstring
-    already scopes out (spectral analysis runs on the MP3/CBR preimport
-    path or FLAC->V0 conversion evaluation — a fresh single measurement
-    never produces one codec's spectral estimate paired against a
+    calibrated to MP3/LAME specifically, and candidate-side spectral
+    analysis is only gated to run on MP3-shaped/CBR or FLAC->V0-conversion
+    candidates (``spectral_gate_trigger``), so a cross-codec spectral
+    pairing is itself evidence of a mismatch this docstring already scopes
+    as a separate-subsystem question (a fresh single measurement never
+    produces one codec's spectral estimate paired against a
     DIFFERENT codec's raw measurement), not an independent decision-logic
     gap. A correct fix would require deciding whether spectral evidence is
     even comparable across codec families at all — out of scope for this
@@ -1168,6 +1186,14 @@ class TestGeneratedSimulatorInvariants(unittest.TestCase):
            reasonable budget — this class needed the deterministic pin to
            be caught reliably) found this at roughly a 1-in-8000 rate over
            the general world space.
+
+        PR #827 review round: both fixes above shipped requiring only ONE
+        side spectral-bound to fire, which introduced two NEW flip worlds
+        (findings F1/F2, pinned in
+        ``tests/test_quality_classification.py::TestLiveBugReproductions``'s
+        ``test_stage_parity_review_f1_*``/``test_stage_parity_review_f2_*``).
+        Both fixes now require BOTH sides bound before firing — see
+        ``both_spectral_bound`` in ``lib/quality/compare.py``.
         """
         stage1, stage2 = _stage_parity_verdicts(world)
         assert_stage1_never_contradicts_stage2(stage1, stage2)

--- a/tests/test_quality_generated.py
+++ b/tests/test_quality_generated.py
@@ -51,12 +51,16 @@ from lib.quality import (
     AudioQualityMeasurement,
     COMPARISON_BASIS_BRANCHES,
     QUALITY_UPGRADE_TIERS,
+    EVIDENCE_PROVENANCE_MEASURED,
     EVIDENCE_SUBJECT_SOURCE,
     EVIDENCE_SUBJECT_INSTALLED,
+    QualityComparisonBasis,
     QualityRankConfig,
     TargetQualityContract,
     VerifiedLosslessProof,
+    build_existing_quality_measurement,
     classify_full_pipeline_decision,
+    compare_quality,
     compute_effective_override_bitrate,
     determine_verified_lossless,
     evidence_decision_name,
@@ -355,13 +359,133 @@ def assert_existing_override_noop_under_shared_clamp(
         )
 
 
+@dataclass(frozen=True)
+class StageParityWorld:
+    """Primitive candidate/existing facts shared by Stage 1
+    (``spectral_import_decision``) and Stage 2 (``compare_quality``) for the
+    SAME evidence — the world space issue #813 Finding 1's no-disagreement
+    property patrols.
+
+    Spectral estimates are kept ``<= their own container`` (``new_spectral
+    <= new_container``, ``existing_spectral <= existing_container``) — the
+    domain ``_shared_spectral_bitrates``/``compute_effective_override_bitrate``
+    assume, since a cliff estimate is a pessimistic FLOOR on real content,
+    never evidence of MORE content than the container itself measured. This
+    is the same established convention as
+    ``test_existing_spectral_override_is_noop_when_candidate_has_spectral``
+    (which clamps ``candidate_spectral``/``existing_spectral`` to their own
+    containers). A stale/mismatched spectral estimate that legitimately
+    EXCEEDS a fresher container reading is real (evidence carry-forward
+    across snapshots, not a fresh single measurement) but is a data-hygiene
+    gap in a different subsystem, not a Stage1/Stage2 decision disagreement
+    — out of scope here, and precisely the domain this property does NOT
+    reach, which is why Stage 1 remains load-bearing (issue #813 Finding 1
+    audit conclusion) even though this property finds zero disagreement
+    inside its own (consistent-evidence) domain.
+
+    ``new_format``/``existing_format`` are deliberately the SAME codec
+    family on both sides (see ``stage_parity_worlds``). Random probing
+    (millions of iterations, outside this property) found the shared
+    spectral clamp ALSO disagrees when the two sides are DIFFERENT codec
+    families — but the spectral bucket table (``LAME_LOWPASS``) is
+    calibrated to MP3/LAME specifically, so a cross-codec spectral pairing
+    is itself evidence of the SAME carry-forward mismatch this docstring
+    already scopes out (spectral analysis runs on the MP3/CBR preimport
+    path or FLAC->V0 conversion evaluation — a fresh single measurement
+    never produces one codec's spectral estimate paired against a
+    DIFFERENT codec's raw measurement), not an independent decision-logic
+    gap. A correct fix would require deciding whether spectral evidence is
+    even comparable across codec families at all — out of scope for this
+    audit.
+    """
+    grade: str
+    new_container: int
+    new_spectral: int
+    existing_container: int
+    existing_spectral: int
+    existing_grade: str | None
+    new_is_cbr: bool
+    existing_is_cbr: bool
+    new_format: str
+    existing_format: str
+
+
+def _stage_parity_verdicts(
+    world: StageParityWorld,
+) -> tuple[str, QualityComparisonBasis]:
+    """Drive the REAL Stage 1 and Stage 2 deciders over the same evidence.
+
+    Builds the candidate/existing ``AudioQualityMeasurement`` pair exactly
+    the way ``full_pipeline_decision``'s native-lossy branch does before
+    calling ``compare_quality`` — ``AudioQualityMeasurement`` directly for
+    the candidate, ``build_existing_quality_measurement`` (the real
+    production constructor) for the existing side. This does not create a
+    new decision path: both are pure data constructors, and every verdict
+    comes only from ``spectral_import_decision``/``compare_quality``
+    themselves — the two decision surfaces this property patrols.
+    """
+    new_m = AudioQualityMeasurement(
+        min_bitrate_kbps=world.new_container,
+        avg_bitrate_kbps=world.new_container,
+        format=world.new_format,
+        is_cbr=world.new_is_cbr,
+        spectral_grade=world.grade,
+        spectral_bitrate_kbps=world.new_spectral,
+        spectral_subject=EVIDENCE_SUBJECT_SOURCE,
+        spectral_provenance=EVIDENCE_PROVENANCE_MEASURED,
+    )
+    existing_m = build_existing_quality_measurement(
+        min_bitrate_kbps=world.existing_container,
+        avg_bitrate_kbps=world.existing_container,
+        format=world.existing_format,
+        is_cbr=world.existing_is_cbr,
+        override_min_bitrate=None,
+        spectral_grade=world.existing_grade,
+        spectral_bitrate_kbps=world.existing_spectral,
+    )
+    # world.existing_container is a definite int, so the builder's
+    # min_bitrate_kbps-is-None early return can never fire here.
+    assert existing_m is not None
+    stage1 = spectral_import_decision(
+        world.grade, world.new_spectral, world.existing_spectral)
+    stage2 = compare_quality(new_m, existing_m, QualityRankConfig.defaults())
+    return stage1, stage2
+
+
+def assert_stage1_never_contradicts_stage2(
+    stage1: str, stage2: QualityComparisonBasis,
+) -> None:
+    """Issue #813 Finding 1 — the core no-disagreement parity contract.
+
+    Operational semantics, from how ``full_pipeline_decision`` actually
+    combines the two stages (``lib/quality/pipeline.py``): Stage 1's ONLY
+    gating effect is its ``"reject"`` verdict, which short-circuits BEFORE
+    Stage 2 ever runs. Every other Stage 1 verdict (``"import"``,
+    ``"import_upgrade"``, ``"import_no_exist"``) defers unconditionally —
+    Stage 2 decides. So the only verdict pair that can operationally
+    "disagree" is Stage 1 rejecting a candidate that Stage 2, given the
+    same evidence, would score ``"better"`` (an upgrade Stage 1's
+    short-circuit would have discarded) — exactly the shape of both the
+    Mark DeNardo (#812) and this PR's remaining same-rank-tiebreak bug.
+    Stage 1 rejecting while Stage 2 says ``"worse"``/``"equivalent"`` is NOT
+    a disagreement: both stages agree the candidate should not be accepted.
+    """
+    if stage1 == "reject" and stage2.verdict == "better":
+        raise AssertionError(
+            "Stage 1 rejected a candidate Stage 2 scores as an upgrade: "
+            f"stage1={stage1!r} stage2.verdict={stage2.verdict!r} "
+            f"stage2.branch={stage2.branch!r}"
+        )
+
+
 _MEASURED_STAGE2_DECISIONS = frozenset({
     "import", "downgrade", "transcode_upgrade", "transcode_downgrade",
     "transcode_first",
 })
 _BASIS_SAME_RANK_BRANCHES = frozenset({
     "lossless_same_rank", "cross_family_same_rank",
-    "label_contract_same_rank", "metric_tiebreak", "metric_missing",
+    "label_contract_same_rank", "spectral_tiebreak", "metric_tiebreak",
+    "metric_missing",
 })
 _BASIS_METRICS = frozenset({"min", "avg", "median", "contract"})
 
@@ -581,6 +705,45 @@ def obvious_lower_rank_lossy_downloads(draw) -> DownloadScenario:
         new_format=draw(st.sampled_from(_LOSSY_FORMATS)),
         is_vbr=not is_cbr,
         avg_bitrate=bitrate,
+    )
+
+
+@st.composite
+def stage_parity_worlds(draw) -> StageParityWorld:
+    """Worlds for the issue #813 Finding 1 no-disagreement property.
+
+    Only ``suspect``/``likely_transcode`` grades ever let Stage 1 reject
+    (``spectral_import_decision`` returns ``"import"`` unconditionally for
+    every other grade) — sampling only these two focuses the search on the
+    space where a disagreement could exist, the same convention
+    ``test_only_strictly_lower_spectral_rejects_at_stage1`` already uses.
+    ``existing_grade`` is free (the shared clamp is grade-tolerant by
+    design — see ``_shared_spectral_bitrates``'s own docstring). Format is
+    shared across both sides (like
+    ``test_existing_spectral_override_is_noop_when_candidate_has_spectral``'s
+    fixed ``"MP3"``) so the search spends its budget on the same-codec-
+    family same-rank tiebreak this property patrols, rather than diluting
+    across the ``cross_family_same_rank`` branch, which can never emit
+    ``"better"`` and so can never disagree with a Stage-1 reject.
+    """
+    new_container = draw(_bitrates(min_value=1, max_value=3000))
+    new_spectral = draw(_bitrates(min_value=1, max_value=new_container))
+    existing_container = draw(_bitrates(min_value=1, max_value=3000))
+    existing_spectral = draw(
+        _bitrates(min_value=1, max_value=existing_container))
+    shared_format = draw(st.sampled_from(_LOSSY_FORMATS))
+    return StageParityWorld(
+        grade=draw(st.sampled_from(("suspect", "likely_transcode"))),
+        new_container=new_container,
+        new_spectral=new_spectral,
+        existing_container=existing_container,
+        existing_spectral=existing_spectral,
+        existing_grade=draw(st.sampled_from(
+            (None, "genuine", "marginal", "suspect", "likely_transcode"))),
+        new_is_cbr=draw(st.booleans()),
+        existing_is_cbr=draw(st.booleans()),
+        new_format=shared_format,
+        existing_format=shared_format,
     )
 
 
@@ -930,6 +1093,84 @@ class TestGeneratedSimulatorInvariants(unittest.TestCase):
         assert_existing_override_noop_under_shared_clamp(
             decide(override), decide(None),
         )
+
+    @given(world=stage_parity_worlds())
+    @example(  # Mark DeNardo request 1308: Stage 1 defers, Stage 2 scores.
+        world=StageParityWorld(
+            grade="suspect", new_container=192, new_spectral=128,
+            existing_container=128, existing_spectral=128,
+            existing_grade="likely_transcode",
+            new_is_cbr=True, existing_is_cbr=True,
+            new_format="MP3", existing_format="MP3",
+        )
+    )
+    @example(  # Deerhunter dl 37725: identical transcode, Stage 1 defers.
+        world=StageParityWorld(
+            grade="likely_transcode", new_container=256, new_spectral=192,
+            existing_container=256, existing_spectral=192,
+            existing_grade="likely_transcode",
+            new_is_cbr=True, existing_is_cbr=True,
+            new_format="MP3", existing_format="MP3",
+        )
+    )
+    @example(  # Shrunk regression: coarse rank band buckets UNEQUAL
+        # spectral (200 vs 230) into the same "good" tier; before the
+        # spectral_tiebreak fix the fully-unclamped raw metric (1000 vs
+        # 235) would launder the worse-spectral candidate in as "better".
+        world=StageParityWorld(
+            grade="likely_transcode", new_container=1000, new_spectral=200,
+            existing_container=235, existing_spectral=230,
+            existing_grade="likely_transcode",
+            new_is_cbr=True, existing_is_cbr=True,
+            new_format="MP3", existing_format="MP3",
+        )
+    )
+    @example(  # Shrunk regression #2: CBR/VBR band-table mismatch. The
+        # spectral bucket values (LAME_LOWPASS) are calibrated to the CBR
+        # thresholds, not the more generous VBR ones. Before the CBR-forced
+        # classification fix, a VBR-tagged candidate's spectral-bound clamp
+        # (245, VBR "transparent") outranked a CBR-tagged existing's
+        # spectral-bound clamp (300, CBR "excellent") purely from table
+        # choice — despite 245 < 300 (Stage 1 correctly rejects).
+        world=StageParityWorld(
+            grade="likely_transcode", new_container=1000, new_spectral=245,
+            existing_container=1000, existing_spectral=300,
+            existing_grade="likely_transcode",
+            new_is_cbr=False, existing_is_cbr=True,
+            new_format="MP3", existing_format="MP3",
+        )
+    )
+    def test_stage1_never_contradicts_stage2(self, world):
+        """PAIR (generated half) — issue #813 Finding 1's core deliverable:
+        for every world, Stage 1's verdict never contradicts Stage 2's.
+
+        Drives the REAL ``spectral_import_decision`` (Stage 1) and
+        ``compare_quality`` (Stage 2) over the same evidence. This property
+        found and pins TWO independent Stage2 gaps, both inside the shared
+        spectral clamp:
+
+        1. Same-rank tiebreak (``spectral_tiebreak`` branch, first
+           ``@example``): the coarse rank band can bucket two genuinely
+           UNEQUAL spectral estimates together, and the fully-unclamped raw
+           metric tiebreak used to decide instead — reversing a real
+           spectral ordering. Deterministic pin twin:
+           ``tests/test_quality_comparison_basis.py``'s "differing clamped
+           values decide the same-rank tiebreak directly" case.
+        2. CBR/VBR band-table mismatch (second ``@example``): the
+           spectral-bucket values are calibrated to the CBR band
+           thresholds (``LAME_LOWPASS`` — see ``_shared_spectral_bitrates``'s
+           docstring), not the more generous VBR ones. Classifying a
+           spectral-bound clamped value through a VBR-tagged side's own
+           ``is_cbr=False`` let a worse-spectral VBR-tagged candidate
+           outrank a better-spectral CBR-tagged existing purely from table
+           choice. Random probing (millions of iterations, not reproduced
+           by Hypothesis at either the suite or fuzz tier within a
+           reasonable budget — this class needed the deterministic pin to
+           be caught reliably) found this at roughly a 1-in-8000 rate over
+           the general world space.
+        """
+        stage1, stage2 = _stage_parity_verdicts(world)
+        assert_stage1_never_contradicts_stage2(stage1, stage2)
 
     @given(
         codec_label=_unmapped_codec_labels(),
@@ -1846,6 +2087,45 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
              "comparison_basis": {"verdict": "equivalent"}},
             {"stage2_import": "downgrade",
              "comparison_basis": {"verdict": "equivalent"}},
+        )
+
+    def test_stage1_stage2_parity_checker_trips_on_planted_disagreement(self):
+        """Issue #813 Finding 1 known-bad self-test: a planted Stage-1
+        reject alongside a planted Stage-2 "better" must trip the checker;
+        every other verdict pairing (including a real reject-vs-worse
+        agreement) must NOT."""
+        with self.assertRaises(AssertionError):
+            assert_stage1_never_contradicts_stage2(
+                "reject",
+                QualityComparisonBasis(
+                    verdict="better", branch="spectral_tiebreak",
+                    new_rank="good", existing_rank="good",
+                ),
+            )
+        # Stage 1 rejecting while Stage 2 agrees (worse/equivalent) is not
+        # a disagreement — must not trip.
+        assert_stage1_never_contradicts_stage2(
+            "reject",
+            QualityComparisonBasis(
+                verdict="worse", branch="spectral_tiebreak",
+                new_rank="good", existing_rank="good",
+            ),
+        )
+        assert_stage1_never_contradicts_stage2(
+            "reject",
+            QualityComparisonBasis(
+                verdict="equivalent", branch="metric_tiebreak",
+                new_rank="good", existing_rank="good",
+            ),
+        )
+        # Stage 1 deferring (any non-reject verdict) never trips, whatever
+        # Stage 2 says — Stage 1 has no gating effect in that case.
+        assert_stage1_never_contradicts_stage2(
+            "import",
+            QualityComparisonBasis(
+                verdict="better", branch="rank",
+                new_rank="transparent", existing_rank="good",
+            ),
         )
 
     def test_unmapped_codec_checker_trips_on_terminal_narrowing(self):

--- a/tests/test_simulator_scenarios.py
+++ b/tests/test_simulator_scenarios.py
@@ -462,7 +462,17 @@ _REJECT_DENYLIST_CAUSES = (
 
 def assert_denylist_has_valid_cause(r: "SimResult") -> None:
     """A denylisted outcome must trace to a real reject/retained-nonterminal
-    decision — never a bare default with no decision behind it."""
+    decision — never a bare default with no decision behind it.
+
+    ``causes`` is deliberately scoped to decisions reachable through
+    ``simulate()`` (Stage 1 / Stage 2 / Stage 3). The five folder/audio-
+    integrity denylist decisions (``audio_corrupt``, ``bad_audio_hash``,
+    ``nested_layout``, ``empty_fileset``, ``mixed_source``) are only
+    reachable via ``full_pipeline_decision_from_evidence`` — ``simulate()``
+    has no flat-kwargs surface for them (see ``dl_params`` in this module)
+    — so their absence here is intentional, not a gap. If ``dl_params``
+    ever grows those facts, this checker needs a matching cause, not a
+    silent false failure."""
     if not r.denylisted:
         return
     causes = (

--- a/tests/test_web_recents.py
+++ b/tests/test_web_recents.py
@@ -2110,6 +2110,34 @@ class TestClassifyComparisonBasis(unittest.TestCase):
         assert c.comparison_basis is not None
         self.assertEqual(c.comparison_basis["tolerance_kbps"], 5)
 
+    def test_spectral_tiebreak_upgrade_shows_clamped_values_not_raw(self):
+        """Issue #813 Finding 1: the coarse "good" band buckets spectral 230
+        and 200 together, so the same-rank tiebreak decides on the clamped
+        values (~230k / ~200k), never the fully-unclamped raw containers
+        (1000 / 235) that would launder a worse-spectral candidate in on a
+        higher declared bitrate alone."""
+        basis = self._basis_dict(
+            dict(min_bitrate_kbps=1000, avg_bitrate_kbps=1000, format="MP3",
+                 is_cbr=True, spectral_grade="likely_transcode",
+                 spectral_bitrate_kbps=230),
+            dict(min_bitrate_kbps=235, avg_bitrate_kbps=235, format="MP3",
+                 is_cbr=True, spectral_grade="likely_transcode",
+                 spectral_bitrate_kbps=200),
+        )
+        self.assertEqual(basis["branch"], "spectral_tiebreak")
+        self.assertEqual(basis["verdict"], "better")
+        entry = _entry(
+            outcome="success",
+            existing_min_bitrate=235,
+            actual_min_bitrate=1000,
+            import_result={"version": 2, "decision": "import",
+                           "comparison_basis": basis},
+        )
+        c = classify_log_entry(entry)
+        self.assertEqual(c.verdict, "Upgrade: MP3 ~200k → ~230k (both good)")
+        self.assertNotIn("1000", c.verdict)
+        self.assertNotIn("235", c.verdict)
+
     def test_verified_lossless_bypass_names_the_bypass(self):
         basis = self._bypass_basis_dict(
             dict(avg_bitrate_kbps=250, format="MP3"),

--- a/web/classify.py
+++ b/web/classify.py
@@ -1059,13 +1059,16 @@ def _verdict_from_basis(basis: QualityComparisonBasis) -> str:
     """
     new_fmt = (basis.new_format or "?").upper()
     ex_fmt = (basis.existing_format or "?").upper()
-    clamped = basis.spectral_clamped and basis.branch == "rank"
+    # spectral_tiebreak (issue #813 Finding 1) carries the same clamped
+    # min(metric, spectral floor) value as the rank branch — the metric
+    # label would lie there too.
+    clamped = basis.spectral_clamped and basis.branch in ("rank", "spectral_tiebreak")
     new_val = _basis_value_phrase(basis.new_metric, basis.new_value_kbps, clamped)
     ex_val = _basis_value_phrase(
         basis.existing_metric, basis.existing_value_kbps, clamped)
 
     if basis.verdict == "better":
-        if basis.branch == "metric_tiebreak":
+        if basis.branch in ("metric_tiebreak", "spectral_tiebreak"):
             return (f"Upgrade: {ex_fmt} {ex_val} → {new_val} "
                     f"(both {basis.new_rank})")
         new_side = new_val if new_fmt == ex_fmt else f"{new_fmt} {new_val}"

--- a/web/js/history.js
+++ b/web/js/history.js
@@ -83,10 +83,27 @@ function withWas(value, wasValue) {
 }
 
 /**
+ * Whether a comparison basis's displayed value is a clamped
+ * min(metric, spectral floor) rather than the named statistic — true for
+ * the `rank` branch and `spectral_tiebreak` (issue #813 Finding 1: the
+ * same-rank tiebreak also decides on clamped values when they differ).
+ * Labelling either with the raw metric name would lie, which is what the
+ * basis exists to prevent.
+ * @param {Object} basis - comparison_basis dict from the API
+ * @returns {boolean}
+ */
+function basisUsesClampedValue(basis) {
+  return Boolean(
+    basis && basis.spectral_clamped
+      && (basis.branch === 'rank' || basis.branch === 'spectral_tiebreak'),
+  );
+}
+
+/**
  * Value phrase for one side of a persisted comparison basis: "avg 288k",
- * or "~250k" when the rank branch classified spectral-clamped values
- * (a clamped number is min(metric, spectral floor) — labelling it with
- * the metric would lie, which is what the basis exists to prevent).
+ * or "~250k" when the basis classified spectral-clamped values (a clamped
+ * number is min(metric, spectral floor) — labelling it with the metric
+ * would lie, which is what the basis exists to prevent).
  * @param {Object} basis - comparison_basis dict from the API
  * @param {'new'|'existing'} side
  * @returns {string} escaped HTML fragment
@@ -96,7 +113,7 @@ function basisValuePhrase(basis, side) {
   const metric = side === 'new' ? basis.new_metric : basis.existing_metric;
   if (metric === 'contract') return 'contract';
   if (value === null || value === undefined) return 'unmeasured';
-  if (basis.spectral_clamped && basis.branch === 'rank') return `~${esc(value)}k`;
+  if (basisUsesClampedValue(basis)) return `~${esc(value)}k`;
   return `${esc(metric)} ${esc(value)}k`;
 }
 
@@ -158,7 +175,7 @@ function comparisonMetricPhrase(avg, median, min, basis, side) {
 
   const metric = side === 'new' ? basis.new_metric : basis.existing_metric;
   const value = side === 'new' ? basis.new_value_kbps : basis.existing_value_kbps;
-  if (basis.spectral_clamped && basis.branch === 'rank') {
+  if (basisUsesClampedValue(basis)) {
     return basisValuePhrase(basis, side);
   }
   if (metric === 'avg') return avgMinPhrase(value, null, min);
@@ -259,10 +276,11 @@ function buildEvidenceCardModel(h) {
     }
   }
   if (h.spectral_grade) {
-    // With a basis, the clamped rank value already carries the floor —
-    // repeating "~250k" in the grade chip would double it up.
+    // With a basis, the clamped rank/spectral_tiebreak value already
+    // carries the floor — repeating "~250k" in the grade chip would
+    // double it up.
     const basisAlreadyHasFloor = Boolean(
-      basis && basis.spectral_clamped && basis.branch === 'rank'
+      basisUsesClampedValue(basis)
       && Number(basis.new_value_kbps) === Number(h.spectral_bitrate),
     );
     const floor = (h.spectral_bitrate && !basisAlreadyHasFloor)


### PR DESCRIPTION
Part of #813.

PR B of issue #813 — Finding 1 (Stage 1 / Stage 2 quality-decision parity audit).

## Audit conclusion (also posted as a comment on #813)

**Core deliverable**: `tests/test_quality_generated.py::test_stage1_never_contradicts_stage2` drives the real `spectral_import_decision` (Stage 1) and `compare_quality` (Stage 2) directly over the same evidence and asserts Stage 1 never rejects a candidate Stage 2 would score `"better"`. Building and running this property found **two independent, real disagreement worlds**, both inside `compare_quality`'s shared spectral clamp (fires whenever both sides carry `spectral_bitrate_kbps`):

1. **Same-rank tiebreak gap** (new `spectral_tiebreak` branch). The coarse `QualityRank` band can bucket two genuinely UNEQUAL clamped spectral values together (e.g. spectral 200 and 230 both land in "good"). The same-rank tiebreak used to fall through to the fully-unclamped raw metric, which can trivially reverse a real spectral ordering — a worse-spectral candidate winning purely because its (already known-unreliable) declared container bitrate is higher. Fix: when the clamp fires and the clamped values themselves differ, they decide the tiebreak directly (mirroring Stage 1's own strict spectral-vs-spectral comparison). A TRUE spectral tie (clamped values EQUAL) still defers to the raw metric exactly as before — this is what lets Mark DeNardo (request 1308, tied spectral 128==128) still import on its higher raw container.
2. **CBR/VBR band-table mismatch**. The spectral bucket values (`lib/spectral_check.py`'s `LAME_LOWPASS` table — 96/128/160/192/256/320) are calibrated to `QualityRankConfig.mp3_cbr`'s thresholds exactly, not `mp3_vbr`'s more generous ones. A side whose clamp is spectral-bound now classifies via CBR bands regardless of that side's own `is_cbr` — otherwise a VBR-tagged candidate's spectral-bound clamp could outrank a CBR-tagged existing's purely from table choice, despite genuinely worse spectral evidence. Found via random probing at roughly a 1-in-8000 rate over the (already-narrowed, same-codec-family) world space — Hypothesis did not reliably reproduce it at either the suite (150 examples) or fuzz (20k examples) tier, so it needed a deterministic `@example` pin to be caught reliably going forward.

Both fixes live in the single shared decision path (`lib/quality/compare.py`) per "quality decisions live in ONE place" — no parallel check was added.

**Review round (fable-tier, 2 blocking findings, both fixed):**

- **F1**: the `spectral_tiebreak` branch (fix 1 above) checked `rank_new_value != rank_existing_value` without consulting which side is actually spectral-bound. When NEITHER side is bound, the "clamped" values are just the raw avg metrics, so the branch silently became a stealth `metric_tiebreak` with **no ±5kbps tolerance**. Flip world: candidate MP3 VBR avg 250/spectral 256 vs existing avg 247/spectral 256 (spectral estimates exactly tied, neither side bound since both containers sit below their own tied spectral estimate) — pre-fix `equivalent`→`better`, `imported` False→True. **Fix**: gate the branch on `new_bound and existing_bound` (both sides must be spectral-bound). Pinned: `tests/test_quality_classification.py::TestLiveBugReproductions::test_stage_parity_review_f1_unbound_tied_spectral_stays_equivalent`, driven through the real `full_pipeline_decision`, asserting `imported` stays `False`. Fault-injection verified (reverting the gate flips the pin RED).
- **F2**: the CBR-forcing for spectral-bound values (fix 2 above) was one-sided — a bound VBR side got demoted to CBR bands while an unbound VBR side kept the more generous VBR bands, creating a NEW inversion. Flip world: existing genuine V0 avg 260/cliff-bucket 256 (bound → forced to CBR "excellent", was VBR "transparent") vs candidate genuine V0 avg 246/cliff-bucket 320 (unbound, stays VBR "transparent") — pre-fix `worse`→`better(rank)`, a lower-container V0 replacing a higher-container V0 purely on asymmetric table choice. **Fix**: apply the CBR-forcing only when BOTH sides are bound (symmetric — `both_spectral_bound = new_bound and existing_bound`, shared with F1's gate). Pinned: `tests/test_quality_classification.py::TestLiveBugReproductions::test_stage_parity_review_f2_asymmetric_cbr_forcing_stays_worse`, also through `full_pipeline_decision`, asserting `imported` stays `False`. Fault-injection verified.
- Both gates share one `both_spectral_bound` boolean in `lib/quality/compare.py`; the shrunk parity-property `@example`s from the original two findings are both-bound by construction and are preserved unchanged by this narrowing.
- **F3 (docstring correction)**: the original `StageParityWorld` docstring (and an earlier draft of this PR body / the #813 comment) claimed `spectral > own container` is reachable ONLY via cross-snapshot evidence carry-forward. **That was false.** `estimate_bitrate_from_cliff` (`lib/spectral_check.py`) emits container-independent per-track bucket values, and `analyze_album` aggregates the album-level estimate as `min()` over only the CLIFFED tracks, computed independently of the album's overall grade threshold — so an ordinary FRESH measurement of a genuine album with a single outlier track cliffing at ≥19,550 Hz yields a spectral estimate of 320 even while the album's overall grade stays "genuine" and its real average container is much lower (e.g. 246). This is an ordinary fresh-measurement world, not a cross-snapshot artifact. Corrected in `StageParityWorld`'s docstring, `docs/quality-verification.md`, and `docs/quality-ranks.md`. The audit conclusion itself is unaffected by this correction — Stage 1 still stays load-bearing for this domain, just for the corrected reason (an everyday single-measurement shape the property's own scoping deliberately excludes, not a rare cross-subsystem hygiene bug).

**Line-189 audit** (`_transcode_candidate_real_rank_regresses`'s early-out when `existing.spectral_grade in SPECTRAL_TRANSCODE_GRADES`): confirmed still correct and necessary via fault injection. Removing the early-out regresses a concrete, constructed case (a transcode-over-transcode candidate whose RAW rank is lower than existing's, but whose spectral evidence is genuinely better) back to a wrong `"worse"` — now pinned as `test_quality_comparison_basis.py`'s "transcode-over-transcode routes to the shared clamp, not the raw pre-check" case, with the mutant verified to fail it. The early-out's purpose is exactly this: route transcode-vs-transcode comparisons past the cruder raw-only pre-check into the shared clamp, which (post this PR's fixes) now fully and correctly handles that domain via spectral evidence.

**Fold decision: Stage 1 stays** (not folded/subordinated into Stage 2). It remains load-bearing in two domains the property deliberately does not reach:
- Existing carries no spectral estimate at all (`spectral_import_decision` returns `import_no_exist`, deferring by design — absence isn't evidence).
- Evidence is internally self-inconsistent (a raw container measured LOWER than its own spectral estimate). Per the F3 correction above, this is reachable from an ordinary fresh measurement (a single outlier cliffed track's container-independent bucket estimate, aggregated via `min()` over only cliffed tracks, can exceed the album's real average container). Stage 1's coarse spectral-vs-spectral comparison protects this; Stage 2's clamp (bound by the existing side's own lower raw container) can be fooled by it.

A third disagreement class was found (different codec families both carrying spectral, e.g. Opus vs Vorbis) but is deliberately **out of scope**: the spectral bucket values are MP3/LAME-calibrated and candidate-side spectral analysis is only gated to run on MP3-shaped/CBR or FLAC→V0-conversion candidates, so a cross-codec spectral pairing is itself evidence of a mismatch in a different subsystem, not an independent decision-logic gap. A correct fix would require deciding whether spectral evidence is even comparable across codec families at all.

## Tests (PAIR)

- Generated property + 4 deterministic `@example` pins in `tests/test_quality_generated.py` (Mark DeNardo / Deerhunter no-regression guards, plus a shrunk world per original bug).
- Known-bad self-test proving the parity checker trips (`test_stage1_stage2_parity_checker_trips_on_planted_disagreement`).
- Branch-table pins in `tests/test_quality_comparison_basis.py` for both original bugs plus the line-189 guard.
- 3 existing `TestCompareQualitySharedSpectralBucket` cases in `tests/test_quality_decisions.py` strengthened to assert the corrected `branch`/rank, not just `verdict`.
- JS (`tests/test_js_history.mjs`) + Python (`tests/test_web_recents.py`) display tests for the new branch's clamped-value suppression (`web/classify.py`, `web/js/history.js` — the new branch carries the same `min(metric, spectral floor)` display value as the `rank` branch and must suppress the raw metric label the same way, or the UI relabels a clamped number as a real measured statistic).
- Review-round pins: `test_stage_parity_review_f1_unbound_tied_spectral_stays_equivalent` and `test_stage_parity_review_f2_asymmetric_cbr_forcing_stays_worse` in `tests/test_quality_classification.py`, both driven through the real `full_pipeline_decision` and asserting the decided `imported` outcome (not a proxy field).
- Fault injection (all fixes, verified manually): reverting any single change makes the corresponding `@example`/pin fail (RED); restoring makes them pass (GREEN). Same for the line-189 early-out.

Also includes the small rider from #826 review: a doc comment on `assert_denylist_has_valid_cause` scoping its cause list to `simulate()`-reachable decisions.

## Verification

- `nix-shell --run "pyright --threads 4"` — 0 errors (whole repo), re-run clean after the review-round amendment.
- `nix-shell --run "bash scripts/run_tests.sh"` — 6728 tests, OK (production strict gate, dead-code sweep, ruff all clean) — run once on the final tree after the review-round amendment.
- `nix-shell --run "bash scripts/fuzz_burst.sh"` — 65/66 modules passed at the fuzz tier (20k examples) on the pre-amendment tree, including `test_quality_generated` (this PR's module, 50 tests / 598s). One unrelated module, `test_dispatch_outcomes_generated`, showed a single flaky failure (`have_analysis_error` outcome mismatch on a `provisional_lossless_upgrade` world) that does **not** touch anything in this diff (no reference to `compare_quality`/`_shared_spectral_bitrates`/`lib/quality/compare.py` anywhere in that test file) and did not reproduce via Hypothesis's own `@reproduce_failure` blob nor via 200 direct re-runs of the identical generated world — consistent with a pre-existing, resource-contention-sensitive flake in that module's harness, unrelated to this change. Not investigated further per scope; flagging for the orchestrating context.

Docs updated in the same PR: `docs/quality-verification.md` (new "Stage 1 / Stage 2 parity" section, amended for the review round + F3) and `docs/quality-ranks.md` (CBR-calibration note on the MP3 CBR band table, amended for the both-bound symmetry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

