### PR TITLE
docs: Phase 0 per-codec spectral research (#829)

### DIFF
--- a/docs/research/spectral-aac.md
+++ b/docs/research/spectral-aac.md
@@ -1,0 +1,158 @@
+# Spectral calibration research — AAC
+
+Issue #829 Phase 0. AAC is the codec family that triggered the calibration project: ordinary AAC-LC around 128 kbps rolls off at roughly 16-17 kHz, landing squarely inside the bucket our analyzer currently reserves for "this is a 128 kbps LAME MP3 wearing a lossless costume."
+
+## Summary
+
+`lib/spectral_check.py` has exactly one calibration table (`LAME_LOWPASS`, lines 31-40) and it is a **LAME MP3 lowpass table**, not a general lossy-codec table. Every cliff `detect_cliff()` finds is run through `estimate_bitrate_from_cliff()`, bucketed into a LAME-shaped bitrate guess, and (via `classify_track`) any file with a detected cliff is graded `"suspect"` outright — regardless of which codec produced it. AAC is the worst-hit family:
+
+- **AAC-LC's designed bandwidth at common bitrates (96-192 kbps) overlaps the same 15-19 kHz window LAME uses for 96-160 kbps MP3.** A genuine libfdk_aac or Apple encode at 128 kbps rolls off close to where a *transcoded* MP3-128-as-AAC would land — the analyzer can't tell "codec's native ceiling" from "upstream lossy source's ceiling."
+- **HE-AAC (SBR) breaks the cliff-detection premise entirely.** The transmitted core signal ends at 8-13 kHz, but the decoder synthesizes everything above from mirrored/patched copies of the core band's own harmonics. What the detector sees past the crossover is neither genuine full bandwidth nor clean silence — it's reconstructed content with its own amplitude profile, which can register as a cliff, a large deficit, or neither, because SBR's shape was never designed to imitate a natural rolloff.
+- **Apple's encoder — the single most common real-world AAC source (qaac / CoreAudio / iTunes Plus / Apple Music) — publishes no cutoff table at all.** It is closed-source and empirically variable; there is no authoritative Hz-per-bitrate reference to calibrate against, unlike LAME or FDK.
+
+## Why AAC broke cratedigger
+
+`estimate_bitrate_from_cliff` was written against LAME's documented lowpass table (cliff at ~17.0 kHz → "this was a 128 kbps MP3"). A genuine, never-transcoded AAC-LC file at 128-160 kbps from libfdk_aac or Apple's encoder rolls off in almost exactly that same 15-17 kHz band by design, not because it was ever an MP3. The analyzer has no AAC-shaped bucket, so it runs the AAC file's real, intentional cliff through the MP3 table and reports "MP3 128 transcode" — the exact false positive this calibration project exists to fix.
+
+## Encoder-by-encoder cutoff behavior
+
+### ffmpeg native `aac` encoder
+
+FFmpeg's built-in encoder (`-c:a aac`) computes its lowpass automatically unless `-cutoff` is given: *"Set cutoff frequency. If unspecified will allow the encoder to dynamically adjust the cutoff to improve clarity on low bitrates."* ([FFmpeg encoders.texi](https://github.com/FFmpeg/FFmpeg/blob/master/doc/encoders.texi)) No published fixed Hz-per-bitrate table exists the way LAME and FDK publish one; the cutoff is derived from a bitrate/bandwidth heuristic in `libavcodec/aaccoder.c` (`rate_bandwidth_multiplier`, tied to `frame_bit_rate` and sample rate) rather than a lookup table `[unverified — exact numeric thresholds not confirmed from source]`.
+
+Quality history matters because the native encoder is a common self-transcode path: it was "considered experimental and poor quality" before a 2015 GSoC rewrite, and FFmpeg declared it stable "and ready for common use" from FFmpeg 3.0 (Feb 2016). Hydrogenaudio now ranks it **second** behind libfdk_aac: *"the native FFmpeg AAC encoder is currently the second highest-quality AAC encoder available in FFmpeg."* ([Hydrogenaudio: AAC encoders](https://wiki.hydrogenaudio.org/?title=AAC_encoders), [FFmpeg wiki: Encode/AAC](https://mirror.hjertaas.com/trac.ffmpeg.org/trac.ffmpeg.org/wiki/Encode/AAC.html))
+
+| Bitrate | Expected cutoff behavior | Source |
+|---|---|---|
+| Any (default, `-cutoff 0`) | Auto-computed per bitrate/sample-rate; no fixed table published | [encoders.texi](https://github.com/FFmpeg/FFmpeg/blob/master/doc/encoders.texi) |
+| Low bitrates (<96 kbps) | Encoder narrows bandwidth further to protect clarity | [encoders.texi](https://github.com/FFmpeg/FFmpeg/blob/master/doc/encoders.texi) |
+| Manual override | `-cutoff <Hz>`; community guidance is against forcing it high at low bitrate — "raising it to 20000 will probably yield lower quality" | [FFmpeg wiki: Encode/AAC](https://mirror.hjertaas.com/trac.ffmpeg.org/trac.ffmpeg.org/wiki/Encode/AAC.html) |
+
+### libfdk_aac (Fraunhofer FDK)
+
+FDK is the only AAC encoder with a fully documented, source-level bandwidth table. Fraunhofer's header states the policy plainly: *"The FDK AAC encoder usually does not use the full frequency range of the input signal... it is not recommended to change these settings, because they are based on numerous listening tests."* ([aacenc_lib.h](https://github.com/mstorsjo/fdk-aac/blob/master/libAACenc/include/aacenc_lib.h)) The table lives in `libAACenc/src/bandwidth.cpp` (`FDKaacEnc_DetermineBandWidth`), keyed by per-channel bitrate:
+
+| Per-channel bitrate | Mono bandwidth | Stereo+ bandwidth |
+|---|---|---|
+| 0 kbps | 3,700 Hz | 5,000 Hz |
+| 12 kbps | 5,000 Hz | 6,400 Hz |
+| 20 kbps | 6,900 Hz | 9,640 Hz |
+| 28 kbps | 9,600 Hz | 13,050 Hz |
+| 40 kbps | 12,060 Hz | 14,260 Hz |
+| 56 kbps | 13,950 Hz | 15,500 Hz |
+| 72 kbps | 14,200 Hz | 16,120 Hz |
+| 96 kbps+ (CBR) | **17,000 Hz (capped)** | **17,000 Hz (capped)** |
+
+Source: [bandwidth.cpp](https://github.com/mstorsjo/fdk-aac/blob/master/libAACenc/src/bandwidth.cpp) (transcribed from the `bandWidthTable` array), cross-referenced against [Hydrogenaudio: Fraunhofer FDK AAC](https://wiki.hydrogenaudio.org/index.php?title=Fraunhofer_FDK_AAC).
+
+The critical, non-obvious fact: **CBR bandwidth caps at 17,000 Hz and never goes higher, however high the bitrate climbs** — the table's last two rows (96 kbps and 576,001 kbps) both map to 17,000/17,000. A 320 kbps FDK-AAC-CBR file has the *same* nominal cutoff as a 96 kbps one — a deliberate psychoacoustic choice (extra bits buy passband precision, not bandwidth). FDK-AAC never produces the near-full-bandwidth ~20.5 kHz cliff LAME 320 does, so a LAME-derived "high bitrate = wide bandwidth" expectation will always read AAC as suspicious, at every bitrate.
+
+FDK's VBR modes (0=CBR, 1-5) use fixed bandwidths, independent of resulting bitrate:
+
+| VBR mode | Bandwidth (mono & stereo) |
+|---|---|
+| VBR 1 | 13,000 Hz |
+| VBR 2 | 13,000 Hz |
+| VBR 3 | 15,750 Hz |
+| VBR 4 | 16,500 Hz |
+| VBR 5 | 19,293 Hz |
+
+Source: [bandwidth.cpp](https://github.com/mstorsjo/fdk-aac/blob/master/libAACenc/src/bandwidth.cpp). Mode-to-approximate-bitrate mapping (e.g. VBR 3 ≈ 96 kbps/channel class) is `[unverified]` — not independently confirmed from a primary source in this pass.
+
+The oft-repeated community line — FFmpeg wiki: *"libfdk_aac defaults to a low-pass filter of around 14kHz... use `-cutoff 18000`"* — matches the 56-96 kbps/channel **mono** rows (13,950-14,200 Hz) rather than stereo (15.5-16.1 kHz at the same bitrates), which is likely why casual command-line encodes so often land near "14 kHz" in folklore. ([FFmpeg wiki: Encode/AAC](https://mirror.hjertaas.com/trac.ffmpeg.org/trac.ffmpeg.org/wiki/Encode/AAC.html))
+
+### Apple AAC (qaac / CoreAudio / afconvert)
+
+This is the encoder behind the single most common real-world AAC source — iTunes Plus, Apple Music downloads, any macOS/iOS rip — and the one encoder here with **no published cutoff table**. Apple's own note (TN2271) documents bitrate control modes (CBR/ABR/CVBR/TVBR quality 0-127) but says nothing about resulting spectral bandwidth. ([Apple TN2271](https://developer.apple.com/library/archive/technotes/tn2271/_index.html))
+
+When a qaac user asked the maintainer directly which lowpass frequencies Apple's encoder uses per bitrate/mode — the kind of table LAME and FDK both publish — the answer was unambiguous:
+
+> "There's no way to control the bandwidth of Apple's encoder... If you want to know encoder's bandwidth, just try encoding and inspect the output yourself." — nu774 (qaac maintainer), [qaac issue #70](https://github.com/nu774/qaac/issues/70#issuecomment-699576953)
+
+The thread closes with no empirical numbers ever supplied. Elsewhere, community observations are device-dependent folklore rather than an encoder spec — e.g. different phone SoCs re-encoding Bluetooth AAC at the same nominal 256 kbps show materially different cutoffs (~16 kHz on one chipset, none apparent on another), which speaks to the codec profile in general, not Apple's own target curve. ([Archimago's Musings](http://archimago.blogspot.com/2023/08/part-ii-comparison-of-bluetooth.html)) `[unverified]` for any specific Apple-encoder Hz-per-bitrate figure.
+
+| Mode | Description | Source |
+|---|---|---|
+| CBR | Constant bitrate, minor fluctuation | [Hydrogenaudio: Apple AAC](https://wiki.hydrogenaudio.org/index.php?title=Apple_AAC) |
+| ABR | Average bitrate target | [Hydrogenaudio: Apple AAC](https://wiki.hydrogenaudio.org/index.php?title=Apple_AAC) |
+| CVBR | What iTunes Plus / Apple Music use — will not exceed the nominal rate (256 kbps) but can dip below it | [Hydrogenaudio: Apple AAC](https://wiki.hydrogenaudio.org/index.php?title=Apple_AAC) |
+| TVBR | Quality-scale VBR (0-127), can exceed the nominal rate for complex stereo content | [Apple TN2271](https://developer.apple.com/library/archive/technotes/tn2271/_index.html) |
+
+Reputation: *"Apple AAC... does consistently well in Hydrogenaudio listening tests"* and is *"known to be one of the highest quality medium-bitrate CBR and VBR LC AAC encoders."* ([Hydrogenaudio: Apple AAC](https://wiki.hydrogenaudio.org/index.php?title=Apple_AAC)) That's the calibration risk in one sentence: a high-quality, non-transcoded Apple encode is exactly the file we must not flag, and exactly the encoder we have the least documented ability to model.
+
+Real-world bitrate history for this encoder: original iTunes Music Store (2003-2007) shipped 128 kbps FairPlay-DRM AAC; iTunes Plus (May 2007) introduced DRM-free 256 kbps AAC; by early 2009 256 kbps CVBR became the sole default, and Apple Music/iTunes downloads remain there today. ([Macworld: iTunes Store goes DRM-free](https://www.macworld.com/article/194277/itunestore.html); [Apple Newsroom: Apple Launches iTunes Plus](https://www.apple.com/newsroom/2007/05/30Apple-Launches-iTunes-Plus/)) A meaningful fraction of "legacy" library rips still in circulation are the older 128 kbps encodes, so both bitrate classes are plausible inputs.
+
+## HE-AAC / SBR and what cliff detection sees
+
+HE-AAC v1 (SBR) and HE-AAC v2 (SBR + Parametric Stereo) are not "AAC-LC with a lower cutoff" — they stack two signals: (1) a **core layer** of ordinary AAC-LC encoded at *half* the nominal output sample rate, carrying only low/mid frequencies ([Hydrogenaudio: Fraunhofer FDK AAC](https://wiki.hydrogenaudio.org/index.php?title=Fraunhofer_FDK_AAC): "the HE-AAC and HE-AACv2 profiles encode audio using AAC-LC at one half the sample rate"); (2) **SBR side info** — a compact description (spectral envelope + noise/tone floor) of what the upper band should look like, computed by the encoder from the full-band original; and (3) **decoder reconstruction** via *spectral patching* — copying adjoining QMF (Quadrature Mirror Filter) subbands from the transmitted low band up into the high band, shaped by the side info, to synthesize plausible highs. ([Wikipedia: Spectral band replication](https://en.wikipedia.org/wiki/Spectral_band_replication); [Hydrogenaudio: Spectral Band Replication](https://wiki.hydrogenaudio.org/index.php?title=Spectral_Band_Replication))
+
+The **SBR crossover frequency** — where "real, transmitted" switches to "encoder-guided, decoder-synthesized" — moves with bitrate: lower bitrate pushes it down because that's the only way to free bits, a quality/data-rate tradeoff, not a free lunch. ([EBU Tech Review 305 — Moser](https://tech.ebu.ch/docs/techreview/trev_305-moser.pdf)) One documented example: at 64 kbps stereo, SBR splits around 7.5 kHz, handing 7.5-15 kHz to the reconstruction tool for ~1.5 kbps of side-info overhead `[unverified — single source, illustrative not universal]`. Typical nominal bitrates: HE-AAC v1 ~48-64 kbps stereo (160 kbps for 5.1); HE-AAC v2 ~24-32 kbps stereo. ([EBU Tech Review 305](https://tech.ebu.ch/docs/techreview/trev_305-moser.pdf); [Broadcast Bridge: HE-AAC](https://www.thebroadcastbridge.com/content/entry/21823/standards-high-efficiency-audio-codecs-he-aac))
+
+**What our cliff detector actually measures on an HE-AAC file:**
+
+- `detect_cliff()` slices only 12,000-20,000 Hz. If the SBR crossover sits below 12 kHz (typical for 48-64 kbps stereo per above), the *real* cliff — the core layer's true information boundary — is invisible to our slicer; everything in our window is 100% SBR-synthesized.
+- Synthesized highs are neither a smooth natural rolloff nor silence — a patched copy of lower harmonics reshaped by an envelope. That copy can: (a) show its own secondary rolloff near the top of the SBR range, read as an unrelated cliff; (b) sit at an unnaturally healthy energy level for its real information content, UNDER-estimating `hf_deficit_db` and letting a file that should be flagged pass as `"genuine"`; or (c) show comb-like irregularities from QMF patching that neither metric characterizes.
+- Net effect: cliff detection and HF-deficit scoring on HE-AAC content isn't "miscalibrated," it's **measuring the wrong thing** — a cliff found in our 12-20 kHz window may sit entirely inside the synthetic region and tell us almost nothing about real information content.
+
+## CBR/VBR nuances
+
+- **FDK CBR bandwidth is bitrate-*insensitive* above 96 kbps/channel** — the single biggest AAC-specific trap for a LAME-modeled bitrate-from-cutoff heuristic (where cutoff keeps climbing to 320 kbps). Expect FDK-AAC from 96 through 320 kbps CBR to cluster at the same ~17 kHz cutoff.
+- **Apple CVBR (what iTunes Plus/Apple Music ship) is bitrate-capped from above, not below** — "256 kbps" is a ceiling, dipping lower on simple passages ([Hydrogenaudio: Apple AAC](https://wiki.hydrogenaudio.org/index.php?title=Apple_AAC)). A track's average bitrate can misrepresent the specific 30-second window our analyzer trims to (`trim_seconds=30` in `analyze_track`) — sharper for VBR/CVBR sources than CBR.
+- **FFmpeg native `aac`'s only documented CBR/VBR distinction is that `-b:a` activates CBR** vs. `-q:a` for VBR; no separate published bandwidth table per mode — "dynamically adjust" is the entire public spec.
+- **HE-AAC has no meaningful CBR/VBR distinction for bandwidth** — the crossover-vs-bitrate tradeoff dominates regardless of rate-control mode, because the core/SBR split is what's traded, not quantizer step size.
+- **Streaming rips add a second layer of uncertainty on top of encoder choice**: YouTube Music serves AAC-LC at 128 kbps (itag 140) or 256 kbps (itag 141, Premium); Spotify's web player offers AAC at 128/256 kbps. A "YouTube rip" or "Spotify rip" is a genuine AAC-LC encode at one of these nominal rates, not evidence of transcoding — but which underlying encoder produced it is generally unknown/unversioned.
+
+## Implications for calibration
+
+**Is a per-encoder AAC ladder viable?** Partially:
+
+- **libfdk_aac: yes.** A public, source-level bitrate→bandwidth table (above) that's stable across versions (the header calls the values deliberately fixed). A ladder keyed on FDK's CBR/VBR-mode bandwidths is directly buildable and testable.
+- **ffmpeg native `aac`: partially.** No public table, but the encoder is open source and deterministic — Phase 3 can build an empirical ladder by encoding reference material at target bitrates and measuring the actual cutoff, pinning the results as the calibration table. Buildable, but requires new measurement, not a source-table transcription.
+- **Apple AAC: no fixed ladder — only an empirical, re-validated one.** No published spec exists, the qaac maintainer confirms none exists, and the closed-source encoder can change silently across OS/Core Audio versions. Treat as the least stable of the three, most likely to need re-calibration after an undocumented Apple change.
+- **HE-AAC/SBR: no ladder makes sense in cliff-detection terms.** The fix is a **pre-classification gate**: if the stream signals SBR (AAC object type 5/29), skip cliff-based grading for that file entirely rather than run the existing 12-20 kHz LAME-shaped detector against it (a dedicated SBR-crossover estimator is out of scope for this calibration pass).
+
+**Distinguishability**: FDK's CBR cutoffs (14-16 kHz mono, 15.5-17 kHz stereo, hard-capping at 17 kHz) sit close enough to LAME's 128-160 kbps window that cliff position alone can't separate "genuine FDK-AAC 128" from "MP3 128 transcoded to AAC" — some other signal (container/encoder tag, or a wide "AAC-plausible" band that simply never fires `"suspect"` across that whole range) will be needed. Apple's cutoffs are undocumented, so distinguishability there can only be established empirically in Phase 3.
+
+## Predictions for Phase 3
+
+Testable claims — encode X at bitrate Y with real reference material, then measure whether the cliff falls in the predicted range:
+
+| Encoder | Bitrate | Predicted cliff/cutoff range | Confidence |
+|---|---|---|---|
+| libfdk_aac CBR | 96 kbps | ~16,000-17,000 Hz | High — from source table |
+| libfdk_aac CBR | 128 kbps | ~17,000 Hz (capped, same as 96 kbps+) | High — from source table |
+| libfdk_aac CBR | 192-320 kbps | ~17,000 Hz — **no increase over 128 kbps** | High — from source table; worth pinning as a regression test |
+| libfdk_aac VBR mode 3 | ~96 kbps-class | ~15,750 Hz | Medium — table confirmed, bitrate mapping unverified |
+| libfdk_aac VBR mode 5 | highest VBR | ~19,293 Hz | Medium — table confirmed, bitrate mapping unverified |
+| ffmpeg native `aac` | 128 kbps | Likely 15,000-17,000 Hz per community consensus, **no table guarantee** | Low — no published table |
+| ffmpeg native `aac` | 256-320 kbps | Likely closer to full-band (18-20 kHz) than FDK at the same rate — no hard 17 kHz cap | Low — inference from doc language, not measurement |
+| Apple AAC CVBR | ~256 kbps (iTunes Plus/Apple Music) | Unknown; plausibly wider than FDK's 17 kHz cap given reputation, but no table to predict from | Very low — explicitly undocumented; must measure real files |
+| Apple AAC | 128 kbps (legacy pre-2007 iTunes) | Unknown | Very low — same caveat |
+| HE-AAC v1 | 64 kbps stereo | Core/SBR crossover ~7.5-9 kHz (below our 12 kHz slice floor); 12-20 kHz window is synthetic | Medium — one concrete example, SBR mechanics well documented |
+| HE-AAC v2 | 24-32 kbps stereo | Crossover pushed lower still (likely <8 kHz); nearly all our slice window is synthetic | Low — mechanics-based inference, no numeric source at this exact bitrate |
+
+Recommended Phase 3 minimum test matrix: encode the same reference album through (a) libfdk_aac CBR at 96/128/192/320, (b) ffmpeg native `aac` at the same four rates, (c) a real Apple Music or iTunes Plus purchase (cannot be synthesized — must be sourced from an actual Apple encode), and (d) libfdk_aac HE-AAC/HE-AACv2 at 48/64/96 — then run each through the existing `analyze_track` and record the actual `cliff_freq_hz` / `hf_deficit_db` against the predictions above.
+
+## Sources
+
+- [FFmpeg encoders.texi — `aac`/`libfdk_aac` `-cutoff` docs](https://github.com/FFmpeg/FFmpeg/blob/master/doc/encoders.texi)
+- [FFmpeg wiki: Encode/AAC](https://mirror.hjertaas.com/trac.ffmpeg.org/trac.ffmpeg.org/wiki/Encode/AAC.html)
+- [Hydrogenaudio: AAC encoders (overview/ranking)](https://wiki.hydrogenaudio.org/?title=AAC_encoders)
+- [Hydrogenaudio: Libavcodec AAC (native ffmpeg encoder history)](https://wiki.hydrogenaudio.org/index.php?title=Libavcodec_AAC)
+- [Hydrogenaudio: Fraunhofer FDK AAC](https://wiki.hydrogenaudio.org/index.php?title=Fraunhofer_FDK_AAC)
+- [fdk-aac source: `aacenc_lib.h` (AACENC_BANDWIDTH docs)](https://github.com/mstorsjo/fdk-aac/blob/master/libAACenc/include/aacenc_lib.h)
+- [fdk-aac source: `bandwidth.cpp` (bandWidthTable)](https://github.com/mstorsjo/fdk-aac/blob/master/libAACenc/src/bandwidth.cpp)
+- [Hydrogenaudio: Apple AAC](https://wiki.hydrogenaudio.org/index.php?title=Apple_AAC)
+- [Apple Developer: TN2271 (AAC encoder bitrate control strategies)](https://developer.apple.com/library/archive/technotes/tn2271/_index.html)
+- [qaac issue #70 — default lowpass frequencies in Apple encoder (none published)](https://github.com/nu774/qaac/issues/70)
+- [Archimago's Musings: Bluetooth AAC encoder comparison](http://archimago.blogspot.com/2023/08/part-ii-comparison-of-bluetooth.html)
+- [Wikipedia: Spectral band replication](https://en.wikipedia.org/wiki/Spectral_band_replication)
+- [Wikipedia: High-Efficiency Advanced Audio Coding](https://en.wikipedia.org/wiki/High-Efficiency_Advanced_Audio_Coding)
+- [Hydrogenaudio: Spectral Band Replication](https://wiki.hydrogenaudio.org/index.php?title=Spectral_Band_Replication)
+- [EBU Technical Review 305 — Moser, "MPEG-4 HE-AAC v2"](https://tech.ebu.ch/docs/techreview/trev_305-moser.pdf)
+- [The Broadcast Bridge: High Efficiency Audio Codecs (HE-AAC)](https://www.thebroadcastbridge.com/content/entry/21823/standards-high-efficiency-audio-codecs-he-aac)
+- [Macworld: iTunes Store goes DRM-free](https://www.macworld.com/article/194277/itunestore.html)
+- [Apple Newsroom: Apple Launches iTunes Plus (2007)](https://www.apple.com/newsroom/2007/05/30Apple-Launches-iTunes-Plus/)
+- [Gist: Converting audio to AAC with Fraunhofer FDK AAC in FFmpeg](https://gist.github.com/ScribbleGhost/54ad17da006e8bba4a1612bd6a64571c)
+- [YouTube Music format IDs (itag 140/141 AAC bitrates)](https://gist.github.com/AgentOak/34d47c65b1d28829bb17c24c04a0096f)
+- Analyzer reviewed for this doc: `lib/spectral_check.py` (`LAME_LOWPASS` lines 31-40, `detect_cliff`/`estimate_bitrate_from_cliff`/`classify_track`)

--- a/docs/research/spectral-mp3-lame.md
+++ b/docs/research/spectral-mp3-lame.md
@@ -1,0 +1,305 @@
+# Spectral calibration research: MP3 / LAME
+
+Issue #829 Phase 0. Cratedigger's spectral cliff detector was built and
+tuned against LAME's default lowpass ladder, so this codec is "home turf."
+Goal: pin down what our code assumes today, verify it against LAME's
+actual source/docs, and size the risk that a peer's MP3 came from a
+non-LAME encoder whose ladder doesn't match ours.
+
+## Summary
+
+- Our `LAME_LOWPASS` table in `lib/spectral_check.py` is a **verbatim
+  transcription of LAME's own `optimum_bandwidth()` lookup table**
+  (`freq_map[]` in `libmp3lame/lame.c`) — not a listening-test estimate,
+  a copy of the encoder's source. Every value matches upstream `master`
+  today, and that CBR table has been stable across the "modern" LAME
+  lineage (3.90 → 3.100+); it is not a moving target.
+- The real fragility is **encoder identity, not LAME version**. A peer's
+  MP3 could plausibly come from Xing/Helix (fixed 16 kHz lowpass at *any*
+  bitrate), Fraunhofer (anecdotally ~16 kHz even at CBR 320 in some
+  builds), or Shine (no lowpass filter and no psychoacoustic model at
+  all). Our cliff-to-bitrate mapping silently assumes LAME authorship on
+  every file it grades.
+- VBR (`-V0`..`-V9`) cutoffs are lower and less sharply banded than CBR,
+  and V0-V2 carry an `-Y`/sfb21 wrinkle that can soften the cliff right
+  where our detector looks for it.
+- `--lowpass -1` / `-k` full-bandwidth encodes exist in the wild but are
+  rare, historically buggy in LAME itself, and discouraged by LAME's own
+  developers — low risk, not zero.
+
+## How cratedigger measures today
+
+`lib/spectral_check.py` slices 12-20 kHz into 500 Hz bands (`SLICE_FREQS`,
+16 slices) plus a 1-4 kHz reference band. Each slice's RMS (via `sox ...
+sinc <lo>-<hi> stat`) becomes dB; `detect_cliff()` looks for
+`MIN_CLIFF_SLICES = 2` consecutive slices whose gradient drops below
+`CLIFF_THRESHOLD_DB_PER_KHZ = -12.0` dB/kHz and reports the frequency of
+the first slice in that run as `cliff_freq_hz`. A coarser `hf_deficit_db`
+(reference dB minus the average of the top four slices) grades
+suspect/marginal (`HF_DEFICIT_SUSPECT = 60.0`, `HF_DEFICIT_MARGINAL =
+40.0`) when there's no sharp cliff but the whole top end is quietly gone.
+
+`estimate_bitrate_from_cliff()` maps a detected cliff back to an assumed
+CBR bitrate via hand-picked midpoint ranges between consecutive
+`LAME_LOWPASS` entries:
+
+```python
+LAME_LOWPASS = [
+    (15100, 96), (15600, 112), (17000, 128), (17500, 160),
+    (18600, 192), (19400, 224), (19700, 256), (20500, 320),
+]
+```
+
+(`lib/spectral_check.py` lines 31-40.) At the album level,
+`classify_album()` grades `likely_transcode` at ≥75% suspect tracks,
+`suspect` at ≥`ALBUM_SUSPECT_PCT = 60.0`%, else `genuine`; `analyze_album()`
+reports the **minimum** per-track estimate (worst-track-wins, always via
+`min` regardless of the configured `bitrate_metric` —
+`docs/quality-ranks.md` § "Bitrate metric"). The CBR band table
+(`mp3_cbr.*`) is explicitly calibrated to line up with these cliff
+numbers ("a cliff-detected 192 IS a `good`-band reading, by construction").
+
+## LAME lowpass ladder — CBR
+
+`optimum_bandwidth()` in `libmp3lame/lame.c` (`freq_map[]`, a
+`bitrate → lowpass Hz` array; LAME snaps an arbitrary CBR bitrate to the
+nearest row via `nearestBitrateFullIndex()`):
+
+| CBR (kbps) | LAME lowpass (Hz) | In our table? |
+|---|---|---|
+| 8/16/24/32/40/48/56/64/80 | 2000/3700/3900/5500/7000/7500/10000/11000/13500 | no (below our floor) |
+| **96** | **15100** | yes |
+| **112** | **15600** | yes |
+| **128** | **17000** | yes |
+| **160** | **17500** | yes |
+| **192** | **18600** | yes |
+| **224** | **19400** | yes |
+| **256** | **19700** | yes |
+| **320** | **20500** | yes |
+
+Confirmed against both `lameproject/lame` (upstream) and the
+`gypified/libmp3lame` mirror — identical `freq_map[]` literal in both
+(<https://github.com/gypified/libmp3lame/blob/master/libmp3lame/lame.c>,
+<https://github.com/lameproject/lame/blob/master/libmp3lame/lame.c>).
+**Every value in our `LAME_LOWPASS` matches exactly.**
+
+Two behavioral wrinkles from the same function: mono CBR/ABR input gets
+`lowpass *= 1.5` (mono needs less bitrate per frame, leaving headroom for
+a higher cutoff — a mono-sourced file's cliff could sit above the
+stereo-table value for its true bitrate, so `estimate_bitrate_from_cliff()`
+could **under-estimate** it); and LAME resamples input >48 kHz down to
+48 kHz max, and at CBR <~104 kbps (and low VBR quality) resamples to a
+lower rate before encoding, so at low bitrates the lowpass is partly a
+consequence of the resampled Nyquist limit rather than a deliberate
+filter choice (<https://wiki.hydrogenaudio.org/index.php/LAME>).
+
+## LAME lowpass ladder — VBR presets (V0-V6)
+
+VBR is internally driven by a continuous quality index (0=best..9=worst,
+extended to 10), interpolated with `linear_int(a, b, m)` between two
+tables depending on the VBR algorithm — `vbr_rh` (`--vbr-old`) vs
+`vbr_mtrh` (`--vbr-new`, default since 3.98):
+
+| Quality index | `vbr_rh` lowpass (Hz) | `vbr_mtrh` lowpass (Hz) |
+|---|---|---|
+| 0 (≈V0) | 19500 | 24000 (≈ unfiltered, above Nyquist) |
+| 1 (≈V1) | 19000 | 19500 |
+| 2 (≈V2) | 18600 | 18500 |
+| 3 (≈V3) | 18000 | 18000 |
+| 4 (≈V4) | 17500 | 17500 |
+| 5 (≈V5) | 16000 | 17000 |
+| 6 (≈V6) | 15600 | 16500 |
+| 7 | 14900 | 15600 |
+| 8 | 12500 | 15200 |
+| 9 | 10000 | 7230 |
+| 10 | 3950 | 3950 |
+
+Source: WebFetch of `libmp3lame/lame.c` `lame_init_params()`, quoting the
+literal `int const x[11]` arrays for `vbr_rh` and `vbr_mtrh`
+(<https://github.com/gypified/libmp3lame/blob/master/libmp3lame/lame.c>).
+The V-level-to-index correspondence (V0=index 0 … V9=index 9) is LAME's
+documented CLI contract; the exact index arithmetic inside
+`lame_init_params` was not independently re-derived — treat row labels as
+`[unverified]` to one-index precision, though the overall monotonic shape
+is solid.
+
+Independent corroboration from real-world file measurements, likely
+reflecting version/psy-model/ATH variation on top of the raw table
+(<https://wiki.hydrogenaudio.org/index.php/LAME>): `-b 320`
+(CBR) 20094–20627 Hz, `-V1` 19383–19916 Hz, `-V2` 18671–19205 Hz, `-V3`
+17960–18494 Hz, `-V4` 17249–17782 Hz, `-V5`–`-V6` 16538–17071 Hz. `-V0`
+has no fixed number in that source, consistent with `vbr_mtrh`'s 24000 Hz
+table entry — "as much bandwidth as the format allows."
+
+**Implication:** our cliff→bitrate table is CBR-only. Labeled VBR (`mp3
+v0`, etc.) bypasses `spectral_check.py`'s bitrate estimate in the rank
+model entirely — routed via `mp3_vbr_levels` instead
+(`docs/quality-ranks.md`). But *unlabeled* bare-codec VBR MP3s still get
+spectral-checked, and a detected cliff still runs through the CBR-shaped
+`estimate_bitrate_from_cliff()` — a mapping never designed for VBR. At V2
+(a common rip default), the real cutoff (~18.6-19.2 kHz) happens to land
+inside our 18050-19000 CBR-192 bucket — coincidence, not design.
+
+## Version stability (3.97 → 3.100)
+
+- No changelog entry found describing a *revision* of the `freq_map[]` Hz
+  values across 3.97/3.98/3.99/3.100 — today's `master` matches our
+  table. `[unverified beyond absence of contrary changelog evidence]`; I
+  did not diff every tagged release literally.
+- The **VBR algorithm default did change**: `--vbr-new` (`mtrh`) became
+  default in LAME 3.98, superseding `--vbr-old` (`rh`), default in
+  3.90-3.97 — a real, documented shift that changes the effective VBR
+  ladder (the two columns above diverge most at V0/V8/V9) depending on
+  which LAME build produced a file
+  (<https://wiki.hydrogenaudio.org/index.php/LAME>; Doom9 corroboration:
+  "Prior to LAME 3.98, the --vbr-new switch enabled the new VBR mode.
+  This is now the default VBR mode" — <http://forum.doom9.org/archive/index.php/t-165982.html>).
+- LAME 3.98.3/3.99-alpha2 changed bit-reservoir growth-cap handling (not
+  itself a lowpass change), and a changelog entry records "Fixed bug with
+  lowpass filters when using VBR with a 64kbps or lower min bitrate
+  setting" (exact version `[unverified]`) — neither matters much for
+  cratedigger's 12-20 kHz window, well above that low-bitrate regime.
+- **Takeaway:** the CBR ladder is old and stable — Phase 3 shouldn't
+  expect to find CBR drift by LAME version. If Phase 3 finds inconsistent
+  VBR cliff behavior across a real-file sample, check pre-/post-3.98
+  encoder version (`vbr-old` vs `vbr-new`) before assuming measurement
+  noise.
+
+## Non-LAME MP3 encoders — divergence table
+
+The real risk surface: cratedigger validates arbitrary Soulseek peer
+uploads, and nothing guarantees LAME authorship — older rips and hardware
+rippers commonly used Xing, Fraunhofer, or (rarely) Helix/Shine.
+
+| Encoder | Lowpass behavior | Divergence from our table | Confidence |
+|---|---|---|---|
+| **LAME** (all modern) | Bitrate/quality-dependent ladder above | None — calibration source | Verified (primary source) |
+| **Xing / Helix** (`hmp3`, RealProducer-era) | **Fixed 16 kHz lowpass by default**, any bitrate, unless `-HF`/`-HF2` (needs VBR quality ≥80) | A Xing 320 kbps file still shows a ~16 kHz cliff → our table reads it as ~112-128 kbps CBR, a severe **under-estimate** | Verified — <https://wiki.hydrogenaudio.org/index.php?title=Helix_MP3_Encoder>, <https://www.speedguide.net/forums/viewtopic.php?t=111037> |
+| **Fraunhofer / FhG** | Anecdotal "brickwall at 16 kHz" even at CBR 320, vs LAME's ~20.5 kHz at the same bitrate | Same failure mode as Xing if true: genuine 320 kbps reads as ~112-128 kbps | `[unverified]` — forum/community testimony only (FhG's reference encoder is closed-source); not FhG documentation or source. <https://community.adobe.com/feature-requests-545/use-lame-mp3-encoder-to-dramatically-improve-quality-1436130>, <https://www.head-fi.org/threads/my-fraunhofer-vs-lame-test-results.49368/> |
+| **Shine** (fixed-point, embedded) | **No lowpass filter, no psychoacoustic model at all** — LAME logs an explicit polyphase-lowpass transition band; Shine's log has no equivalent | No detectable cliff regardless of quality → likely graded `genuine` even though overall quality is poor (missing psy model). False-**negative** on quality, not a bandwidth issue our detector can see | `[unverified precisely]` but consistent across independent sources: <https://github.com/toots/shine>, <https://news.ycombinator.com/item?id=30998693> |
+| **BladeEnc / other late-90s** | Not researched for this doc | `[unverified]` — flag for Phase 3 if any turn up live | Not researched |
+
+**Net read:** our cliff table is a *LAME* lowpass-inversion table, not a
+generic MP3 one — correct when the encoder was LAME (the de facto
+standard for high-quality MP3 since the early 2000s), but systematically
+**under-estimating** true bitrate for Xing/Helix or (anecdotally) FhG
+material, pushing those files toward a lower rank than deserved. Safer
+than false-accepting a bad file, but it can cause unnecessary re-searches
+on files that were already fine.
+
+## CBR/VBR nuances
+
+- **sfb21 / `-Y` switch (V0-V2 only).** Scale-factor band 21 (roughly
+  ≥16 kHz on 44.1 kHz material) has no independent scale factor in the
+  bitstream, so encoding it with full precision can force LAME to lower
+  *global* gain, inflating bitrate across the whole frame. `-V3`-`-V9`
+  default to `-Y` (don't chase sfb21 precision if it bloats bitrate);
+  `-V0`-`-V2` do **not**, so those tiers spend extra bits on top-band
+  accuracy instead of filtering more aggressively
+  (<https://wiki.hydrogenaudio.org/index.php?title=LAME_Y_switch>). Effect:
+  at V0-V2 the top slices may show bit-starved-but-present energy rather
+  than a clean rolloff — our detector may see *less* of a cliff there
+  than a naive Hz-vs-bitrate model predicts.
+- **Joint stereo.** LAME's default (`-m j`) lets the encoder choose
+  per-frame (~40×/sec at 44.1 kHz) between L/R and mid/side coding; joint
+  stereo is default when `-V` > 4 or fixed bitrate ≤160 kbps, plain
+  stereo otherwise (<https://www.mankier.com/1/lame>, corroborated by
+  <https://sourceforge.net/p/lame/bugs/454/>). M/S coding concentrates
+  energy in the sum channel; our sox band-RMS measurement doesn't
+  explicitly downmix, so this is at most a second-order effect on which
+  channel's rolloff we measure — `[unverified]` beyond that general
+  mechanism; no source quantifies a direct M/S-vs-cutoff interaction.
+- **`--lowpass -1` / full-bandwidth encodes exist but are rare and
+  discouraged.** `--lowpass -1` documented-disables LAME's automatic
+  filter; `-k` is a related full-bandwidth switch. Both exist in the wild
+  ("preserve everything" users) but LAME's developers discourage this —
+  reproducing >~16 kHz / <20 Hz mostly wastes bits — and `-k` has a
+  documented history of not reliably disabling the filter in some 3.98
+  builds (bug #302). When present, produces a file with **no cliff
+  regardless of true bitrate** — same false-negative shape as Shine, but
+  for LAME (<https://mediamonkey.com/forum/viewtopic.php?t=105263>,
+  <https://sourceforge.net/p/lame/bugs/302/>,
+  <https://sourceforge.net/p/bonkenc/discussion/85470/thread/aafde90b/>).
+
+## Implications for calibration
+
+1. **The CBR table needs no re-derivation** — it's a direct source
+   transcription matching upstream `master`. Phase 3 should *validate* it
+   against real LAME CBR files (confirm cliffs land where predicted; tune
+   `CLIFF_THRESHOLD_DB_PER_KHZ`/`MIN_CLIFF_SLICES` if noisier than
+   assumed), not re-derive the Hz values.
+2. **The VBR path is the actual gap.** `estimate_bitrate_from_cliff()`
+   reuses CBR bucket boundaries for any detected cliff regardless of
+   `is_cbr`. It's gone unnoticed because the VBR ladder sits close to the
+   CBR ladder at mid-tiers (V2 ≈ CBR-192, V4 ≈ CBR-128), but this has
+   never been verified against real VBR files; V0/V1 has no corresponding
+   bucket at all, though that correctly falls through to "no cliff,
+   genuine" by accident of the table's open top end.
+3. **Non-LAME encoder identity is undetectable from spectral evidence
+   alone today.** Nothing distinguishes "no cliff, genuinely high
+   quality" from "no cliff, Shine/full-bandwidth," or "cliff read as
+   CBR-128, actually Xing/FhG at CBR-320." Phase 3 should check
+   suspect-graded files for other fingerprints (LAME writes an
+   identifiable Xing/LAME VBR header + version string; Xing/Helix/FhG
+   have their own header signatures) before trusting an unusual cliff
+   reading. The fail direction is safe-ish but not free: under-estimating
+   quality triggers conservative behavior (requeue, no accept) rather
+   than false-accepting a bad file — consistent with "never auto-decide
+   anything irreversible" — but it costs needless search churn on files
+   that were actually fine, worth measuring in Phase 3.
+
+## Predictions for Phase 3 (testable)
+
+| Setting | Expected cliff Hz (if LAME) | Our bucket → estimated bitrate | Prediction holds if... |
+|---|---|---|---|
+| LAME CBR 128 | ~17000 (±300) | 15400-17250 → 128 | Cliff detected in 16700-17300 Hz |
+| LAME CBR 192 | ~18600 | 18050-19000 → 192 | Cliff detected in 18300-18900 Hz |
+| LAME CBR 320 | ~20500 | ≥19550 → 320 | **No cliff** — our slices top out at 19500-20000, at/past a 20500 cutoff; if Phase 3 finds cliffs reliably appearing in the last slice for known-320 files, our slice window is too narrow |
+| LAME `-V2` (VBR, unlabeled) | ~18671-19205 | 18050-19000 → 192, or 19000-19550 → 256 (straddles our boundary at 19000) | A meaningful fraction of genuine V2 files land right on the 192/256 boundary — expect noisy bitrate estimates for V2 specifically (table mismatch, not measurement noise) |
+| LAME `-V0`/`-V1` (VBR, unlabeled) | ~19383-19916, or unfiltered if `vbr_mtrh` | No matching cliff | **No cliff, `genuine`** — correct outcome; confirm it isn't landing in the 19550+/320 bucket and getting mis-labeled CBR-320 |
+| Xing/Helix file, any true bitrate | ~16000 (fixed) | 15400-17250 → 128 | Any Xing/Helix file reads as ~128 kbps regardless of true quality — sharpest test of the non-LAME risk if a known-Xing high-bitrate file can be sourced |
+| Shine-encoded file | No cliff at all | No cliff → `genuine` (false negative on quality, not bandwidth) | Confirms "invisible to bandwidth detection"; would need a separate signal (missing Xing/LAME header, flat/noisy spectrum below 12 kHz) to catch Shine's real quality problem |
+| `--lowpass -1` / full-bandwidth LAME | No cliff (content-dependent rolloff only) | No cliff → `genuine` | Rare in practice; same blind spot as Shine if found |
+| Mono-sourced CBR file | ~1.5× stereo-table value for the same bitrate | Systematic under-estimate | If Phase 3 samples include mono-source rips (common for older mono originals), expect our bitrate estimate to read low relative to tags/history |
+
+## Sources
+
+- `lib/spectral_check.py`, `docs/quality-ranks.md` — this repo.
+- LAME source, CBR `optimum_bandwidth()`/`freq_map[]` + VBR quality-index
+  tables (`vbr_rh`/`vbr_mtrh` in `lame_init_params()`):
+  <https://github.com/gypified/libmp3lame/blob/master/libmp3lame/lame.c>,
+  <https://github.com/lameproject/lame/blob/master/libmp3lame/lame.c>
+- LAME source, ABR/VBR preset struct (`safejoint`, no lowpass column):
+  <https://fossies.org/linux/quicktime4linux/thirdparty/lame-3.93.1/libmp3lame/presets.c>,
+  <https://github.com/lameproject/lame/blob/master/libmp3lame/presets.c>
+- LAME USAGE doc (`--lowpass`, `--lowpass-width`, `-Y`):
+  <https://raw.githubusercontent.com/lameproject/lame/master/USAGE>
+- Hydrogenaudio LAME page: <https://wiki.hydrogenaudio.org/index.php/LAME>
+- Hydrogenaudio `-Y` switch page:
+  <https://wiki.hydrogenaudio.org/index.php?title=LAME_Y_switch>
+- Hydrogenaudio Helix MP3 Encoder page:
+  <https://wiki.hydrogenaudio.org/index.php?title=Helix_MP3_Encoder>
+- Hydrogenaudio High-frequency content in MP3s page (general rationale
+  only, no encoder-specific Hz comparisons found there):
+  <https://wiki.hydrogenaudio.org/index.php?title=High-frequency_content_in_MP3s>
+- Doom9 archive, LAME 3.98 `--vbr-new` default change:
+  <http://forum.doom9.org/archive/index.php/t-165982.html>
+- Fossies, LAME 3.99.5 → 3.100 changelog diff:
+  <https://fossies.org/diffs/lame/3.99.5_vs_3.100/ChangeLog-diff.html>
+- Speedguide forum, Xing vs LAME:
+  <https://www.speedguide.net/forums/viewtopic.php?t=111037>
+- Adobe Community + Head-Fi, Fraunhofer 16 kHz brickwall claim (forum
+  testimony only, not FhG documentation):
+  <https://community.adobe.com/feature-requests-545/use-lame-mp3-encoder-to-dramatically-improve-quality-1436130>,
+  <https://www.head-fi.org/threads/my-fraunhofer-vs-lame-test-results.49368/>
+- Shine encoder repo + HN discussion (no psychoacoustic model, no
+  lowpass filter): <https://github.com/toots/shine>,
+  <https://news.ycombinator.com/item?id=30998693>
+- MediaMonkey forum, `--lowpass -1` confirmation; LAME bug #302 (`-k` not
+  reliably disabling filter in 3.98b6); fre:ac/BonkEnc forum on
+  "Disable all filtering" and developer pushback on full-bandwidth
+  encodes: <https://mediamonkey.com/forum/viewtopic.php?t=105263>,
+  <https://sourceforge.net/p/lame/bugs/302/>,
+  <https://sourceforge.net/p/bonkenc/discussion/85470/thread/aafde90b/>
+- Mankier LAME man page + bug #454, default joint-stereo threshold:
+  <https://www.mankier.com/1/lame>, <https://sourceforge.net/p/lame/bugs/454/>

--- a/docs/research/spectral-opus.md
+++ b/docs/research/spectral-opus.md
@@ -1,0 +1,299 @@
+# Spectral calibration research: Opus
+
+Issue #829 Phase 0. Companion to `docs/research/spectral-mp3-lame.md`. The
+question here is narrower than for MP3: does *any* bitrate-proportional
+lowpass ladder exist for Opus that `lib/spectral_check.py`'s cliff detector
+and `LAME_LOWPASS`/`estimate_bitrate_from_cliff()` could be adapted to, or
+is that mechanism architecturally inapplicable to this codec? **Expected
+conclusion, checked against primary sources below: no usable ladder
+exists.** Opus's CELT layer does not apply an encoder-side lowpass filter
+that moves with bitrate the way LAME's `optimum_bandwidth()` does. What
+moves with bitrate in Opus is *within-band precision*, not *which bands are
+coded at all* — and our analyzer only measures the latter.
+
+## Summary
+
+- Opus's audio bandwidth (NB/MB/WB/SWB/FB) is a **discrete 5-step mode**,
+  not a continuous bitrate-proportional cutoff. The step to full 20 kHz
+  bandwidth (FB) happens at a very low bitrate — on the order of 12-16 kbps
+  for stereo music — confirmed directly from `libopus`'s own
+  `opus_encoder.c` threshold tables
+  (<https://github.com/xiph/opus/blob/main/src/opus_encoder.c>).
+- Above that threshold, **every bitrate our library actually contains**
+  (32/48/64/96/128/192/256 kbps stereo music) selects the same FB mode.
+  There is no further bandwidth narrowing as bitrate rises — the "ladder"
+  the MP3 doc found bottoms out below the range that matters for music and
+  is flat above it.
+- The 20 kHz ceiling itself is a **fixed architectural constant**, not a
+  bitrate-dependent artifact: RFC 6716 states Opus "never codes audio above
+  20 kHz" full stop, and the CELT/MDCT layer achieves the lower bandwidth
+  modes by *zeroing* bands in the frequency domain, not by a variable-cutoff
+  filter (<https://www.rfc-editor.org/rfc/rfc6716.html>).
+- Even within FB mode at low per-band bit allocation, CELT's band-energy
+  preservation and **spectral/band folding** design keeps every band's
+  *energy* transmitted and present, borrowing shape from lower bands when
+  there aren't enough bits for independent detail
+  (<https://en.wikipedia.org/wiki/CELT>). A coarse RMS-per-band detector
+  like ours cannot tell "independently coded detail" apart from
+  "folded/reused shape at the correct energy" — both read as full-bandwidth,
+  non-silent energy.
+- Net result: our cliff detector and `hf_deficit_db` metric will read
+  **"genuine, no cliff" for essentially all Opus files at ≥64 kbps**,
+  regardless of whether the true encode was 64 or 256 kbps. Not a detector
+  bug — it measures bandwidth presence, and Opus doesn't vary that signal
+  with quality the way MP3/AAC do.
+- The private-tracker "spectral analysis" reference guides the MP3/AAC
+  community uses for visual transcode detection do not cover Opus at all
+  (checked <https://interview.orpheus.network/spectral-analysis.php> and
+  <https://interviewfor.red/en/spectrals.html> — neither mentions Opus).
+  Weak corroborating evidence: the community that built spectrogram-cliff
+  heuristics for every other lossy codec has not produced one for Opus.
+
+## Opus architecture in 10 lines
+
+1. Opus (RFC 6716) is a container for two sub-codecs: **SILK** (linear
+   prediction, speech-oriented, effective bandwidth up to 8 kHz) and
+   **CELT** (MDCT-based, up to 20 kHz), plus a **hybrid** mode that runs
+   both at once <https://www.rfc-editor.org/rfc/rfc6716.html>.
+2. In hybrid mode, SILK codes 0-8 kHz and CELT codes 8 kHz upward, crossing
+   over at 8 kHz — the maximum wideband (WB) frequency
+   (<https://www.rfc-editor.org/rfc/rfc6716.html>).
+3. The **CELT/MDCT layer always runs internally at 48 kHz**, irrespective
+   of bandwidth mode; lower bandwidths are produced by zeroing
+   high-frequency bands in the frequency domain, not a separate filter
+   stage (<https://www.rfc-editor.org/rfc/rfc6716.html>).
+4. CELT's spectrum is split into **21 fixed critical bands** up to 20 kHz
+   (`eband5ms[]` in `celt/modes.c`, values `0,1,2,...,78,100` in units of
+   200 Hz — band 21's edge is `100*200 Hz = 20000 Hz` exactly)
+   (<https://github.com/xiph/opus/blob/main/celt/modes.c>).
+5. This band layout is **fixed regardless of bitrate**. Bitrate changes how
+   many bits (PVQ pulses) each band gets, not how many bands exist or where
+   their edges fall.
+6. Each band's **energy is coded first and separately** ("coarse energy"),
+   then the normalized residual shape is coded via **Pyramid Vector
+   Quantization** (<https://en.wikipedia.org/wiki/CELT>).
+7. When a band gets too few bits for its own shape, CELT applies **band
+   folding** — reusing lower bands' decoded shape, rescaled to the
+   transmitted energy — "similar effect to spectral band replication
+   (SBR)... but has much less impact on... algorithmic delay and
+   computational complexity" (<https://en.wikipedia.org/wiki/CELT>).
+8. Opus picks SILK-only / hybrid / CELT-only and NB/MB/WB/SWB/FB
+   automatically per-frame from bitrate and a speech/music probability
+   estimate (`voice_est`), unless overridden via
+   `OPUS_SET_BANDWIDTH`/`OPUS_SET_MAX_BANDWIDTH`
+   (<https://opus-codec.org/docs/opus_api-1.5/group__opus__encoderctls.html>).
+9. For music, the mode threshold sits around equivalent-bitrate ~10 kbps —
+   below every practical music bitrate — so **CELT-only is the default
+   mode for music** at 32 kbps and up (`mode_thresholds[][1] = 10000` for
+   mono and stereo, <https://github.com/xiph/opus/blob/main/src/opus_encoder.c>).
+10. `ffmpeg`/`opusenc` default to `application=audio`, VBR on, complexity
+    10 — settings a music library is almost certainly encoded with
+    (<https://ffmpeg.org/ffmpeg-codecs.html>).
+
+## Bandwidth mode thresholds — the real (coarse) ladder
+
+RFC 6716 Table 1, the five bandwidth modes and their nominal audio
+bandwidth / internal sample rate
+(<https://www.rfc-editor.org/rfc/rfc6716.html>):
+
+| Mode | Audio bandwidth | Effective sample rate |
+|------|------------------|------------------------|
+| NB (narrowband) | 4 kHz | 8 kHz |
+| MB (medium-band) | 6 kHz | 12 kHz |
+| WB (wideband) | 8 kHz | 16 kHz |
+| SWB (super-wideband) | 12 kHz | 24 kHz |
+| FB (fullband) | 20 kHz (hard ceiling, human-hearing rationale) | 48 kHz |
+
+`libopus`'s automatic-bandwidth logic in `opus_encoder.c`
+(<https://github.com/xiph/opus/blob/main/src/opus_encoder.c>) picks the
+bandwidth from an **equivalent bitrate** (`equiv_rate`, the configured
+bitrate adjusted for frame-rate overhead, VBR/CBR, and complexity — at the
+defaults a music encode is likely to use, complexity 10 and VBR on,
+`equiv_rate` is close to the nominal bitrate) against threshold/hysteresis
+pairs, blended between "voice" and "music" tables by a per-frame
+speech/music probability estimate:
+
+```c
+static const opus_int32 stereo_music_bandwidth_thresholds[8] = {
+         9000,  700, /* NB<->MB */
+         9000,  700, /* MB<->WB */
+        11000, 1000, /* WB<->SWB */
+        12000, 2000, /* SWB<->FB */
+};
+```
+
+(mono music table is nearly identical: `9000/700, 9000/700, 11000/1000,
+12000/2000`; "voice" tables push WB<->SWB/SWB<->FB slightly higher —
+13500-14000 bps — but real music weights almost entirely toward the music
+table.) Reading the SWB<->FB row: a stereo music stream reaches FB (full
+20 kHz) once `equiv_rate` clears roughly **12 kbps**, with 2000 bps of
+hysteresis. Mode selection (SILK-only vs. CELT-only) uses a separate, lower
+threshold for music (`mode_thresholds[stereo][music] = 10000` bps, same
+source).
+
+Corroborating secondary source (Hydrogenaudio's Opus wiki page): "bandwidth
+progresses from narrowband (4 kHz) at 6 kbps, through wideband and
+superwideband intermediate ranges, reaching fullband (20 kHz) by
+approximately 16-24 kbps for music content"
+(<https://wiki.hydrogenaudio.org/index.php?title=Opus>). FFmpeg's own docs
+independently confirm the low end of this behavior: "libopus forces a
+wideband cutoff for bitrates < 15 kbps, unless CELT-only (application set
+to `lowdelay`) mode is used" (<https://ffmpeg.org/ffmpeg-codecs.html>).
+
+**The practical consequence: every bitrate this library is likely to
+contain is already past the ladder.** 32, 48, 64, 96, 128, 192, and
+256 kbps stereo music all sit far above the ~12-16 kbps FB threshold —
+they all select the *same* bandwidth mode. The only place a real,
+bitrate-driven bandwidth *step* exists is below ~16 kbps, a range that
+essentially never appears for music (it's a voice/podcast bitrate).
+
+## What cliff detection sees per bitrate
+
+| Nominal bitrate (stereo music, VBR, `application=audio`) | Selected bandwidth mode | What `sox`-based 12-20 kHz slicing measures | `spectral_check.py` grade |
+|---|---|---|---|
+| ≤ ~10-12 kbps | SWB or lower (cutoff ≤ 12 kHz) | Real, near-total silence 12-20 kHz | Genuine cliff/HF-deficit — but not music-relevant |
+| ~16-32 kbps | FB, very few bits per high band | Attenuated but present energy 12-20 kHz — folded shape at the band's true (low) energy, not silence | Likely `genuine`/borderline `marginal`; not a clean cliff |
+| 64 kbps | FB | Energy present across all 21 bands; folding fills fine detail in the least-allocated high bands | `genuine` [unverified: exact `hf_deficit_db` at 64 kbps not measured against a real file for this doc — see Phase 3] |
+| 96 / 128 kbps | FB | Same — Hydrogenaudio's own table calls 96-128 kbps "good quality approaching transparency" to "very close to transparency," i.e. higher per-band precision, not more bandwidth (<https://wiki.hydrogenaudio.org/index.php?title=Opus>) | `genuine` |
+| 192 / 256 kbps | FB | Same bandwidth as 64 kbps; only per-band precision (PVQ pulse count) differs | `genuine` — **indistinguishable from 96 kbps by our detector** |
+
+Mechanism behind the flat middle/right side of that table: CELT's coarse
+energy for every band up to the mode's top edge is coded and transmitted
+regardless of how many bits are left for shape detail
+(<https://en.wikipedia.org/wiki/CELT>, PVQ/normalization description);
+folding then fills in shape for starved bands using rescaled lower-band
+content. Our detector measures *band RMS* — exactly the value CELT
+preserves first and always — so it reads "present" even where detail is
+folded/approximate. It was built to find LAME's *removed* bands (zero
+content past the lowpass); it has no comparable signal for Opus's
+*degraded-but-present* bands.
+
+## The 20 kHz shelf vs. LAME cliffs
+
+Two genuinely different mechanisms produce superficially similar-looking
+"stuff stops near 20 kHz" spectrograms:
+
+- **LAME** (see the companion MP3 doc) computes a bitrate-specific lowpass
+  frequency via `optimum_bandwidth()` and applies it at encode time — the
+  cutoff frequency *is* a function of bitrate, ranging from ~15.1 kHz at
+  96 kbps to ~20.5 kHz at 320 kbps. That's the entire basis of
+  `LAME_LOWPASS`/`estimate_bitrate_from_cliff()`.
+- **Opus** has one fixed ceiling at 20 kHz for the FB mode, justified
+  purely by human-hearing limits, independent of bitrate: "Opus never
+  codes audio above 20 kHz, as that is the generally accepted upper limit
+  of human hearing" (<https://www.rfc-editor.org/rfc/rfc6716.html>). There
+  is no bitrate variable anywhere in that statement.
+
+This has been a live complaint on Opus's own mailing list, not just a
+theoretical distinction. In January 2013 a user reported that "at 96 kbps
+the cutoff of the filter starts at 16kHz and is completely cut at 20kHz"
+and asked for a `--lowpass` option to move it; Xiph developer Benjamin
+Schwartz replied: "Opus is a single-purpose codec for audio going into
+human ears. Human ears can't hear above 20 kHz, so Opus can't code higher
+frequencies," and recommended FLAC for anyone who needs content above
+20 kHz (<https://lists.xiph.org/pipermail/opus/2013-January/001939.html>).
+The reporter's observed shape (taper from ~16 kHz, fully attenuated by
+20 kHz) resembles our cliff detector's target shape, but Schwartz's reply
+confirms the boundary is the fixed 20 kHz ceiling, not a 96-kbps-specific
+artifact — the same shape appears at 128, 192, or 256 kbps.
+
+A more pointed, non-primary version of the same complaint (the NamuWiki
+Opus article) argues the 20 kHz ceiling is unnecessarily strict for
+listeners who can hear 21-22 kHz, and that "even from a technical
+standpoint, it isn't difficult to support up to 24 kHz" given the 48 kHz
+internal rate (<https://en.namu.wiki/w/Opus(오디오 코덱)> —
+[unverified: the specific "22-23 kHz would fix half the complaints" claim]).
+Whatever the merits, it corroborates the structural point: the 20 kHz
+behavior is one fixed policy decision, not a bitrate ladder.
+
+## Implications for calibration
+
+- **Above the SWB/FB threshold (~12-16 kbps for stereo music) — every
+  practical music bitrate — spectral cliff/bitrate-ladder detection is
+  architecturally inapplicable to Opus.** `estimate_bitrate_from_cliff()`
+  and `LAME_LOWPASS` must never be applied to an Opus track; nothing in
+  Opus's design produces the bitrate→cliff-frequency relationship that
+  table encodes. The right policy for #829 is **audit-only** for Opus at
+  ≥64 kbps: full-bandwidth energy presence is at best a sanity check that
+  the file isn't a from-MP3 transcode carrying a visible legacy cliff
+  underneath the Opus re-encode — a genuinely different, still-detectable
+  signal, but not a quality/bitrate estimator.
+- **Below the SWB/FB threshold**, a real, sourced, bitrate-driven boundary
+  exists (12 kHz at SWB, 8 kHz at WB) and *could* drive a coarse detector,
+  but only matters for Opus files under ~16 kbps — a speech/podcast
+  bitrate, not a music-library one. Low priority; likely not worth building
+  unless Phase 3 finds such files in the wild.
+- **What our existing detector *can* still catch**: a cliff inside the
+  12-20 kHz slice range on a file that is *not* near the SWB/FB boundary is
+  not explainable by Opus's own architecture — only by a band-limited
+  source feeding the encoder (MP3/AAC-sourced transcode-to-Opus). Legitimate
+  signal, but a *source* flag, not a bitrate estimate; `LAME_LOWPASS` must
+  not be reused to label it with an assumed original bitrate.
+
+## Predictions for Phase 3 (testable)
+
+These are falsifiable predictions Phase 3 should check against real
+encodes (e.g., `ffmpeg -c:a libopus -b:a <N>k -vbr on -application audio`
+at 32/48/64/96/128/192/256 kbps stereo music, run through
+`lib/spectral_check.py::analyze_track`):
+
+1. **All of 32/48/64/96/128/192/256 kbps should report `cliff_detected =
+   False`**, because all of them select FB bandwidth per the thresholds
+   above.
+2. **`hf_deficit_db` should stay well under `HF_DEFICIT_MARGINAL = 40.0`
+   for 64 kbps and above**, and should *not* shrink monotonically as
+   bitrate rises the way it does for LAME — if it does, the folding
+   mechanism doesn't fully mask the energy differences our slice widths
+   can see, and that's a genuine finding against this doc's prediction.
+3. **A cliff tripped in the 12-20 kHz range should correlate with either
+   (a) an encode bitrate under ~16 kbps** (mode boundary — verify via the
+   file's actual bitrate/VBR average) **or (b) a band-limited upstream
+   source**, not with the music bitrate itself. A genuine music-bitrate
+   (≥64 kbps) Opus file with a clean cliff correlating with *bitrate*
+   rather than *source* would falsify this doc's central claim.
+4. **`estimate_bitrate_from_cliff()` should never be called on an Opus
+   file in practice** — Phase 3's harness should assert this (a
+   fast-failing guard or generated property), not merely document it.
+5. A very-low-bitrate control point (12-16 kbps, voice-ish content) should
+   show a real, reproducible cliff near 12 kHz — the one place this doc
+   predicts the detector's mechanism still corresponds to something real.
+
+## Sources
+
+- `lib/spectral_check.py` (this repo) — the code under calibration.
+- `docs/research/spectral-mp3-lame.md` (this repo) — companion doc, the
+  LAME ladder this doc contrasts Opus against.
+- RFC 6716, "Definition of the Opus Audio Codec" — bandwidth mode table,
+  20 kHz rationale, 48 kHz internal MDCT rate, hybrid crossover at 8 kHz:
+  <https://www.rfc-editor.org/rfc/rfc6716.html>
+- `xiph/opus` source, `src/opus_encoder.c` — `mode_thresholds`, mono/stereo
+  voice/music `*_bandwidth_thresholds`, `compute_equiv_rate()`, default
+  bitrate formula: <https://github.com/xiph/opus/blob/main/src/opus_encoder.c>
+- `xiph/opus` source, `celt/modes.c` — `eband5ms[]` 21-band CELT layout:
+  <https://github.com/xiph/opus/blob/main/celt/modes.c>
+- Opus API docs — `OPUS_SET_BANDWIDTH`/`OPUS_SET_MAX_BANDWIDTH` semantics:
+  <https://opus-codec.org/docs/opus_api-1.5/group__opus__encoderctls.html>
+- Wikipedia, "CELT" — band energy normalization, PVQ, band folding:
+  <https://en.wikipedia.org/wiki/CELT>
+- Xiph mailing list, opus@xiph.org, Jan 2013 ("low pass filter frequency
+  adjustable") — 96 kbps taper 16→20 kHz; Schwartz's 20 kHz reply:
+  <https://lists.xiph.org/pipermail/opus/2013-January/001939.html>
+- XiphWiki, "OpusFAQ" — SILK/CELT/hybrid frequency split, 20 kHz rationale:
+  <https://wiki.xiph.org/OpusFAQ>
+- XiphWiki, "Opus Recommended Settings" — bandwidth-threshold pointer,
+  stereo/mono downmix threshold, complexity default:
+  <https://wiki.xiph.org/Opus_Recommended_Settings>
+- Hydrogenaudio Knowledgebase, "Opus" — bandwidth-by-bitrate progression
+  for music, 64/96/128/160-192 kbps quality characterizations:
+  <https://wiki.hydrogenaudio.org/index.php?title=Opus>
+- FFmpeg documentation, `libopus` encoder options — `cutoff` values,
+  wideband-cutoff-below-15kbps note, VBR/application defaults:
+  <https://ffmpeg.org/ffmpeg-codecs.html>
+- Orpheus and Redacted-lineage interview-prep spectral analysis guides —
+  checked for Opus coverage, found none (MP3-only ladders documented):
+  <https://interview.orpheus.network/spectral-analysis.php>,
+  <https://interviewfor.red/en/spectrals.html>
+- NamuWiki, "Opus (오디오 코덱)" — community criticism of the fixed 20 kHz
+  ceiling; cited only for the structural point that the ceiling doesn't
+  move with bitrate — the "22-23 kHz" remediation claim is unverified:
+  <https://en.namu.wiki/w/Opus(오디오 코덱)> [unverified: numeric claim]

--- a/docs/research/spectral-transcode-detection.md
+++ b/docs/research/spectral-transcode-detection.md
@@ -1,0 +1,340 @@
+# Spectral transcode-detection prior art (issue #829 Phase 0)
+
+What distinguishes a NATIVE low-bitrate encode from a TRANSCODE
+(lossy→lossy or lossy→lossless), beyond a bare frequency cliff. Written
+2026-07-23. Every claim carries an inline source URL; anything
+unverifiable is marked `[unverified]`.
+
+## Summary
+
+The "fake lossless" detection industry — from the 2004 `auCDtect` console
+tool to 2026's browser checkers — converges on the same base signal
+cratedigger already uses: a hard spectral cliff at a codec-characteristic
+frequency (https://m.afterdawn.com/article.cfm/2004/04/06/aucdtect_tool_determines_the_authenticity_of_musical_cd_records,
+https://www.getspectro.app/blog/what-is-fake-lossless-audio). Tools that
+grow past that baseline add secondary signals — rolloff shape, time
+consistency, encoder-family-specific artifacts, and cross-checks against a
+codec's own known table — because the bare cliff alone has two documented
+failure modes: it is blind to a same-codec transcode whose second pass
+re-applies a correct lowpass for its claimed bitrate, and legitimate
+mastering (vinyl rips, cassette transfers, quiet acoustic recordings, some
+encoders' own filter quirks) can look like a lossy cliff
+(https://www.getspectro.app/blog/what-is-fake-lossless-audio,
+https://github.com/Guillain-RDCDE/FLAC_Detective). The forensic/academic
+line (MDCT coefficient statistics, Benford's-law tests) goes further but
+needs bitstream-internal access sox/ffmpeg's PCM-only output cannot give
+(https://link.springer.com/article/10.1007/s12559-010-9045-4).
+
+## What cratedigger does today
+
+`lib/spectral_check.py` slices 12–20 kHz into 500 Hz sox `sinc`+`stat` RMS
+bands, flags a cliff at ≥2 consecutive slices steeper than -12 dB/kHz, and
+maps the cliff frequency through a hard-coded LAME lowpass table to an
+estimated source bitrate; a secondary HF-deficit signal (1–4 kHz reference
+minus the top 4 slices) grades tracks without a detected cliff too. Bare
+cliff + LAME table — no artifact-shape analysis, no time-consistency
+check, no cross-codec table, no distinction between a native low-bitrate
+encode and a transcode landing on the same cliff.
+
+## Tool-by-tool prior art
+
+**Lossless Audio Checker** — AES Convention Paper 9416 (Lacroix, Prime,
+Remy, Derrien, 2015): detects upscaling/upsampling/AAC transcoding in
+lossless containers, validated at "100% success for upscaling and
+transcoding, and 91.3% for upsampling"
+(https://secure.aes.org/forum/pubs/conventions/?elib=17972). A 2019 AES
+Journal follow-up (Derrien, JAES 67(3):116–123) detects AAC quantization
+errors in the time-frequency domain without ML, reporting "null false
+positive ratios and very low false negative ratios" on 1576 files
+(https://www.researchgate.net/publication/331400801_Detection_of_Genuine_Lossless_Audio_Files_Application_to_the_MPEG-AAC_Codec,
+https://hal.science/hal-02055742). Open-source GUI:
+https://github.com/emps/Lossless-Audio-Checker-GUI.
+
+**auCDtect / Tau Analyzer** — searches for "the frequency cut-off... at
+about 18kHz" plus reduced dynamics
+(https://m.afterdawn.com/article.cfm/2004/04/06/aucdtect_tool_determines_the_authenticity_of_musical_cd_records).
+Vendor claims ">95%" accuracy, but independent Head-Fi testing found it
+"detected about 1/10 MP3 to FLAC conversions" and false-positived on a
+legitimate FLAC ("said MPEG with high confidence"), concluding "it doesn't
+do what the AES paper claimed to do"
+(https://www.head-fi.org/threads/fake-flac-identification.826737/).
+Hydrogenaudio hosts several threads specifically about its unreliability
+(https://hydrogenaudio.org/index.php/topic,27910.0.html,
+https://hydrogenaudio.org/index.php/topic,20408.0.html,
+https://hydrogenaudio.org/index.php/topic,60888.msg544600.html); modern
+derivatives use it only as one signal among several
+(https://alessandrocomito.github.io/audiofakedetectorpro/).
+
+**Fakin' the Funk** — Windows DJ batch tool catching 128→320 kbps
+upscales via bitrate/frequency-peak analysis
+(https://fakinthefunk.net/en/); lineage traces to D'Alessandro & Shi, "MP3
+Bit Rate Quality Detection Through Frequency Spectrum Analysis," ACM
+MM&Sec '09, pp. 57–62
+(https://djtechtools.com/2018/01/30/review-fakin-funk-low-bitrate-detection-utility/).
+
+**Spek** — pure spectrogram visualizer, no verdict; FFTW-based, default
+2048-pt FFT, switchable window/size — the substrate for classic
+Hydrogenaudio-style manual inspection
+(https://deepwiki.com/alexkay/spek/1.2-using-spek, https://www.spek.cc/).
+
+**Modern browser tools** (brizm.dev, LosslessRadar, Fabl, Audio Fake
+Detector PRO) operationalize the same lore. brizm's checker is the most
+explicit public multi-signal write-up: 4096-pt FFT/Hann window, then a
+"6-signal scoring system analyzing gradient sharpness, noise floor above
+cutoff, spectral sparsity, cutoff variance, intensity stereo correlation,
+and cutoff position against known codec signatures"
+(https://brizm.dev/lossless-audio-checker/). Audio Fake Detector PRO scans
+segments "via a GDI+ LockBits spectrogram for high-frequency cutoff
+behaviour, roll-off ratio, peak energy, and anomaly flags," classifying
+≤16.5 kHz as FAKE and 16.5–18.5 kHz as SUSPECT, with majority voting plus
+auCDtect as an extra signal (https://alessandrocomito.github.io/audiofakedetectorpro/).
+
+**FLAC_Detective** (Guillain-RDCDE) — open-source CLI/API/beets-plugin,
+"11-rule spectral analysis plus an optional CNN classifier," grouped as
+cutoff-frequency detection, MP3-bitrate signature matching, and
+compression-artifact checks, plus protection rules "so genuine vinyl
+rips, cassette transfers and naturally quiet recordings aren't flagged"
+(https://github.com/Guillain-RDCDE/FLAC_Detective). Score bands: ≤30
+authentic, 31–54 warning, 55–85 suspicious, ≥86 fake_certain; the optional
+CNN rule raised specificity from 80% to 95% on 11,234 authentic FLACs per
+the project's own case study (same URL). Per-rule thresholds live in a
+linked technical-details doc this survey could not fetch
+`[unverified — not retrievable via WebFetch]`.
+
+**Forensic MDCT-coefficient line** — detects double compression (any
+recompression, even same-format/same-bitrate) via quantized-MDCT
+statistics: Benford's-law distributions (Yang, Shi, Huang — first such
+work, SVM) (https://digitalcommons.njit.edu/fac_pubs/6316/); a 2015
+"Difference of Calibration Histogram" method tested on ~13,830 files
+(https://link.springer.com/article/10.1007/s11042-015-2758-3); Bianchi et
+al.'s method, comparing against a *simulated* singly-compressed reference
+derived from the file itself, which can localize which portion was
+recompressed
+(https://jis-eurasipjournals.springeropen.com/articles/10.1186/1687-417X-2014-10);
+and an AAC scale-factor-difference extension
+(https://www.researchgate.net/publication/326140876_AAC_Double_Compression_Audio_Detection_Algorithm_Based_on_the_Difference_of_Scale_Factor).
+All need quantized transform coefficients from inside the bitstream — not
+exposed by sox/ffmpeg's PCM output — so these are forensic-grade, not
+deployable with our tool stack.
+
+**ML/CNN line** — Seichter et al.'s CNN for AAC bitrate detection
+(https://www.researchgate.net/publication/303590383_AAC_encoding_detection_and_bitrate_estimation_using_a_convolutional_neural_network);
+Deezer's Hennequin et al. (ICASSP), codec-independent, observing "lossy
+compression leaves traces in the spectrogram... namely holes, band
+frequency cuts, and clusters," 92.4% accuracy in a follow-up
+(https://research.deezer.com/publication/2017/04/05/icassp-hennequin.html,
+https://ieeexplore.ieee.org/iel7/7943262/7951776/07952251.pdf). Koops et
+al. 2024 found naive training "obtain[s] near perfect... test set
+[performance], but severely degraded performance on... codec parameters
+not seen in training" because models "rel[y] solely on the training set's
+codec cutoff frequency," fixed via random spectrogram masking
+(https://arxiv.org/pdf/2407.21545). This warns directly against a
+hand-tuned table that only covers LAME's bitrate/lowpass pairs.
+
+## The fingerprint catalogue
+
+What it looks like / cause / sox-ffmpeg computability, for each signature.
+
+1. **Bare frequency cliff** (cratedigger today) — steep dB/kHz drop at a
+   codec-characteristic frequency, from the encoder's lowpass or
+   psychoacoustic model discarding inaudible HF content
+   (https://wiki.hydrogenaudio.org/index.php?title=Spectrogram). Already
+   implemented via `detect_cliff`.
+
+2. **sfb21 "spray"/"bloat"** — noise-like smear just above 16 kHz, LAME
+   MP3 `-V0`–`-V2` without `-Y`/lowpass, because MP3 has no scale-factor
+   band above ~16 kHz, forcing inefficient bit spend there
+   (https://wiki.themixingbowl.org/LAME, https://news.ycombinator.com/item?id=37850250).
+   Computable: finer slices (<500 Hz) across 15.5–17 kHz looking for a
+   local energy *bump* vs. neighbors, not a monotonic rolloff.
+
+3. **Double lowpass / stacked shelves** — two distinct cliffs: a lower one
+   from an original lossy encode, a higher one from a second pass. Not a
+   formally-named artifact in the sources surveyed, but the direct
+   consequence of the "holes, band frequency cuts, and clusters" Deezer's
+   paper describes for cascaded compression
+   (https://research.deezer.com/publication/2017/04/05/icassp-hennequin.html)
+   `[cascade framing verified via that paper; the "double lowpass" label
+   itself is unverified against a primary source]`. Computable: extend
+   `detect_cliff` over the full spectrum and report every cliff found.
+
+4. **SBR mirror/replication artifact (HE-AAC)** — high frequencies
+   transposed up from low/mid bands via a QMF bank rather than coded
+   directly (https://en.wikipedia.org/wiki/Spectral_band_replication),
+   producing a textured band, softer/gradual at higher bitrates rather
+   than a flat cliff
+   (https://www.getspectro.app/blog/how-to-detect-fake-lossless)
+   `[perceptual "watery" framing unverified against a primary source]`.
+   NOT cheap with sox `stat` RMS bands — needs cross-correlation between
+   the low band and transposed high band (real FFT-bin data). Research-
+   grade, not near-term deployable.
+
+5. **Spectral holes/clusters above the shelf** — localized dropouts
+   rather than a uniformly flat floor, per Deezer's own description of
+   what its CNN keys on
+   (https://research.deezer.com/publication/2017/04/05/icassp-hennequin.html).
+   Computable as variance/non-monotonicity across top slices instead of
+   collapsing to one average (as `avg_hf_db` does today).
+
+6. **Noise-floor character above cutoff** — true digital silence (flat,
+   near-floor) means "encoder cut it, nothing there"; a low structured
+   noise/dither tail means a genuine recording
+   (https://brizm.dev/lossless-audio-checker/). Computable via variance
+   across the topmost 2–3 slices, not just their mean — a full flatness
+   measure needs real FFT bins, which band-summed RMS collapses away.
+
+7. **Cutoff consistency across time** — an encoder's lowpass is
+   time-invariant; a natural rolloff shifts slightly with the material
+   (https://brizm.dev/lossless-audio-checker/). **Cratedigger's single
+   30-second trim can't see this** — needs the cliff/HF-deficit computed
+   on multiple windows across the track and compared for invariance.
+
+8. **Intensity-stereo / joint-stereo correlation** — joint-stereo coding
+   forces mid/side correlation above a threshold, deviating from natural
+   decorrelation (https://brizm.dev/lossless-audio-checker/). Computable
+   via sox M/S `remix` + HF-band correlation; moderate added cost over
+   the current mono-collapsing pipeline.
+
+9. **Pre-echo / transient backward smear** — MDCT quantization noise
+   spreads backward from a transient within a coding block, because
+   transient energy spans many frequencies, forcing low-bit quantization
+   whose noise smears across the block on decode
+   (https://en.wikipedia.org/wiki/Pre-echo). NOT sox-alone computable —
+   needs onset detection plus short-window, time-localized comparison; a
+   different analysis shape than whole-track averaging.
+
+10. **MDCT double-quantization statistics** (Benford's law, calibration
+    histograms) — see the forensic line above
+    (https://digitalcommons.njit.edu/fac_pubs/6316/). Needs quantized
+    transform coefficients from inside the bitstream; sox/ffmpeg expose
+    PCM only. Out of scope for a sox/ffmpeg-based Phase 3.
+
+11. **Cutoff-vs-declared-codec mismatch** — the cliff sits where a
+    *different* codec's/bitrate's table says it should, not the file's
+    own claimed codec (e.g. AAC-256 that cliffs where MP3-128 cliffs) —
+    the cascaded-compression tell: "an AAC file transcoded from an MP3
+    source would typically show the MP3's original lower cutoff... rather
+    than AAC's characteristic behavior"
+    (https://research.deezer.com/publication/2017/04/05/icassp-hennequin.html,
+    https://arxiv.org/pdf/2511.11527). Directly computable from
+    cratedigger's existing `cliff_freq_hz` plus the file's real
+    container/codec cross-checked against per-codec tables — cratedigger
+    has only ONE table today (LAME's), so it can only detect
+    "MP3-shaped," never "wrong-codec-shaped."
+
+12. **Per-codec natural spectral envelope shape** — each codec's
+    loudness-reduction-before-cliff shape differs: MP3-320/MP3-128
+    "elevate the loudness of the entire frequency range before cutoff
+    occurs at 18 kHz and 15 kHz respectively, while AAC CBR 256 kbps
+    loudness reduction happens much earlier... around 7 kHz... AAC VBR
+    level 5 loudness closely matches... FLAC" (https://arxiv.org/pdf/2511.11527).
+    Computable with existing band-RMS machinery but needs per-codec
+    reference curves, not one reference-band-vs-HF comparison applied
+    uniformly — this IS "per-codec spectral calibration."
+
+## Within-codec native-vs-transcode analysis
+
+**Same codec, same nominal target** (native 128 kbps MP3 vs. a 96 kbps
+MP3 transcoded up and re-tagged 128): if the transcoder re-applies a
+correct lowpass for the claimed target, the cliff sits at the SAME
+frequency either way. LAME's table is public and deterministic — a
+SourceForge bug report's `lame.c` excerpt shows `{192,18600}`,
+`{224,19400}`, `{256,19700}`, `{320,20500}`
+(https://sourceforge.net/p/lame/bugs/492/), matching cratedigger's own
+`LAME_LOWPASS` exactly for those four bitrates. So **the bare
+cliff-position test is fundamentally blind to a well-executed same-codec
+re-encode** — cratedigger cannot tell "native 128" from "96, cleanly
+re-lowpassed to 128's cutoff." Distinguishing signals here are NOT cliff
+position: a residual lower shelf if the transcoder's lowpass was looser
+than ideal (#3); sfb21-style irregularities inconsistent with a genuine
+single-generation encode (#2); and, at the forensic tier, MDCT coefficient
+statistics that differ between single- and double-quantized signals even
+at a matching nominal cutoff (https://digitalcommons.njit.edu/fac_pubs/6316/).
+Time-invariance (#7) doesn't disambiguate this case either — both a
+native and a clean re-encode have a time-invariant cliff.
+
+**Cross-codec** (MP3-128 source transcoded into AAC-256): here the cliff
+DOES betray the source, because AAC-256's natural shape doesn't cliff
+sharply in the 15–17 kHz range the way MP3-128 does — its loudness
+reduction starts earlier (~7 kHz) but gradually
+(https://arxiv.org/pdf/2511.11527). An AAC-tagged file showing an
+MP3-128-shaped hard cliff at ~17 kHz is a strong, cheap "wrong codec's
+fingerprint" tell (#11) — the most reliable and least expensive
+native-vs-transcode signal surveyed, but it needs more than one codec's
+table, which cratedigger lacks today.
+
+**Lossy → lossless** (cratedigger's actual importer scenario: verifying
+an alleged FLAC is genuinely lossless) is the easiest case, and the one
+the current cliff detector is already built for — genuine lossless has no
+codec-imposed cliff at all, so any clean, time-invariant, table-matching
+cliff is itself the red flag, with no "which codec's shape is this"
+ambiguity to resolve.
+
+## What's deployable for cratedigger — ranked shortlist
+
+1. **Multi-window cliff-consistency check** (#7) — reuses existing sox
+   band-RMS machinery entirely; run the same slicing over N windows
+   across the track instead of one 30s trim, check invariance. Highest
+   value-for-effort: no new sox invocation shape, just a loop + compare.
+2. **Per-codec cutoff-and-shape table cross-check** (#11/#12) — the
+   highest-leverage Phase-0 item and literally what "per-codec spectral
+   calibration" means: build a table per codec (not only LAME) of
+   cutoff-vs-bitrate AND pre-cliff loudness shape, cross-check the file's
+   actual codec against ALL tables, flag cross-codec mismatches.
+3. **Full-spectrum multi-cliff scan** (#3) — extend `detect_cliff` to the
+   full spectrum, return every cliff found; answers "cascaded through two
+   lossy passes," which the current single-cliff detector cannot
+   represent even in principle.
+4. **HF noise-floor variance, not just mean** (#6) — cheap addition:
+   variance across the topmost 2–3 slices alongside their average, to
+   separate a hard digital floor from a low structured noise tail.
+5. **sfb21 bump detector** (#2) — narrow 15.5–17 kHz local-bump check vs.
+   neighbors; closes a named false-negative gap (un-lowpassed LAME
+   `-V0`–`-V2`) a pure-cliff approach misses by construction.
+6. **Stereo mid/side correlation above cutoff** (#8) — moderate added
+   cost (M/S remix step); useful secondary signal, lower priority than
+   1–5.
+
+**Not deployable near-term:** SBR-mirror cross-correlation (#4) and
+pre-echo/transient smear (#9) need real FFT-bin or time-localized
+analysis, not sox `stat` band-RMS; MDCT/Benford's-law statistics (#10)
+need bitstream-internal access sox/ffmpeg can't provide. Record as a
+follow-up research spike only if the Phase 3 calibration corpus shows
+residual false negatives the deployable set can't explain — don't build
+speculatively now.
+
+## Sources
+
+- https://secure.aes.org/forum/pubs/conventions/?elib=17972
+- https://github.com/emps/Lossless-Audio-Checker-GUI
+- https://www.researchgate.net/publication/331400801_Detection_of_Genuine_Lossless_Audio_Files_Application_to_the_MPEG-AAC_Codec
+- https://hal.science/hal-02055742
+- https://m.afterdawn.com/article.cfm/2004/04/06/aucdtect_tool_determines_the_authenticity_of_musical_cd_records
+- https://www.head-fi.org/threads/fake-flac-identification.826737/
+- https://hydrogenaudio.org/index.php/topic,27910.0.html
+- https://hydrogenaudio.org/index.php/topic,20408.0.html
+- https://hydrogenaudio.org/index.php/topic,60888.msg544600.html
+- https://fakinthefunk.net/en/
+- https://djtechtools.com/2018/01/30/review-fakin-funk-low-bitrate-detection-utility/
+- https://deepwiki.com/alexkay/spek/1.2-using-spek
+- https://www.spek.cc/
+- https://brizm.dev/lossless-audio-checker/
+- https://www.getspectro.app/blog/what-is-fake-lossless-audio
+- https://www.getspectro.app/blog/how-to-detect-fake-lossless
+- https://alessandrocomito.github.io/audiofakedetectorpro/
+- https://github.com/Guillain-RDCDE/FLAC_Detective
+- https://wiki.themixingbowl.org/LAME
+- https://news.ycombinator.com/item?id=37850250
+- https://wiki.hydrogenaudio.org/index.php?title=Spectrogram
+- https://sourceforge.net/p/lame/bugs/492/
+- https://en.wikipedia.org/wiki/Spectral_band_replication
+- https://en.wikipedia.org/wiki/Pre-echo
+- https://research.deezer.com/publication/2017/04/05/icassp-hennequin.html
+- https://ieeexplore.ieee.org/iel7/7943262/7951776/07952251.pdf
+- https://arxiv.org/pdf/2407.21545
+- https://arxiv.org/pdf/2511.11527
+- https://digitalcommons.njit.edu/fac_pubs/6316/
+- https://link.springer.com/article/10.1007/s11042-015-2758-3
+- https://jis-eurasipjournals.springeropen.com/articles/10.1186/1687-417X-2014-10
+- https://www.researchgate.net/publication/326140876_AAC_Double_Compression_Audio_Detection_Algorithm_Based_on_the_Difference_of_Scale_Factor
+- https://www.researchgate.net/publication/303590383_AAC_encoding_detection_and_bitrate_estimation_using_a_convolutional_neural_network

--- a/docs/research/spectral-vorbis.md
+++ b/docs/research/spectral-vorbis.md
@@ -1,0 +1,315 @@
+# Spectral calibration research: Vorbis
+
+Issue #829 Phase 0. Cratedigger's cliff detector (`lib/spectral_check.py`)
+was built and tuned against LAME's lowpass ladder (`LAME_LOWPASS`, 8 rows,
+96-320 kbps). Vorbis (`.ogg`) is a real Soulseek population — old game
+rips, Spotify-stream rips, and legacy YouTube DASH audio all circulate as
+native Vorbis — and none of it goes through an encoder whose ladder we've
+checked. This doc pins down libvorbis's/aoTuV's actual quality-level
+lowpass table from source, compares it against our LAME-shaped bucket
+math, and sizes the risk.
+
+## Summary
+
+- **libvorbis has its own explicit, per-quality-level hard lowpass table**
+  (`_psy_lowpass_44` in `xiph/vorbis/lib/modes/psych_44.h`), just like LAME's
+  `freq_map[]`. It only applies at low/mid quality — from **q6 (~192 kbps)
+  upward, reference libvorbis imposes NO artificial lowpass at all**
+  (sentinel `999.`, "unbounded, limited only by source/Nyquist"). This is
+  the biggest structural difference from LAME, which keeps trimming right
+  up through its top 320 kbps row (20.5 kHz).
+- **aoTuV's tuning is not as separate from "reference" as the branding
+  suggests.** Its Beta2-era changes were merged into mainline libvorbis
+  1.1 (2004), and further aoTuV work was merged again from libvorbis 1.3.4
+  onward (<https://en.wikipedia.org/wiki/Vorbis>). `xiph/vorbis` `master`
+  today already carries aoTuV DNA; a direct source diff (below) shows
+  aoTuV's *current* fork is still 0.4-0.9 kHz more conservative than
+  reference at q0/q4/q5, but both ladders share the same nominal-bitrate
+  steps and both go uncapped at the same point (q6+).
+- **Spotify is a real, identifiable Vorbis population on Soulseek**, via
+  tools that dump Spotify's raw stream unmodified (Zotify, Soggfy) —
+  Free/Normal ≈ 160 kbps (`-q5`), Premium/Very-High ≈ 320 kbps (`-q9`),
+  independently measured by SoundExpert at ~151 kbps and ~313 kbps.
+  `-q9`/320 kbps is squarely in libvorbis's no-lowpass zone.
+- **Our slice window may not cover the one Vorbis cutoff most likely to
+  appear in the wild.** Reference libvorbis q5 (~160 kbps, Spotify's
+  free/normal tier) cuts at **20.1 kHz** — past `SLICE_FREQS`'s last band
+  (19500-20000 Hz). A genuine 160 kbps Spotify rip could plausibly show
+  **no cliff at all**, not because it's transparent, but because our
+  window ends ~100 Hz short of libvorbis's own filter. aoTuV's q5
+  (19.5 kHz) lands just inside the window; reference's doesn't. This is
+  the sharpest, most testable finding here.
+- **Where a Vorbis cliff IS caught, mapping it through `LAME_LOWPASS`
+  systematically overestimates quality**, because Vorbis preserves more
+  high-frequency content per kbps than LAME at matched nominal bitrates.
+  This isn't cosmetic: `lib/quality/compare.py` folds
+  `spectral_bitrate_kbps` into rank comparison via `mp3_cbr` band
+  thresholds (128=acceptable, 192=good, 256=excellent, 320=transparent).
+  A lawfully-cliffed Vorbis file can read as "transparent" under those
+  bands when its true source was materially worse.
+- Managed/streaming (ABR) mode reuses the same baseline quality tables
+  internally, so the VBR predictions below should transfer to Spotify's
+  presumed managed-bitrate delivery — but bit-reservoir constraints can
+  still shift the *effective* per-passage cutoff, which one fixed
+  30-second window won't average out reliably.
+
+## Encoder landscape: libvorbis, aoTuV, and Spotify
+
+**Reference libvorbis.** `xiph/vorbis/lib/vorbisenc.c` (`vorbis_encode_setup_vbr`/
+`_managed` → `vorbis_encode_setup_init`) drives everything off
+per-samplerate `ve_setup_data_template` structs (`xiph/vorbis/lib/modes/setup_44.h`
+for 44.1/48 kHz), built from a `quality_mapping` array of quality floats
+and a matching `psy_lowpass` array —
+<https://raw.githubusercontent.com/xiph/vorbis/master/lib/vorbisenc.c>,
+<https://raw.githubusercontent.com/xiph/vorbis/master/lib/modes/setup_44.h>.
+This is the codec behind `ffmpeg -c:a libvorbis` and most modern Linux
+`oggenc` installs — anywhere the tool doesn't call out a "tuned" variant.
+
+**aoTuV.** Aoyumi's fork, "based on Xiph.Org's libvorbis," improves
+coding quality mainly via the psychoacoustic model
+(`aotuv_hf_weighting` in `psy.c`) and bitrate allocation
+(<https://hydrogenaudio.org/index.php/topic,72797.0.html>). Beta2-era
+work merged into libvorbis 1.1 in 2004 (commit "Put AoTuV tunings merge
+(along with bugfixes) on the mainline" —
+<https://github.com/xiph/vorbis/commit/50c1cc2d20>); later merges landed
+from 1.3.4 onward (<https://en.wikipedia.org/wiki/Vorbis>). Later betas
+(b3 through the long-lived b6.03, "based on libvorbis 1.3.2," refreshed
+against 1.3.4-1.3.7 through 2021) were never folded back —
+<https://ao-yumi.github.io/aotuv_web/>. aoTuV b4.51 ("Release 1",
+recommended through mid-2007) and b5/b6.x were the Hydrogenaudio
+default for most of Vorbis's enthusiast era —
+<https://wiki.hydrogenaudio.org/index.php?title=Recommended_Ogg_Vorbis>.
+`oggenc2.exe` bundled aoTuV-tuned libvorbis and was the standard
+command-line frontend for scene/enthusiast rips; some scene command
+lines **disabled the lowpass filter entirely**
+(`--advanced-encode-option lowpass_frequency=99`, the documented API
+disable value — see managed-bitrate section) —
+<https://forum.dbpoweramp.com/forum/other-topics/developers-corner/10112-ogg-vorbis-lancer-20060131-release>.
+A no-lowpass low-bitrate Vorbis file is real in the wild, not a
+theoretical edge case. Full aoTuV source:
+<https://github.com/AO-Yumi/vorbis_aotuv>; a "Lancer" patch set on top
+(piping/threading fixes only, no psychoacoustic changes) also circulated:
+<https://github.com/enzo1982/vorbis-aotuv-lancer>. Vorbis was also a
+common in-game audio codec (FMOD/Wwise-era titles bundled `.ogg` assets
+directly); scene rippers of games and CDs alike used this same
+oggenc2+aoTuV tooling.
+
+**Spotify.** Spotify's own support material (quoted verbatim across
+multiple threads) lists three Vorbis quality ratings: "q3 (~96 kbps) ...
+q5 (~160 kbps) ... q9 (~320 kbps)" — secondary-sourced, not independently
+re-verified against a live Spotify page here, so treat the exact
+q3/q2 low-tier mapping as **[unverified]**. The q5/q9 tiers are
+corroborated independently: SoundExpert measured Spotify's actual stream
+at "Vorbis VBR at 151.1 kbps" (free) and "313.4 kbps" (premium) using
+"Xiph's libvorbis 1.3.1 encoder" —
+<http://soundexpert.org/articles/-/blogs/spotify-uses-vorbis-q5-and-q9-for-audio-streaming>.
+Wikipedia's Vorbis page separately notes "The Spotify audio streaming
+service primarily uses Vorbis as well as AAC"
+(<https://en.wikipedia.org/wiki/Vorbis>). Two tools capture the *exact,
+unmodified* Spotify Vorbis stream (not a re-encode) — the direct source
+of any "Spotify rip" `.ogg` a peer might share: **Zotify** ("Free
+accounts are limited to 160kbps, while premium accounts can get up to
+320kbps," native format Ogg Vorbis —
+<https://github.com/zotify-dev/zotify>) and **Soggfy** (intercepts
+Spotify's own OGG parser during playback for "an exact copy of the
+original file... with no loss in quality"; "160Kb/s or 320Kb/s for free
+and premium plans" — <https://github.com/Rafiuth/Soggfy>).
+
+**Legacy YouTube DASH audio.** Before YouTube standardized on Opus,
+webm DASH audio-only streams were served as Vorbis under itag **171**
+(128 kbps) — confirmed in a live `youtube-dl -F` listing quoted in an
+upstream issue: "171 webm audio only DASH audio 162k, vorbis@128k,
+2.53MiB" — <https://github.com/ytdl-org/youtube-dl/issues/21509>. A
+paired higher-bitrate itag **172** also existed; sources disagree on its
+exact rate (192 vs. 256 kbps quoted in different tables) — mark that
+number **[unverified]**; itag 171 = 128 kbps Vorbis is solid. Relevant
+because cratedigger's YouTube rescue-ingest path pulls audio via
+`yt-dlp`, and a sufficiently old cached stream could still hand back one
+of these itags rather than Opus/AAC.
+
+## Quality-level lowpass ladder (source-verified)
+
+`xiph/vorbis/lib/modes/psych_44.h::_psy_lowpass_44` (reference libvorbis, current
+`master` — <https://raw.githubusercontent.com/xiph/vorbis/master/lib/modes/psych_44.h>)
+and the matching array in AO-Yumi's aoTuV mirror
+(<https://raw.githubusercontent.com/AO-Yumi/vorbis_aotuv/master/lib/modes/psych_44.h>),
+indexed against each project's own `quality_mapping_44`/
+`rate_mapping_44_stereo` in `setup_44.h`. The stereo nominal-bitrate
+ladder (halve the raw `rate_mapping` array — it's stored
+per-channel-equivalent — for the commonly quoted stereo figure) is
+**identical** between reference and aoTuV from q-1 upward; only the
+lowpass column and aoTuV's extra q-2 step differ:
+
+| `-q` | nominal avg bitrate (stereo) | reference libvorbis lowpass | aoTuV lowpass |
+|---|---|---|---|
+| -2 | ~32 kbps | *(unsupported)* | 12.9 kHz |
+| -1 | ~45 kbps (aoTuV: ~48) | 13.9 kHz | 13.8 kHz |
+| 0 | ~64 kbps | 15.1 kHz | 14.7 kHz |
+| 1 | ~80 kbps | 15.8 kHz | 15.6 kHz |
+| 2 | ~96 kbps | 16.5 kHz | 16.5 kHz |
+| 3 | ~112 kbps | 17.2 kHz | 17.1 kHz |
+| 4 | ~128 kbps | 18.9 kHz | 18.0 kHz |
+| 5 | ~160 kbps | **20.1 kHz** | 19.5 kHz |
+| 6 | ~192 kbps | no cap (`48.` sentinel) | no cap |
+| 7 | ~224 kbps | no cap (`999.`) | no cap |
+| 8 | ~256 kbps | no cap | no cap |
+| 9 | ~320 kbps | no cap | no cap |
+| 10 | ~500 kbps | no cap | no cap |
+
+Wikipedia independently cites the same 45-500 kbit/s stereo ladder for
+`-q-1`..`-q10` (<https://en.wikipedia.org/wiki/Vorbis>), and Hydrogenaudio
+separately confirms the aoTuV-b3+-vs-reference 45/48 kbps split at `-q-1`
+(<https://wiki.hydrogenaudio.org/index.php?title=Recommended_Ogg_Vorbis>)
+— both cross-check the source extraction above.
+
+Two structural notes for calibration: the "no cap" rows use two
+different sentinel values (`48.` at q6, `999.` from q7 up) in both
+forks' source, but both exceed any real 44.1/48 kHz Nyquist —
+functionally both just mean "no encoder-imposed lowpass." And
+`_psy_lowpass_44`'s own source comment shows the *previous* table
+(11 values, no q-1 row) — the ladder has moved over time even within
+"reference," so a pre-1.1 (pre-2004) build could differ. Low real-world
+risk: 1.1 shipped in 2004 and essentially nothing still circulating
+predates it.
+
+## Managed-bitrate nuances
+
+Vorbis is natively VBR-by-quality (`vorbis_encode_setup_vbr`): request a
+quality float, bitrate floats freely. **Managed mode**
+(`vorbis_encode_setup_managed`, used for streaming) instead takes
+explicit min/nominal/max bitrate targets — nominal-only yields ABR-like
+behavior, min=nominal=max forces CBR —
+<https://xiph.org/vorbis/doc/vorbisenc/vorbis_encode_setup_managed.html>.
+Internally, managed setup still selects its baseline lowpass by locating
+the requested bitrate against the *same* `rate_mapping`/
+`quality_mapping` tables (`vorbisenc.c` ~lines 880-890: `hi->lowpass_kHz
+= setup->psy_lowpass[is]*(1.-ds) + setup->psy_lowpass[is+1]*ds`,
+interpolated from the nearest baseline) —
+<https://raw.githubusercontent.com/xiph/vorbis/master/lib/vorbisenc.c>.
+A managed 160 kbps stream should therefore land on essentially the same
+lowpass as native `-q5` VBR — the ladder above should transfer to
+Spotify-style ABR delivery, not just command-line `-q` encodes.
+
+Two caveats for Phase 3: (1) **bit-reservoir pressure can still bite
+locally** — `bitrate_reservoir`/`bitrate_av_damp` let short-term bitrate
+deviate from the average, so a transient-dense passage could get a
+tighter cutoff than the nominal-bitrate row predicts, a sparse one a
+looser one; our fixed 30-second window samples one point in that
+variation, not the track as a whole. (2) **the explicit override is real
+and used** — `OV_ECTL_LOWPASS_SET` clamps to `[2, 99]` kHz, and 99 is the
+documented way to disable the filter entirely (`vorbisenc.c` ~lines
+1165-1172), exposed via `oggenc --advanced-encode-option
+lowpass_frequency=` and used by scene groups (cited above). Cutoff
+absence is no more proof of quality for Vorbis than for LAME's own
+`--lowpass -1`.
+
+## Where the LAME table misreads Vorbis
+
+`estimate_bitrate_from_cliff()` (`lib/spectral_check.py:132-156`) buckets
+any detected `cliff_freq_hz` against `LAME_LOWPASS`'s midpoints
+(96/112/128/160/192/224/256/320 kbps at 15100/15600/17000/17500/18600/
+19400/19700/20500 Hz). Feeding genuine Vorbis cliffs from the table above
+through that same bucket math:
+
+| Genuine Vorbis source | Real cliff | LAME-bucket estimate | Error |
+|---|---|---|---|
+| aoTuV q-2, ~32 kbps | 12.9 kHz | 96 kbps (floor bucket) | **+200%** |
+| reference q-1, ~45 kbps | 13.9 kHz | 96 kbps | **+113%** |
+| reference q0, ~64 kbps | 15.1 kHz | 96 kbps | **+50%** |
+| reference q2, ~96 kbps | 16.5 kHz | 128 kbps | +33% |
+| reference q3, ~112 kbps | 17.2 kHz | 128 kbps | +14% |
+| aoTuV q4, ~128 kbps | 18.0 kHz | 160 kbps | +25% |
+| reference q4, ~128 kbps | 18.9 kHz | 192 kbps | +50% |
+| aoTuV q5, ~160 kbps | 19.5 kHz | 256 kbps | +60% |
+| reference q5, ~160 kbps | 20.1 kHz | **no cliff in-window** | undefined |
+| reference/aoTuV q6+, ≥192 kbps | none (uncapped) | no cliff → genuine | correct |
+
+Every case where a cliff *is* detected reads as a substantially higher
+LAME-equivalent bitrate than the true source, because Vorbis preserves
+more top-end per kbps than LAME at matched nominal bitrates — the same
+efficiency gap that makes Vorbis generally regarded the stronger codec at
+a given size. One-directional bias, not noise.
+
+**The q5/160 kbps row is the sharpest concrete example**, because it's
+also the single most likely real-world Vorbis population (Spotify
+Normal/Free via Zotify/Soggfy, or any native `-q5` rip). `SLICE_FREQS`
+stops at `19500-20000` Hz (`range(12000, 20000, 500)`); reference
+libvorbis's own q5 cutoff, 20.1 kHz, sits *past* that window.
+`detect_cliff()` needs two consecutive steep-gradient slices
+(`MIN_CLIFF_SLICES = 2`) fully inside the measured range to fire — if the
+real drop only begins at/after 20 kHz, the last slice pair may show only
+the leading edge, not enough to trip `CLIFF_THRESHOLD_DB_PER_KHZ =
+-12.0`. A genuine 160 kbps Spotify-sourced `.ogg` could plausibly score
+`genuine` — not because it's transparent, but because our detector can't
+see that far.
+
+**This is decision-relevant, not cosmetic.** `lib/quality/compare.py`
+folds a detected `spectral_bitrate_kbps` into rank comparison as a clamp
+bound, calibrated against `QualityRankConfig.mp3_cbr`'s bands
+("128=acceptable, 192=good, 256=excellent, 320=transparent" —
+`lib/quality/compare.py` docstring, ~lines 160-165). A real aoTuV q5
+(160 kbps) file with a genuinely-detected 19.5 kHz cliff buckets to
+**256 kbps ("excellent")**; a file dodging detection entirely (the
+reference q5/20.1 kHz case) skips the clamp and keeps whatever rank its
+tag metadata implies. Either way, the pipeline can end up treating a
+160 kbps lossy Vorbis source as materially better than it is when
+comparing it against a replacement candidate.
+
+## Implications for calibration
+
+A dedicated Vorbis lowpass ladder is viable and cheap to build — the
+numbers above are direct source extractions, not estimates, and the
+reference-vs-aoTuV spread is small (≤0.9 kHz) everywhere both forks
+overlap. Three things make it more than "swap in a second lookup table":
+
+1. **`estimate_bitrate_from_cliff()` has no codec awareness** — called
+   with only a frequency, no encoder hint. A Vorbis-specific bucket table
+   needs something upstream to know "this cliff came from an `.ogg`
+   source"; the extension is known at `analyze_track()` time but isn't
+   threaded through to the estimator.
+2. **The dangerous gap is the missed-cliff risk at q5/160 kbps** — the
+   most common real-world tier — because our slice window ends at 20 kHz
+   while reference libvorbis's own filter sits at 20.1 kHz. Extending
+   `SLICE_FREQS` by one more 500 Hz slice (to 20500) closes this
+   specific gap regardless of whether a full ladder ships.
+3. **q6+ (≥192 kbps) is a real "no signal" zone for cliff detection** in
+   Vorbis specifically (LAME keeps a real filter through 320). Any
+   Vorbis judgment above ~160 kbps must rely on `hf_deficit_db`/natural
+   rolloff shape, not `detect_cliff()` — worth confirming in Phase 3
+   whether genuine q6-q10 Vorbis ever trips a false "marginal" on
+   `hf_deficit_db` alone (smooth psychoacoustic attenuation without a
+   hard wall could plausibly cross `HF_DEFICIT_MARGINAL = 40.0` dB on
+   fine material — needs real files, not source-reading, to answer).
+
+## Predictions for Phase 3 (testable)
+
+| Source | Expected cliff (Hz) | Our bucket → estimate today | Prediction holds if... |
+|---|---|---|---|
+| Reference libvorbis `-q0` (~64 kbps) | ~15100 (±300) | <15400 → 96 | Cliff lands 14800-15400 Hz; estimate reads 96, not 64 |
+| Reference libvorbis `-q2` (~96 kbps) | ~16500 | 15400-17250 → 128 | Cliff lands 16200-16800 Hz |
+| Reference libvorbis `-q4` (~128 kbps) | ~18900 | 18050-19000 → 192 | Cliff lands 18600-19200 Hz |
+| aoTuV `-q4` (~128 kbps, oggenc2/aoTuV b4.51+ rip) | ~18000 | <18050 → 160 | Cliff lands 17700-18300 Hz — **aoTuV and reference land in different buckets at the identical nominal bitrate** |
+| Reference libvorbis `-q5` / Spotify Normal (~160 kbps) | ~20100 | **likely no cliff** (past window) | **Headline test**: feed a known-160-kbps reference-libvorbis or Spotify-Normal `.ogg` through `analyze_track`; if it grades `genuine` with `cliff_detected=False`, that confirms the window gap and justifies extending `SLICE_FREQS` |
+| aoTuV `-q5` / oggenc2 rip (~160 kbps) | ~19500 | 19000-19550 → 256 | Cliff lands 19200-19800 Hz — just inside the window; noisier detection than reference |
+| Spotify Premium / Zotify/Soggfy Very-High (~320 kbps, `-q9`) | none (uncapped) | no cliff → `genuine` | Correct if confirmed — verify it isn't landing as a false cliff from container/decode artifacts |
+| Legacy YouTube itag 171 (128 kbps Vorbis, webm) | ~18900 (reference) or ~18000 (if aoTuV-tuned) | 18050-19000 → 192, or <18050 → 160 | If `yt-dlp` ever hands back this itag on an old cached stream, same reference-vs-aoTuV bucket ambiguity as the `-q4` row applies |
+| Scene rip with `lowpass_frequency=99` (disabled) | none, regardless of bitrate | no cliff → `genuine` | A deliberately low-bitrate (e.g. `-q0`, ~64 kbps) file reads genuine purely because the encoder-side filter was off — same blind-spot class as LAME's `--lowpass -1` |
+
+## Sources
+
+- This repo: `lib/spectral_check.py`, `lib/quality/compare.py`, `docs/quality-ranks.md`.
+- libvorbis source, `master`, retrieved 2026-07-23: <https://raw.githubusercontent.com/xiph/vorbis/master/lib/vorbisenc.c>, <https://raw.githubusercontent.com/xiph/vorbis/master/lib/modes/setup_44.h>, <https://raw.githubusercontent.com/xiph/vorbis/master/lib/modes/psych_44.h>
+- libvorbis repo + aoTuV-merge commit: <https://github.com/xiph/vorbis>, <https://github.com/xiph/vorbis/commit/50c1cc2d20>
+- aoTuV source mirror (AO-Yumi): <https://raw.githubusercontent.com/AO-Yumi/vorbis_aotuv/master/lib/modes/psych_44.h>, <https://raw.githubusercontent.com/AO-Yumi/vorbis_aotuv/master/lib/modes/setup_44.h>, <https://github.com/AO-Yumi/vorbis_aotuv>
+- aoTuV project page/changelog: <https://ao-yumi.github.io/aotuv_web/>
+- aoTuV+Lancer patch repo: <https://github.com/enzo1982/vorbis-aotuv-lancer>
+- Scene-era oggenc2/aoTuV lowpass-disable convention (dbpoweramp forum): <https://forum.dbpoweramp.com/forum/other-topics/developers-corner/10112-ogg-vorbis-lancer-20060131-release>
+- Hydrogenaudio, recommended encoder/settings history + aoTuV-vs-reference q-1 bitrate split: <https://wiki.hydrogenaudio.org/index.php?title=Recommended_Ogg_Vorbis>
+- Hydrogenaudio forum, aoTuV psychoacoustic-model divergence summary: <https://hydrogenaudio.org/index.php/topic,72797.0.html>
+- Wikipedia, Vorbis (nominal bitrate table, aoTuV merge history, Spotify usage): <https://en.wikipedia.org/wiki/Vorbis>
+- Xiph libvorbisenc API docs (VBR vs. managed-bitrate setup): <https://xiph.org/vorbis/doc/vorbisenc/vorbis_encode_setup_managed.html>, <https://xiph.org/vorbis/doc/vorbisenc/overview.html>
+- SoundExpert, measured Spotify Vorbis bitrates (libvorbis 1.3.1, -q5/-q9): <http://soundexpert.org/articles/-/blogs/spotify-uses-vorbis-q5-and-q9-for-audio-streaming>
+- Zotify (direct Spotify-stream Vorbis downloader): <https://github.com/zotify-dev/zotify>
+- Soggfy (Spotify OGG stream interceptor): <https://github.com/Rafiuth/Soggfy>
+- Legacy YouTube DASH audio itag 171 (128 kbps Vorbis), live `youtube-dl -F` listing quoted in issue: <https://github.com/ytdl-org/youtube-dl/issues/21509>
+- Legacy YouTube DASH audio itag 172 (256 kbps claimed; bitrate **[unverified]**, sources disagree): <https://github.com/ytdl-org/youtube-dl/issues/1596>

--- a/docs/research/spectral-wma.md
+++ b/docs/research/spectral-wma.md
@@ -1,0 +1,250 @@
+# Spectral calibration research: WMA (Windows Media Audio)
+
+Part of issue #829 Phase 0. Scope: assess whether Windows Media Audio
+(Standard / Pro / Lossless / Voice) can be given a calibrated cutoff→bitrate
+mapping analogous to `lib/spectral_check.py::LAME_LOWPASS`, and whether it
+belongs in the Phase 2 encode matrix at all.
+
+**Bottom line up front: WMA should be DROPPED from the Phase 2 encode
+matrix.** See "Recommendation" below for full reasoning; short version: the
+only Linux-available encoder (`ffmpeg`'s `wmav1`/`wmav2`) is not the encoder
+that produced real WMA files in the wild, so any matrix built would
+calibrate the wrong thing, and the affected population is small and shrinking.
+
+## How our analyzer works (context)
+
+`lib/spectral_check.py` measures RMS energy in 500 Hz slices from 12 kHz to
+20 kHz, looks for a steep multi-slice dB/kHz drop (`detect_cliff`,
+`CLIFF_THRESHOLD_DB_PER_KHZ = -12.0`), and maps the cliff frequency to an
+estimated source bitrate via `LAME_LOWPASS` — a table taken from LAME's own
+source code (comment: "from source code"), i.e. it encodes exactly one
+encoder's internal lowpass-filter design decisions. WMA/M4A/ALAC files are
+decoded once via `ffmpeg` to WAV before the same sox pipeline runs
+(`_ffmpeg_to_wav`); there is no codec-aware branch — every file, regardless
+of source codec, gets bucketed through the LAME table. This is exactly the
+cross-codec miscalibration issue #829 exists to fix.
+
+## WMA family taxonomy
+
+Windows Media Audio is Microsoft's umbrella name for several unrelated
+codecs sharing the ASF container and a `wma` extension convention:
+
+| Variant | Type | Introduced | Notes |
+|---|---|---|---|
+| WMA (v1) | lossy | Aug 1999 | First release ([Wikipedia](https://en.wikipedia.org/wiki/Windows_Media_Audio)) |
+| WMA (v2) | lossy | 1999 | Minor bitstream syntax changes over v1 ([Wikipedia](https://en.wikipedia.org/wiki/Windows_Media_Audio)) |
+| WMA 7 / 8 / **9 ("WMA 9 Standard")** | lossy | 2000 / 2001 / 2003 | Same family, iterative encoder-only improvements; v9.1/9.2/10 stay bitstream-compatible with v9 decoders ([Wikipedia](https://en.wikipedia.org/wiki/Windows_Media_Audio)) |
+| WMA Pro (9 Pro / 10 Pro) | lossy | 2003 | Multichannel (up to 7.1), up to 24-bit/96kHz, improved entropy coding ([Wikipedia](https://en.wikipedia.org/wiki/Windows_Media_Audio)) |
+| WMA Lossless | **lossless** | 2003 | Unpublished bitstream spec, reverse-engineered; compression ratio ~1.7:1–3:1 ([Wikipedia](https://en.wikipedia.org/wiki/Windows_Media_Audio); [Hydrogenaudio](https://wiki.hydrogenaudio.org/index.php?title=Windows_Media_Audio)) |
+| WMA Voice | lossy (speech) | 2003 | Mono, ≤22.05 kHz, CBR only, ≤20 kbit/s, speech/music auto-switching ([Wikipedia](https://en.wikipedia.org/wiki/Windows_Media_Audio)) |
+
+"WMA 9 Standard" in period ripper UIs (Windows Media Player 9/10,
+~2003–2008) refers to the plain lossy WMA v9 codec — almost certainly the
+variant behind most legacy WMA files an archivist would encounter, since
+WMP defaulted to it for CD ripping.
+
+Codec internals, relevant to why cliff-detection may not transfer cleanly
+from LAME: WMA Standard is an MDCT transform codec like MP3/AAC/Vorbis, but
+uses **5 block sizes** (128–2048 samples) versus MP3/AAC's 2, does
+mid/side stereo coding, and below ~17 kbit/s substitutes line-spectral-pair
+coding and below ~33 kbit/s substitutes noise coding for parts of the
+spectrum instead of a plain filter cutoff ([Wikipedia](https://en.wikipedia.org/wiki/Windows_Media_Audio)). That is a materially
+different HF-discard mechanism than LAME's fixed per-bitrate lowpass filter
+— there is no a priori reason WMA's rolloff shape should resemble LAME's.
+
+Microsoft's own release claim was "near-CD-quality at 64 kbit/s" / "MP3
+quality at half the bitrate" — independent listening tests debunked this
+for WMA Standard specifically ([Hydrogenaudio](https://wiki.hydrogenaudio.org/index.php?title=Windows_Media_Audio)). WMA Pro, by contrast,
+"scored as statistically tied with top encoders" in blind tests
+([Hydrogenaudio](https://wiki.hydrogenaudio.org/index.php?title=Windows_Media_Audio)) — but WMA Pro is essentially absent from consumer
+rips (see Prevalence).
+
+## Cutoff behavior per variant/bitrate — best-effort table
+
+**This is the thin part of the doc, as expected.** Unlike LAME (a public,
+source-derived lowpass table) or AAC (Hydrogenaudio-maintained encoder
+comparison pages), there is no equivalent published bitrate→cutoff-frequency
+table for WMA anywhere we could find — not Hydrogenaudio's wiki, not
+Microsoft's developer docs, not forum lore. Repeated targeted searches
+(Hydrogenaudio wiki/forum, Microsoft Learn, empegBBS, AnandTech, multimedia.cx)
+turned up bitrate *ranges* and *marketing claims* but no third-party spectral
+measurement of WMA Standard's actual rolloff frequency at specific bitrates.
+
+| Bitrate | Claimed/observed behavior | Confidence |
+|---|---|---|
+| 64 kbit/s | Microsoft called this "CD quality"; forum listeners at the time called that false and reported "too many artifacts," judging 96 kbit/s the practical floor ([empegBBS](https://empegbbs.com/ubbthreads.php/ubb/printthread/Board/1/main/5778/type/thread)) | Anecdotal only, no measured cutoff Hz |
+| 96–128 kbit/s | No documented cutoff frequency found. Generic lossy-codec forum lore treats ~16 kHz as a rule-of-thumb cutoff "at 128kbps" but every citable instance of that figure is about MP3/LAME, not WMA — sources conflate the two by analogy, not measurement ([forum synthesis, unverified for WMA specifically]) | [unverified] |
+| 160–192 kbit/s | No documented cutoff frequency found | [unverified] |
+| WMA Pro (any rate) | No cutoff data found; low-bitrate WMA Pro mode exists down to ~48 kbit/s for multichannel content (NBC Olympics example) but is not a consumer CD-rip shape ([Wikipedia](https://en.wikipedia.org/wiki/Windows_Media_Audio)) | [unverified] |
+| WMA Lossless | Not applicable — lossless, no cutoff (bit-exact reconstruction is the claim) ([Wikipedia](https://en.wikipedia.org/wiki/Windows_Media_Audio_9_Lossless) via search synthesis) | N/A |
+| WMA Voice | Band-limited to speech range by design (low-pass + high-pass filtering outside speech band) — a real cutoff exists but is a speech-bandwidth artifact, not a bitrate-quality signal, and this variant essentially never appears as a music-file rip ([Wikipedia](https://en.wikipedia.org/wiki/Windows_Media_Audio)) | Design-documented, not spectrally measured by us |
+
+We could not find a single hydrogenaudio-wiki-style page, Microsoft
+white paper, or forum spectrogram thread that pins an actual measured
+rolloff frequency to a specific WMA Standard bitrate the way the LAME page
+does for MP3. This absence is itself the key finding of this section.
+
+## What ffmpeg can encode, and how representative it is
+
+- `ffmpeg` ships **native encoders for `wmav1` and `wmav2`** (WMA v1/v2,
+  i.e. the original 1999-era codec, not "WMA 9"), confirmed via FFmpeg's own
+  source/doxygen (`libavcodec/wmadec.c`, `wma.h`: "1 = 0x160 (WMAV1), 2 =
+  0x161 (WMAV2)") and mailing-list `ffmpeg -codecs` dumps showing both as
+  encode+decode capable ([FFmpeg doxygen](https://ffmpeg.org/doxygen/0.6/wmadec_8c.html); [ffmpeg-user mailing list](https://ffmpeg.org/pipermail/ffmpeg-user/2013-August/016651.html)).
+- **No WMA Pro or WMA Lossless encoder exists in ffmpeg, or anywhere on
+  Linux** — decode only for both. fre:ac's own docs state Linux builds
+  can't produce WMA Lossless output because "it doesn't look like any WMA
+  Lossless encoder exists besides the Microsoft one included with Windows"
+  ([SourceForge fre:ac thread](https://sourceforge.net/p/bonkenc/discussion/85470/thread/fe31a0ff4f/); [ffmpeg WMA decoder history](https://news.slashdot.org/story/02/10/28/1331251/ffmpeg-free-softwares-wma-decoder)).
+- **`wmav1`/`wmav2` quality reputation is poor.** FFmpeg's own encoding-guide
+  content (mirrored, since the canonical `trac.ffmpeg.org` page is behind
+  bot-protection at fetch time) ranks encoders "high to low" as `libopus >
+  libvorbis >= libfdk_aac > aac > libmp3lame >= eac3/ac3 > libtwolame >
+  vorbis > mp2 > wmav2/wmav1` and states plainly that "the wmav1/wmav2
+  encoder does not reach transparency at any bitrate" ([mirror: williamyaps](https://williamyaps.blogspot.com/2017/02/ffmpeg-quality-compare.html); [mirror: evilsoup](https://evilsoup.wordpress.com/2013/02/10/general-ffmpeg-encoding-guide-2/)).
+- **The representativeness gap is the load-bearing fact for this doc.**
+  ffmpeg's `wmav2` is a clean-room reimplementation of the old WMA v1/v2
+  bitstream — not Microsoft's WMA 9 encoder (the one bundled with WMP 9/10
+  that produced the vast majority of real "WMA 9 Standard" rips), and
+  definitely not WMA Pro/Lossless (neither encodable on Linux at all). Any
+  Phase-2-style ladder built on doc2/Linux would characterize **ffmpeg's own
+  encoder's HF-discard behavior**, not the Microsoft encoder that produced
+  the population this project models — a different failure mode from the
+  AAC/Opus docs in this series, where ffmpeg's native/libfdk encoders are at
+  least *real, shipping* implementations of the target format.
+
+## Prevalence in the wild
+
+- WMA (specifically WMA Standard v9, "WMA 9 Standard" in WMP's UI) was
+  Windows Media Player's **default rip format for years in the 2000s**,
+  common among casual Windows users ripping CDs with the out-of-the-box
+  tool rather than a dedicated MP3 encoder ([search synthesis, AnandTech-era discussion](https://forums.anandtech.com/threads/whats-the-deal-with-wma-files-these-days.1296482/post-11225827)).
+- Contemporary file-sharing-scene sentiment treated WMA as the mark of a
+  casual/non-audiophile ripper: a period AnandTech thread is quoted as
+  "Default format for Media Centre rips, so any noobs posting songs often
+  do so in WMA" ([AnandTech forum](https://forums.anandtech.com/threads/whats-the-deal-with-wma-files-these-days.1296482/post-11225827)). Dedicated "scene" traders on
+  Napster/Kazaa/LimeWire/Soulseek-era networks skewed MP3 (universal
+  compatibility, non-Windows-only container) and, later, lossless — WMA's
+  ASF container was itself a compatibility tax outside Windows. We could not
+  find any source quantifying WMA's share of Soulseek traffic specifically,
+  in 2026 or any other year — **[unverified]**, an inference from cultural
+  context, not a measurement.
+- Practical implication: any WMA files this archive encounters are almost
+  certainly legacy WMP rips from ~2000–2008 at 64–192 kbit/s CBR/VBR,
+  essentially never WMA Pro (near-zero consumer software wrote it) and
+  never WMA Lossless in meaningful volume (niche, Windows-only, and itself
+  hard to decode correctly — "several releases of Windows 10 had faulty
+  decoders" per Hydrogenaudio ([Hydrogenaudio](https://wiki.hydrogenaudio.org/index.php?title=Windows_Media_Audio))). The population is old, finite,
+  and can only shrink as it's replaced by better-sourced re-rips —
+  consistent with cratedigger's own upgrade mandate.
+
+## Implications for calibration
+
+1. **No ground-truth reference exists to calibrate against even in
+   principle**, absent building one from real WMA9-encoded material — and
+   the only "encoder" Linux can drive (`ffmpeg wmav2`) is not that material's
+   producer (see above). A matrix built by encoding our ground-truth FLACs
+   through `ffmpeg wmav2` would tell us about `wmav2`, not about "WMA 9
+   Standard," so it would not answer the calibration question issue #829
+   asks.
+2. **The codec's internal HF-discard mechanism differs structurally from
+   LAME's.** WMA Standard trades spectral resolution via block-size
+   switching, LSP coding below ~17 kbit/s, and noise substitution below
+   ~33 kbit/s, rather than a single fixed lowpass filter per bitrate tier
+   ([Wikipedia](https://en.wikipedia.org/wiki/Windows_Media_Audio)). There is no structural reason to expect a clean,
+   LAME-shaped single-frequency cliff at all, let alone one that lines up
+   with LAME's specific frequency thresholds.
+3. **Would a real WMP9-produced WMA9 128 kbit/s file be misread by our
+   `LAME_LOWPASS` table today?** Qualitatively: almost certainly yes — the
+   table's boundaries are LAME's internal filter choices, not a validated
+   cross-codec mapping; any agreement would be coincidental. We cannot say
+   *how wrong*, or in which direction, without measuring real Microsoft-
+   encoder WMA files, a different acquisition problem than the
+   ffmpeg-encode-a-ladder approach Phase 2 uses for every other codec here
+   ([unverified] — no source gives measured WMA cutoff frequencies to
+   compare against the LAME table's 17000 Hz→128 boundary). Net: the
+   achievable outcome for WMA is not "a calibrated table with confidence
+   bounds" (the Phase 2/3 goal elsewhere) but "a documented decision to
+   treat WMA as non-decision-grade" — already the taxonomy's own fallback
+   for "lossy non-MP3".
+
+## Recommendation: drop WMA from the Phase 2 encode matrix
+
+**Drop it.** Reasoning, weighted by cost vs. expected value:
+
+- The corpus/encoder mismatch means a Phase 2 WMA ladder would calibrate the
+  wrong encoder. Spending budget on it produces a table that doesn't
+  describe the files it's meant to protect against — worse than doing
+  nothing, since a wrong-but-present table looks authoritative later.
+- WMA Pro and WMA Lossless can't be encoded on Linux at all, so at most 1 of
+  4 lossy variants (plain WMA Standard) could even be attempted, and that
+  attempt is the mismatched one above.
+- Prevalence is low, skewed toward the population cratedigger already wants
+  to upgrade away from (legacy 64–192 kbit/s WMP rips), and can only shrink
+  over time — unlike AAC/Opus/Vorbis, live formats worth calibrating well.
+- The issue text itself hedges this codec uniquely — "WMA if ffmpeg encodes
+  it sanely" — the only conditional phrasing in the Phase 2 codec list.
+- Dropping WMA creates no gap: per the three-domain taxonomy, "lossy
+  non-MP3" (WMA included) already defaults to audit-only/fail-closed
+  absent a validated table. WMA just stays in that bucket permanently
+  instead of graduating out — the honest state of our knowledge.
+
+**What "drop" should mean for Phase 4/5:** treat WMA (all variants) as a
+codec where spectral evidence is measured (cliff detection still runs — a
+genuine near-DC-to-0dB cliff is still evidence of something, e.g. a
+lossless-container fake) but is **not decision-grade for bitrate estimation
+or transcode verdicts** — no `LAME_LOWPASS`-style bucket, no
+`likely_transcode` stamp derived from a WMA cliff. This is exactly the
+audit-only/fail-closed treatment #829 already specifies for uncalibrated
+lossy-non-MP3 codecs; WMA needs no bespoke code path beyond correct
+classification into that treatment.
+
+Confidence: **high** for "don't build a matrix via ffmpeg" (the
+encoder-mismatch argument is structural, not probabilistic); **medium** for
+the prevalence argument (no hard Soulseek telemetry exists — leans on
+cultural/historical inference).
+
+## Predictions for Phase 3 (if the operator overrides this and includes WMA anyway)
+
+If a future decision reverses this and an `ffmpeg wmav2` ladder gets built
+anyway, predictions worth pinning now so Phase 3 can check them:
+
+1. **The cliff detector will behave less cleanly on WMA than on LAME MP3.**
+   Because WMA's HF discard spreads across block-size switching and noise
+   substitution rather than one lowpass filter, expect more tracks to land
+   in `marginal` (gradual HF deficit, no qualifying cliff) than
+   `suspect`-via-cliff, especially at mid bitrates (128–192 kbit/s).
+2. **Any cliff frequency measured from `ffmpeg`-encoded WMA describes
+   `wmav2`'s filter design, not WMA9's** — should NOT be merged into or
+   compared against real-world WMA measurements without that caveat.
+3. **Low bitrates (64–96 kbit/s) are where `wmav2`'s "never reaches
+   transparency" reputation should show up most visibly** — expect early,
+   broad-band HF loss rather than a clean cliff, possibly triggering
+   suspect grades via `HF_DEFICIT_SUSPECT` (60 dB) rather than `detect_cliff`.
+4. **WMA Pro/Lossless cannot be added to any matrix on Linux** — a hard
+   tooling constraint, not a probabilistic guess.
+5. If real WMP9 files are later sourced for genuine ground truth (e.g.
+   pulled live off Soulseek rather than re-encoded locally), expect the
+   true WMA9 curve to sit close to, but not exactly on, the LAME curve at
+   mid bitrates (contemporary tests rated WMA roughly comparable to
+   LAME-era MP3) — and diverge more at low bitrates where WMA's
+   LSP/noise-substitution mechanisms have no LAME analogue.
+
+## Sources
+
+- https://wiki.hydrogenaudio.org/index.php?title=Windows_Media_Audio
+- https://en.wikipedia.org/wiki/Windows_Media_Audio
+- https://en.wikipedia.org/wiki/Windows_Media_Audio_9_Lossless
+- https://wiki.multimedia.cx/index.php/Windows_Media_Audio_9
+- https://ffmpeg.org/doxygen/0.6/wmadec_8c.html
+- https://ffmpeg.org/doxygen/1.2/wma_8h_source.html
+- https://ffmpeg.org/pipermail/ffmpeg-user/2013-August/016651.html
+- https://williamyaps.blogspot.com/2017/02/ffmpeg-quality-compare.html
+- https://evilsoup.wordpress.com/2013/02/10/general-ffmpeg-encoding-guide-2/
+- https://sourceforge.net/p/bonkenc/discussion/85470/thread/fe31a0ff4f/
+- https://news.slashdot.org/story/02/10/28/1331251/ffmpeg-free-softwares-wma-decoder
+- https://empegbbs.com/ubbthreads.php/ubb/printthread/Board/1/main/5778/type/thread
+- https://forums.anandtech.com/threads/whats-the-deal-with-wma-files-these-days.1296482/post-11225827
+- https://www.nch.com.au/kb/10098.html
+- https://listening-tests.freetzi.com/html/Multiformat_128kbps_public_listening_test_results.htm
+- GitHub issue #829 (this repo) — problem statement and Phase 2 plan text, quoted for context on the operator's own hedge language ("WMA if ffmpeg encodes it sanely")


### PR DESCRIPTION
Part of #829 — Phase 0 (research sweep) complete.

Six research documents under `docs/research/`, written by parallel research agents against primary sources (encoder source code, RFCs, AES papers, hydrogenaudio), each with inline citations, explicit `[unverified]` flags, and a **testable Phase 3 prediction table** so the corpus measurements confirm or refute the literature.

Headline findings:
- **Our `LAME_LOWPASS` table is byte-exact against LAME's own `optimum_bandwidth()` source** — but it's *LAME* calibration, not *MP3* calibration: Xing/Helix apply a fixed 16 kHz lowpass at any bitrate, so a genuine Helix 320 reads as ~128-class today.
- **libfdk AAC CBR bandwidth caps at 17 kHz from 96 kbps/channel upward** (source table) — FDK-AAC at 320 has the same cutoff as at 96. Apple AAC has no published cutoff table at all (qaac maintainer confirmed). HE-AAC/SBR needs an object-type pre-classification gate; its real information boundary sits below our 12 kHz slice floor.
- **Opus: no usable bitrate→cutoff ladder exists** (libopus threshold arrays: fullband from ~12 kbps equivalent for stereo music; CELT band folding keeps HF energy present regardless of quality). Audit-only above ~64 kbps.
- **Vorbis: viable source-extracted ladder** (q-1 to q5), no encoder lowpass at q6+; reference q5 — the Spotify Normal tier, a real Soulseek population — cuts at 20.1 kHz, just past our slice window's 20 kHz edge.
- **WMA: drop from the Phase 2 matrix** — ffmpeg's `wmav2` is not the encoder that produced real-world WMA files, so a matrix would calibrate the wrong thing. Stays audit-only permanently.
- **Transcode detection: bare cliff tests are provably blind to well-executed same-codec transcodes**; ranked sox/ffmpeg-deployable feature shortlist for Phase 3 (multi-window cliff consistency, per-codec table cross-check, full-spectrum multi-cliff scan).

Verification: whole-repo pyright 0 errors; full suite 6728 tests OK on this exact tree (docs audit including the living-code-reference and dead-link scanners passes — upstream libvorbis source paths are written as `xiph/vorbis/lib/...` to keep the scanner honest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)