### PR TITLE
docs: commit the #829 per-codec spectral calibration project plan

### DIFF
--- a/docs/plans/2026-07-22-001-feat-829-spectral-calibration-plan.md
+++ b/docs/plans/2026-07-22-001-feat-829-spectral-calibration-plan.md
@@ -1,0 +1,154 @@
+# Per-Codec Spectral Calibration — Project Plan (issue #829)
+
+**Status**: Phase 1 in flight (temporary instance stood up 2026-07-22).
+**Issue**: https://github.com/abl030/cratedigger/issues/829
+**Origin**: #828 item 1 correction (2026-07-22) — the codec-blind spectral seam.
+
+## Why
+
+The spectral subsystem's cliff→bitrate table (`lib/spectral_check.py::LAME_LOWPASS`)
+and its grade thresholds are calibrated to exactly one encoder: LAME MP3. But the
+attempt spectral audit (`collect_attempt_spectral_audit`, `harness/import_one.py` +
+the preview worker) measures every codec, persists its output as decision-facing
+evidence (`album_quality_evidence.spectral_grade` / `spectral_bitrate_kbps`,
+`subject=source`, `provenance=measured`), and the decider's gate mirror
+(`spectral_gate_trigger`, `lib/quality/gates.py`) receives only
+`is_flac`/`is_cbr`/`is_vbr` — it cannot see codec. The measurement-side gate's
+`is_mp3` condition (`lib/measurement.py::_needs_spectral_check`) has no decider
+mirror. Net: MP3-calibrated spectral grades on AAC/Opus/Vorbis candidates drive
+Stage 1, the shared spectral clamp, and transcode detection in live production
+(canonical live example: download_log 37946, 2026-07-22 — an ordinary AAC's natural
+~16–17 kHz rolloff stamped `likely_transcode 128` and clamped cross-codec against
+an MP3 existing).
+
+Operator decision (2026-07-22, recorded on #828/#829): solve this with real
+empirical calibration — a ground-truth corpus, a full encoder×bitrate matrix, and
+per-codec research — not a codec gate at the decision seam.
+
+The three-domain taxonomy the project preserves:
+
+- **MP3** — calibrated today (LAME buckets); the matrix re-validates it as a control.
+- **Lossless sources (FLAC/WAV/ALAC)** — spectral stays load-bearing exactly as-is:
+  cliff = fake-FLAC detector, `genuine` = the affirmative input verified-lossless
+  proof requires. Untouchable.
+- **Lossy non-MP3 (AAC/Opus/Vorbis/WMA)** — uncalibrated; the defect domain this
+  project defines semantics for.
+
+## Goal
+
+An empirically calibrated, per-codec spectral model: for each codec/encoder family,
+either a real cutoff→quality mapping with measured confidence bounds, or an
+evidence-backed verdict that spectral is not decision-grade for that codec
+(→ audit-only, fail-closed). Then extend the #827 Stage-1/Stage-2 parity property's
+domain with the defined semantics (closing #828 item 1 properly) and correct the
+three shipped statements of the falsified scoping claim (`StageParityWorld`
+docstring, `docs/quality-verification.md` § stage parity, the #813 audit record).
+
+## Phases
+
+### Phase 0 — Research sweep (docs first)
+
+Research documents under `docs/research/`: `spectral-mp3-lame.md`, `spectral-aac.md`
+(ffmpeg native vs libfdk vs Apple; HE-AAC/SBR breaks naive cliff detection),
+`spectral-opus.md` (CELT band allocation; expectation: no usable bitrate→cutoff
+mapping), `spectral-vorbis.md`, `spectral-wma.md`, and
+`spectral-transcode-detection.md` (prior art: hydrogenaudio lore, Lossless Audio
+Checker, the auCDtect lineage; what distinguishes native-low-bitrate from
+transcoded beyond a bare cliff).
+
+### Phase 1 — Ground-truth corpus via a temporary cratedigger instance
+
+Topology is forced by the network (verified 2026-07-22): slskd is a microVM at
+`192.168.21.2` on a doc2-local DMZ bridge — unreachable from doc1 — so the
+acquisition pipeline runs on doc2. Encode/measure phases run on doc1 over the
+shared `/mnt/virtio` files.
+
+- **Database**: scratch `cratedigger_calib` in the existing nspawn PG cluster
+  (`10.20.0.11`). Advisory locks are database-scoped (no prod collision); schema
+  via the migrator; teardown is one `DROP DATABASE`.
+- **Filesystem** (virtiofs-shared, visible from both hosts):
+
+  ```
+  /mnt/virtio/Music/calibration-tmp/
+  ├── state/            # config.ini, BEETSDIR, denylists, lock
+  ├── Incoming/         # staging (auto-import/, post-validation/)
+  ├── Beets/            # temp beets library tree (FLACs land here)
+  ├── beets-library.db
+  ├── encodes/          # Phase 2 matrix output (written from doc1)
+  └── measurements/     # Phase 3 raw analyzer output + manifests
+  ```
+
+- **Config**: `CRATEDIGGER_RUNTIME_CONFIG` (`lib/config.py`) points every
+  entrypoint at a clone of prod's rendered config.ini with: calib DSN, calib
+  staging/beets paths, notifiers blanked, same slskd + mirror + quality ranks.
+  The main loop takes `--config-dir` instead. Calib BEETSDIR is a clone of the
+  module-rendered config.yaml with library/directory swapped; same pinned beets.
+- **Runtime**: no deploys, no nixosconfig changes, no committed units. Prod's
+  installed store-path binaries + three `systemd-run` transient units
+  (`cratedigger-calib-cycle` on an `--on-unit-inactive=120` transient timer,
+  `cratedigger-calib-preview`, `cratedigger-calib-importer`). Transient units die
+  on reboot; the agent re-arms them next session.
+- **Seeding**: `pipeline-cli add <exact MB release ID>` + `set-intent lossless`
+  per request (FLAC-only search + keep-lossless target). Corpus = the quality
+  test-set albums (`TestLiveBugReproductions`) + ~30 picks across a wide spectrum,
+  deliberately including false-positive traps (pre-1975 masters, vinyl rips,
+  lo-fi/shoegaze/ambient, dense metal, full-spectrum electronic, classical,
+  loudness-war pop). Acceptance bar per album: verified-lossless proof. YouTube
+  rescue is excluded (not a lossless source).
+- **Shared-slskd safety**: #571 good-citizen ownership makes two instances on one
+  slskd safe by construction — each instance's ledgers scope its own searches,
+  transfers, purges, and disk reaping; foreign keys and unledgered state are never
+  touched, in either direction.
+
+### Phase 2 — Encode matrix (doc1)
+
+From each ground-truth FLAC: LAME CBR 320/256/224/192/160/128/96/64 + V0/V2/V4/V6;
+AAC (ffmpeg native + libfdk, HE-AAC at low rates); Opus and Vorbis ladders; WMA if
+ffmpeg encodes it sanely; plus second-generation fraud shapes (MP3-128→FLAC,
+MP3-128→AAC-256, AAC-128→MP3-320, Opus-96→FLAC, …). Deterministic manifest;
+encoders pinned from nixpkgs.
+
+### Phase 3 — Measure and tabulate (doc1)
+
+Run the production analyzer over everything, capturing raw per-track cliff
+frequency (Hz), not just LAME-bucket outputs. Tables: codec × encoder × setting →
+rolloff distribution, committed inside the research docs. Four questions the data
+must answer:
+
+1. Does codec X have a stable bitrate→cutoff mapping at all? (Opus expected: no.)
+2. Within codec X, is native-low-bitrate distinguishable from transcoded-from-lossy?
+3. False-positive rate on genuinely band-limited lossless material (the traps)?
+4. What common currency makes cross-codec spectral comparison meaningful — the
+   semantics the parity-property domain extension needs.
+
+### Phase 4 — Synthesis and model design
+
+Per-codec verdict (decision-grade with tables, or audit-only fail-closed);
+evidence semantics (store cutoff Hz as the primitive?); migration story for
+persisted LAME-bucketed evidence rows; parity-property domain-extension design;
+UI display semantics for non-decision-grade codecs.
+
+### Phase 5 — Implementation
+
+Staged PRs, each with the pin + generated-property PAIR; fable-tier review with
+merges held for operator approval (quality-core rule). Temporary-instance
+teardown.
+
+## Teardown (order is load-bearing)
+
+1. Final calib cycle → its own convergence/reapers clean its slskd state.
+2. Sweep calib's remaining files in the shared slskd download dir using calib's
+   event-stamped `local_path`s / ledger **before** dropping the DB — once the DB
+   is gone its ownership evidence is gone, and leftovers become permanently
+   unreapable debris (prod's fail-closed reaper never touches unowned files, by
+   design).
+3. Corpus FLACs are keepers (real verified-lossless pressings): import into prod
+   via the normal request flow or archive, then remove `calibration-tmp`
+   (encodes/measurements pruned after the research tables are committed).
+4. `DROP DATABASE cratedigger_calib`; stop remaining transient units.
+
+## Open questions (tracked on #829)
+
+- Interim mitigation while the project runs (lossy non-MP3 spectral still drives
+  live decisions today) — flagged, not decided.
+- Scratch storage: ~100–200 GB on `/mnt/virtio` for the matrix (prunable).


### PR DESCRIPTION
Part of #829.

Commits the project plan to `docs/plans/2026-07-22-001-feat-829-spectral-calibration-plan.md`: the codec-blind spectral seam finding (#828 item 1 correction), the six phases, the Phase 1 temporary-instance topology (doc2 transient units, scratch nspawn DB, `/mnt/virtio/Music/calibration-tmp` tree), the shared-slskd safety case, and the ownership-ordered teardown checklist.

Docs-only. Verification: whole-repo pyright 0 errors; full suite 6728 tests OK on this exact tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)