### PR TITLE
Model live current-evidence scars in the world fuzzer

### DIFF
--- a/docs/generated-testing.md
+++ b/docs/generated-testing.md
@@ -147,6 +147,17 @@ authoritative. Ordinary and force-import pins then prove installed-only facts
 produce the expected `have_analysis_error`, keep the request wanted, and
 converge after the production enrichment path measures the exact new snapshot.
 
+The #855 audit adds the separate 429-row `current_evidence_missing` cohort:
+each row has one uniquely installed Beets album but no current-evidence FK.
+Its anonymized marginal vocabularies retain historical origin, status,
+MusicBrainz/Discogs identity, installed codec/container, operator search and
+target intent, and legacy spectral/bitrate scalar presence. The real-store
+state rule crosses those independent axes, first requiring the shared
+invariant bank to report `current_evidence_missing`, then requiring the
+production evidence loader to rebuild and link a lineage-4 snapshot without
+mutating operator-owned request state. Explicit OGG/Vorbis and Windows
+Media/WMA examples keep the native Beets format labels at that boundary.
+
 Every lifecycle import — ordinary automation and force alike — hands its
 enqueued job to the real preview worker (`process_claimed_preview_job`, the
 shared `_run_preview_worker` step) before the importer may claim it, so

--- a/docs/quality-verification.md
+++ b/docs/quality-verification.md
@@ -444,6 +444,13 @@ exact installed Beets album before deciding. A same-snapshot repair preserves
 its original `measured_at` and atomic neutral facts so historical Recents cards
 remain pre-attempt evidence.
 
+Beets's native `items.format` is normalized only at the library projection
+boundary: its observed `OGG` label becomes bare `vorbis`, and `Windows Media`
+becomes bare `wma`, before the value reaches rank policy or evidence storage.
+Canonical labels otherwise retain Beets's existing spelling/case. This is a
+closed alias map, not tokenization: an unfamiliar multiword label reaches the
+evidence validator unchanged and fails closed rather than being guessed.
+
 **Motivation (request 6039 / download_log 36608):** a genuine avg 196→288
 rank upgrade (GOOD → TRANSPARENT) rendered as "Upgrade: MP3 V2 to MP3 V2"
 because every UI label re-derived from min bitrate (194 on both sides).

--- a/lib/beets_db.py
+++ b/lib/beets_db.py
@@ -234,6 +234,15 @@ def validate_beets_storage_pair(
         )
 
 
