### PR TITLE
Isolate Beets database authority from the music root

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ If a design drifts toward "good enough" matches, "smart" defaults, or auto-throt
 | Path | Machine | Purpose |
 |------|---------|---------|
 | `10.20.0.11:5432/cratedigger` | doc2 nspawn | Pipeline DB (PostgreSQL) |
-| `/mnt/virtio/Music/beets-library.db` | shared | Beets library DB |
+| `/mnt/virtio/cratedigger/beets-db/beets-library.db` | shared | Beets library DB, journals, import log, and harness audit |
 | `/mnt/virtio/Music/Beets` | shared | Beets library (tagged files) |
 | `/mnt/virtio/Music/Incoming` | shared | Staging root (`auto-import/` requests, `post-validation/` manual review) |
 | `/mnt/virtio/music/slskd` | doc2 | slskd download directory |

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ You need: **NixOS**, **a dedicated slskd instance** (`services.slskd` is in nixp
             pipelineDb.createLocally = true;   # local postgres, peer auth, no passwords
             beets.config = {
               directory = "/srv/music/library";
-              library = "/srv/music/beets-library.db";
+              library = "/var/lib/cratedigger-beets-db/beets-library.db";
             };
             beets.validation = {
               stagingDir = "/srv/music/incoming";

--- a/docs/beets-primer.md
+++ b/docs/beets-primer.md
@@ -41,7 +41,7 @@ To change the config:
 ```yaml
 # Library
 directory: /mnt/virtio/Music/Beets
-library: /mnt/virtio/Music/beets-library.db
+library: /mnt/virtio/cratedigger/beets-db/beets-library.db
 
 # Import behavior
 import:
@@ -152,8 +152,8 @@ fetchart:
 | Path | Purpose |
 |------|---------|
 | `/mnt/virtio/Music/Beets` | Tagged library — organized by beets path templates |
-| `/mnt/virtio/Music/beets-library.db` | SQLite database — the DB source of truth |
-| `/mnt/virtio/Music/beets-import.log` | Import log |
+| `/mnt/virtio/cratedigger/beets-db/beets-library.db` | SQLite database — the DB source of truth |
+| `/mnt/virtio/cratedigger/beets-db/beets-import.log` | Import log |
 | `/mnt/virtio/Music/AI` | Staging area — raw copies from `/Me`, pre-import |
 | `/mnt/virtio/Music/Incoming` | Processing staging root — `/Incoming/auto-import` for request auto-imports, `/Incoming/post-validation` for redownload/manual-review staging |
 | `/mnt/virtio/Music/Re-download` | Re-download queue — each album has a README.md explaining why |
@@ -406,7 +406,7 @@ not exactly one same-release album.
 ### Constants
 
 ```python
-BEETS_DB = "/mnt/virtio/Music/beets-library.db"
+BEETS_DB = "/mnt/virtio/cratedigger/beets-db/beets-library.db"
 HARNESS_TIMEOUT = 300   # 5 min for match selection
 IMPORT_TIMEOUT = 1800   # 30 min for actual import (fetchart, embedart, lyrics can be slow)
 max_distance = 0.5      # Reject matches above this distance
@@ -525,7 +525,7 @@ successful only when the complete postcondition was already satisfied.
 
 ## The Beets SQLite Database
 
-Located at `/mnt/virtio/Music/beets-library.db`. Two main tables:
+Located at `/mnt/virtio/cratedigger/beets-db/beets-library.db`. Two main tables:
 
 ### `albums` table (key fields)
 

--- a/docs/nixos-module.md
+++ b/docs/nixos-module.md
@@ -193,7 +193,7 @@ the module VM, because it can prevent config rendering before the worker starts.
 
 | Unit | Writable paths |
 |---|---|
-| web | `stateDir`, `processingDir`, `slskd.downloadDir`, Beets root, parent of the Beets library DB, validation staging root |
+| web | `stateDir`, `processingDir`, `slskd.downloadDir`, Beets root, dedicated parent of the Beets library DB, validation staging root |
 | importer | web paths plus parent of `beets.validation.trackingFile` |
 | import-preview-worker | `stateDir`, `processingDir`, `slskd.downloadDir` |
 | youtube-ingest | `stateDir`, `youtubeIngest.tempDir`, validation staging root |
@@ -207,8 +207,10 @@ reopen its target even when the upstream `ReadWritePaths` list is narrower.
 For a consumer using `TemporaryFileSystem=/mnt`, the recommended composition is
 broad shared-tree visibility through `BindReadOnlyPaths`, followed by
 `BindPaths` only for that unit's exact writable roots from the table above.
-Those writable binds must be narrow and per-unit; do not bind an entire shared
-music or data parent writable for every worker. Verify effective denial rather
+Those writable binds must be narrow and per-unit; the default Beets DB parent is
+`${stateDir}-beets-db` (not the music root or stateDir), and explicit library overrides keep
+their parent operator-owned. Do not bind an entire shared music or data parent
+writable for every worker. Verify effective denial rather
 than inferring confinement from the rendered property strings alone. The
 upstream module VM proves the generic module boundary without downstream
 writable binds.

--- a/docs/security-audit-2026-07-12.md
+++ b/docs/security-audit-2026-07-12.md
@@ -317,7 +317,7 @@ claiming a narrower filter that would prevent the real services from starting.
 Each unit receives a `ReadWritePaths` list derived from its own authority
 roots rather than a shared blanket grant. All four get `stateDir`; importer,
 preview worker, and web get `processingDir`; only importer and web get the
-Beets root and library-DB parent; importer and web get the validation staging
+Beets root and dedicated library-DB parent; importer and web get the validation staging
 root, with importer additionally getting the tracking-file parent; and the
 YouTube worker gets only `youtubeIngest.tempDir` plus validation staging. The
 slskd download directory is writable only for web, importer, and preview

--- a/docs/solutions/runtime-errors/lucksmiths-mbid-drift-out-of-band-harness.md
+++ b/docs/solutions/runtime-errors/lucksmiths-mbid-drift-out-of-band-harness.md
@@ -21,4 +21,4 @@ NOT a bug. `tagging-workspace/scripts/fix_reissues.py` deliberately retagged "Fi
 
 ## Mitigation
 
-Mitigated by the harness MBID-swap audit log at `/mnt/virtio/Music/.harness-mutations.jsonl` (see `_mbid_swap_event`).
+Mitigated by the harness MBID-swap audit log at `/mnt/virtio/cratedigger/beets-db/.harness-mutations.jsonl` (see `_mbid_swap_event`).

--- a/docs/solutions/ui-dev-server-screenshot-loop.md
+++ b/docs/solutions/ui-dev-server-screenshot-loop.md
@@ -31,7 +31,7 @@ ssh -N -L 15432:10.20.0.11:5432 doc2 &
 export PIPELINE_DB_DSN="postgresql://cratedigger:$(ssh doc2 'sudo cat /run/secrets/cratedigger-pgpass' | grep '^PGPASSWORD=' | cut -d= -f2)@127.0.0.1:15432/cratedigger"
 setsid nix-shell --run "python3 scripts/web_dev_server.py --data live-db \
   --host 127.0.0.1 --port 8096 \
-  --beets-db /mnt/virtio/Music/beets-library.db \
+  --beets-db /mnt/virtio/cratedigger/beets-db/beets-library.db \
   --mb-api http://192.168.1.35:5200/ws/2 \
   --discogs-api https://discogs.ablz.au" \
   > /tmp/devserver.log 2>&1 < /dev/null &

--- a/docs/webui-primer.md
+++ b/docs/webui-primer.md
@@ -12,7 +12,7 @@ Browser → https://music.ablz.au
              → localhost:8085
                → web/server.py (stdlib http.server)
                  → PostgreSQL (pipeline DB, nspawn container 10.20.0.11)
-                 → SQLite (beets library, /mnt/virtio/Music/beets-library.db, read-only)
+                 → SQLite (beets library, /mnt/virtio/cratedigger/beets-db/beets-library.db, read-only)
                  → MusicBrainz API (local mirror, 192.168.1.35:5200)
 ```
 
@@ -400,7 +400,7 @@ Key endpoints used:
 
 ## Beets Library Integration
 
-Reads `/mnt/virtio/Music/beets-library.db` (SQLite, read-only) to show what you own:
+Reads `/mnt/virtio/cratedigger/beets-db/beets-library.db` (SQLite, read-only) to show what you own:
 - Queries `albums` table by `albumartist LIKE %name%`
 - Distinguishes MB imports (UUID in `mb_albumid`) from Discogs imports (numeric ID or `discogs_albumid` set)
 - Also checks individual release MBIDs against beets for the "in library" badge on editions

--- a/examples/cratedigger.nix
+++ b/examples/cratedigger.nix
@@ -71,7 +71,9 @@
     # and rendered configuration as automated imports.
     beets.config = {
       directory = "/srv/music/library";          # where tagged albums live
-      library = "/srv/music/beets-library.db";   # parent dir must exist
+      # Keep DB, journals, import log, and harness audit outside the curated
+      # music root. Explicit override parents remain operator-provisioned.
+      library = "/var/lib/cratedigger-beets-db/beets-library.db";
     };
     beets.validation = {
       stagingDir = "/srv/music/incoming";        # validated albums stage here
@@ -131,7 +133,7 @@
   # The staging/library parents must exist; the module manages only its
   # own state and private processing roots.
   systemd.tmpfiles.rules = [
-    "d /srv/music 2775 cratedigger users -"
+    "d /srv/music 0755 root root -"
     "d /srv/music/library 2775 cratedigger users -"
     "d /srv/music/incoming 2775 cratedigger users -"
   ];

--- a/lib/config.py
+++ b/lib/config.py
@@ -137,7 +137,7 @@ class CratediggerConfig:
     # SQLite database paired with ``beets_directory`` by the shipped Beets
     # config. Production readers must open both through ``open_beets_db``;
     # neither path is independently authoritative.
-    beets_library_db: str = "/mnt/virtio/Music/beets-library.db"
+    beets_library_db: str = "/var/lib/cratedigger-beets-db/beets-library.db"
 
     # Module-rendered beets runtime (tier-2 plan U5, R6). The NixOS module
     # renders these into config.ini so every beets subprocess resolves the
@@ -334,7 +334,7 @@ class CratediggerConfig:
             # which exists for legacy reasons). Empty string → unset.
             beets_directory=get("Beets", "directory", ""),
             beets_library_db=get(
-                "Beets", "library", "/mnt/virtio/Music/beets-library.db",
+                "Beets", "library", "/var/lib/cratedigger-beets-db/beets-library.db",
             ),
             beets_config_dir=get("Beets", "config_dir", ""),
             beets_python=get("Beets", "python", ""),

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -17,6 +17,20 @@
 
   cfg = config.services.cratedigger;
   src = cfg.src;
+  # A canonical stateDir is a hard boundary: the default Beets DB is its
+  # sibling, while preview and YouTube retain stateDir itself for rendering
+  # and working-directory needs.
+  canonicalStateDir = cfg.stateDir;
+  canonicalStateDirIsValid =
+    lib.hasPrefix "/" canonicalStateDir
+    && canonicalStateDir != "/"
+    && !lib.hasSuffix "/" canonicalStateDir
+    && !lib.hasInfix "//" canonicalStateDir
+    && !lib.hasInfix "/./" canonicalStateDir
+    && !lib.hasSuffix "/." canonicalStateDir
+    && !lib.hasInfix "/../" canonicalStateDir
+    && !lib.hasSuffix "/.." canonicalStateDir;
+  defaultBeetsDbDir = "${canonicalStateDir}-beets-db";
 
   # Every unit/wrapper interpolates the DSN; guard it so a missing value
   # yields the actionable message even if string coercion is forced before
@@ -651,7 +665,7 @@ in {
     stateDir = mkOption {
       type = types.str;
       default = "/var/lib/cratedigger";
-      description = "Runtime state directory (config.ini, lock file).";
+      description = "Runtime state directory (config.ini, lock file). Must be an absolute normalized non-root path without a trailing slash.";
     };
 
     processingDir = mkOption {
@@ -954,13 +968,15 @@ in {
         };
         library = mkOption {
           type = types.str;
-          default = "/mnt/virtio/Music/beets-library.db";
+          default = "${defaultBeetsDbDir}/beets-library.db";
           description = ''
-            Beets library SQLite DB (config.yaml `library:`). The import log
-            renders next to it as beets-import.log. The parent directory must
-            exist at runtime: `beet` prompts interactively ("Create it
-            (Y/n)?") when it's missing, which blocks any non-interactive
-            invocation.
+            Beets library SQLite DB (config.yaml `library:`). Defaults to a
+            dedicated sibling of stateDir so a fresh hardened install
+            does not need write access to its music root. The import log and
+            harness mutation audit render beside this file. The module creates
+            the default parent on first boot; an explicitly overridden parent
+            remains operator-owned and must already exist at runtime because
+            `beet` otherwise prompts interactively ("Create it (Y/n)?").
           '';
         };
         fetchart = {
@@ -1371,6 +1387,10 @@ in {
   config = mkIf cfg.enable {
     assertions = [
       {
+        assertion = canonicalStateDirIsValid;
+        message = "services.cratedigger.stateDir must be an absolute normalized non-root path without a trailing slash (for example, /var/lib/cratedigger).";
+      }
+      {
         assertion = cfg.slskd.apiKeyFile != null;
         message = "services.cratedigger.slskd.apiKeyFile is not set: point it at a file containing your slskd API key (readable by services.cratedigger.user).";
       }
@@ -1473,6 +1493,12 @@ in {
         # U4 renders config.yaml into it; the dir must exist regardless so
         # the wrapper works on a fresh boot.
         "d ${beetsConfigDir} 0755 ${cfg.user} ${cfg.group} -"
+        # The default library parent is module-owned and outside stateDir: the
+        # preview and YouTube workers legitimately need stateDir but must not
+        # thereby gain database authority. Do not create or chown
+        # an arbitrary explicit library override: that path is the operator's
+        # authority and its parent must be provisioned by the operator.
+        "d ${defaultBeetsDbDir} 2775 ${cfg.user} ${cfg.group} -"
       ]
       ++ optional cfg.youtubeIngest.enable
         "d ${cfg.youtubeIngest.tempDir} 0755 ${cfg.user} ${cfg.group} -";

--- a/nix/tests/module-vm.nix
+++ b/nix/tests/module-vm.nix
@@ -48,6 +48,7 @@ let
     assert mb["ratelimit"] == 1, mb
 
     assert cfg["include"] == ["secrets.yaml"], cfg.get("include")
+    assert cfg["library"] == "/var/lib/cratedigger-beets-db/beets-library.db", cfg
 
     # Path-affecting keys present and production-shaped. path_disambig is
     # the never-empty aunique disambiguator (Passenger collision fix,
@@ -66,8 +67,8 @@ let
     from pathlib import Path
     from beets import library
 
-    root = Path("/var/lib/cratedigger-music")
-    db_path = root / "beets-library.db"
+    root = Path("/var/lib/cratedigger-music/Beets")
+    db_path = Path("/var/lib/cratedigger-beets-db/beets-library.db")
     target_id = "cccccccc-cccc-cccc-cccc-cccccccccccc"
     child_target_id = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"
     sibling_id = "dddddddd-dddd-dddd-dddd-dddddddddddd"
@@ -153,11 +154,25 @@ pkgs.testers.nixosTest {
       touch /var/lib/cratedigger/.sandbox-probe
       touch /var/lib/cratedigger/processing/.sandbox-probe
       touch /var/lib/cratedigger-downloads/.sandbox-probe
-      touch /var/lib/cratedigger-music/.sandbox-probe
-      touch /var/lib/cratedigger-staging/.sandbox-probe
-      touch /var/lib/cratedigger-tracking/.sandbox-probe
+      touch /var/lib/cratedigger-music/Beets/.sandbox-probe
+      touch /var/lib/cratedigger-beets-db/.sandbox-probe
+      touch /var/lib/cratedigger-music/Incoming/.sandbox-probe
+      touch /var/lib/cratedigger-music/Re-download/.sandbox-probe
+      if touch /var/lib/cratedigger-music/unrelated/escape 2>/dev/null; then
+        echo "sandbox allowed a write to an unrelated music sibling" >&2
+        exit 1
+      fi
       if touch /var/lib/cratedigger-world-writable/escape 2>/dev/null; then
         echo "sandbox allowed a write outside ReadWritePaths" >&2
+        exit 1
+      fi
+    '';
+    stateDbDenialProbe = pkgs.writeShellScript "cratedigger-state-db-denial-probe" ''
+      set -euo pipefail
+      probe=/var/lib/cratedigger-beets-db/worker-escape
+      if touch "$probe" 2>/dev/null; then
+        rm -f "$probe"
+        echo "sandbox allowed a worker write to the Beets DB parent" >&2
         exit 1
       fi
     '';
@@ -247,22 +262,20 @@ pkgs.testers.nixosTest {
       # what a real first boot produces.
       beets.validation = {
         enable = true;
-        stagingDir = "/var/lib/cratedigger-staging";
+        stagingDir = "/var/lib/cratedigger-music/Incoming";
         # Keep the tracking parent distinct from staging so the sandbox
         # contract proves it is derived from its own option.
-        trackingFile = "/var/lib/cratedigger-tracking/tracking.jsonl";
+        trackingFile = "/var/lib/cratedigger-music/Re-download/tracking.jsonl";
       };
       beets.package = {
         discogsTokenFile = "/etc/cratedigger/discogs-token";
         discogsOperatorGroup = "cratedigger-ops";
       };
-      # Stranger-set beets paths (VM-local). The library's PARENT dir must
-      # exist or `beet` prompts "Create it (Y/n)?" interactively — which
-      # blocks forever under the test driver's backdoor shell. stateDir
-      # exists by tmpfiles, so the library parent is guaranteed.
+      # Keep the library root separate from the default DB parent. The module
+      # must create its sibling-of-stateDir default without granting writes to
+      # the music root.
       beets.config = {
-        directory = "/var/lib/cratedigger-music";
-        library = "/var/lib/cratedigger-music/beets-library.db";
+        directory = "/var/lib/cratedigger-music/Beets";
       };
       web = {
         enable = true;
@@ -297,10 +310,12 @@ pkgs.testers.nixosTest {
     # Only the independent renderer may materialise runtime configuration on
     # first boot; the test removes this hold before exercising the apps.
     systemd.tmpfiles.rules = [
-      "d /var/lib/cratedigger-music 2775 cratedigger beets-library -"
+      "d /var/lib/cratedigger-music 0777 root root -"
+      "d /var/lib/cratedigger-music/Beets 2775 cratedigger beets-library -"
+      "d /var/lib/cratedigger-music/Incoming 2775 cratedigger beets-library -"
+      "d /var/lib/cratedigger-music/Re-download 0755 cratedigger beets-library -"
+      "d /var/lib/cratedigger-music/unrelated 0777 root root -"
       "d /var/lib/cratedigger-downloads 0770 slskd-writer slskd-writer -"
-      "d /var/lib/cratedigger-staging 2775 cratedigger beets-library -"
-      "d /var/lib/cratedigger-tracking 0755 cratedigger beets-library -"
       "d /var/lib/cratedigger-world-writable 0777 root root -"
       "f /run/cratedigger-test-config-hold 0644 root root - held"
     ];
@@ -319,6 +334,12 @@ pkgs.testers.nixosTest {
         # The probe is test-only and ordered after the module's config render.
         cratedigger-importer.serviceConfig.ExecStartPre =
           lib.mkAfter [importerSandboxProbe];
+        # Preview and YouTube retain stateDir for their established workflows,
+        # but the sibling DB parent must remain unreachable in both sandboxes.
+        cratedigger-import-preview-worker.serviceConfig.ExecStartPre =
+          lib.mkAfter [stateDbDenialProbe];
+        cratedigger-youtube-ingest.serviceConfig.ExecStartPre =
+          lib.mkAfter [stateDbDenialProbe];
         # The blocker has no dependency edge from the application units. Its
         # ordering matters only while the VM test has explicitly queued both
         # jobs, which gives us a deterministic real systemd `start/waiting`.
@@ -570,6 +591,28 @@ pkgs.testers.nixosTest {
     else:
         raise AssertionError("sandbox checker accepted NoNewPrivileges=no")
 
+    # The DB parent is a distinct authority. A broad music parent grant must
+    # fail the same data-driven checker rather than merely being absent from
+    # a source-level scan.
+    known_bad = _unit_properties("cratedigger-web.service")
+    known_bad["ReadWritePaths"] += " /var/lib/cratedigger-music"
+    try:
+        _assert_sandbox_properties(
+            "known-bad-broad-parent.service", known_bad,
+            [
+                "/var/lib/cratedigger",
+                "/var/lib/cratedigger/processing",
+                "/var/lib/cratedigger-downloads",
+                "/var/lib/cratedigger-music/Beets",
+                "/var/lib/cratedigger-beets-db",
+                "/var/lib/cratedigger-music/Incoming",
+            ],
+        )
+    except AssertionError:
+        pass
+    else:
+        raise AssertionError("sandbox checker accepted a broad music-parent grant")
+
     known_bad = _unit_properties("cratedigger-web.service")
     known_bad["SystemCallFilter"] += " mount"
     try:
@@ -579,8 +622,9 @@ pkgs.testers.nixosTest {
                 "/var/lib/cratedigger",
                 "/var/lib/cratedigger/processing",
                 "/var/lib/cratedigger-downloads",
-                "/var/lib/cratedigger-music",
-                "/var/lib/cratedigger-staging",
+                "/var/lib/cratedigger-music/Beets",
+                "/var/lib/cratedigger-beets-db",
+                "/var/lib/cratedigger-music/Incoming",
             ],
         )
     except AssertionError:
@@ -592,16 +636,18 @@ pkgs.testers.nixosTest {
         "/var/lib/cratedigger",
         "/var/lib/cratedigger/processing",
         "/var/lib/cratedigger-downloads",
-        "/var/lib/cratedigger-music",
-        "/var/lib/cratedigger-staging",
+        "/var/lib/cratedigger-music/Beets",
+        "/var/lib/cratedigger-beets-db",
+        "/var/lib/cratedigger-music/Incoming",
     ])
     _assert_sandbox_contract("cratedigger-importer.service", [
         "/var/lib/cratedigger",
         "/var/lib/cratedigger/processing",
         "/var/lib/cratedigger-downloads",
-        "/var/lib/cratedigger-music",
-        "/var/lib/cratedigger-staging",
-        "/var/lib/cratedigger-tracking",
+        "/var/lib/cratedigger-music/Beets",
+        "/var/lib/cratedigger-beets-db",
+        "/var/lib/cratedigger-music/Incoming",
+        "/var/lib/cratedigger-music/Re-download",
     ])
     _assert_sandbox_contract("cratedigger-import-preview-worker.service", [
         "/var/lib/cratedigger",
@@ -611,7 +657,7 @@ pkgs.testers.nixosTest {
     _assert_sandbox_contract("cratedigger-youtube-ingest.service", [
         "/var/lib/cratedigger",
         "/var/lib/cratedigger/youtube-ingest-temp",
-        "/var/lib/cratedigger-staging",
+        "/var/lib/cratedigger-music/Incoming",
     ])
     for unit in (
         "cratedigger.service",
@@ -628,8 +674,12 @@ pkgs.testers.nixosTest {
         assert properties["ReadWritePaths"] == "", (unit, properties)
 
     # The importer probe ran inside the unit's sandbox. These pins prove every
-    # configured authority root was writable while the world-writable sibling
-    # remained effectively read-only despite its Unix mode.
+    # configured authority root was writable while unrelated world-writable
+    # locations remained effectively read-only despite their Unix modes.
+    machine.succeed("test \"$(stat -c %U:%G:%a /var/lib/cratedigger-beets-db)\" = cratedigger:beets-library:2775")
+    machine.succeed("runuser -u cratedigger -- test -w /var/lib/cratedigger-beets-db")
+    machine.succeed("test \"$(stat -c %a /var/lib/cratedigger-music/unrelated)\" = 777")
+    machine.fail("test -e /var/lib/cratedigger-music/unrelated/escape")
     machine.succeed("test \"$(stat -c %a /var/lib/cratedigger-world-writable)\" = 777")
     machine.fail("test -e /var/lib/cratedigger-world-writable/escape")
     machine.succeed("test -s /var/lib/cratedigger/processing/sandbox-probe/tone.mp3")
@@ -637,9 +687,10 @@ pkgs.testers.nixosTest {
         "/var/lib/cratedigger",
         "/var/lib/cratedigger/processing",
         "/var/lib/cratedigger-downloads",
-        "/var/lib/cratedigger-music",
-        "/var/lib/cratedigger-staging",
-        "/var/lib/cratedigger-tracking",
+        "/var/lib/cratedigger-music/Beets",
+        "/var/lib/cratedigger-beets-db",
+        "/var/lib/cratedigger-music/Incoming",
+        "/var/lib/cratedigger-music/Re-download",
     ):
         machine.succeed(f"test -f {root}/.sandbox-probe")
 
@@ -703,7 +754,9 @@ pkgs.testers.nixosTest {
     # U5 (tier-2): the module renders the beets runtime keys so every
     # beets subprocess resolves the pinned interpreter + rendered config.
     machine.succeed("grep -q 'config_dir = /var/lib/cratedigger/beets' /var/lib/cratedigger/config.ini")
-    machine.succeed("grep -q '^library = /var/lib/cratedigger-music/beets-library.db$' /var/lib/cratedigger/config.ini")
+    machine.succeed("grep -q '^library = /var/lib/cratedigger-beets-db/beets-library.db$' /var/lib/cratedigger/config.ini")
+    machine.succeed("test -d /var/lib/cratedigger-beets-db")
+    machine.succeed("test -f /var/lib/cratedigger-beets-db/.sandbox-probe")
     machine.succeed("grep -q 'python = /nix/store/' /var/lib/cratedigger/config.ini")
     # U6 (tier-2): one MB value, rendered for the python consumers too.
     machine.succeed("grep -q 'api_base = https://musicbrainz.org' /var/lib/cratedigger/config.ini")
@@ -883,8 +936,8 @@ pkgs.testers.nixosTest {
     child_request = json.dumps({
         "album_id": child_album_id,
         "expected_release_id": "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
-        "library_db_path": "/var/lib/cratedigger-music/beets-library.db",
-        "library_root": "/var/lib/cratedigger-music",
+        "library_db_path": "/var/lib/cratedigger-beets-db/beets-library.db",
+        "library_root": "/var/lib/cratedigger-music/Beets",
     }, separators=(",", ":"))
     child_out = machine.succeed(
         f"printf '%s' '{child_request}' | "

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -8,11 +8,15 @@ from __future__ import annotations
 
 import json
 import msgspec
+import os
 import requests
 import types
+import tempfile
+import configparser
+from copy import deepcopy
 from contextlib import contextmanager
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Callable, Generator
 from unittest.mock import MagicMock, patch
 
 from lib.grab_list import DownloadFile, GrabListEntry
@@ -46,6 +50,98 @@ from lib.quality import (
 )
 from lib.quality_evidence import snapshot_fingerprint
 from lib.slskd_client import DownloadDirectory, DownloadUser, TransferSnapshot
+
+
+_DEPLOYED_BEETS_DB_PATHS = frozenset({
+    "/mnt/virtio/Music/beets-library.db",
+    "/var/lib/cratedigger-beets-db/beets-library.db",
+})
+
+
+@contextmanager
+def hermetic_beets_config_defaults() -> Generator[tuple[str, str], None, None]:
+    """Give one test module a disposable complete Beets authority pair.
+
+    Omitted authority receives the pair. A test that supplies either half must
+    supply both, so no test silently combines a disposable DB with a deployed
+    root (or the reverse).
+    """
+    from beets import library as beets_library
+    from lib.beets_db import validate_beets_storage_pair
+    from lib.config import CratediggerConfig
+
+    with tempfile.TemporaryDirectory(prefix="cratedigger-test-beets-") as root:
+        library_root = f"{root}/library"
+        library_db = f"{root}/beets-library.db"
+        os.mkdir(library_root)
+        library = beets_library.Library(library_db, library_root)
+        library._close()
+        validate_beets_storage_pair(
+            db_path=library_db,
+            library_root=library_root,
+        )
+
+        original_init: Callable[..., None] = CratediggerConfig.__init__
+        original_from_ini = CratediggerConfig.from_ini.__func__
+        constructed_configs: list[CratediggerConfig] = []
+
+        def hermetic_init(
+            self: CratediggerConfig,
+            *args: object,
+            **kwargs: object,
+        ) -> None:
+            if args:
+                raise AssertionError(
+                    "hermetic Beets test configs must use keyword arguments"
+                )
+            has_db = "beets_library_db" in kwargs
+            has_root = "beets_directory" in kwargs
+            if has_db != has_root:
+                raise AssertionError(
+                    "test Beets authority must specify both library DB and root"
+                )
+            if not has_db:
+                kwargs["beets_library_db"] = library_db
+                kwargs["beets_directory"] = library_root
+            original_init(self, *args, **kwargs)
+            constructed_configs.append(self)
+
+        def hermetic_from_ini(
+            cls: type[CratediggerConfig],
+            config: configparser.RawConfigParser,
+            config_dir: str = ".",
+            var_dir: str = ".",
+        ) -> CratediggerConfig:
+            has_db = config.has_option("Beets", "library")
+            has_root = config.has_option("Beets", "directory")
+            if has_db != has_root:
+                raise AssertionError(
+                    "test Beets INI authority must specify both library and directory"
+                )
+            if not has_db:
+                config = deepcopy(config)
+                if not config.has_section("Beets"):
+                    config.add_section("Beets")
+                config.set("Beets", "library", library_db)
+                config.set("Beets", "directory", library_root)
+            return original_from_ini(cls, config, config_dir, var_dir)
+
+        CratediggerConfig.__init__ = hermetic_init
+        setattr(CratediggerConfig, "from_ini", classmethod(hermetic_from_ini))
+        try:
+            yield (library_db, library_root)
+        finally:
+            CratediggerConfig.__init__ = original_init
+            setattr(CratediggerConfig, "from_ini", classmethod(original_from_ini))
+            deployed = [
+                config.beets_library_db
+                for config in constructed_configs
+                if config.beets_library_db in _DEPLOYED_BEETS_DB_PATHS
+            ]
+            if deployed:
+                raise AssertionError(
+                    f"test config retained deployed Beets DB authority: {deployed}"
+                )
 
 
 def make_request_row(**overrides: Any) -> dict[str, Any]:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -423,7 +423,7 @@ class TestReadRuntimeConfig(unittest.TestCase):
         self.assertEqual(cfg.beets_directory, "")
         self.assertEqual(
             cfg.beets_library_db,
-            "/mnt/virtio/Music/beets-library.db",
+            "/var/lib/cratedigger-beets-db/beets-library.db",
         )
 
     def test_beets_directory_read_from_config(self):

--- a/tests/test_import_dispatch.py
+++ b/tests/test_import_dispatch.py
@@ -14,6 +14,7 @@ import shutil
 import subprocess as sp
 import tempfile
 import unittest
+from contextlib import AbstractContextManager
 from typing import Never
 from unittest.mock import MagicMock, patch
 
@@ -39,7 +40,88 @@ from tests.helpers import (
     make_request_row,
     noop_quality_gate,
     patch_dispatch_externals,
+    hermetic_beets_config_defaults,
 )
+
+
+_HERMETIC_BEETS_DEFAULTS: AbstractContextManager[tuple[str, str]] | None = None
+_HERMETIC_BEETS_PAIR: tuple[str, str] | None = None
+
+
+def setUpModule() -> None:
+    global _HERMETIC_BEETS_DEFAULTS, _HERMETIC_BEETS_PAIR
+    _HERMETIC_BEETS_DEFAULTS = hermetic_beets_config_defaults()
+    _HERMETIC_BEETS_PAIR = _HERMETIC_BEETS_DEFAULTS.__enter__()
+
+
+def tearDownModule() -> None:
+    assert _HERMETIC_BEETS_DEFAULTS is not None
+    _HERMETIC_BEETS_DEFAULTS.__exit__(None, None, None)
+
+
+class TestHermeticBeetsConfigDefaults(unittest.TestCase):
+    def test_implicit_config_uses_disposable_complete_pair(self) -> None:
+        from lib.beets_db import validate_beets_storage_pair
+
+        config = CratediggerConfig()
+
+        self.assertNotIn(config.beets_library_db, {
+            "/mnt/virtio/Music/beets-library.db",
+            "/var/lib/cratedigger-beets-db/beets-library.db",
+        })
+        self.assertNotIn(config.beets_directory, {
+            "/mnt/virtio/Music/Beets",
+            "/var/lib/cratedigger",
+        })
+        self.assertTrue(os.path.isfile(config.beets_library_db))
+        self.assertTrue(os.path.isdir(config.beets_directory))
+        validate_beets_storage_pair(
+            db_path=config.beets_library_db,
+            library_root=config.beets_directory,
+        )
+
+    def test_direct_config_rejects_one_sided_authority(self) -> None:
+        for library_db in (
+            "/mnt/virtio/Music/beets-library.db",
+            "/var/lib/cratedigger-beets-db/beets-library.db",
+        ):
+            with self.subTest(library_db=library_db):
+                with self.assertRaisesRegex(AssertionError, "both library DB and root"):
+                    CratediggerConfig(beets_library_db=library_db)
+        with self.assertRaisesRegex(AssertionError, "both library DB and root"):
+            CratediggerConfig(beets_directory="/music/library")
+
+    def test_ini_config_requires_complete_authority(self) -> None:
+        assert _HERMETIC_BEETS_PAIR is not None
+        library_db, library_root = _HERMETIC_BEETS_PAIR
+
+        absent = CratediggerConfig.from_ini(configparser.ConfigParser())
+        self.assertEqual(absent.beets_library_db, library_db)
+        self.assertEqual(absent.beets_directory, library_root)
+
+        for library in (
+            "/mnt/virtio/Music/beets-library.db",
+            "/var/lib/cratedigger-beets-db/beets-library.db",
+        ):
+            partial = configparser.ConfigParser()
+            partial["Beets"] = {"library": library}
+            with self.subTest(library=library):
+                with self.assertRaisesRegex(AssertionError, "both library and directory"):
+                    CratediggerConfig.from_ini(partial)
+
+        root_only = configparser.ConfigParser()
+        root_only["Beets"] = {"directory": "/music/library"}
+        with self.assertRaisesRegex(AssertionError, "both library and directory"):
+            CratediggerConfig.from_ini(root_only)
+
+        complete = configparser.ConfigParser()
+        complete["Beets"] = {
+            "library": library_db,
+            "directory": library_root,
+        }
+        config = CratediggerConfig.from_ini(complete)
+        self.assertEqual(config.beets_library_db, library_db)
+        self.assertEqual(config.beets_directory, library_root)
 
 
 # --- Local helpers for auto-import seam tests ---
@@ -3398,7 +3480,6 @@ class TestDispatchJellyfinPinCaptureSlice(unittest.TestCase):
     (``lib.util._jellyfin_get_json``) faked."""
 
     NEW_REL = "Test Artist/0000 - Test Album"
-    OLD_ABS = "/lib/Beets/Test Artist/2007 - Test Album"
     OLD_CONTAINER = "/jf/Test Artist/2007 - Test Album"
     ORIGINAL = "2026-04-01T00:00:00Z"
 
@@ -3422,6 +3503,9 @@ class TestDispatchJellyfinPinCaptureSlice(unittest.TestCase):
     def test_replaced_album_old_path_reaches_capture_and_pins(self):
         from lib.dispatch import dispatch_import_core
 
+        assert _HERMETIC_BEETS_PAIR is not None
+        beets_library_db, beets_library_root = _HERMETIC_BEETS_PAIR
+        old_album_path = f"{beets_library_root}/Test Artist/2007 - Test Album"
         db = FakePipelineDB()
         db.seed_request(make_request_row(
             id=42, status="downloading",
@@ -3429,17 +3513,18 @@ class TestDispatchJellyfinPinCaptureSlice(unittest.TestCase):
         cfg = CratediggerConfig(
             beets_harness_path=_HARNESS,
             pipeline_db_enabled=True,
-            beets_directory="/lib/Beets",
+            beets_library_db=beets_library_db,
+            beets_directory=beets_library_root,
             jellyfin_url="http://jf:8096",
             jellyfin_token="tok",
-            jellyfin_path_map="/lib/Beets:/jf",
+            jellyfin_path_map=f"{beets_library_root}:/jf",
         )
         ir = make_import_result(
             decision="import", imported_path=self.NEW_REL)
         ir.postflight.replaced_albums = [DuplicateRemoveCandidate(
             beets_album_id=3902,
             mb_albumid="test-mbid",
-            album_path=self.OLD_ABS,
+            album_path=old_album_path,
             item_count=19,
         )]
 
@@ -3471,6 +3556,8 @@ class TestDispatchJellyfinPinCaptureSlice(unittest.TestCase):
                     quality_gate_fn=noop_quality_gate,
                     candidate_import_job_id=claimed.id,
                     prevalidated_candidate_result=candidate,
+                    beets_library_db_path=beets_library_db,
+                    beets_library_root=beets_library_root,
                 )
         finally:
             shutil.rmtree(tmpdir, ignore_errors=True)

--- a/tests/test_import_preview.py
+++ b/tests/test_import_preview.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import tempfile
 import unittest
+from contextlib import AbstractContextManager
 from types import SimpleNamespace
 from typing import Any, TYPE_CHECKING
 from unittest.mock import patch
@@ -53,7 +54,22 @@ from tests.helpers import (
     make_album_quality_evidence,
     make_audio_corrupt_validation_report,
     make_request_row,
+    hermetic_beets_config_defaults,
 )
+
+
+_HERMETIC_BEETS_DEFAULTS: AbstractContextManager[tuple[str, str]] | None = None
+
+
+def setUpModule() -> None:
+    global _HERMETIC_BEETS_DEFAULTS
+    _HERMETIC_BEETS_DEFAULTS = hermetic_beets_config_defaults()
+    _HERMETIC_BEETS_DEFAULTS.__enter__()
+
+
+def tearDownModule() -> None:
+    assert _HERMETIC_BEETS_DEFAULTS is not None
+    _HERMETIC_BEETS_DEFAULTS.__exit__(None, None, None)
 
 
 _PREVIEW_RUNTIME = tempfile.TemporaryDirectory()
@@ -81,7 +97,6 @@ def _preview_runtime_config(
     *,
     beets_harness_path: str = "",
     pipeline_db_enabled: bool = False,
-    beets_directory: str = "",
     verified_lossless_target: str = "",
 ) -> CratediggerConfig:
     """Direct-test config with the same private-root contract as Nix."""
@@ -90,7 +105,6 @@ def _preview_runtime_config(
         processing_dir=_PREVIEW_PROCESSING_ROOT,
         beets_harness_path=beets_harness_path,
         pipeline_db_enabled=pipeline_db_enabled,
-        beets_directory=beets_directory,
         verified_lossless_target=verified_lossless_target,
     )
 
@@ -1840,7 +1854,6 @@ class TestImportPreviewPath(unittest.TestCase):
             with patch("lib.config.read_runtime_config",
                        return_value=_preview_runtime_config(
                            beets_harness_path="/fake/harness/run_beets_harness.sh",
-                           beets_directory="/srv/music/Beets",
                            pipeline_db_enabled=True,
                        )), \
                  patch("lib.import_preview.inspect_local_files",

--- a/tests/test_import_queue.py
+++ b/tests/test_import_queue.py
@@ -7,7 +7,7 @@ import tempfile
 import threading
 import time
 import unittest
-from contextlib import contextmanager
+from contextlib import AbstractContextManager, contextmanager
 from datetime import datetime, timedelta, timezone
 from typing import Any, cast
 from unittest.mock import ANY, MagicMock, patch
@@ -48,7 +48,23 @@ from tests.helpers import (
     make_download_file,
     make_grab_list_entry,
     make_request_row,
+    hermetic_beets_config_defaults,
 )
+
+
+_HERMETIC_BEETS_DEFAULTS: AbstractContextManager[tuple[str, str]] | None = None
+_HERMETIC_BEETS_PAIR: tuple[str, str] | None = None
+
+
+def setUpModule() -> None:
+    global _HERMETIC_BEETS_DEFAULTS, _HERMETIC_BEETS_PAIR
+    _HERMETIC_BEETS_DEFAULTS = hermetic_beets_config_defaults()
+    _HERMETIC_BEETS_PAIR = _HERMETIC_BEETS_DEFAULTS.__enter__()
+
+
+def tearDownModule() -> None:
+    assert _HERMETIC_BEETS_DEFAULTS is not None
+    _HERMETIC_BEETS_DEFAULTS.__exit__(None, None, None)
 
 
 # Migration 021 helpers — seed evidence and wire the FK chain that
@@ -2088,7 +2104,11 @@ class TestImportPreviewWorker(unittest.TestCase):
         )
         claimed = db.claim_next_import_preview_job(worker_id="preview")
         assert claimed is not None
-        cfg = CratediggerConfig(beets_directory="/music/library")
+        assert _HERMETIC_BEETS_PAIR is not None
+        cfg = CratediggerConfig(
+            beets_library_db=_HERMETIC_BEETS_PAIR[0],
+            beets_directory=_HERMETIC_BEETS_PAIR[1],
+        )
 
         def prepare(db_arg: Any, **kwargs: Any) -> str:
             self.assertIs(db_arg, db)
@@ -2096,7 +2116,7 @@ class TestImportPreviewWorker(unittest.TestCase):
                 "request_id": 42,
                 "mb_release_id": "mbid-42",
                 "quality_ranks": cfg.quality_ranks,
-                "beets_library_root": "/music/library",
+                "beets_library_root": cfg.beets_directory,
             })
             order.append("prepare")
             return "ready"
@@ -2107,7 +2127,7 @@ class TestImportPreviewWorker(unittest.TestCase):
                 "request_id": 42,
                 "mb_release_id": "mbid-42",
                 "quality_ranks": cfg.quality_ranks,
-                "beets_library_root": "/music/library",
+                "beets_library_root": cfg.beets_directory,
             })
             order.append("enrich")
             return "complete"
@@ -2157,7 +2177,11 @@ class TestImportPreviewWorker(unittest.TestCase):
                 )
                 claimed = db.claim_next_import_preview_job(worker_id="preview")
                 assert claimed is not None
-                cfg = CratediggerConfig(beets_directory="/music/library")
+                assert _HERMETIC_BEETS_PAIR is not None
+                cfg = CratediggerConfig(
+                    beets_library_db=_HERMETIC_BEETS_PAIR[0],
+                    beets_directory=_HERMETIC_BEETS_PAIR[1],
+                )
                 prepare = MagicMock(return_value="ready")
                 enrich = MagicMock(return_value="complete")
                 config_error = (

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -11,7 +11,7 @@ and _check_quality_gate_core run for real, not patched.
 import os
 import shutil
 import configparser
-from contextlib import contextmanager
+from contextlib import AbstractContextManager, contextmanager
 import tempfile
 from typing import Any, Never, cast
 import unittest
@@ -52,7 +52,22 @@ from tests.helpers import (
     make_request_row,
     make_requests_http_error,
     patch_dispatch_externals,
+    hermetic_beets_config_defaults,
 )
+
+
+_HERMETIC_BEETS_DEFAULTS: AbstractContextManager[tuple[str, str]] | None = None
+
+
+def setUpModule() -> None:
+    global _HERMETIC_BEETS_DEFAULTS
+    _HERMETIC_BEETS_DEFAULTS = hermetic_beets_config_defaults()
+    _HERMETIC_BEETS_DEFAULTS.__enter__()
+
+
+def tearDownModule() -> None:
+    assert _HERMETIC_BEETS_DEFAULTS is not None
+    _HERMETIC_BEETS_DEFAULTS.__exit__(None, None, None)
 
 
 _HARNESS = "/nix/store/fake/harness/run_beets_harness.sh"

--- a/tests/test_nix_module.py
+++ b/tests/test_nix_module.py
@@ -19,13 +19,15 @@ leaks here have caused pipeline-wide failures that were hard to trace:
 These grep-based contracts are cheap to write and catch the whole
 class of "an export in module.nix leaked into a subprocess and broke
 something five layers away". They run inside the Python suite because
-we don't want to depend on ``nix eval`` at test time — a text grep
-against the source file is enough for the invariants we care about.
+most invariants only need a source-level check. The state-directory authority
+boundary is the exception: it has a known-bad ``nix eval`` pin because the
+failure depends on Nix option assertion evaluation.
 """
 
 from __future__ import annotations
 
 import re
+import subprocess
 import unittest
 from pathlib import Path
 
@@ -346,6 +348,55 @@ class TestRenderedBeetsConfigContract(unittest.TestCase):
         self.assertIn("library = ${cfg.beets.config.library}", text)
         self.assertIn("config_dir = ${beetsConfigDir}", text)
         self.assertIn("python = ${pythonEnv}/bin/python", text)
+
+    def test_default_library_has_a_module_owned_dedicated_parent(self) -> None:
+        """#847: fresh hardened installs need no Music-root DB write grant."""
+        text = MODULE_NIX.read_text(encoding="utf-8")
+        self.assertIn('defaultBeetsDbDir = "${canonicalStateDir}-beets-db";', text)
+        self.assertIn('default = "${defaultBeetsDbDir}/beets-library.db";', text)
+        self.assertIn('"d ${defaultBeetsDbDir} 2775 ${cfg.user} ${cfg.group} -"', text)
+
+    def test_state_dir_requires_a_canonical_sibling_boundary(self) -> None:
+        """#847: a trailing slash would place the sibling DB inside stateDir."""
+        text = MODULE_NIX.read_text(encoding="utf-8")
+        self.assertIn("canonicalStateDirIsValid =", text)
+        self.assertIn('!lib.hasSuffix "/" canonicalStateDir', text)
+        self.assertIn("assertion = canonicalStateDirIsValid;", text)
+
+    def test_trailing_state_dir_fails_nix_evaluation(self) -> None:
+        """#847: `/srv/cratedigger/` must not turn the DB sibling into a child."""
+        expression = '''
+          let
+            f = builtins.getFlake (toString ./.);
+            system = f.inputs.nixpkgs.lib.nixosSystem {
+              system = builtins.currentSystem;
+              modules = [
+                f.nixosModules.default
+                ({ ... }: {
+                  services.cratedigger = {
+                    enable = true;
+                    src = ./.;
+                    stateDir = "/srv/cratedigger/";
+                    slskd.apiKeyFile = "/tmp/cratedigger-test-key";
+                    slskd.downloadDir = "/srv/cratedigger-downloads";
+                  };
+                })
+              ];
+            };
+          in system.config.system.build.toplevel.drvPath
+        '''
+        result = subprocess.run(
+            ["nix", "eval", "--impure", "--expr", expression],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "services.cratedigger.stateDir must be an absolute normalized non-root path without a trailing slash",
+            result.stderr,
+        )
 
     def test_web_wrapper_exports_beetsdir(self) -> None:
         """cratedigger-web imports beets in-process (beets_distance) —


### PR DESCRIPTION
## Summary

- default the module-owned Beets SQLite database, import log, and harness mutation audit to a dedicated sibling of `stateDir`
- keep preview and YouTube workers out of that authority while retaining it for web/importer, with real module-VM denial probes and known-bad evaluation coverage
- update the doc2 consumer to use `/mnt/virtio/cratedigger/beets-db` and replace broad Music-root write binds with explicit reviewed children
- make affected import/preview test worlds use a complete disposable Beets DB/root pair instead of host authority
- update current configuration and operator documentation for the new path

## Validation

- `nix-shell --run "pyright --threads 4"` — 0 errors
- `nix-shell --run "bash scripts/run_tests.sh"` — 6,913 tests, OK, no skips
- `nix build .#checks.x86_64-linux.moduleVm -L` — passed
- focused config/module tests — 134 passed
- affected import/preview modules — 417 passed
- downstream doc2 evaluation and `nix flake check --no-build` — passed
- Sol final cross-repository review — clean

## Deployment

The tracked downstream overlay and controlled storage cutover are intentionally performed after merge. The deploy will hold every Beets consumer, back up and move the exact SQLite/log/audit files once, verify counts and exact lookups, then prove both the controlled source cycle and an ordinary successor before closing the issue.

Refs #847
