### PR TITLE
Harden the daily candidate test gate

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -46,6 +46,7 @@ in
 pkgs.mkShell {
   packages = [
     pkgs.postgresql          # initdb, pg_ctl for ephemeral test DB
+    pkgs.util-linux          # flock for deploy-pin concurrency tests
     pkgs.ruff                # per-module F401 liveness (aggregate vulture masks it)
     testPythonEnv
     pkgs.sox                 # spectral analysis tests

--- a/scripts/run_fuzz_tests.py
+++ b/scripts/run_fuzz_tests.py
@@ -297,6 +297,11 @@ def _settings_max_examples(configured: settings) -> int:
     return raw_max_examples
 
 
+def _settings_deadline(configured: settings) -> object:
+    """Return the effective deadline so fuzz work never depends on timing."""
+    return getattr(configured, "deadline", None)
+
+
 def _discover_module_child(module_name: str, result_path: Path) -> int:
     suite = unittest.defaultTestLoader.loadTestsFromName(module_name)
     cases = tuple(_iter_test_cases(suite))
@@ -345,6 +350,12 @@ def _discover_module_child(module_name: str, result_path: Path) -> int:
             )
         if configured is None:
             raise TypeError(f"Hypothesis test has no settings: {test.id()}")
+        deadline = _settings_deadline(configured)
+        if deadline is not None:
+            raise RuntimeError(
+                "Hypothesis test has non-None deadline: "
+                f"{test.id()}: {deadline!r}"
+            )
         configured_max_examples = _settings_max_examples(configured)
         hypothesis_tests.append(
             FuzzPropertyManifest(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,21 +15,20 @@ import sys
 # issue #95 dual-load footgun (module reachable as both `quality` and `lib.quality`).
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-# Try to start ephemeral PostgreSQL if tools are available
+# A test process must own a live disposable database. Falling through to an
+# unset DSN makes PipelineDB silently target ambient localhost instead.
 _pg = None
 TEST_DSN = os.environ.get("TEST_DB_DSN")
 
-if not TEST_DSN and shutil.which("initdb") and shutil.which("pg_ctl"):
-    try:
-        from ephemeral_pg import EphemeralPostgres
-        _pg = EphemeralPostgres()
-        _pg.start()
-        TEST_DSN = _pg.dsn
-        if TEST_DSN is not None:
-            os.environ["TEST_DB_DSN"] = TEST_DSN
-    except Exception as e:
-        print(f"[WARN] Could not start ephemeral PostgreSQL: {e}", file=sys.stderr)
-        _pg = None
+if not TEST_DSN:
+    if not shutil.which("initdb") or not shutil.which("pg_ctl"):
+        raise RuntimeError("initdb/pg_ctl are required for the test database")
+    from tests.ephemeral_pg import EphemeralPostgres
+    _pg = EphemeralPostgres()
+    _pg.start()
+    TEST_DSN = _pg.dsn
+    assert TEST_DSN is not None
+    os.environ["TEST_DB_DSN"] = TEST_DSN
 
 if TEST_DSN and os.environ.get("CRATEDIGGER_TEST_SCHEMA_READY") != "1":
     # Apply schema once at session start for either an externally supplied

--- a/tests/ephemeral_pg.py
+++ b/tests/ephemeral_pg.py
@@ -1,126 +1,142 @@
-"""Ephemeral PostgreSQL server for tests.
-
-Spins up an isolated PostgreSQL instance on a random port with a temp data
-directory. Completely independent of any system PostgreSQL. Requires initdb
-and pg_ctl on PATH (provided by pkgs.postgresql in Nix).
-
-Usage:
-    from ephemeral_pg import EphemeralPostgres
-
-    # Module-level (shared across all tests):
-    pg = EphemeralPostgres()
-    pg.start()
-    DSN = pg.dsn
-
-    # In teardown:
-    pg.stop()
-
-Or as a context manager:
-    with EphemeralPostgres() as pg:
-        db = PipelineDB(pg.dsn)
-"""
+"""Disposable PostgreSQL clusters for tests, isolated on private Unix sockets."""
 
 import atexit
 import os
+from pathlib import Path
 import shutil
-import socket
 import subprocess
 import tempfile
 import time
+from urllib.parse import quote
 
 
-def _find_free_port():
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
+class EphemeralPostgresError(RuntimeError):
+    """A disposable cluster could not start, with its useful diagnostics."""
 
 
 class EphemeralPostgres:
-    def __init__(self):
-        self.tmpdir = None
-        self.port = None
-        self.dsn = None
+    def __init__(self) -> None:
+        self.tmpdir: Path | None = None
+        self.dsn: str | None = None
+        self._server_started = False
         self._started = False
 
-    def start(self):
+    @property
+    def _datadir(self) -> Path:
+        assert self.tmpdir is not None
+        return self.tmpdir / "data"
+
+    @property
+    def _logfile(self) -> Path:
+        assert self.tmpdir is not None
+        return self.tmpdir / "pg.log"
+
+    @property
+    def _socket_dir(self) -> Path:
+        assert self.tmpdir is not None
+        return self.tmpdir / "socket"
+
+    def _failure_detail(self, error: subprocess.CalledProcessError) -> str:
+        command = " ".join(str(part) for part in error.cmd)
+        stdout = (error.stdout or b"").decode("utf-8", errors="replace")
+        stderr = (error.stderr or b"").decode("utf-8", errors="replace")
+        log = ""
+        if self.tmpdir is not None and self._logfile.is_file():
+            log = self._logfile.read_text(encoding="utf-8", errors="replace")
+        return (
+            f"PostgreSQL command failed ({error.returncode}): {command}\n"
+            f"stdout:\n{stdout}\nstderr:\n{stderr}\npg.log:\n{log}"
+        )
+
+    def _cleanup(self) -> None:
+        if self._server_started and self.tmpdir is not None:
+            subprocess.run(
+                ["pg_ctl", "-D", str(self._datadir), "-m", "immediate", "stop"],
+                capture_output=True,
+                check=False,
+            )
+        self._server_started = False
+        self._started = False
+        self.dsn = None
+        if self.tmpdir is not None:
+            shutil.rmtree(self.tmpdir, ignore_errors=True)
+        self.tmpdir = None
+
+    def start(self) -> None:
         if self._started:
             return
-
-        # Check that initdb/pg_ctl are available
         if not shutil.which("initdb") or not shutil.which("pg_ctl"):
-            raise RuntimeError(
-                "initdb/pg_ctl not found. Run tests inside: "
-                "nix-shell -p postgresql python3Packages.psycopg2"
+            raise EphemeralPostgresError(
+                "initdb/pg_ctl not found; run tests inside nix-shell"
             )
 
-        self.tmpdir = tempfile.mkdtemp(prefix="cratedigger_test_pg_")
-        self.port = _find_free_port()
-        datadir = os.path.join(self.tmpdir, "data")
-        logfile = os.path.join(self.tmpdir, "pg.log")
-        sockdir = self.tmpdir
+        self.tmpdir = Path(tempfile.mkdtemp(prefix="cratedigger_test_pg_"))
+        self._socket_dir.mkdir()
+        user = os.getenv("USER", "root")
+        try:
+            subprocess.run(
+                [
+                    "initdb", "-D", str(self._datadir), "--no-locale", "-E", "UTF8",
+                    "-A", "trust",
+                ],
+                capture_output=True,
+                check=True,
+            )
+            subprocess.run(
+                [
+                    "pg_ctl", "-D", str(self._datadir), "-l", str(self._logfile), "-o",
+                    f"-k {self._socket_dir} -c listen_addresses=''", "start",
+                ],
+                capture_output=True,
+                check=True,
+            )
+            self._server_started = True
 
-        # initdb
-        subprocess.run(
-            ["initdb", "-D", datadir, "--no-locale", "-E", "UTF8", "-A", "trust"],
-            capture_output=True, check=True,
-        )
+            import psycopg2
 
-        # Start postgres on random port, unix socket in tmpdir
-        subprocess.run(
-            ["pg_ctl", "-D", datadir, "-l", logfile, "-o",
-             f"-p {self.port} -k {sockdir} -c listen_addresses=127.0.0.1",
-             "start"],
-            capture_output=True, check=True,
-        )
-
-        # Wait for it to be ready
-        for _ in range(30):
-            try:
-                import psycopg2
-                conn = psycopg2.connect(
-                    host="127.0.0.1", port=self.port, dbname="postgres", user=os.getenv("USER", "root")
+            for _ in range(30):
+                try:
+                    with psycopg2.connect(
+                        host=str(self._socket_dir), dbname="postgres", user=user,
+                    ):
+                        break
+                except psycopg2.OperationalError:
+                    time.sleep(0.1)
+            else:
+                log = self._logfile.read_text(encoding="utf-8", errors="replace")
+                raise EphemeralPostgresError(
+                    f"PostgreSQL did not become ready. pg.log:\n{log}"
                 )
-                conn.close()
-                break
-            except Exception:
-                time.sleep(0.1)
-        else:
-            self.stop()
-            raise RuntimeError(f"PostgreSQL failed to start. Log: {logfile}")
 
-        # Create test database
-        import psycopg2
-        conn = psycopg2.connect(
-            host="127.0.0.1", port=self.port, dbname="postgres", user=os.getenv("USER", "root")
-        )
-        conn.autocommit = True
-        conn.cursor().execute("CREATE DATABASE cratedigger_test")
-        conn.close()
+            connection = psycopg2.connect(
+                host=str(self._socket_dir), dbname="postgres", user=user,
+            )
+            try:
+                connection.autocommit = True
+                with connection.cursor() as cursor:
+                    cursor.execute("CREATE DATABASE cratedigger_test")
+            finally:
+                connection.close()
+            self.dsn = (
+                f"postgresql://{quote(user)}@/cratedigger_test?host="
+                f"{quote(str(self._socket_dir), safe='')}"
+            )
+            self._started = True
+            atexit.register(self.stop)
+        except subprocess.CalledProcessError as error:
+            detail = self._failure_detail(error)
+            self._cleanup()
+            raise EphemeralPostgresError(detail) from error
+        except Exception:
+            self._cleanup()
+            raise
 
-        self.dsn = f"postgresql://{os.getenv('USER', 'root')}@127.0.0.1:{self.port}/cratedigger_test"
-        self._started = True
+    def stop(self) -> None:
+        self._cleanup()
 
-        # Register cleanup in case stop() is never called
-        atexit.register(self.stop)
-
-    def stop(self):
-        if not self._started:
-            return
-        self._started = False
-
-        assert self.tmpdir is not None
-        datadir = os.path.join(self.tmpdir, "data")
-        subprocess.run(
-            ["pg_ctl", "-D", datadir, "-m", "immediate", "stop"],
-            capture_output=True,
-        )
-
-        shutil.rmtree(self.tmpdir, ignore_errors=True)
-        self.tmpdir = None
-
-    def __enter__(self):
+    def __enter__(self) -> "EphemeralPostgres":
         self.start()
         return self
 
-    def __exit__(self, *args):
+    def __exit__(self, *_args: object) -> None:
         self.stop()

--- a/tests/test_browse_route_generated.py
+++ b/tests/test_browse_route_generated.py
@@ -11,7 +11,7 @@ from urllib.error import HTTPError, URLError
 
 from hypothesis import given, strategies as st
 
-from tests import _hypothesis_profiles  # noqa: F401 — registers active profile
+import tests._hypothesis_profiles  # noqa: F401 - registers active profile
 from web.routes.browse import _resolve_discogs, get_artist
 
 

--- a/tests/test_cleanup_ghost_imported_generated.py
+++ b/tests/test_cleanup_ghost_imported_generated.py
@@ -8,6 +8,8 @@ import unittest
 
 from hypothesis import given, strategies as st
 
+import tests._hypothesis_profiles  # noqa: F401 - registers active profile
+
 from lib.beets_db import BeetsDB
 from lib.release_identity import ReleaseIdentity
 from scripts.cleanup_ghost_imported import classify_imported_rows

--- a/tests/test_ephemeral_pg.py
+++ b/tests/test_ephemeral_pg.py
@@ -1,0 +1,62 @@
+"""Deterministic contracts for disposable PostgreSQL test clusters."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import psycopg2
+
+from tests.ephemeral_pg import EphemeralPostgres, EphemeralPostgresError
+
+
+class TestEphemeralPostgresFailures(unittest.TestCase):
+    def test_initdb_failure_is_diagnostic_and_cleans_its_temporary_state(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            base = Path(directory)
+            failed_dir = base / "failed-cluster"
+
+            def make_tempdir(*_args: object, **_kwargs: object) -> str:
+                failed_dir.mkdir()
+                return str(failed_dir)
+
+            with (
+                patch("tests.ephemeral_pg.shutil.which", return_value="/bin/tool"),
+                patch("tests.ephemeral_pg.tempfile.mkdtemp", make_tempdir),
+                patch(
+                    "tests.ephemeral_pg.subprocess.run",
+                    side_effect=subprocess.CalledProcessError(
+                        1,
+                        ["initdb"],
+                        output=b"initdb stdout",
+                        stderr=b"initdb stderr",
+                    ),
+                ),
+                self.assertRaisesRegex(EphemeralPostgresError, "initdb stderr"),
+            ):
+                EphemeralPostgres().start()
+
+            self.assertFalse(failed_dir.exists())
+
+
+class TestEphemeralPostgresIsolation(unittest.TestCase):
+    def test_multiple_instances_have_isolated_live_unix_socket_clusters(self) -> None:
+        def start_query_stop(_: int) -> str:
+            with EphemeralPostgres() as pg:
+                assert pg.dsn is not None
+                self.assertIn("host=%2F", pg.dsn)
+                with psycopg2.connect(pg.dsn) as connection:
+                    with connection.cursor() as cursor:
+                        cursor.execute("SELECT current_database()")
+                        row = cursor.fetchone()
+                        assert row is not None
+                        return str(row[0])
+
+        with ThreadPoolExecutor(max_workers=4) as executor:
+            databases = tuple(executor.map(start_query_stop, range(4)))
+
+        self.assertEqual(databases, ("cratedigger_test",) * 4)

--- a/tests/test_evidence_rekey_migration.py
+++ b/tests/test_evidence_rekey_migration.py
@@ -29,12 +29,14 @@ import tempfile
 import unittest
 import uuid
 from typing import Sequence
+from unittest.mock import patch
 
 sys.path.append(os.path.dirname(__file__))
 import conftest  # noqa: F401 — sets TEST_DB_DSN env var
 
 
 import psycopg2  # noqa: E402
+from psycopg2.extensions import make_dsn, parse_dsn  # noqa: E402
 
 from lib.migrator import (  # noqa: E402
     DEFAULT_MIGRATIONS_DIR,
@@ -57,33 +59,47 @@ def requires_postgres(cls):
     return cls
 
 
-def _parse_dsn(dsn: str) -> tuple[str, str, int, str]:
-    """Return (user, host, port, dbname) from a postgres DSN."""
-    # postgresql://user@host:port/dbname
-    body = dsn.split("://", 1)[1]
-    userhost, dbname = body.rsplit("/", 1)
-    user, hostport = userhost.split("@", 1)
-    if ":" in hostport:
-        host, port_str = hostport.split(":", 1)
-        port = int(port_str)
-    else:
-        host = hostport
-        port = 5432
-    return user, host, port, dbname
-
-
 def _build_isolated_dsn(template_dsn: str, db_name: str) -> str:
-    user, host, port, _ = _parse_dsn(template_dsn)
-    return f"postgresql://{user}@{host}:{port}/{db_name}"
+    """Override only dbname while preserving every libpq connection option."""
+    return make_dsn(template_dsn, dbname=db_name)
 
 
 def _maintenance_conn(template_dsn: str):
-    user, host, port, _ = _parse_dsn(template_dsn)
-    conn = psycopg2.connect(
-        host=host, port=port, dbname="postgres", user=user
-    )
+    conn = psycopg2.connect(make_dsn(template_dsn, dbname="postgres"))
     conn.autocommit = True
     return conn
+
+
+class TestIsolatedDatabaseDsnDerivation(unittest.TestCase):
+    SOCKET_DSN = (
+        "postgresql://test-user@/cratedigger_test?"
+        "host=%2Frun%2Fprivate%2Fpg&application_name=migration-test"
+    )
+
+    def test_isolated_dsn_preserves_private_socket_and_query_options(self) -> None:
+        derived = _build_isolated_dsn(self.SOCKET_DSN, "isolated_database")
+
+        self.assertEqual(
+            parse_dsn(derived),
+            {
+                "user": "test-user",
+                "dbname": "isolated_database",
+                "host": "/run/private/pg",
+                "application_name": "migration-test",
+            },
+        )
+
+    def test_maintenance_connection_preserves_private_socket(self) -> None:
+        with patch(
+            "tests.test_evidence_rekey_migration.psycopg2.connect"
+        ) as connect:
+            connection = connect.return_value
+            _maintenance_conn(self.SOCKET_DSN)
+
+        connect.assert_called_once_with(
+            _build_isolated_dsn(self.SOCKET_DSN, "postgres")
+        )
+        self.assertTrue(connection.autocommit)
 
 
 def _make_isolated_db(template_dsn: str) -> tuple[str, str]:

--- a/tests/test_fuzz_runner_generated.py
+++ b/tests/test_fuzz_runner_generated.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import unittest
 from dataclasses import replace
+import os
+from pathlib import Path
+import tempfile
 
 from hypothesis import given
 from hypothesis import strategies as st
@@ -14,6 +17,7 @@ from scripts.run_fuzz_tests import (
     FuzzPropertyManifest,
     assert_exact_fuzz_coverage,
     build_fuzz_targets,
+    discover_fuzz_manifests,
 )
 
 
@@ -139,6 +143,35 @@ class TestFuzzCoverageCheckerKnownBad(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "changed fuzz property budget"):
             assert_exact_fuzz_coverage((manifest,), targets)
+
+
+class TestFuzzDiscoverySettingsContract(unittest.TestCase):
+    def test_discovery_rejects_property_with_default_deadline(self) -> None:
+        """A module that omits profile registration must fail before sharding."""
+        with tempfile.TemporaryDirectory() as directory:
+            fixture_root = Path(directory)
+            fixture = fixture_root / "unprofiled_fuzz_fixture.py"
+            fixture.write_text(
+                "from hypothesis import given, strategies as st\n"
+                "import unittest\n\n"
+                "class TestUnprofiled(unittest.TestCase):\n"
+                "    @given(st.integers())\n"
+                "    def test_property(self, value):\n"
+                "        self.assertIsInstance(value, int)\n",
+                encoding="utf-8",
+            )
+            environment = dict(os.environ)
+            old_pythonpath = environment.get("PYTHONPATH", "")
+            environment["PYTHONPATH"] = os.pathsep.join(
+                part for part in (str(fixture_root), old_pythonpath) if part
+            )
+            with self.assertRaisesRegex(RuntimeError, "non-None deadline"):
+                discover_fuzz_manifests(
+                    ("unprofiled_fuzz_fixture",),
+                    worker_count=1,
+                    environment=environment,
+                    work_directory=fixture_root,
+                )
 
 
 if __name__ == "__main__":

--- a/tests/test_migrator.py
+++ b/tests/test_migrator.py
@@ -10,13 +10,13 @@ import shutil
 import sys
 import tempfile
 import unittest
-import urllib.parse
 
 sys.path.append(os.path.dirname(__file__))
 import conftest  # noqa: F401 — sets TEST_DB_DSN env var
 
 
 import psycopg2  # noqa: E402
+from psycopg2.extensions import make_dsn  # noqa: E402
 
 from lib.migrator import (  # noqa: E402
     DEFAULT_MIGRATIONS_DIR,
@@ -4973,8 +4973,7 @@ def _maintenance_dsn() -> str:
     cluster -- used to CREATE/DROP a throwaway database with no tracking
     table for TestAssertSchemaCurrent.test_raises_when_tracking_table_missing.
     """
-    parts = urllib.parse.urlsplit(TEST_DSN)
-    return urllib.parse.urlunsplit(parts._replace(path="/postgres"))
+    return make_dsn(TEST_DSN, dbname="postgres")
 
 
 def _create_fresh_database(name: str) -> str:
@@ -4984,8 +4983,7 @@ def _create_fresh_database(name: str) -> str:
         cur.execute(f"DROP DATABASE IF EXISTS {name}")
         cur.execute(f"CREATE DATABASE {name}")
     conn.close()
-    parts = urllib.parse.urlsplit(TEST_DSN)
-    return urllib.parse.urlunsplit(parts._replace(path=f"/{name}"))
+    return make_dsn(TEST_DSN, dbname=name)
 
 
 def _drop_database(name: str) -> None:

--- a/tests/test_quality_lineage_generated.py
+++ b/tests/test_quality_lineage_generated.py
@@ -10,6 +10,8 @@ from unittest.mock import patch
 from hypothesis import example, given, strategies as st
 import msgspec
 
+import tests._hypothesis_profiles  # noqa: F401 - registers active profile
+
 from harness.import_one import projected_is_cbr_from_bitrates
 from lib.beets_db import (
     CurrentBeetsUnique,
@@ -60,6 +62,7 @@ from tests.helpers import (
     make_audio_corrupt_validation_report,
     make_request_row,
 )
+from web.classify import LogEntry, classify_log_entry
 
 
 def _coherent_three_track_metrics(
@@ -72,7 +75,6 @@ def _coherent_three_track_metrics(
     minimum, median, maximum = sorted((first, second, third))
     average = int((minimum + median + maximum) / 3)
     return minimum, average, median, minimum == maximum
-from web.classify import LogEntry, classify_log_entry
 
 
 def assert_source_target_lineage(result: ImportResult) -> None:

--- a/tests/test_terminal_outcomes_generated.py
+++ b/tests/test_terminal_outcomes_generated.py
@@ -7,6 +7,8 @@ import unittest
 
 from hypothesis import example, given, settings, strategies as st
 
+import tests._hypothesis_profiles  # noqa: F401 - registers active profile
+
 from lib import transitions
 from lib.import_queue import IMPORT_JOB_FORCE
 from lib.pipeline_db import PipelineDB


### PR DESCRIPTION
## Summary

- provide `flock` through the pinned development/test shell
- make fuzz discovery reject timing deadlines before sharding and restore the shared Hypothesis profile in every affected generated module
- give every PostgreSQL-backed test process a fail-closed, private Unix-socket cluster with preserved startup diagnostics and libpq-aware sibling database handling

PR #849 already restored disposable paired Beets authority for the four preview/import targets reported by #848. This change keeps production lifecycle and quality policy unchanged and covers the remaining candidate-gate failures.

## Validation

- `nix-shell --run "pyright --threads 4"` — 0 errors
- `nix-shell --run "bash scripts/run_tests.sh"` — 6,918 tests, OK, no skips
- exact restricted sandbox lifecycle/permissions cohort — 424 tests, OK
- 30-way disposable PostgreSQL start/query/stop stress — passed
- Sol adversarial review of the final signed tree — clean

Refs #848