+_BEETS_FORMAT_ALIASES = {
+    # Beets exposes these container/product labels, while quality policy ranks
+    # bare codec families. Keep this boundary deliberately closed: unfamiliar
+    # multiword labels must still reach evidence validation unchanged.
+    "windows media": "wma",
+    "ogg": "vorbis",
+}
+
+
 def _reduce_album_format(
     formats_on_disk: set[str],
     cfg: "QualityRankConfig",
@@ -242,18 +251,32 @@ def _reduce_album_format(
 
     Uses cfg.mixed_format_precedence (worst-first). If the album contains
     any codec listed in the precedence tuple, the first match wins. Otherwise
-    returns the first format alphabetically (stable but not meaningful) or
-    an empty string if the set is empty.
+    returns the first normalized format alphabetically (stable but not
+    meaningful) or an empty string if the set is empty.
     """
     if not formats_on_disk:
         return ""
-    # Normalized lookup: lowercase -> original.
-    normalized: dict[str, str] = {f.lower(): f for f in formats_on_disk if f}
+    # Normalized lookup: rank family -> original canonical label. The two
+    # native Beets aliases return their policy family; canonical Beets labels
+    # retain their original spelling/case for existing callers.
+    normalized: dict[str, str] = {}
+    for observed in sorted(formats_on_disk):
+        if not observed:
+            continue
+        key = observed.lower()
+        alias = _BEETS_FORMAT_ALIASES.get(key)
+        if alias is None:
+            normalized[key] = observed
+        else:
+            normalized.setdefault(alias, alias)
     for preferred in cfg.mixed_format_precedence:
         if preferred in normalized:
             return normalized[preferred]
-    # No precedence match — pick a deterministic fallback.
-    return sorted(formats_on_disk)[0]
+    # No precedence match — pick a deterministic normalized fallback. Native
+    # Beets aliases stay canonical even when a user deliberately omits their
+    # family from mixed_format_precedence; unknown labels retain their source
+    # spelling and therefore still fail evidence validation when multiword.
+    return normalized[sorted(normalized)[0]] if normalized else ""
 
 
 @dataclass

--- a/tests/beets_world.py
+++ b/tests/beets_world.py
@@ -371,6 +371,10 @@ class BeetsWorld:
             encoder_args = ["-c:a", "libopus", "-b:a", "128k"]
         elif codec_key == "m4a":
             encoder_args = ["-c:a", "aac", "-b:a", "192k"]
+        elif codec_key == "ogg":
+            encoder_args = ["-c:a", "libvorbis", "-q:a", "4"]
+        elif codec_key == "wma":
+            encoder_args = ["-c:a", "wmav2", "-b:a", "192k"]
         else:
             raise ValueError(f"unsupported scratch-world codec {codec!r}")
         subprocess.run(
@@ -542,6 +546,38 @@ class BeetsWorld:
                 duplicate.remove(delete=True)
         album.move(MoveOperation.MOVE)
         return self.snapshot_album(album)
+
+    def set_release_item_format(self, release_id: str, format_label: str) -> None:
+        """Set the Beets projection label after importing genuine audio bytes."""
+
+        matches = [
+            album
+            for album in self.library.albums()
+            if self._album_release_id(album) == release_id
+        ]
+        if len(matches) != 1:
+            raise AssertionError(
+                f"format release must resolve once: {release_id!r} -> "
+                f"{len(matches)}"
+            )
+        for item in matches[0].items():
+            item["format"] = format_label
+            item.store()
+
+    def release_item_formats(self, release_id: str) -> tuple[str, ...]:
+        """Return the actual Beets item.format labels for one exact release."""
+
+        matches = [
+            album
+            for album in self.library.albums()
+            if self._album_release_id(album) == release_id
+        ]
+        if len(matches) != 1:
+            raise AssertionError(
+                f"format release must resolve once: {release_id!r} -> "
+                f"{len(matches)}"
+            )
+        return tuple(str(item["format"]) for item in matches[0].items())
 
     def set_discogs_identity_layout(
         self,
@@ -825,6 +861,43 @@ class BeetsWorld:
 
     def snapshots(self) -> tuple[LibraryAlbumSnapshot, ...]:
         return tuple(self.snapshot_album(album) for album in self.library.albums())
+
+    def release_stream_codecs(self, release_id: str) -> tuple[str, ...]:
+        """Read actual ffprobe codecs for one installed exact release.
+
+        This deliberately probes the real files rather than inferring an
+        encoder from their suffix, so unusual observed containers (Ogg and
+        Windows Media) cannot regress into renamed MP3 stand-ins.
+        """
+        album = next(
+            (
+                snapshot for snapshot in self.snapshots()
+                if snapshot.release_id == release_id
+            ),
+            None,
+        )
+        if album is None:
+            raise AssertionError(f"release is not installed: {release_id!r}")
+        codecs: list[str] = []
+        for item_path in album.item_paths:
+            result = subprocess.run(
+                [
+                    "ffprobe",
+                    "-v", "error",
+                    "-select_streams", "a:0",
+                    "-show_entries", "stream=codec_name",
+                    "-of", "default=nokey=1:noprint_wrappers=1",
+                    item_path,
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            codec = result.stdout.strip()
+            if not codec:
+                raise AssertionError(f"ffprobe found no audio codec: {item_path}")
+            codecs.append(codec)
+        return tuple(codecs)
 
 
 __all__ = [

--- a/tests/test_beets_db.py
+++ b/tests/test_beets_db.py
@@ -11,13 +11,14 @@ import sys
 import tempfile
 import unittest
 from contextlib import closing
+from dataclasses import replace
 from unittest.mock import patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from lib.beets_db import AlbumInfo, BeetsDB, open_beets_db
 from lib.config import CratediggerConfig
-from lib.quality import QualityRankConfig
+from lib.quality import AudioQualityMeasurement, QualityRankConfig
 
 
 def _create_test_db(path: str) -> None:
@@ -954,6 +955,72 @@ class TestReduceAlbumFormat(unittest.TestCase):
         from lib.beets_db import _reduce_album_format
         self.assertEqual(
             _reduce_album_format({"FLAC", "Opus", "AAC"}, self.cfg), "AAC")
+
+    def test_native_beets_container_labels_reduce_to_rank_families(self) -> None:
+        """Beets labels WMA/OGG with container names, not rank families."""
+        from lib.beets_db import _reduce_album_format
+
+        self.assertEqual(
+            _reduce_album_format({"Windows Media"}, self.cfg), "wma")
+        self.assertEqual(_reduce_album_format({"OGG"}, self.cfg), "vorbis")
+
+    def test_native_container_aliases_obey_existing_mixed_precedence(self) -> None:
+        from lib.beets_db import _reduce_album_format
+
+        self.assertEqual(
+            _reduce_album_format({"Windows Media", "MP3"}, self.cfg), "wma")
+        self.assertEqual(
+            _reduce_album_format({"OGG", "AAC"}, self.cfg), "vorbis")
+
+    def test_native_alias_does_not_rewrite_an_existing_canonical_label(self) -> None:
+        from lib.beets_db import _reduce_album_format
+
+        self.assertEqual(
+            _reduce_album_format({"OGG", "Vorbis"}, self.cfg), "Vorbis")
+        self.assertEqual(
+            _reduce_album_format({"Windows Media", "WMA"}, self.cfg), "WMA")
+
+    def test_native_aliases_survive_custom_precedence_without_their_family(self) -> None:
+        """Alias reduction is a projection fact, not a default-policy accident."""
+        from lib.beets_db import _reduce_album_format
+
+        without_native_families = replace(
+            self.cfg,
+            mixed_format_precedence=("mp3", "aac"),
+        )
+        self.assertEqual(
+            _reduce_album_format({"Windows Media"}, without_native_families),
+            "wma",
+        )
+        self.assertEqual(
+            _reduce_album_format({"OGG"}, without_native_families),
+            "vorbis",
+        )
+        self.assertEqual(
+            _reduce_album_format(
+                {"Windows Media", "OGG"},
+                without_native_families,
+            ),
+            "vorbis",
+        )
+
+    def test_unknown_multiword_format_is_not_guessed(self) -> None:
+        """Only observed Beets labels are aliases; unknown labels fail closed."""
+        from lib.beets_db import _reduce_album_format
+
+        reduced = _reduce_album_format({"Alien Codec"}, self.cfg)
+        self.assertEqual(reduced, "Alien Codec")
+        self.assertEqual(
+            _reduce_album_format(
+                {"Alien Codec"},
+                replace(self.cfg, mixed_format_precedence=("mp3",)),
+            ),
+            "Alien Codec",
+        )
+        self.assertIn(
+            "measurement.format must be a bare measured codec label",
+            AudioQualityMeasurement(format=reduced).new_row_validation_errors(),
+        )
 
 
 class TestGetMinBitrate(unittest.TestCase):

--- a/tests/test_world_census_seeds.py
+++ b/tests/test_world_census_seeds.py
@@ -8,10 +8,19 @@ import unittest
 from tests.world_model.census_seeds import (
     EVIDENCE_DRIFT_FACT_SEEDS,
     EVIDENCE_DRIFT_MUTATION_SEEDS,
+    MISSING_CURRENT_EVIDENCE_FORMAT_SEEDS,
+    MISSING_CURRENT_EVIDENCE_IDENTITY_SEEDS,
+    MISSING_CURRENT_EVIDENCE_LEGACY_BITRATE_SEEDS,
+    MISSING_CURRENT_EVIDENCE_LEGACY_SPECTRAL_SEEDS,
+    MISSING_CURRENT_EVIDENCE_ORIGIN_SEEDS,
+    MISSING_CURRENT_EVIDENCE_SEARCH_OVERRIDE_SEEDS,
+    MISSING_CURRENT_EVIDENCE_STATUS_SEEDS,
+    MISSING_CURRENT_EVIDENCE_TARGET_FORMAT_SEEDS,
     STATEFUL_WORLD_CENSUS_SEEDS,
     WORLD_CENSUS_SEEDS,
     assert_census_seed_anonymized,
     assert_evidence_drift_seed_anonymized,
+    assert_missing_current_evidence_seed_anonymized,
 )
 
 
@@ -111,6 +120,144 @@ class TestWorldCensusSeeds(unittest.TestCase):
             *EVIDENCE_DRIFT_FACT_SEEDS,
         ):
             assert_evidence_drift_seed_anonymized(seed)
+
+    def test_missing_current_evidence_census_preserves_every_live_axis(self) -> None:
+        axes = (
+            MISSING_CURRENT_EVIDENCE_ORIGIN_SEEDS,
+            MISSING_CURRENT_EVIDENCE_STATUS_SEEDS,
+            MISSING_CURRENT_EVIDENCE_IDENTITY_SEEDS,
+            MISSING_CURRENT_EVIDENCE_FORMAT_SEEDS,
+            MISSING_CURRENT_EVIDENCE_SEARCH_OVERRIDE_SEEDS,
+            MISSING_CURRENT_EVIDENCE_TARGET_FORMAT_SEEDS,
+            MISSING_CURRENT_EVIDENCE_LEGACY_SPECTRAL_SEEDS,
+            MISSING_CURRENT_EVIDENCE_LEGACY_BITRATE_SEEDS,
+        )
+        self.assertTrue(all(sum(seed.observed_rows for seed in axis) == 429 for axis in axes))
+        self.assertEqual(
+            {seed.status for seed in MISSING_CURRENT_EVIDENCE_STATUS_SEEDS},
+            {"wanted", "unsearchable"},
+        )
+        self.assertEqual(
+            {seed.identity_shape for seed in MISSING_CURRENT_EVIDENCE_IDENTITY_SEEDS},
+            {"musicbrainz", "discogs"},
+        )
+        self.assertEqual(
+            {seed.codec for seed in MISSING_CURRENT_EVIDENCE_FORMAT_SEEDS},
+            {"mp3", "m4a", "ogg", "opus", "wma"},
+        )
+
+    def test_missing_current_evidence_census_preserves_exact_live_marginals(self) -> None:
+        self.assertEqual(
+            [(seed.name, seed.observed_rows, seed.origin)
+             for seed in MISSING_CURRENT_EVIDENCE_ORIGIN_SEEDS],
+            [
+                ("pre_rekey_existing_library_add", 249, "pre_rekey_existing_library_add"),
+                ("pre_rekey_completed_import", 60, "pre_rekey_completed_import"),
+                ("post_rekey_existing_library_add", 120, "post_rekey_existing_library_add"),
+            ],
+        )
+        self.assertEqual(
+            [(seed.name, seed.observed_rows, seed.status)
+             for seed in MISSING_CURRENT_EVIDENCE_STATUS_SEEDS],
+            [("wanted", 427, "wanted"), ("unsearchable", 2, "unsearchable")],
+        )
+        self.assertEqual(
+            [(seed.name, seed.observed_rows, seed.identity_shape)
+             for seed in MISSING_CURRENT_EVIDENCE_IDENTITY_SEEDS],
+            [("musicbrainz", 362, "musicbrainz"), ("discogs", 67, "discogs")],
+        )
+        self.assertEqual(
+            [(seed.name, seed.observed_rows, seed.codec, seed.installed_format)
+             for seed in MISSING_CURRENT_EVIDENCE_FORMAT_SEEDS],
+            [
+                ("mp3", 404, "mp3", "MP3"),
+                ("aac_m4a", 14, "m4a", "AAC"),
+                ("ogg", 7, "ogg", "OGG"),
+                ("opus", 3, "opus", "Opus"),
+                ("windows_media_wma", 1, "wma", "Windows Media"),
+            ],
+        )
+        self.assertEqual(
+            [(seed.name, seed.observed_rows, seed.search_override)
+             for seed in MISSING_CURRENT_EVIDENCE_SEARCH_OVERRIDE_SEEDS],
+            [
+                ("default", 207, None),
+                ("lossless_mp3_v0_mp3_320", 129, "lossless,mp3 v0,mp3 320"),
+                ("lossless", 89, "lossless"),
+                ("lossless_mp3_v0", 2, "lossless,mp3 v0"),
+                ("full_legacy_ladder", 2, "lossless,mp3 v0,mp3 320,aac,opus,ogg"),
+            ],
+        )
+        self.assertEqual(
+            [(seed.name, seed.observed_rows, seed.target_format)
+             for seed in MISSING_CURRENT_EVIDENCE_TARGET_FORMAT_SEEDS],
+            [("default", 424, None), ("lossless", 5, "lossless")],
+        )
+        self.assertEqual(
+            [(seed.name, seed.observed_rows, seed.spectral_grade, seed.has_bitrate)
+             for seed in MISSING_CURRENT_EVIDENCE_LEGACY_SPECTRAL_SEEDS],
+            [
+                ("absent_no_bitrate", 246, None, False),
+                ("genuine_no_bitrate", 80, "genuine", False),
+                ("likely_transcode_bitrate", 64, "likely_transcode", True),
+                ("genuine_bitrate", 30, "genuine", True),
+                ("suspect_bitrate", 4, "suspect", True),
+                ("likely_transcode_no_bitrate", 3, "likely_transcode", False),
+                ("suspect_no_bitrate", 2, "suspect", False),
+            ],
+        )
+        self.assertEqual(
+            [(seed.name, seed.observed_rows, seed.has_min_bitrate,
+              seed.has_prev_min_bitrate)
+             for seed in MISSING_CURRENT_EVIDENCE_LEGACY_BITRATE_SEEDS],
+            [
+                ("min_and_prev_present", 190, True, True),
+                ("both_absent", 189, False, False),
+                ("min_present_prev_absent", 50, True, False),
+            ],
+        )
+
+    def test_missing_current_evidence_census_contains_no_identity_or_path(self) -> None:
+        for axis in (
+            MISSING_CURRENT_EVIDENCE_ORIGIN_SEEDS,
+            MISSING_CURRENT_EVIDENCE_STATUS_SEEDS,
+            MISSING_CURRENT_EVIDENCE_IDENTITY_SEEDS,
+            MISSING_CURRENT_EVIDENCE_FORMAT_SEEDS,
+            MISSING_CURRENT_EVIDENCE_SEARCH_OVERRIDE_SEEDS,
+            MISSING_CURRENT_EVIDENCE_TARGET_FORMAT_SEEDS,
+            MISSING_CURRENT_EVIDENCE_LEGACY_SPECTRAL_SEEDS,
+            MISSING_CURRENT_EVIDENCE_LEGACY_BITRATE_SEEDS,
+        ):
+            for seed in axis:
+                assert_missing_current_evidence_seed_anonymized(seed)
+
+    def test_missing_current_evidence_anonymizer_rejects_raw_field_leakage(self) -> None:
+        known_bads = (
+            replace(
+                MISSING_CURRENT_EVIDENCE_IDENTITY_SEEDS[0],
+                identity_shape="123456789",
+            ),
+            replace(
+                MISSING_CURRENT_EVIDENCE_FORMAT_SEEDS[0],
+                installed_format="Artist Album Title",
+            ),
+            replace(
+                MISSING_CURRENT_EVIDENCE_ORIGIN_SEEDS[0],
+                origin="/mnt/virtio/Music/private",
+            ),
+            replace(
+                MISSING_CURRENT_EVIDENCE_STATUS_SEEDS[0],
+                status="12345678-1234-1234-1234-123456789abc",
+            ),
+            replace(
+                MISSING_CURRENT_EVIDENCE_SEARCH_OVERRIDE_SEEDS[0],
+                search_override='{"request_id": 42}',
+            ),
+        )
+        for known_bad in known_bads:
+            with self.subTest(seed=known_bad.name):
+                with self.assertRaisesRegex(AssertionError, "anonymized"):
+                    assert_missing_current_evidence_seed_anonymized(known_bad)
 
 
 if __name__ == "__main__":

--- a/tests/test_world_census_seeds_generated.py
+++ b/tests/test_world_census_seeds_generated.py
@@ -10,12 +10,22 @@ import tests._hypothesis_profiles  # noqa: F401  (loads active profile)
 from tests.world_model.census_seeds import (
     EVIDENCE_DRIFT_FACT_SEEDS,
     EVIDENCE_DRIFT_MUTATION_SEEDS,
+    MISSING_CURRENT_EVIDENCE_FORMAT_SEEDS,
+    MISSING_CURRENT_EVIDENCE_IDENTITY_SEEDS,
+    MISSING_CURRENT_EVIDENCE_LEGACY_BITRATE_SEEDS,
+    MISSING_CURRENT_EVIDENCE_LEGACY_SPECTRAL_SEEDS,
+    MISSING_CURRENT_EVIDENCE_ORIGIN_SEEDS,
+    MISSING_CURRENT_EVIDENCE_SEARCH_OVERRIDE_SEEDS,
+    MISSING_CURRENT_EVIDENCE_STATUS_SEEDS,
+    MISSING_CURRENT_EVIDENCE_TARGET_FORMAT_SEEDS,
     WORLD_CENSUS_SEEDS,
     EvidenceDriftFactSeed,
     EvidenceDriftMutationSeed,
+    MissingCurrentEvidenceSeed,
     WorldCensusSeed,
     assert_census_seed_anonymized,
     assert_evidence_drift_seed_anonymized,
+    assert_missing_current_evidence_seed_anonymized,
 )
 
 
@@ -36,6 +46,22 @@ class TestWorldCensusSeedsGenerated(unittest.TestCase):
         seed: EvidenceDriftMutationSeed | EvidenceDriftFactSeed,
     ) -> None:
         assert_evidence_drift_seed_anonymized(seed)
+
+    @given(seed=st.sampled_from((
+        *MISSING_CURRENT_EVIDENCE_ORIGIN_SEEDS,
+        *MISSING_CURRENT_EVIDENCE_STATUS_SEEDS,
+        *MISSING_CURRENT_EVIDENCE_IDENTITY_SEEDS,
+        *MISSING_CURRENT_EVIDENCE_FORMAT_SEEDS,
+        *MISSING_CURRENT_EVIDENCE_SEARCH_OVERRIDE_SEEDS,
+        *MISSING_CURRENT_EVIDENCE_TARGET_FORMAT_SEEDS,
+        *MISSING_CURRENT_EVIDENCE_LEGACY_SPECTRAL_SEEDS,
+        *MISSING_CURRENT_EVIDENCE_LEGACY_BITRATE_SEEDS,
+    )))
+    def test_every_sampled_missing_evidence_seed_remains_anonymized(
+        self,
+        seed: MissingCurrentEvidenceSeed,
+    ) -> None:
+        assert_missing_current_evidence_seed_anonymized(seed)
 
 
 if __name__ == "__main__":

--- a/tests/world_model/census_seeds.py
+++ b/tests/world_model/census_seeds.py
@@ -61,6 +61,93 @@ class EvidenceDriftFactSeed:
     verified_lossless: bool
 
 
+@dataclass(frozen=True)
+class MissingCurrentEvidenceOriginSeed:
+    """Historical origin vocabulary for the 429-row #855 cohort."""
+
+    name: str
+    observed_rows: int
+    origin: str
+
+
+@dataclass(frozen=True)
+class MissingCurrentEvidenceStatusSeed:
+    """Current operator lifecycle status in the #855 cohort."""
+
+    name: str
+    observed_rows: int
+    status: str
+
+
+@dataclass(frozen=True)
+class MissingCurrentEvidenceIdentitySeed:
+    """Exact-provider shape, without retaining a production identity."""
+
+    name: str
+    observed_rows: int
+    identity_shape: str
+
+
+@dataclass(frozen=True)
+class MissingCurrentEvidenceFormatSeed:
+    """Actual installed container/extension vocabulary for #855."""
+
+    name: str
+    observed_rows: int
+    codec: str
+    installed_format: str
+
+
+@dataclass(frozen=True)
+class MissingCurrentEvidenceSearchOverrideSeed:
+    """Operator-owned persisted search scope in the #855 cohort."""
+
+    name: str
+    observed_rows: int
+    search_override: str | None
+
+
+@dataclass(frozen=True)
+class MissingCurrentEvidenceTargetFormatSeed:
+    """Legacy target-format intent beside the missing evidence link."""
+
+    name: str
+    observed_rows: int
+    target_format: str | None
+
+
+@dataclass(frozen=True)
+class MissingCurrentEvidenceLegacySpectralSeed:
+    """Legacy request-level spectral scalar presence, not evidence facts."""
+
+    name: str
+    observed_rows: int
+    spectral_grade: str | None
+    has_bitrate: bool
+
+
+@dataclass(frozen=True)
+class MissingCurrentEvidenceLegacyBitrateSeed:
+    """Legacy request-level min/previous bitrate scalar presence."""
+
+    name: str
+    observed_rows: int
+    has_min_bitrate: bool
+    has_prev_min_bitrate: bool
+
+
+MissingCurrentEvidenceSeed = (
+    MissingCurrentEvidenceOriginSeed
+    | MissingCurrentEvidenceStatusSeed
+    | MissingCurrentEvidenceIdentitySeed
+    | MissingCurrentEvidenceFormatSeed
+    | MissingCurrentEvidenceSearchOverrideSeed
+    | MissingCurrentEvidenceTargetFormatSeed
+    | MissingCurrentEvidenceLegacySpectralSeed
+    | MissingCurrentEvidenceLegacyBitrateSeed
+)
+
+
 WORLD_CENSUS_SEEDS = (
     WorldCensusSeed(
         name="imported_mb_lineage1_verified_v0",
@@ -297,6 +384,161 @@ EVIDENCE_DRIFT_FACT_SEEDS = (
 )
 
 
+# #855's 429 current_evidence_missing rows are an installed-album scar-tissue
+# vocabulary. These are independent observed marginals, not invented row joins.
+MISSING_CURRENT_EVIDENCE_ORIGIN_SEEDS = (
+    MissingCurrentEvidenceOriginSeed(
+        name="pre_rekey_existing_library_add", observed_rows=249,
+        origin="pre_rekey_existing_library_add",
+    ),
+    MissingCurrentEvidenceOriginSeed(
+        name="pre_rekey_completed_import", observed_rows=60,
+        origin="pre_rekey_completed_import",
+    ),
+    MissingCurrentEvidenceOriginSeed(
+        name="post_rekey_existing_library_add", observed_rows=120,
+        origin="post_rekey_existing_library_add",
+    ),
+)
+
+MISSING_CURRENT_EVIDENCE_STATUS_SEEDS = (
+    MissingCurrentEvidenceStatusSeed(
+        name="wanted", observed_rows=427, status="wanted",
+    ),
+    MissingCurrentEvidenceStatusSeed(
+        name="unsearchable", observed_rows=2, status="unsearchable",
+    ),
+)
+
+MISSING_CURRENT_EVIDENCE_IDENTITY_SEEDS = (
+    MissingCurrentEvidenceIdentitySeed(
+        name="musicbrainz", observed_rows=362, identity_shape="musicbrainz",
+    ),
+    MissingCurrentEvidenceIdentitySeed(
+        name="discogs", observed_rows=67, identity_shape="discogs",
+    ),
+)
+
+MISSING_CURRENT_EVIDENCE_FORMAT_SEEDS = (
+    MissingCurrentEvidenceFormatSeed(
+        name="mp3", observed_rows=404, codec="mp3", installed_format="MP3",
+    ),
+    MissingCurrentEvidenceFormatSeed(
+        name="aac_m4a", observed_rows=14, codec="m4a", installed_format="AAC",
+    ),
+    MissingCurrentEvidenceFormatSeed(
+        name="ogg", observed_rows=7, codec="ogg", installed_format="OGG",
+    ),
+    MissingCurrentEvidenceFormatSeed(
+        name="opus", observed_rows=3, codec="opus", installed_format="Opus",
+    ),
+    MissingCurrentEvidenceFormatSeed(
+        name="windows_media_wma", observed_rows=1, codec="wma",
+        installed_format="Windows Media",
+    ),
+)
+
+MISSING_CURRENT_EVIDENCE_SEARCH_OVERRIDE_SEEDS = (
+    MissingCurrentEvidenceSearchOverrideSeed(
+        name="default", observed_rows=207, search_override=None,
+    ),
+    MissingCurrentEvidenceSearchOverrideSeed(
+        name="lossless_mp3_v0_mp3_320", observed_rows=129,
+        search_override="lossless,mp3 v0,mp3 320",
+    ),
+    MissingCurrentEvidenceSearchOverrideSeed(
+        name="lossless", observed_rows=89, search_override="lossless",
+    ),
+    MissingCurrentEvidenceSearchOverrideSeed(
+        name="lossless_mp3_v0", observed_rows=2,
+        search_override="lossless,mp3 v0",
+    ),
+    MissingCurrentEvidenceSearchOverrideSeed(
+        name="full_legacy_ladder", observed_rows=2,
+        search_override="lossless,mp3 v0,mp3 320,aac,opus,ogg",
+    ),
+)
+
+MISSING_CURRENT_EVIDENCE_TARGET_FORMAT_SEEDS = (
+    MissingCurrentEvidenceTargetFormatSeed(
+        name="default", observed_rows=424, target_format=None,
+    ),
+    MissingCurrentEvidenceTargetFormatSeed(
+        name="lossless", observed_rows=5, target_format="lossless",
+    ),
+)
+
+MISSING_CURRENT_EVIDENCE_LEGACY_SPECTRAL_SEEDS = (
+    MissingCurrentEvidenceLegacySpectralSeed(
+        name="absent_no_bitrate", observed_rows=246,
+        spectral_grade=None, has_bitrate=False,
+    ),
+    MissingCurrentEvidenceLegacySpectralSeed(
+        name="genuine_no_bitrate", observed_rows=80,
+        spectral_grade="genuine", has_bitrate=False,
+    ),
+    MissingCurrentEvidenceLegacySpectralSeed(
+        name="likely_transcode_bitrate", observed_rows=64,
+        spectral_grade="likely_transcode", has_bitrate=True,
+    ),
+    MissingCurrentEvidenceLegacySpectralSeed(
+        name="genuine_bitrate", observed_rows=30,
+        spectral_grade="genuine", has_bitrate=True,
+    ),
+    MissingCurrentEvidenceLegacySpectralSeed(
+        name="suspect_bitrate", observed_rows=4,
+        spectral_grade="suspect", has_bitrate=True,
+    ),
+    MissingCurrentEvidenceLegacySpectralSeed(
+        name="likely_transcode_no_bitrate", observed_rows=3,
+        spectral_grade="likely_transcode", has_bitrate=False,
+    ),
+    MissingCurrentEvidenceLegacySpectralSeed(
+        name="suspect_no_bitrate", observed_rows=2,
+        spectral_grade="suspect", has_bitrate=False,
+    ),
+)
+
+MISSING_CURRENT_EVIDENCE_LEGACY_BITRATE_SEEDS = (
+    MissingCurrentEvidenceLegacyBitrateSeed(
+        name="min_and_prev_present", observed_rows=190,
+        has_min_bitrate=True, has_prev_min_bitrate=True,
+    ),
+    MissingCurrentEvidenceLegacyBitrateSeed(
+        name="both_absent", observed_rows=189,
+        has_min_bitrate=False, has_prev_min_bitrate=False,
+    ),
+    MissingCurrentEvidenceLegacyBitrateSeed(
+        name="min_present_prev_absent", observed_rows=50,
+        has_min_bitrate=True, has_prev_min_bitrate=False,
+    ),
+)
+
+
+def _missing_current_evidence_seed_is_allowed(
+    seed: MissingCurrentEvidenceSeed,
+) -> bool:
+    """Accept only the finite, anonymized #855 marginal vocabulary."""
+
+    if isinstance(seed, MissingCurrentEvidenceOriginSeed):
+        return seed in MISSING_CURRENT_EVIDENCE_ORIGIN_SEEDS
+    if isinstance(seed, MissingCurrentEvidenceStatusSeed):
+        return seed in MISSING_CURRENT_EVIDENCE_STATUS_SEEDS
+    if isinstance(seed, MissingCurrentEvidenceIdentitySeed):
+        return seed in MISSING_CURRENT_EVIDENCE_IDENTITY_SEEDS
+    if isinstance(seed, MissingCurrentEvidenceFormatSeed):
+        return seed in MISSING_CURRENT_EVIDENCE_FORMAT_SEEDS
+    if isinstance(seed, MissingCurrentEvidenceSearchOverrideSeed):
+        return seed in MISSING_CURRENT_EVIDENCE_SEARCH_OVERRIDE_SEEDS
+    if isinstance(seed, MissingCurrentEvidenceTargetFormatSeed):
+        return seed in MISSING_CURRENT_EVIDENCE_TARGET_FORMAT_SEEDS
+    if isinstance(seed, MissingCurrentEvidenceLegacySpectralSeed):
+        return seed in MISSING_CURRENT_EVIDENCE_LEGACY_SPECTRAL_SEEDS
+    if isinstance(seed, MissingCurrentEvidenceLegacyBitrateSeed):
+        return seed in MISSING_CURRENT_EVIDENCE_LEGACY_BITRATE_SEEDS
+    return False
+
+
 _UUID = re.compile(
     r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b",
     re.IGNORECASE,
@@ -310,6 +552,10 @@ _SAFE_NAME_TOKENS = frozenset({
     "replacement", "same",
     "size", "source", "spectral", "path", "three", "tier", "transcode",
     "to", "unsearchable", "v0", "verified", "wanted", "without",
+    "320", "aac", "absent", "add", "and", "bitrate", "completed", "current", "default",
+    "discogs", "existing", "library", "media", "min", "musicbrainz",
+    "genuine", "import", "no", "ogg", "post", "pre", "present", "prev", "rekey", "request", "scalar",
+    "suspect", "target", "windows", "wma",
 })
 
 
@@ -351,14 +597,56 @@ def assert_evidence_drift_seed_anonymized(
         raise AssertionError("drift seed must represent at least one live row")
 
 
+def assert_missing_current_evidence_seed_anonymized(
+    seed: MissingCurrentEvidenceSeed,
+) -> None:
+    """Reject identity, path, and raw-row leakage from the #855 vocabularies."""
+
+    rendered = repr(asdict(seed))
+    name_tokens = frozenset(seed.name.split("_"))
+    if (
+        not name_tokens
+        or not name_tokens.issubset(_SAFE_NAME_TOKENS)
+        or not _missing_current_evidence_seed_is_allowed(seed)
+        or "/" in rendered
+        or "\\" in rendered
+        or _UUID.search(rendered) is not None
+    ):
+        raise AssertionError(
+            f"missing-current-evidence seed is not anonymized: {seed.name!r}"
+        )
+    if seed.observed_rows < 1:
+        raise AssertionError(
+            "missing-current-evidence seed must represent at least one live row"
+        )
+
+
 __all__ = [
     "EVIDENCE_DRIFT_FACT_SEEDS",
     "EVIDENCE_DRIFT_MUTATION_SEEDS",
+    "MISSING_CURRENT_EVIDENCE_FORMAT_SEEDS",
+    "MISSING_CURRENT_EVIDENCE_IDENTITY_SEEDS",
+    "MISSING_CURRENT_EVIDENCE_LEGACY_BITRATE_SEEDS",
+    "MISSING_CURRENT_EVIDENCE_LEGACY_SPECTRAL_SEEDS",
+    "MISSING_CURRENT_EVIDENCE_ORIGIN_SEEDS",
+    "MISSING_CURRENT_EVIDENCE_SEARCH_OVERRIDE_SEEDS",
+    "MISSING_CURRENT_EVIDENCE_STATUS_SEEDS",
+    "MISSING_CURRENT_EVIDENCE_TARGET_FORMAT_SEEDS",
     "STATEFUL_WORLD_CENSUS_SEEDS",
     "WORLD_CENSUS_SEEDS",
     "EvidenceDriftFactSeed",
     "EvidenceDriftMutationSeed",
+    "MissingCurrentEvidenceFormatSeed",
+    "MissingCurrentEvidenceIdentitySeed",
+    "MissingCurrentEvidenceLegacyBitrateSeed",
+    "MissingCurrentEvidenceLegacySpectralSeed",
+    "MissingCurrentEvidenceOriginSeed",
+    "MissingCurrentEvidenceSearchOverrideSeed",
+    "MissingCurrentEvidenceSeed",
+    "MissingCurrentEvidenceStatusSeed",
+    "MissingCurrentEvidenceTargetFormatSeed",
     "WorldCensusSeed",
     "assert_census_seed_anonymized",
     "assert_evidence_drift_seed_anonymized",
+    "assert_missing_current_evidence_seed_anonymized",
 ]

--- a/tests/world_model/state_machine.py
+++ b/tests/world_model/state_machine.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import os
 import sys
 import unittest
+from typing import TypeVar
 from unittest.mock import patch
 
 from beets import config as beets_config
@@ -43,13 +44,33 @@ from tests.beets_world import (  # noqa: E402
     HISTORICAL_PASSENGER_PATH_TEMPLATE,
 )
 from lib.mbid_replace_service import MbidReplaceService  # noqa: E402
+from lib.quality_evidence import (  # noqa: E402
+    snapshot_audio_files,
+    snapshot_fingerprint,
+)
 from tests.world_model.support import LifecycleWorld, repository_root  # noqa: E402
 from tests.world_model.census_seeds import (  # noqa: E402
     EVIDENCE_DRIFT_FACT_SEEDS,
     EVIDENCE_DRIFT_MUTATION_SEEDS,
+    MISSING_CURRENT_EVIDENCE_FORMAT_SEEDS,
+    MISSING_CURRENT_EVIDENCE_IDENTITY_SEEDS,
+    MISSING_CURRENT_EVIDENCE_LEGACY_BITRATE_SEEDS,
+    MISSING_CURRENT_EVIDENCE_LEGACY_SPECTRAL_SEEDS,
+    MISSING_CURRENT_EVIDENCE_ORIGIN_SEEDS,
+    MISSING_CURRENT_EVIDENCE_SEARCH_OVERRIDE_SEEDS,
+    MISSING_CURRENT_EVIDENCE_STATUS_SEEDS,
+    MISSING_CURRENT_EVIDENCE_TARGET_FORMAT_SEEDS,
     STATEFUL_WORLD_CENSUS_SEEDS,
     EvidenceDriftFactSeed,
     EvidenceDriftMutationSeed,
+    MissingCurrentEvidenceFormatSeed,
+    MissingCurrentEvidenceIdentitySeed,
+    MissingCurrentEvidenceLegacyBitrateSeed,
+    MissingCurrentEvidenceLegacySpectralSeed,
+    MissingCurrentEvidenceOriginSeed,
+    MissingCurrentEvidenceSearchOverrideSeed,
+    MissingCurrentEvidenceStatusSeed,
+    MissingCurrentEvidenceTargetFormatSeed,
     WorldCensusSeed,
 )
 
@@ -67,6 +88,91 @@ def _mb_release_id(counter: int) -> str:
 
 def _discogs_release_id(counter: int) -> str:
     return str(7_000_000 + counter)
+
+
+_MISSING_EVIDENCE_PRESERVED_FIELDS = (
+    "status",
+    "search_filetype_override",
+    "target_format",
+    "final_format",
+    "current_spectral_grade",
+    "current_spectral_bitrate",
+    "min_bitrate",
+    "prev_min_bitrate",
+    "verified_lossless",
+)
+
+
+_AxisSeed = TypeVar("_AxisSeed")
+
+
+def _axis(axis: tuple[_AxisSeed, ...], name: str) -> _AxisSeed:
+    return next(seed for seed in axis if getattr(seed, "name") == name)
+
+
+def _assert_missing_evidence_converges(
+    world: LifecycleWorld,
+    request_id: int,
+) -> None:
+    """Qualify the shared audit before, and convergence after, one scar."""
+    before = world.db.get_request(request_id)
+    assert before is not None
+    preserved = {key: before[key] for key in _MISSING_EVIDENCE_PRESERVED_FIELDS}
+    before_codes = {
+        violation.code
+        for violation in world.violations()
+        if violation.request_id == request_id
+    }
+    if "current_evidence_missing" not in before_codes:
+        raise AssertionError(
+            "missing-evidence scar did not qualify the real invariant checker"
+        )
+
+    result = world.touch_current_evidence(request_id)
+    if not result.available or result.evidence is None:
+        raise AssertionError(
+            "production current-evidence action did not converge missing scar: "
+            f"{result.provenance.fallback_reason!r}"
+        )
+    row = world.db.get_request(request_id)
+    assert row is not None
+    if {key: row[key] for key in _MISSING_EVIDENCE_PRESERVED_FIELDS} != preserved:
+        raise AssertionError("current-evidence convergence mutated request scalars")
+    evidence_id = world.db.get_request_current_evidence_id(request_id)
+    evidence = world.db.load_album_quality_evidence_by_id(evidence_id)
+    if evidence is None:
+        raise AssertionError("convergence did not link current evidence")
+    release = world._release_by_request[request_id]
+    album = next(
+        snapshot for snapshot in world.beets.snapshots()
+        if snapshot.release_id == release.release_id
+    )
+    if evidence.snapshot_fingerprint != snapshot_fingerprint(
+        snapshot_audio_files(album.album_path)
+    ):
+        raise AssertionError("current evidence did not fingerprint installed bytes")
+    if evidence.lineage_version != 4:
+        raise AssertionError("current evidence did not rebuild to lineage 4")
+    expected_policy_format = {
+        "ogg": "vorbis",
+        "wma": "wma",
+    }.get(release.codec)
+    if (
+        expected_policy_format is not None
+        and evidence.measurement.format != expected_policy_format
+    ):
+        raise AssertionError(
+            "current evidence did not reduce the native Beets label: "
+            f"{evidence.measurement.format!r}"
+        )
+    after_codes = {
+        violation.code
+        for violation in world.violations()
+        if violation.request_id == request_id
+    }
+    if "current_evidence_missing" in after_codes:
+        raise AssertionError("convergence left current_evidence_missing behind")
+    world.assert_invariants()
 
 
 class TestPinnedLifecycleWorld(unittest.TestCase):
@@ -489,6 +595,136 @@ class TestPinnedLifecycleWorld(unittest.TestCase):
             self.assertEqual(after.lineage_version, 4)
             world.assert_invariants()
 
+    def test_missing_current_evidence_installed_census_converges(self) -> None:
+        """#855 pins actual rare containers and operator-owned state."""
+        cases = (
+            (
+                "pre_rekey_existing_library_add", "wanted", "musicbrainz",
+                "mp3", "default", "default", "absent_no_bitrate",
+                "both_absent", "mp3",
+            ),
+            (
+                "pre_rekey_completed_import", "wanted", "discogs", "aac_m4a",
+                "lossless_mp3_v0_mp3_320", "lossless", "genuine_no_bitrate",
+                "min_and_prev_present", "aac",
+            ),
+            (
+                "post_rekey_existing_library_add", "unsearchable", "musicbrainz",
+                "ogg", "lossless", "default", "likely_transcode_no_bitrate",
+                "min_present_prev_absent", "vorbis",
+            ),
+            (
+                "pre_rekey_existing_library_add", "wanted", "discogs", "opus",
+                "lossless_mp3_v0", "default", "suspect_bitrate", "both_absent",
+                "opus",
+            ),
+            (
+                "post_rekey_existing_library_add", "wanted", "musicbrainz", "windows_media_wma",
+                "full_legacy_ladder", "default", "likely_transcode_bitrate",
+                "min_and_prev_present", "wmav2",
+            ),
+        )
+        assert TEST_DSN is not None
+        for index, (
+            origin_name, status_name, identity_name, format_name, search_name,
+            target_name, spectral_name, bitrate_name, expected_codec,
+        ) in enumerate(cases, start=1):
+            with self.subTest(format=format_name, status=status_name):
+                origin = _axis(MISSING_CURRENT_EVIDENCE_ORIGIN_SEEDS, origin_name)
+                status = _axis(MISSING_CURRENT_EVIDENCE_STATUS_SEEDS, status_name)
+                identity = _axis(MISSING_CURRENT_EVIDENCE_IDENTITY_SEEDS, identity_name)
+                installed = _axis(MISSING_CURRENT_EVIDENCE_FORMAT_SEEDS, format_name)
+                search = _axis(MISSING_CURRENT_EVIDENCE_SEARCH_OVERRIDE_SEEDS, search_name)
+                target = _axis(MISSING_CURRENT_EVIDENCE_TARGET_FORMAT_SEEDS, target_name)
+                spectral = _axis(MISSING_CURRENT_EVIDENCE_LEGACY_SPECTRAL_SEEDS, spectral_name)
+                bitrate = _axis(MISSING_CURRENT_EVIDENCE_LEGACY_BITRATE_SEEDS, bitrate_name)
+                release_id = (
+                    _discogs_release_id(85_500 + index)
+                    if identity.identity_shape == "discogs"
+                    else _mb_release_id(85_500 + index)
+                )
+                with LifecycleWorld(TEST_DSN, repository_root()) as world:
+                    request_id = world.seed_missing_current_evidence_release(
+                        BeetsWorldRelease(
+                            release_id=release_id,
+                            artist="Missing Evidence Archive",
+                            album=f"Installed Census {index}",
+                            year=2008,
+                            codec=installed.codec,
+                        ),
+                        origin=origin,
+                        status=status,
+                        identity=identity,
+                        installed_format=installed,
+                        search_override=search,
+                        target_format=target,
+                        legacy_spectral=spectral,
+                        legacy_bitrate=bitrate,
+                    )
+                    self.assertEqual(
+                        world.missing_current_evidence_origin(request_id),
+                        origin.origin,
+                    )
+                    self.assertEqual(
+                        world.beets.release_stream_codecs(release_id),
+                        (expected_codec,) * 2,
+                    )
+                    _assert_missing_evidence_converges(world, request_id)
+
+    def test_missing_evidence_beets_label_casing_is_not_normalized_away(self) -> None:
+        """Known-bad setter: exact captured Beets labels are audit facts."""
+
+        origin = _axis(
+            MISSING_CURRENT_EVIDENCE_ORIGIN_SEEDS,
+            "pre_rekey_existing_library_add",
+        )
+        status = _axis(MISSING_CURRENT_EVIDENCE_STATUS_SEEDS, "wanted")
+        identity = _axis(MISSING_CURRENT_EVIDENCE_IDENTITY_SEEDS, "musicbrainz")
+        installed = _axis(MISSING_CURRENT_EVIDENCE_FORMAT_SEEDS, "ogg")
+        search = _axis(MISSING_CURRENT_EVIDENCE_SEARCH_OVERRIDE_SEEDS, "default")
+        target = _axis(MISSING_CURRENT_EVIDENCE_TARGET_FORMAT_SEEDS, "default")
+        spectral = _axis(
+            MISSING_CURRENT_EVIDENCE_LEGACY_SPECTRAL_SEEDS,
+            "absent_no_bitrate",
+        )
+        bitrate = _axis(
+            MISSING_CURRENT_EVIDENCE_LEGACY_BITRATE_SEEDS,
+            "both_absent",
+        )
+        assert TEST_DSN is not None
+        with LifecycleWorld(TEST_DSN, repository_root()) as world:
+            real_setter = world.beets.set_release_item_format
+
+            def lower_label(release_id: str, format_label: str) -> None:
+                real_setter(release_id, format_label.lower())
+
+            with patch.object(
+                world.beets,
+                "set_release_item_format",
+                side_effect=lower_label,
+            ):
+                with self.assertRaisesRegex(
+                    AssertionError,
+                    "format axis did not reach the real Beets DB",
+                ):
+                    world.seed_missing_current_evidence_release(
+                        BeetsWorldRelease(
+                            release_id=_mb_release_id(85_599),
+                            artist="Format Fidelity Archive",
+                            album="Exact OGG Label",
+                            year=2008,
+                            codec=installed.codec,
+                        ),
+                        origin=origin,
+                        status=status,
+                        identity=identity,
+                        installed_format=installed,
+                        search_override=search,
+                        target_format=target,
+                        legacy_spectral=spectral,
+                        legacy_bitrate=bitrate,
+                    )
+
     def test_live_drift_retry_stays_closed_until_new_facts_exist(self) -> None:
         """Shrunk #743 world: installed facts die with the old fingerprint."""
 
@@ -885,6 +1121,53 @@ class LifecycleWorldMachine(RuleBasedStateMachine):
                 "changed snapshot bypassed its enrichment gate: "
                 f"{mutation.name}"
             )
+
+    @rule(
+        origin=st.sampled_from(MISSING_CURRENT_EVIDENCE_ORIGIN_SEEDS),
+        status=st.sampled_from(MISSING_CURRENT_EVIDENCE_STATUS_SEEDS),
+        identity=st.sampled_from(MISSING_CURRENT_EVIDENCE_IDENTITY_SEEDS),
+        installed=st.sampled_from(MISSING_CURRENT_EVIDENCE_FORMAT_SEEDS),
+        search=st.sampled_from(MISSING_CURRENT_EVIDENCE_SEARCH_OVERRIDE_SEEDS),
+        target_axis=st.sampled_from(MISSING_CURRENT_EVIDENCE_TARGET_FORMAT_SEEDS),
+        spectral=st.sampled_from(MISSING_CURRENT_EVIDENCE_LEGACY_SPECTRAL_SEEDS),
+        bitrate=st.sampled_from(MISSING_CURRENT_EVIDENCE_LEGACY_BITRATE_SEEDS),
+    )
+    def missing_evidence_scar_then_converge(
+        self,
+        origin: MissingCurrentEvidenceOriginSeed,
+        status: MissingCurrentEvidenceStatusSeed,
+        identity: MissingCurrentEvidenceIdentitySeed,
+        installed: MissingCurrentEvidenceFormatSeed,
+        search: MissingCurrentEvidenceSearchOverrideSeed,
+        target_axis: MissingCurrentEvidenceTargetFormatSeed,
+        spectral: MissingCurrentEvidenceLegacySpectralSeed,
+        bitrate: MissingCurrentEvidenceLegacyBitrateSeed,
+    ) -> None:
+        """Keep the deliberately incoherent scar inside one clean transition."""
+        self._release_counter += 1
+        release_id = (
+            _discogs_release_id(90_000 + self._release_counter)
+            if identity.identity_shape == "discogs"
+            else _mb_release_id(90_000 + self._release_counter)
+        )
+        request_id = self.world.seed_missing_current_evidence_release(
+            BeetsWorldRelease(
+                release_id=release_id,
+                artist="Scar Tissue Archive",
+                album=f"Missing Evidence {self._release_counter}",
+                year=2009,
+                codec=installed.codec,
+            ),
+            origin=origin,
+            status=status,
+            identity=identity,
+            installed_format=installed,
+            search_override=search,
+            target_format=target_axis,
+            legacy_spectral=spectral,
+            legacy_bitrate=bitrate,
+        )
+        _assert_missing_evidence_converges(self.world, request_id)
 
     @invariant()
     def cross_engine_invariants_hold(self) -> None:

--- a/tests/world_model/support.py
+++ b/tests/world_model/support.py
@@ -113,7 +113,16 @@ from tests.world_model.census_seeds import (
     STATEFUL_WORLD_CENSUS_SEEDS,
     EvidenceDriftFactSeed,
     EvidenceDriftMutationSeed,
+    MissingCurrentEvidenceIdentitySeed,
+    MissingCurrentEvidenceFormatSeed,
+    MissingCurrentEvidenceLegacyBitrateSeed,
+    MissingCurrentEvidenceLegacySpectralSeed,
+    MissingCurrentEvidenceOriginSeed,
+    MissingCurrentEvidenceSearchOverrideSeed,
+    MissingCurrentEvidenceStatusSeed,
+    MissingCurrentEvidenceTargetFormatSeed,
     WorldCensusSeed,
+    assert_missing_current_evidence_seed_anonymized,
 )
 from scripts.import_preview_worker import process_claimed_preview_job
 
@@ -180,6 +189,7 @@ class LifecycleWorld:
             prefix="cratedigger-world-processing-",
         )
         self._release_by_request: dict[int, BeetsWorldRelease] = {}
+        self._missing_current_evidence_origins: dict[int, str] = {}
         self._dispatch_counter = 0
         self._operator_counter = 0
         self._last_subprocess_run: ImportOneRun | None = None
@@ -411,6 +421,99 @@ class LifecycleWorld:
         ):
             raise AssertionError("failed to apply drift request facts")
         return request_id
+
+    def seed_missing_current_evidence_release(
+        self,
+        release: BeetsWorldRelease,
+        *,
+        origin: MissingCurrentEvidenceOriginSeed,
+        status: MissingCurrentEvidenceStatusSeed,
+        identity: MissingCurrentEvidenceIdentitySeed,
+        installed_format: MissingCurrentEvidenceFormatSeed,
+        search_override: MissingCurrentEvidenceSearchOverrideSeed,
+        target_format: MissingCurrentEvidenceTargetFormatSeed,
+        legacy_spectral: MissingCurrentEvidenceLegacySpectralSeed,
+        legacy_bitrate: MissingCurrentEvidenceLegacyBitrateSeed,
+    ) -> int:
+        """Inject one #855 installed-album/no-evidence scar into real stores.
+
+        The direct historical state belongs only in this disposable harness:
+        the album is installed through real Beets while the request has no
+        current evidence. Normal convergence below still uses the production
+        action loader. Historical origin has no durable production column, so
+        it is retained as model history for sampling and assertions.
+        """
+        release_identity = ReleaseIdentity.from_id(release.release_id)
+        if release_identity is None or release_identity.source != identity.identity_shape:
+            raise ValueError(
+                "release identity does not match missing-evidence census axis: "
+                f"{release.release_id!r} / {identity.identity_shape!r}"
+            )
+        if release.codec.casefold() != installed_format.codec:
+            raise ValueError(
+                "release codec does not match missing-evidence format axis: "
+                f"{release.codec!r} / {installed_format.codec!r}"
+            )
+        assert_missing_current_evidence_seed_anonymized(installed_format)
+        request_id = self.add_release(release)
+        self.beets.import_release(release)
+        self.beets.set_release_item_format(
+            release.release_id,
+            installed_format.installed_format,
+        )
+        expected_formats = (installed_format.installed_format,) * release.track_count
+        actual_formats = self.beets.release_item_formats(release.release_id)
+        if actual_formats != expected_formats:
+            raise AssertionError(
+                "missing-evidence format axis did not reach the real Beets DB: "
+                f"{actual_formats!r} != {expected_formats!r}"
+            )
+        if self.db.get_request_current_evidence_id(request_id) is not None:
+            raise AssertionError("scar-tissue seed unexpectedly linked evidence")
+
+        row = self._require_request(request_id)
+        if status.status == "unsearchable":
+            require_transition_applied(finalize_request(
+                self.db,
+                request_id,
+                RequestTransition.to_unsearchable(
+                    from_status=str(row["status"]),
+                ),
+            ))
+        elif status.status != "wanted":
+            raise ValueError(
+                f"unsupported missing-evidence status: {status.status!r}"
+            )
+
+        scalar_status = str(self._require_request(request_id)["status"])
+        if not self.db.update_request_fields(
+            request_id,
+            expected_status=scalar_status,
+            search_filetype_override=search_override.search_override,
+            target_format=target_format.target_format,
+            final_format=None,
+            verified_lossless=False,
+            current_spectral_grade=legacy_spectral.spectral_grade,
+            current_spectral_bitrate=(
+                192 if legacy_spectral.has_bitrate else None
+            ),
+            min_bitrate=192 if legacy_bitrate.has_min_bitrate else None,
+            prev_min_bitrate=(
+                185 if legacy_bitrate.has_prev_min_bitrate else None
+            ),
+        ):
+            raise AssertionError("failed to apply missing-evidence scar scalars")
+        self._missing_current_evidence_origins[request_id] = origin.origin
+        return request_id
+
+    def missing_current_evidence_origin(self, request_id: int) -> str:
+        """Return the anonymized historical origin attached to one scar."""
+        try:
+            return self._missing_current_evidence_origins[request_id]
+        except KeyError as exc:
+            raise AssertionError(
+                f"request {request_id} is not a missing-evidence scar"
+            ) from exc
 
     def inject_evidence_drift(
         self,


### PR DESCRIPTION
## Summary

- promote all 429 live `current_evidence_missing` shapes into anonymized census axes consumed by the existing real-PostgreSQL/real-Beets lifecycle state machine
- materialize genuine MP3, AAC/M4A, OGG/Vorbis, Opus, and WMA scars with an exact installed album and no evidence link, then require the production loader to converge without changing operator state or legacy policy scalars
- normalize Beets' observed `OGG` and `Windows Media` labels to the existing `vorbis` and `wma` rank/evidence vocabulary, including custom-precedence configurations
- retain the already-complete 238-row fingerprint-drift corpus unchanged and keep production data strictly read-only

The new real-store WMA pin found the production label-boundary defect: `Windows Media` could not satisfy the one-token evidence schema. The fuzzer found the bug before the fix; the committed deterministic/generated pair now patrols it.

## Verification

- Sol adversarial review: clean after two correction rounds
- whole-repository Pyright: 0 errors
- full suite: 6,968 tests across 12 workers, `OK`, no skips
- signed commit: `8716d5a01e23d88f3b378116ffd9bb8d0d450a22`

Refs #855
