### PR TITLE
fix: converge candidate evidence after normalization

### DIFF
--- a/docs/nixos-module.md
+++ b/docs/nixos-module.md
@@ -84,6 +84,13 @@ the Cratedigger user and do not put processing beneath a parent writable by
 slskd. The module rejects relative and lexically overlapping paths, while the
 runtime also refuses symlinked/unsafe roots.
 
+The descriptor-verified publish into `albums/` is the trust transition:
+Cratedigger may repair or normalize that owned working copy in place before
+measurement and import. slskd and quarantine bytes remain untrusted and are
+never passed to mutating media tools directly. A force/quarantine preview keeps
+one private normalized action copy through Beets; its original path remains the
+job's audit and recovery authority.
+
 ### The `permissions` plugin + `fix_library_modes`
 
 The rendered beets config enables the built-in `permissions` plugin with `file = "0664"` and `dir = "02775"` (setgid + group-writable) — these are fixed literals in `nix/module.nix`, not module options. Its `art_set` listener (`fix_art`) fixes fetched-art mode on BOTH initial import and a manual `beet fetchart` re-fetch. This exists because beets' own `fetchart` writes art via `mkstemp` (which forces `0600` regardless of umask) and nothing else chmods it afterward — without the plugin, art lands `0600` and a media server reading it as a different user throws `UnauthorizedAccessException` (issue #570 defect 1).

--- a/lib/dispatch/core.py
+++ b/lib/dispatch/core.py
@@ -115,6 +115,7 @@ def dispatch_import_core(
     attempt_spectral_audit: "SpectralDetail | None" = None,
     attempt_result: ImportAttemptResult | None = None,
     candidate_download_log_id: int | None = None,
+    launch_authority_path: str | None = None,
     prevalidated_candidate_result: CandidateEvidenceActionResult | None = None,
     quality_gate_fn: QualityGateFn = _check_quality_gate_core,
     run_import_fn: ImportOneRunner | None = None,
@@ -277,6 +278,35 @@ def dispatch_import_core(
                 beets_library_root=effective_beets_library_root,
                 **evidence_gate_kwargs,
             )
+            if prevalidated_candidate_result is not None:
+                # Re-check the queue-owned action copy before *any* evidence
+                # decision can become terminal. A late content change is a
+                # typed preview retry, never a false quality rejection.
+                from lib.import_evidence import ensure_candidate_evidence_for_action
+
+                fresh_candidate = ensure_candidate_evidence_for_action(
+                    db,
+                    source_path=path,
+                    import_job_id=candidate_import_job_id,
+                )
+                if (
+                    not fresh_candidate.available
+                    or fresh_candidate.evidence is None
+                    or evidence_gate.candidate is None
+                    or fresh_candidate.evidence.id != evidence_gate.candidate.id
+                    or fresh_candidate.evidence.snapshot_fingerprint
+                        != evidence_gate.candidate.snapshot_fingerprint
+                ):
+                    reason = (
+                        fresh_candidate.provenance.fallback_reason
+                        or fresh_candidate.provenance.candidate_status
+                        or "candidate evidence changed before dispatch"
+                    )
+                    return _requeue_import_job_to_preview(
+                        db,
+                        import_job_id=candidate_import_job_id,
+                        reason=reason,
+                    )
             if (
                 evidence_gate.candidate is not None
                 and _current_evidence_analysis_failed(evidence_gate)
@@ -435,6 +465,7 @@ def dispatch_import_core(
                             cfg.quality_ranks if cfg is not None else None
                         ),
                         audio_quarantine_root=beets_cfg.slskd_download_dir,
+                        preserve_corrupt_source=force,
                     )
                 quality_evidence_action_file = _write_quality_evidence_action_file(
                     candidate=evidence_gate.candidate,
@@ -453,11 +484,15 @@ def dispatch_import_core(
                     ),
                     code="launch_authority_missing",
                 )
+            # A force action can run from a retained private copy, but the
+            # job's original source remains the durable launch/recovery
+            # authority.  The action copy is separately bound by the
+            # candidate-evidence snapshot above.
             authorized_job = db.authorize_import_job_launch(
                 candidate_import_job_id,
                 request_id=request_id,
                 release_id=mb_release_id,
-                source_path=path,
+                source_path=launch_authority_path or path,
             )
             if authorized_job is None:
                 return DispatchOutcome(

--- a/lib/dispatch/entry_points.py
+++ b/lib/dispatch/entry_points.py
@@ -38,6 +38,7 @@ def dispatch_import_from_db(
     request_id: int,
     failed_path: str,
     *,
+    source_reference_path: str | None = None,
     source_username: str | None = None,
     source_dirs: list[str] | None = None,
     import_job_id: int | None = None,
@@ -112,6 +113,7 @@ def dispatch_import_from_db(
             )
         return _dispatch_import_from_db_locked(
             db, request_id, failed_path,
+            source_reference_path=source_reference_path,
             source_username=source_username,
             source_dirs=source_dirs,
             import_job_id=import_job_id,
@@ -129,6 +131,7 @@ def _dispatch_import_from_db_locked(
     request_id: int,
     failed_path: str,
     *,
+    source_reference_path: str | None = None,
     source_username: str | None,
     source_dirs: list[str] | None,
     import_job_id: int | None,
@@ -164,6 +167,7 @@ def _dispatch_import_from_db_locked(
         )
 
     source_dirs = normalize_source_dirs(source_dirs or [])
+    launch_authority_path = source_reference_path or failed_path
 
     req = db.get_request(request_id)
     if not req:
@@ -175,23 +179,6 @@ def _dispatch_import_from_db_locked(
 
     if not os.path.isdir(failed_path):
         return DispatchOutcome(success=False, message=f"Path not found: {failed_path}")
-
-    attempt_result = ImportAttemptResult.from_import_job(db, import_job_id)
-    manifest_reject = _guard_force_import_audio_manifest(
-        db,
-        request_id=request_id,
-        failed_path=failed_path,
-        download_log_id=download_log_id,
-        source_username=source_username,
-        attempt_result=attempt_result,
-        import_job_id=import_job_id,
-    )
-    if manifest_reject is not None:
-        return _persist_terminal_dispatch_outcome(
-            db,
-            manifest_reject,
-            defer=_job_is_running(db, import_job_id),
-        )
 
     from lib.config import read_runtime_config
 
@@ -225,6 +212,29 @@ def _dispatch_import_from_db_locked(
             import_job_id=import_job_id,
             reason=reason,
         )
+
+    # Candidate freshness is the first force-import gate.  Manifest drift is
+    # evidence drift, not a terminal audit outcome: preview will snapshot the
+    # current action tree and re-establish the candidate before this guard
+    # evaluates the operator's expected audio manifest.
+    attempt_result = ImportAttemptResult.from_import_job(db, import_job_id)
+    manifest_reject = _guard_force_import_audio_manifest(
+        db,
+        request_id=request_id,
+        failed_path=failed_path,
+        audit_source_path=source_reference_path,
+        download_log_id=download_log_id,
+        source_username=source_username,
+        attempt_result=attempt_result,
+        import_job_id=import_job_id,
+    )
+    if manifest_reject is not None:
+        return _persist_terminal_dispatch_outcome(
+            db,
+            manifest_reject,
+            defer=_job_is_running(db, import_job_id),
+        )
+
     dl_info = _download_info_from_candidate_evidence(
         candidate_result.evidence,
         username=source_username,
@@ -256,6 +266,7 @@ def _dispatch_import_from_db_locked(
         candidate_import_job_id=import_job_id,
         attempt_result=attempt_result,
         candidate_download_log_id=download_log_id,
+        launch_authority_path=launch_authority_path,
         prevalidated_candidate_result=candidate_result,
         quality_gate_fn=resolved_quality_gate_fn,
         run_import_fn=run_import_fn,

--- a/lib/dispatch/manifest_guard.py
+++ b/lib/dispatch/manifest_guard.py
@@ -61,6 +61,7 @@ def _guard_reject(
     *,
     request_id: int,
     failed_path: str,
+    audit_source_path: str | None = None,
     source_username: str | None,
     attempt_result: ImportAttemptResult,
     detail: str,
@@ -75,16 +76,11 @@ def _guard_reject(
     ``wanted`` request, or one whose search was explicitly stopped by the
     operator; neither state belongs to this guard to rewrite.
 
-    The audit row carries no ``validation_result.failed_path``, so it never
-    becomes a *new* Wrong Matches entry (``get_wrong_matches`` keys on that
-    JSONB field).
+    When a private action copy is used, the audit retains its original
+    operator-owned source path rather than exposing the disposable copy.
 
     Always returns ``DISPATCH_CODE_IMPORT_MANIFEST_REJECTED`` so the importer
-    worker (``scripts/importer.py::_cleanup_failed_force_import``) PRESERVES
-    the operator's source folder — that path skips cleanup on any code other
-    than ``QUALITY_PIPELINE_REJECTED``, and for a FORCE job
-    ``QUALITY_PIPELINE_REJECTED`` runs ``delete_wrong_match`` →
-    ``shutil.rmtree`` (``lib/wrong_matches.py``). The guard only ever sees a
+    worker preserves the original operator source. The guard only ever sees a
     *non-empty* folder (an empty source returns ``None`` from the caller and
     reaches the evidence pipeline's ``empty_fileset`` early-exit instead), so
     deleting here would always destroy real audio the operator
@@ -108,7 +104,7 @@ def _guard_reject(
             distance=None,
             scenario=scenario,
             detail=detail,
-            failed_path=failed_path,
+            failed_path=audit_source_path or failed_path,
         ).to_json(),
         requeue=False,
         outcome_label="rejected",
@@ -134,6 +130,7 @@ def _guard_force_import_audio_manifest(
     *,
     request_id: int,
     failed_path: str,
+    audit_source_path: str | None = None,
     download_log_id: int | None,
     source_username: str | None,
     attempt_result: ImportAttemptResult,
@@ -167,13 +164,14 @@ def _guard_force_import_audio_manifest(
     manifest = _origin_manifest_for_download_log(
         db,
         download_log_id=download_log_id,
-        failed_path=failed_path,
+        failed_path=audit_source_path or failed_path,
     )
     actual_audio = audio_relative_paths(failed_path)
 
     def incomplete(detail: str) -> DispatchOutcome:
         return _guard_reject(
             db, request_id=request_id, failed_path=failed_path,
+            audit_source_path=audit_source_path,
             source_username=source_username, detail=detail,
             scenario="incomplete_fileset", attempt_result=attempt_result,
             import_job_id=import_job_id,
@@ -182,6 +180,7 @@ def _guard_force_import_audio_manifest(
     def extra(detail: str, *, scenario: str = "untracked_audio") -> DispatchOutcome:
         return _guard_reject(
             db, request_id=request_id, failed_path=failed_path,
+            audit_source_path=audit_source_path,
             source_username=source_username, detail=detail,
             scenario=scenario, attempt_result=attempt_result,
             import_job_id=import_job_id,

--- a/lib/dispatch/outcome_actions.py
+++ b/lib/dispatch/outcome_actions.py
@@ -70,6 +70,7 @@ def _reject_import_from_evidence_decision(
     source_download_log_id: int | None = None,
     quality_ranks: QualityRankConfig | None = None,
     audio_quarantine_root: str | None = None,
+    preserve_corrupt_source: bool = False,
 ) -> DispatchOutcome:
     """Record a persisted-evidence rejection before beets can mutate files.
 
@@ -178,12 +179,15 @@ def _reject_import_from_evidence_decision(
                     if db.check_and_apply_cooldown(username):
                         cooled_down_users.add(username)
     cleanup_plan: PostCommitCleanup | None = None
-    if action.cleanup and decision == "audio_corrupt":
+    if action.cleanup and decision == "audio_corrupt" and not preserve_corrupt_source:
         # Corrupt audio is retained for audit in every caller mode. Force
         # imports deliberately do not satisfy ``_should_cleanup_path`` until
         # they succeed, because ordinary force cleanup deletes the reviewed
         # Wrong Matches source. Quarantine is a separate, archival ownership
-        # transfer and must not inherit that destructive gate.
+        # transfer and must not inherit that destructive gate. A force action
+        # copy is different: it is disposable private processing state, and
+        # the queue owner reclaims it after acknowledgement instead of moving
+        # it into the operator's protected quarantine tree.
         if import_job_id is not None:
             cleanup_plan = PostCommitCleanup(
                 audio_quarantine_source_path=staged_path,

--- a/lib/import_job_recovery_service.py
+++ b/lib/import_job_recovery_service.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Protocol
 
 import msgspec
 
 from lib.import_queue import ImportJob
+
+logger = logging.getLogger("cratedigger")
 
 
 RECOVERY_RESOLUTION_RETRY = "retry"
@@ -85,6 +88,24 @@ def resolve_import_job_recovery(
             ),
         )
     job, retry_job = resolved
+    if job.job_type == "force_import" and job.preview_result is not None:
+        action_path = job.preview_result.get("action_path")
+        if isinstance(action_path, str) and action_path:
+            try:
+                from lib.config import read_runtime_config
+                from lib.import_preview import cleanup_force_action_copy_for_job
+
+                cleanup_force_action_copy_for_job(
+                    action_path,
+                    read_runtime_config(),
+                    import_job_id=job.id,
+                )
+            except Exception:
+                # The operator resolution is durable. A private deterministic
+                # copy can be reclaimed later; it must not undo that decision.
+                logger.exception(
+                    "Failed to remove resolved force action copy for job %s", job.id,
+                )
     return ImportRecoveryResolution(
         outcome=("retry_queued" if retry_job is not None else "closed"),
         job=job,

--- a/lib/import_preview.py
+++ b/lib/import_preview.py
@@ -1,9 +1,8 @@
-"""Unified import preview service.
+"""Preview measurement and candidate-evidence persistence.
 
-Preview answers the operator's "would this import?" question without beets,
-pipeline DB, queue, denylist, or source-folder mutation. Real-folder preview
-uses the same preimport gates and import_one.py harness protocol as force-import,
-but runs both against isolated temporary copies.
+Foreign paths are descriptor-copied before media tools run. A completed album
+under the private processing root is Cratedigger working state: it may be
+normalized in place, measured, and imported as those exact bytes.
 """
 
 from __future__ import annotations
@@ -85,7 +84,11 @@ from lib.fs_authority import (
     open_regular_relative,
     remove_relative_tree,
 )
-from lib.processing_paths import processing_preview_dir
+from lib.processing_paths import (
+    path_is_within_root,
+    processing_albums_dir,
+    processing_preview_dir,
+)
 from lib.util import repair_mp3_headers
 from lib.validation_envelope import decode_validation_envelope
 from lib.v0_probe import probe_installed_album_as_v0
@@ -117,6 +120,7 @@ class PreviewSnapshotLimits:
 
 PreviewCopyFn = Callable[..., int]
 PreviewAvailableBytesFn = Callable[[int], int]
+HeaderRepairFn = Callable[[str], None]
 
 
 def _preview_available_bytes(preview_fd: int) -> int:
@@ -343,6 +347,75 @@ def _remove_preview_tree(path: str, cfg: CratediggerConfig) -> None:
 def remove_preview_snapshot(path: str, cfg: CratediggerConfig) -> None:
     """Public counterpart for callers that own a private preview snapshot."""
     _remove_preview_tree(path, cfg)
+
+
+def retain_preview_snapshot_for_force_action(
+    path: str,
+    cfg: CratediggerConfig,
+    *,
+    import_job_id: int,
+) -> str:
+    """Promote one verified private snapshot to a force-import action copy.
+
+    The source has already crossed the descriptor-copy boundary.  This is a
+    rename wholly inside Cratedigger's private processing tree, not another
+    copy of the operator's quarantine folder.  The returned path survives
+    preview so the importer consumes the exact normalized bytes evidence
+    describes.
+    """
+    name = os.path.basename(path)
+    if name == path or not name.startswith("preview-"):
+        raise FilesystemAuthorityError("not a private preview snapshot")
+    if os.path.dirname(path) != processing_preview_dir(cfg.processing_dir):
+        raise FilesystemAuthorityError("preview snapshot is outside private root")
+    action_name = f"force-action-{import_job_id}"
+    with open_private_processing_root(
+        cfg.processing_dir, cfg.slskd_download_dir,
+    ) as processing_fd:
+        with open_private_child_directory(processing_fd, "preview") as preview_fd:
+            with open_private_child_directory(processing_fd, "albums") as albums_fd:
+                with exclusive_relative_lock(
+                    albums_fd, f".force-action-{import_job_id}.lock",
+                ):
+                    remove_relative_tree(albums_fd, action_name)
+                    os.rename(
+                        name, action_name,
+                        src_dir_fd=preview_fd, dst_dir_fd=albums_fd,
+                    )
+    return os.path.join(processing_albums_dir(cfg.processing_dir), action_name)
+
+
+def remove_force_action_copy(path: str, cfg: CratediggerConfig) -> None:
+    """Remove one unneeded retained force action copy after a terminal result."""
+    name = os.path.basename(path)
+    if name == path or not name.startswith("force-action-"):
+        raise FilesystemAuthorityError("not a private force action copy")
+    if os.path.dirname(path) != processing_albums_dir(cfg.processing_dir):
+        raise FilesystemAuthorityError("force action copy is outside private root")
+    with open_private_processing_root(
+        cfg.processing_dir, cfg.slskd_download_dir,
+    ) as processing_fd:
+        with open_private_child_directory(processing_fd, "albums") as albums_fd:
+            remove_relative_tree(albums_fd, name)
+
+
+def cleanup_force_action_copy_for_job(
+    path: str,
+    cfg: CratediggerConfig,
+    *,
+    import_job_id: int,
+) -> None:
+    """Remove only the deterministic force copy owned by this job."""
+    if path != force_action_copy_path(cfg, import_job_id):
+        raise FilesystemAuthorityError("force action copy does not belong to job")
+    remove_force_action_copy(path, cfg)
+
+
+def force_action_copy_path(cfg: CratediggerConfig, import_job_id: int) -> str:
+    """The one reclaimable private action directory for a force job."""
+    return os.path.join(
+        processing_albums_dir(cfg.processing_dir), f"force-action-{import_job_id}",
+    )
 
 
 def _prefer_successful_spectral_detail(
@@ -1390,6 +1463,10 @@ class ImportPreviewResult(msgspec.Struct):
     request_id: int | None = None
     download_log_id: int | None = None
     source_path: str | None = None
+    # Force/quarantine previews retain this private copy through Beets.  It is
+    # action data, not launch/audit authority; ``source_path`` remains the
+    # original source reference.
+    action_path: str | None = None
     import_result: ImportResult | None = None
     simulation: dict[str, Any] | None = None
     failure: MeasurementFailure | None = None
@@ -1689,6 +1766,7 @@ def measure_and_persist_candidate_evidence(
     existing_spectral_resolver: ExistingSpectralResolver | None = None,
     current_evidence_loader: Callable[..., EvidenceBuildResult] | None = None,
     runtime_config: CratediggerConfig | None = None,
+    repair_fn: HeaderRepairFn | None = None,
 ) -> ImportPreviewResult:
     """Measure a source folder and persist candidate evidence; never decide.
 
@@ -1807,8 +1885,15 @@ def measure_and_persist_candidate_evidence(
         )
     preserve_have_source = preserve_existing_source_spectral(current_evidence)
 
+    repair = repair_fn or repair_mp3_headers
+    owns_path = path_is_within_root(path, processing_albums_dir(cfg.processing_dir))
+    # The processing album is the trust transition.  Normalise it before the
+    # preview snapshot so evidence and the later importer both see the same
+    # bytes.  Foreign paths still reach repair only after descriptor copying.
+    if owns_path:
+        repair(path)
     try:
-        temp_root = _snapshot_authorized_directory(path, cfg)
+        temp_root = None if owns_path else _snapshot_authorized_directory(path, cfg)
     except (FilesystemAuthorityError, OSError) as exc:
         return _measurement_failed_result(
             mode="path",
@@ -1820,11 +1905,9 @@ def measure_and_persist_candidate_evidence(
             source_path=audit_path,
         )
     try:
-        preview_path = temp_root
-        try:
-            repair_mp3_headers(preview_path)
-        except Exception:
-            pass
+        preview_path = path if temp_root is None else temp_root
+        if not owns_path:
+            repair(preview_path)
         try:
             # Address evidence from precisely the immutable private bytes
             # being inspected and passed to the harness.  Never re-inventory
@@ -2010,7 +2093,7 @@ def measure_and_persist_candidate_evidence(
 
         try:
             preview_spectral_file = _write_preview_spectral_evidence_file(
-                directory=temp_root,
+                directory=preview_path,
                 mb_release_id=mbid,
                 source_path=audit_path,
                 measurement=measurement,
@@ -2263,7 +2346,8 @@ def measure_and_persist_candidate_evidence(
             import_result=run.import_result,
         )
     finally:
-        _remove_preview_tree(temp_root, cfg)
+        if temp_root is not None:
+            _remove_preview_tree(temp_root, cfg)
 
 
 def _measurement_decision_hint(measurement: Any) -> str:

--- a/lib/pipeline_db/import_jobs.py
+++ b/lib/pipeline_db/import_jobs.py
@@ -532,11 +532,11 @@ class _ImportJobsMixin(_PipelineDBBase):
                         importable_at,
                         candidate_evidence_id,
                         expected_request_status
-                    )
-                    VALUES (
-                        %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
-                        %s
-                    )
+                )
+                VALUES (
+                    %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                    %s
+                )
                     RETURNING *
                 """, (
                     original.job_type,
@@ -544,18 +544,41 @@ class _ImportJobsMixin(_PipelineDBBase):
                     original.dedupe_key,
                     psycopg2.extras.Json(msgspec.to_builtins(original.payload)),
                     f"Operator-authorized retry of recovery job {original.id}",
-                    original.preview_status,
                     (
-                        psycopg2.extras.Json(original.preview_result)
-                        if original.preview_result is not None
-                        else None
+                        IMPORT_JOB_PREVIEW_WAITING
+                        if original.job_type == "force_import"
+                        else original.preview_status
                     ),
-                    original.preview_message,
-                    original.preview_error,
-                    original.preview_attempts,
-                    original.preview_completed_at,
-                    original.importable_at,
-                    original.candidate_evidence_id,
+                    (
+                        None
+                        if original.job_type == "force_import"
+                        else (
+                            psycopg2.extras.Json(original.preview_result)
+                            if original.preview_result is not None
+                            else None
+                        )
+                    ),
+                    (
+                        None if original.job_type == "force_import"
+                        else original.preview_message
+                    ),
+                    (
+                        None if original.job_type == "force_import"
+                        else original.preview_error
+                    ),
+                    0 if original.job_type == "force_import" else original.preview_attempts,
+                    (
+                        None if original.job_type == "force_import"
+                        else original.preview_completed_at
+                    ),
+                    (
+                        None if original.job_type == "force_import"
+                        else original.importable_at
+                    ),
+                    (
+                        None if original.job_type == "force_import"
+                        else original.candidate_evidence_id
+                    ),
                     original.expected_request_status,
                 ))
                 retry_raw = retry_cur.fetchone()

--- a/scripts/import_preview_worker.py
+++ b/scripts/import_preview_worker.py
@@ -30,15 +30,18 @@ from lib.import_preview import (
     PREVIEW_VERDICT_EVIDENCE_READY,
     PREVIEW_VERDICT_MEASUREMENT_FAILED,
     ImportPreviewResult,
+    cleanup_force_action_copy_for_job,
     enrich_incomplete_current_evidence_for_request,
     load_current_evidence_for_preview,
     load_persisted_existing_spectral,
     measure_and_persist_candidate_evidence,
     remove_preview_snapshot,
+    retain_preview_snapshot_for_force_action,
     snapshot_configured_quarantine_directory,
     persist_exact_current_spectral_from_attempt,
     prepare_current_evidence_for_failure,
     preserve_existing_source_spectral,
+    force_action_copy_path,
 )
 from lib.import_evidence import (
     CANDIDATE_STATUS_REUSED,
@@ -117,20 +120,68 @@ def _candidate_evidence_ready_for_job(
     source_path = result.source_path
     if not source_path:
         return False, "preview_source_path_missing"
+    # Completion is deliberately stricter than the reuse/action loader: this
+    # preview must have written the *job's* FK and a non-empty fingerprint.
+    # In particular, do not quietly accept an older download-log FK here.
+    evidence_id = db.get_import_job_candidate_evidence_id(job.id)
+    if evidence_id is None:
+        return False, "preview did not link candidate evidence to import job"
+    evidence = db.load_album_quality_evidence_by_id(evidence_id)
+    if evidence is None:
+        return False, f"candidate evidence id {evidence_id} not found"
+    if not evidence.snapshot_fingerprint:
+        return False, "candidate evidence has empty snapshot fingerprint"
+    action_path = result.action_path or source_path
     candidate = ensure_candidate_evidence_for_action(
         db,
-        source_path=source_path,
+        source_path=action_path,
         import_job_id=job.id,
-        download_log_id=_download_log_id_from_job(job),
     )
     if candidate.available and candidate.evidence is not None:
-        return True, "ready"
+        if candidate.evidence.id == evidence_id:
+            return True, "ready"
+        return False, "candidate evidence id does not match import job FK"
     return (
         False,
         candidate.provenance.fallback_reason
         or candidate.provenance.candidate_status
         or "candidate_evidence_unavailable",
     )
+
+
+def _cleanup_terminal_preview_force_action(
+    job: ImportJob,
+    terminal_job: ImportJob | None,
+    *,
+    action_path: str | None,
+    runtime_config: CratediggerConfig | None,
+) -> ImportJob | None:
+    """Discard a force action only after preview reaches a known terminal state."""
+    if (
+        job.job_type != IMPORT_JOB_FORCE
+        or terminal_job is None
+        or terminal_job.status == "recovery_required"
+    ):
+        return terminal_job
+    # A preparation failure can occur before this claim publishes a new action
+    # copy.  Reclaim the deterministic path anyway: it can only be the stale
+    # private copy left by the prior import attempt, and this preview claim is
+    # still its owner until it returns a terminal outcome.
+    try:
+        resolved_config = _resolve_runtime_config(runtime_config)
+        terminal_action_path = (
+            action_path or force_action_copy_path(resolved_config, job.id)
+        )
+        cleanup_force_action_copy_for_job(
+            terminal_action_path,
+            resolved_config,
+            import_job_id=job.id,
+        )
+    except Exception:
+        # Preview's DB outcome is already durable. A stale private copy is
+        # reclaimable on its deterministic path and must not change it.
+        logger.exception("Failed to remove terminal preview force action for job %s", job.id)
+    return terminal_job
 
 
 def derive_canonical_import_folder(
@@ -305,6 +356,8 @@ def _reused_evidence_preview_payload(
     evidence: AlbumQualityEvidence,
     source_path: str,
     import_result: ImportResult,
+    *,
+    action_path: str | None = None,
 ) -> dict[str, object]:
     """Synthesize a preview_result payload for the reused-evidence branch.
 
@@ -335,7 +388,40 @@ def _reused_evidence_preview_payload(
         type=dict[str, object],
     )
     payload["candidate_status"] = CANDIDATE_STATUS_REUSED
+    if action_path is not None:
+        payload["action_path"] = action_path
     return payload
+
+
+def _prepare_force_action_path(
+    db: object,
+    job: ImportJob,
+    cfg: CratediggerConfig,
+    *,
+    raw_path: str,
+) -> str:
+    """Publish one normalized, private action copy for a force job.
+
+    This is the only force-copy lifecycle owner.  Repeating a preview replaces
+    the job's deterministic action directory, so retrying cannot accumulate
+    random copies of an operator-owned quarantine source.
+    """
+    del db
+    snapshot = snapshot_configured_quarantine_directory(raw_path, cfg)
+    try:
+        # The descriptor copy is now private working state.  Normalize before
+        # inventorying/persisting evidence, and never touch ``raw_path``.
+        from lib.util import repair_mp3_headers
+
+        repair_mp3_headers(snapshot)
+        return retain_preview_snapshot_for_force_action(
+            snapshot,
+            cfg,
+            import_job_id=job.id,
+        )
+    finally:
+        if os.path.isdir(snapshot):
+            remove_preview_snapshot(snapshot, cfg)
 
 
 def _front_gate_check(
@@ -344,10 +430,10 @@ def _front_gate_check(
     *,
     runtime_config: CratediggerConfig | None = None,
     candidate_evidence_loader: Callable[..., EvidenceBuildResult] | None = None,
-) -> tuple[EvidenceBuildResult | None, str | None]:
+) -> tuple[EvidenceBuildResult | None, str | None, str | None]:
     """Run the cheap candidate-evidence front-gate for ``job``.
 
-    Returns ``(result, source_path)``. ``result is None`` means the
+    Returns ``(result, source_path, action_path)``. ``result is None`` means the
     front-gate could not run at all (path-derivation deferred to the
     measurement path) and the caller should fall through. A non-None
     result with ``status == 'ready'`` means measurement can be skipped.
@@ -357,21 +443,29 @@ def _front_gate_check(
         try:
             download_log_id, raw_path = _force_download_log_failed_path(db, job)
             cfg = _resolve_runtime_config(runtime_config)
-            snapshot = snapshot_configured_quarantine_directory(raw_path, cfg)
-            try:
-                load_candidate = (
-                    candidate_evidence_loader
-                    or load_candidate_evidence_for_source
-                )
-                result = load_candidate(
-                    db,
-                    source_path=snapshot,
-                    download_log_id=download_log_id,
-                    import_job_id=job.id,
-                )
-            finally:
-                remove_preview_snapshot(snapshot, cfg)
-            return result, raw_path
+            action_path = _prepare_force_action_path(
+                db, job, cfg, raw_path=raw_path,
+            )
+            load_candidate = (
+                candidate_evidence_loader or load_candidate_evidence_for_source
+            )
+            result = load_candidate(
+                db,
+                source_path=action_path,
+                download_log_id=download_log_id,
+                import_job_id=job.id,
+            )
+            # Reuse is allowed to discover a content-addressed evidence row
+            # through the originating audit record, but completion is not:
+            # bind the proven exact action snapshot to this job before its
+            # strict completion gate runs.
+            if (
+                result.status == "ready"
+                and result.evidence is not None
+                and result.evidence.id is not None
+            ):
+                db.set_import_job_candidate_evidence(job.id, result.evidence.id)
+            return result, raw_path, action_path
         except Exception:
             logger.debug(
                 "force front-gate isolation failed for job %s; falling through",
@@ -381,11 +475,11 @@ def _front_gate_check(
             # The front gate has already recovered the persisted force source.
             # Keep it for a later failure audit even when its isolated snapshot
             # was not available; only the evidence-reuse optimization failed.
-            return None, raw_path
+            return None, raw_path, None
 
     source_path = _front_gate_source_path(db, job)
     if not source_path:
-        return None, None
+        return None, None, None
     try:
         result = load_candidate_evidence_for_source(
             db,
@@ -400,8 +494,8 @@ def _front_gate_check(
             job.id,
             exc_info=True,
         )
-        return None, source_path
-    return result, source_path
+        return None, source_path, None
+    return result, source_path, None
 
 
 def _preview_input(db: Any, job: ImportJob) -> dict[str, Any]:
@@ -451,26 +545,31 @@ def execute_preview_job(
     job: ImportJob,
     *,
     runtime_config: CratediggerConfig | None = None,
+    prepared_force_action_path: str | None = None,
+    prepared_force_source_path: str | None = None,
 ) -> ImportPreviewResult:
     if job.job_type == IMPORT_JOB_FORCE:
         if job.request_id is None:
             raise ValueError("Import job has no request_id")
         download_log_id, raw_path = _force_download_log_failed_path(db, job)
+        if prepared_force_source_path is not None:
+            raw_path = prepared_force_source_path
         cfg = _resolve_runtime_config(runtime_config)
-        snapshot = snapshot_configured_quarantine_directory(raw_path, cfg)
-        try:
-            return measure_and_persist_candidate_evidence(
-                db,
-                request_id=job.request_id,
-                path=snapshot,
-                source_display_path=raw_path,
-                force=True,
-                download_log_id=download_log_id,
-                import_job_id=job.id,
-                runtime_config=cfg,
-            )
-        finally:
-            remove_preview_snapshot(snapshot, cfg)
+        action_path = prepared_force_action_path or _prepare_force_action_path(
+            db, job, cfg, raw_path=raw_path,
+        )
+        result = measure_and_persist_candidate_evidence(
+            db,
+            request_id=job.request_id,
+            path=action_path,
+            source_display_path=raw_path,
+            force=True,
+            download_log_id=download_log_id,
+            import_job_id=job.id,
+            runtime_config=cfg,
+            repair_fn=lambda _path: None,
+        )
+        return msgspec.structs.replace(result, action_path=action_path)
     preview_input = _preview_input(db, job)
     return measure_and_persist_candidate_evidence(
         db,
@@ -612,12 +711,18 @@ def process_claimed_preview_job(
     runtime_config: CratediggerConfig | None = None,
 ) -> ImportJob | None:
     def handle_measurement_failed(result: ImportPreviewResult) -> ImportJob | None:
-        return _handle_measurement_failed(
+        terminal = _handle_measurement_failed(
             db,
             job,
             result,
             prepare_failure_have_fn=prepare_failure_have_fn,
             enrich_failure_have_fn=enrich_failure_have_fn,
+            runtime_config=runtime_config,
+        )
+        return _cleanup_terminal_preview_force_action(
+            job,
+            terminal,
+            action_path=result.action_path,
             runtime_config=runtime_config,
         )
 
@@ -638,6 +743,7 @@ def process_claimed_preview_job(
             reason="measurement_crashed",
             detail=detail,
             source_path=source_path,
+            action_path=front_gate_action,
             request_id=job.request_id,
             download_log_id=_download_log_id_from_job(job),
             failure=failure,
@@ -647,7 +753,7 @@ def process_claimed_preview_job(
     # snapshot guard, mark the job importable without invoking measurement.
     # The post-measurement gate below remains as belt-and-braces for the
     # fall-through path.
-    front_gate_result, front_gate_source = _front_gate_check(
+    front_gate_result, front_gate_source, front_gate_action = _front_gate_check(
         db,
         job,
         runtime_config=runtime_config,
@@ -745,7 +851,7 @@ def process_claimed_preview_job(
             else:
                 audit_resolver = existing_spectral_resolver_for_config(audit_cfg)
         audit, have_lookup = collect_release_attempt_spectral_audit(
-            front_gate_source,
+            front_gate_action or front_gate_source,
             mb_release_id,
             existing_spectral_evidence=persisted_existing,
             preserve_existing_source_spectral=preserve_have_source,
@@ -793,6 +899,7 @@ def process_claimed_preview_job(
             front_gate_result.evidence,
             front_gate_source,
             ImportResult(spectral=audit),
+            action_path=front_gate_action,
         )
         logger.info(
             "Reused candidate evidence for import job %s; skipping preview measurement",
@@ -816,6 +923,8 @@ def process_claimed_preview_job(
                 db,
                 job,
                 runtime_config=runtime_config,
+                prepared_force_action_path=front_gate_action,
+                prepared_force_source_path=front_gate_source,
             )
     except Exception as exc:
         logger.exception("Import job %s preview crashed", job.id)
@@ -837,6 +946,7 @@ def process_claimed_preview_job(
             request_id=job.request_id,
             download_log_id=_download_log_id_from_job(job),
             source_path=front_gate_source,
+            action_path=front_gate_action,
             failure=crash_payload,
         )
         return handle_measurement_failed(crash_result)
@@ -873,6 +983,7 @@ def process_claimed_preview_job(
             reason="evidence_persist_failed",
             detail=evidence_reason,
             source_path=result.source_path,
+            action_path=result.action_path,
             request_id=result.request_id,
             download_log_id=result.download_log_id,
             import_result=result.import_result,
@@ -900,6 +1011,7 @@ def process_claimed_preview_job(
         reason=result.verdict,
         detail=f"unexpected verdict: {result.verdict}",
         source_path=result.source_path,
+        action_path=result.action_path,
         request_id=result.request_id,
         download_log_id=result.download_log_id,
         import_result=result.import_result,

--- a/scripts/importer.py
+++ b/scripts/importer.py
@@ -19,10 +19,10 @@ if REPO_ROOT not in sys.path:
 import msgspec
 
 from lib.dispatch import (
-    DISPATCH_CODE_QUALITY_PIPELINE_REJECTED,
     DISPATCH_CODE_REQUEUE_FAILED,
     DISPATCH_CODE_REQUEUED_FOR_PREVIEW,
     DispatchOutcome,
+    _requeue_import_job_to_preview,
 )
 from lib.dispatch.types import (
     PostCommitCleanup,
@@ -186,6 +186,59 @@ def _force_job_wrong_match_payload(job: ImportJob) -> tuple[int, str | None] | N
     return job.payload.download_log_id, job.payload.failed_path
 
 
+def _force_action_path(job: ImportJob) -> str | None:
+    """Return the retained private copy selected by this preview, if any."""
+    preview = job.preview_result
+    value = preview.get("action_path") if preview is not None else None
+    return value if isinstance(value, str) and value else None
+
+
+def _cleanup_terminal_force_action(job: ImportJob) -> dict[str, object] | None:
+    """Best-effort cleanup after a terminal force outcome.
+
+    The action copy must outlive Beets, but it is disposable once no launch is
+    pending.  Cleanup is deliberately reported after the real outcome rather
+    than allowed to replace it.
+    """
+    action_path = _force_action_path(job)
+    if action_path is None:
+        return None
+    try:
+        from lib.config import read_runtime_config
+        from lib.import_preview import cleanup_force_action_copy_for_job
+
+        cfg = read_runtime_config()
+        cleanup_force_action_copy_for_job(action_path, cfg, import_job_id=job.id)
+        return {"action_path": action_path, "removed": True}
+    except Exception as exc:
+        logger.exception("Failed to remove retained force action copy %s", action_path)
+        return {
+            "action_path": action_path,
+            "removed": False,
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+
+
+def _record_terminal_force_action_cleanup(
+    db: PipelineDB,
+    job: ImportJob,
+    terminal_job: ImportJob | None,
+) -> ImportJob | None:
+    cleanup = _cleanup_terminal_force_action(job)
+    if cleanup is None:
+        return terminal_job
+    try:
+        merged = db.merge_import_job_result(
+            job.id, {"force_action_cleanup": cleanup},
+        )
+    except Exception:  # terminal acknowledgement must remain authoritative
+        logger.exception(
+            "Failed to record retained force action cleanup for job %s", job.id,
+        )
+        return terminal_job
+    return merged or terminal_job
+
+
 def _cleanup_failed_force_import(
     db: PipelineDB,
     job: ImportJob,
@@ -214,55 +267,30 @@ def _cleanup_failed_force_import(
             "dispatch_code": outcome.code,
             "dispatch_message": outcome.message,
         }
-    if outcome.code != DISPATCH_CODE_QUALITY_PIPELINE_REJECTED:
-        return {
-            "success": False,
-            "download_log_id": download_log_id,
-            "failed_path_hint": failed_path_hint,
-            "outcome": "skipped_non_quality_pipeline_failure",
-            "skipped": True,
-            "dispatch_code": outcome.code,
-            "dispatch_message": outcome.message,
-        }
-    try:
-        from lib.wrong_match_delete_service import delete_wrong_match
-
-        # Dispatch already made the canonical import decision via
-        # full_pipeline_decision_from_evidence; this step only removes the
-        # reviewed source from Wrong Matches.
-        if not isinstance(job.payload, ForceImportPayload):
-            raise AssertionError("force_import payload type mismatch")
-        result = delete_wrong_match(
-            db,
-            download_log_id,
-            failed_path_hint=failed_path_hint,
-            source_dirs_hint=job.payload.source_dirs,
-            ignore_import_job_id=job.id,
-            require_visible=False,
-        )
-        data = result.to_dict()
-        data["dispatch_code"] = outcome.code
-        data["dispatch_message"] = outcome.message
-        if result.success:
-            data["reason"] = "quality_pipeline_rejected"
-        return data
-    except Exception as exc:
-        logger.exception(
-            "Failed to clean wrong-match source for import job %s",
-            job.id,
-        )
-        return {
-            "success": False,
-            "download_log_id": download_log_id,
-            "failed_path_hint": failed_path_hint,
-            "error": f"{type(exc).__name__}: {exc}",
-        }
+    # The original force/quarantine directory is operator authority and audit
+    # evidence. Dispatch consumes only the private action copy; cleanup of the
+    # raw source requires a distinct operator action, never a quality result.
+    return {
+        "success": True,
+        "download_log_id": download_log_id,
+        "failed_path_hint": failed_path_hint,
+        "outcome": "preserved_operator_force_source",
+        "skipped": True,
+        "dispatch_code": outcome.code,
+        "dispatch_message": outcome.message,
+    }
 
 
 def _dismiss_successful_force_import(
     db: PipelineDB,
     job: ImportJob,
 ) -> dict[str, object] | None:
+    """Remove a successfully imported source from Wrong Matches, never disk.
+
+    This runs only after the terminal acknowledgement.  The raw quarantine
+    directory remains operator evidence; the dismissed pointers only stop it
+    appearing as an actionable Wrong Matches entry.
+    """
     force_payload = _force_job_wrong_match_payload(job)
     if force_payload is None:
         return None
@@ -277,7 +305,7 @@ def _dismiss_successful_force_import(
         ).to_dict()
     except Exception as exc:
         logger.exception(
-            "Failed to dismiss wrong-match source for import job %s",
+            "Failed to dismiss successful force import source for job %s",
             job.id,
         )
         return {
@@ -313,10 +341,26 @@ def execute_import_job(
         if not isinstance(job.payload, ForceImportPayload):
             raise AssertionError("force_import payload type mismatch")
         payload = job.payload
+        from lib.config import read_runtime_config
+        from lib.import_preview import force_action_copy_path
+
+        action_path = _force_action_path(job)
+        expected_action_path = force_action_copy_path(read_runtime_config(), job.id)
+        if (
+            action_path is None
+            or action_path != expected_action_path
+            or not os.path.isdir(action_path)
+        ):
+            return _requeue_import_job_to_preview(
+                db,
+                import_job_id=job.id,
+                reason="force action copy unavailable; preview must rebuild it",
+            )
         return dispatch_import_from_db(
             db,
             request_id=job.request_id,
-            failed_path=payload.failed_path,
+            failed_path=action_path,
+            source_reference_path=payload.failed_path,
             source_username=payload.source_username,
             source_dirs=(
                 [source_dir for source_dir in payload.source_dirs if source_dir]
@@ -648,12 +692,13 @@ def process_claimed_job(
         )
         if recovery is not None:
             return recovery
-        return db.mark_import_job_failed(
+        failed = db.mark_import_job_failed(
             job.id,
             error=type(exc).__name__,
             message=str(exc),
             result={"success": False},
         )
+        return _record_terminal_force_action_cleanup(db, job, failed)
 
     result = _job_result(outcome)
     if outcome.success:
@@ -678,6 +723,13 @@ def process_claimed_job(
                 )
                 if merged is not None:
                     terminal_job = merged
+            if job.job_type != IMPORT_JOB_FORCE:
+                _cleanup_committed_wrong_match_rejection(
+                    db,
+                    job,
+                    terminal.download_log_id,
+                    outcome,
+                )
             dismissal = _dismiss_successful_force_import(db, job)
             if dismissal is not None:
                 merged = db.merge_import_job_result(
@@ -686,13 +738,7 @@ def process_claimed_job(
                 )
                 if merged is not None:
                     terminal_job = merged
-            _cleanup_committed_wrong_match_rejection(
-                db,
-                job,
-                terminal.download_log_id,
-                outcome,
-            )
-            return terminal_job
+            return _record_terminal_force_action_cleanup(db, job, terminal_job)
         recovery = db.mark_import_job_recovery_required(
             job.id,
             reason="Beets returned without a terminal acknowledgement bundle",
@@ -708,11 +754,11 @@ def process_claimed_job(
             return None
         dismissal = _dismiss_successful_force_import(db, job)
         if dismissal is not None:
-            return db.merge_import_job_result(
+            completed = db.merge_import_job_result(
                 job.id,
                 {"wrong_match_dismissal": dismissal},
             ) or completed
-        return completed
+        return _record_terminal_force_action_cleanup(db, job, completed)
     # U2: dispatch flipped this row back to the preview lane (or tried to).
     # We do NOT write a terminal failed status, do NOT bump retry counters,
     # and do NOT run the wrong-match cleanup decision. The dispatch-side
@@ -724,6 +770,9 @@ def process_claimed_job(
             job.request_id,
             outcome.message,
         )
+        # The preview claim now owns this deterministic action path.  It may
+        # publish its fresh copy before this importer frame returns, so an old
+        # importer must never reclaim it after the durable requeue.
         return None
     if outcome.code == DISPATCH_CODE_REQUEUE_FAILED:
         # The requeue UPDATE itself failed (DB transient). Mark the job
@@ -744,12 +793,13 @@ def process_claimed_job(
         )
         if recovery is not None:
             return recovery
-        return db.mark_import_job_failed(
+        failed = db.mark_import_job_failed(
             job.id,
             error=outcome.message,
             message=f"requeue-to-preview failed: {outcome.message}",
             result=result,
         )
+        return _record_terminal_force_action_cleanup(db, job, failed)
     if outcome.terminal_outcome is not None:
         terminal = db.persist_import_terminal_outcome(
             outcome.terminal_outcome.with_job(ImportJobTerminal(
@@ -777,13 +827,14 @@ def process_claimed_job(
             merged = db.merge_import_job_result(job.id, {"cleanup": cleanup})
             if merged is not None:
                 terminal_job = merged
-        _cleanup_committed_wrong_match_rejection(
-            db,
-            job,
-            terminal.download_log_id,
-            outcome,
-        )
-        return terminal_job
+        if job.job_type != IMPORT_JOB_FORCE:
+            _cleanup_committed_wrong_match_rejection(
+                db,
+                job,
+                terminal.download_log_id,
+                outcome,
+            )
+        return _record_terminal_force_action_cleanup(db, job, terminal_job)
     recovery = db.mark_import_job_recovery_required(
         job.id,
         reason="Beets returned without a terminal acknowledgement bundle",
@@ -809,11 +860,11 @@ def process_claimed_job(
             terminal_job = merged
     cleanup = _cleanup_failed_force_import(db, job, outcome)
     if cleanup is not None:
-        return db.merge_import_job_result(
+        terminal_job = db.merge_import_job_result(
             job.id,
             {"cleanup": cleanup},
         ) or terminal_job
-    return terminal_job
+    return _record_terminal_force_action_cleanup(db, job, terminal_job)
 
 
 def run_once(

--- a/tests/fakes/pipeline_db.py
+++ b/tests/fakes/pipeline_db.py
@@ -1363,18 +1363,19 @@ class FakePipelineDB:
                 payload=msgspec.to_builtins(original.payload),
                 message=f"Operator-authorized retry of recovery job {original.id}",
             )
-            retry_row = next(
-                item for item in self._import_jobs if item["id"] == retry.id
-            )
-            retry_row["preview_status"] = original.preview_status
-            retry_row["preview_result"] = copy.deepcopy(original.preview_result)
-            retry_row["preview_message"] = original.preview_message
-            retry_row["preview_error"] = original.preview_error
-            retry_row["preview_attempts"] = original.preview_attempts
-            retry_row["preview_completed_at"] = original.preview_completed_at
-            retry_row["importable_at"] = original.importable_at
-            retry_row["candidate_evidence_id"] = original.candidate_evidence_id
-            retry = ImportJob.from_row(copy.deepcopy(retry_row))
+            if original.job_type != "force_import":
+                retry_row = next(
+                    item for item in self._import_jobs if item["id"] == retry.id
+                )
+                retry_row["preview_status"] = original.preview_status
+                retry_row["preview_result"] = copy.deepcopy(original.preview_result)
+                retry_row["preview_message"] = original.preview_message
+                retry_row["preview_error"] = original.preview_error
+                retry_row["preview_attempts"] = original.preview_attempts
+                retry_row["preview_completed_at"] = original.preview_completed_at
+                retry_row["importable_at"] = original.importable_at
+                retry_row["candidate_evidence_id"] = original.candidate_evidence_id
+                retry = ImportJob.from_row(copy.deepcopy(retry_row))
         return resolved, retry
 
     def mark_import_job_failed(

--- a/tests/test_dispatch_outcomes_generated.py
+++ b/tests/test_dispatch_outcomes_generated.py
@@ -65,6 +65,7 @@ from lib.quality import (
     DownloadInfo,
     dispatch_action,
 )
+from lib.quality_evidence import snapshot_audio_files
 from tests.fakes import DownloadLogRow, FakePipelineDB
 from tests.beets_world import BeetsWorld
 from tests.helpers import (
@@ -233,9 +234,12 @@ def _run_dispatch(
             request_id=42,
             payload={"download_log_id": 1, "failed_path": tmpdir} if force else {},
         )
+        with open(os.path.join(tmpdir, "01 - Track.mp3"), "wb") as handle:
+            handle.write(b"generated fixture audio")
         evidence = make_album_quality_evidence(
             mb_release_id="mbid-generated",
             source_path=tmpdir,
+            files=snapshot_audio_files(tmpdir),
         )
         db.upsert_album_quality_evidence(evidence)
         persisted = db.find_album_quality_evidence(
@@ -559,17 +563,6 @@ def _run_have_analysis_abort(
         search_filetype_override=search_override,
         active_download_state={"files": [], "filetype": "flac"},
     ))
-    candidate = make_album_quality_evidence(
-        mb_release_id="generated-have-analysis-mbid",
-        source_path="/tmp/generated-candidate",
-    )
-    candidate_result = CandidateEvidenceActionResult(
-        evidence=candidate,
-        provenance=ActionEvidenceProvenance(
-            candidate_status="reused",
-            snapshot_guard="matched",
-        ),
-    )
     current_result = CurrentEvidenceActionResult(
         evidence=None,
         provenance=ActionEvidenceProvenance(
@@ -590,6 +583,8 @@ def _run_have_analysis_abort(
     }[mode]
 
     with tempfile.TemporaryDirectory() as tmpdir:
+        with open(os.path.join(tmpdir, "01 - Track.mp3"), "wb") as handle:
+            handle.write(b"generated HAVE fixture")
         payload = (
             {}
             if mode == "auto"
@@ -599,6 +594,25 @@ def _run_have_analysis_abort(
             job_type,
             request_id=42,
             payload=payload,
+        )
+        candidate = make_album_quality_evidence(
+            mb_release_id="generated-have-analysis-mbid",
+            source_path=tmpdir,
+            files=snapshot_audio_files(tmpdir),
+        )
+        db.upsert_album_quality_evidence(candidate)
+        persisted = db.find_album_quality_evidence(
+            mb_release_id=candidate.mb_release_id,
+            snapshot_fingerprint=candidate.snapshot_fingerprint,
+        )
+        assert persisted is not None and persisted.id is not None
+        db.set_import_job_candidate_evidence(job.id, persisted.id)
+        candidate_result = CandidateEvidenceActionResult(
+            evidence=persisted,
+            provenance=ActionEvidenceProvenance(
+                candidate_status="reused",
+                snapshot_guard="matched",
+            ),
         )
         with patch_dispatch_externals():
             outcome = dispatch_import_core(

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -3616,6 +3616,60 @@ class TestFakePipelineDBNewStubs(unittest.TestCase):
         assert failed is not None
         self.assertEqual(failed.status, "failed")
 
+    def test_force_recovery_retry_restarts_preview_without_old_action_state(self):
+        """Fake parity for #853's force-only recovery retry reset."""
+        from lib.import_queue import IMPORT_JOB_FORCE
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42, mb_release_id="fake-recovery-force", status="wanted",
+        ))
+        job = db.enqueue_import_job(
+            IMPORT_JOB_FORCE,
+            request_id=42,
+            dedupe_key="force:fake-recovery-preview",
+            payload={"download_log_id": 1, "failed_path": "/tmp/raw"},
+        )
+        evidence = make_album_quality_evidence(
+            mb_release_id="fake-recovery-force", source_path="/tmp/raw",
+        )
+        db.upsert_album_quality_evidence(evidence)
+        persisted = db.find_album_quality_evidence(
+            mb_release_id=evidence.mb_release_id,
+            snapshot_fingerprint=evidence.snapshot_fingerprint,
+        )
+        assert persisted is not None and persisted.id is not None
+        db.set_import_job_candidate_evidence(job.id, persisted.id)
+        db.mark_import_job_preview_importable(
+            job.id,
+            preview_result={"action_path": "/processing/albums/force-action-1"},
+        )
+        claimed = db.claim_next_import_job(worker_id="fake-recovery")
+        assert claimed is not None
+        assert db.authorize_import_job_launch(
+            claimed.id,
+            request_id=42,
+            release_id="fake-recovery-force",
+            source_path="/tmp/raw",
+        ) is not None
+        recovery = db.mark_import_job_recovery_required(
+            claimed.id, reason="ambiguous operation",
+        )
+        assert recovery is not None
+
+        resolved = db.resolve_import_job_recovery(
+            recovery.id,
+            resolution="retry",
+            reason="operator reconciled external mutation",
+        )
+
+        assert resolved is not None
+        _closed, retry = resolved
+        assert retry is not None
+        self.assertEqual(retry.preview_status, "waiting")
+        self.assertIsNone(retry.preview_result)
+        self.assertIsNone(retry.candidate_evidence_id)
+
     def test_requeue_import_job_for_preview_flips_running_back_to_waiting(self):
         from lib.import_queue import IMPORT_JOB_FORCE
 

--- a/tests/test_import_dispatch.py
+++ b/tests/test_import_dispatch.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock, patch
 import msgspec
 
 from lib.config import CratediggerConfig
+from lib.quality_evidence import snapshot_audio_files, snapshot_fingerprint
 from lib.quality import (DownloadInfo, ImportResult, ConversionInfo,
                          DuplicateRemoveCandidate, DuplicateRemoveGuardInfo,
                          AlbumQualityV0Metric, AudioQualityMeasurement,
@@ -213,6 +214,14 @@ def _claim_dispatch_job(
     )
     from lib.import_queue import IMPORT_JOB_AUTOMATION, IMPORT_JOB_FORCE
 
+    # Production-shaped dispatch tests must persist the snapshot of the path
+    # they later hand to the freshness guard.
+    os.makedirs(path, mode=0o700, exist_ok=True)
+    fixture_track = os.path.join(path, "01 - Track.mp3")
+    if not os.path.exists(fixture_track):
+        with open(fixture_track, "wb") as handle:
+            handle.write(b"fixture audio")
+    files = snapshot_audio_files(path)
     request = db.request(request_id)
     request["mb_release_id"] = release_id
     if not force:
@@ -228,6 +237,7 @@ def _claim_dispatch_job(
     evidence = make_album_quality_evidence(
         mb_release_id=release_id,
         source_path=path,
+        files=files,
         **(evidence_kwargs or {}),
     )
     db.upsert_album_quality_evidence(evidence)
@@ -463,6 +473,8 @@ class TestCleanupStagedDir(unittest.TestCase):
         from lib.dispatch import _cleanup_staged_dir
         tmpdir = tempfile.mkdtemp()
         try:
+            with open(os.path.join(tmpdir, "01 - Track.mp3"), "wb") as handle:
+                handle.write(b"fixture audio")
             parent = os.path.join(tmpdir, "Artist")
             staged = os.path.join(parent, "Album")
             os.makedirs(staged)
@@ -1399,6 +1411,8 @@ class TestHaveAnalysisErrorAbort(unittest.TestCase):
         )
 
         with tempfile.TemporaryDirectory() as tmpdir:
+            with open(os.path.join(tmpdir, "01 - Track.mp3"), "wb") as handle:
+                handle.write(b"fixture audio")
             request = db.request(42)
             request["mb_release_id"] = "test-mbid"
             request["active_download_state"] = {
@@ -1415,6 +1429,10 @@ class TestHaveAnalysisErrorAbort(unittest.TestCase):
                 candidate,
                 mb_release_id="test-mbid",
                 source_path=tmpdir,
+                files=snapshot_audio_files(tmpdir),
+                snapshot_fingerprint=snapshot_fingerprint(
+                    snapshot_audio_files(tmpdir),
+                ),
             )
             db.upsert_album_quality_evidence(candidate)
             persisted = db.find_album_quality_evidence(
@@ -1679,6 +1697,8 @@ class TestDispatchImport(unittest.TestCase):
         mock_gate = RecordingQualityGate()
         tmpdir = tempfile.mkdtemp()
         try:
+            with open(os.path.join(tmpdir, "01 - Track.mp3"), "wb") as handle:
+                handle.write(b"fixture audio")
             del queued  # every Beets seam now requires a claimed job
             db = FakePipelineDB()
             supplied_overrides = dict(request_overrides or {})
@@ -1714,6 +1734,7 @@ class TestDispatchImport(unittest.TestCase):
             evidence = make_album_quality_evidence(
                 mb_release_id="test-mbid",
                 source_path=tmpdir,
+                files=snapshot_audio_files(tmpdir),
             )
             db.upsert_album_quality_evidence(evidence)
             persisted = db.find_album_quality_evidence(

--- a/tests/test_import_manifest.py
+++ b/tests/test_import_manifest.py
@@ -6,6 +6,7 @@ from typing import Any, cast
 from lib.grab_list import DownloadFile
 from lib.dispatch import (
     DISPATCH_CODE_IMPORT_MANIFEST_REJECTED,
+    DispatchOutcome,
     dispatch_import_from_db,
 )
 from lib.import_manifest import (
@@ -14,8 +15,9 @@ from lib.import_manifest import (
     tracked_audio_paths_for_downloads,
 )
 from lib.import_queue import IMPORT_JOB_FORCE
+from lib.quality_evidence import snapshot_audio_files
 from tests.fakes import FakePipelineDB
-from tests.helpers import make_request_row
+from tests.helpers import make_album_quality_evidence, make_request_row
 
 
 class TestImportManifest(unittest.TestCase):
@@ -142,12 +144,58 @@ class TestImportManifest(unittest.TestCase):
 
 class TestForceImportManifestGuard(unittest.TestCase):
     @staticmethod
-    def _queued_job(db: FakePipelineDB, failed_path: str) -> int:
-        return db.enqueue_import_job(
+    def _persist_deferred_terminal(
+        db: FakePipelineDB,
+        outcome: DispatchOutcome,
+    ) -> None:
+        terminal = outcome.terminal_outcome
+        if terminal is not None:
+            from tests.helpers import finalize_claimed_dispatch
+
+            job = db.get_import_job(terminal.import_job_id)
+            assert job is not None
+            finalize_claimed_dispatch(db, job, outcome)
+
+    @staticmethod
+    def _claimed_job(
+        db: FakePipelineDB,
+        failed_path: str,
+        *,
+        download_log_id: int | None = None,
+        preview_result: dict[str, object] | None = None,
+    ) -> int:
+        job = db.enqueue_import_job(
             IMPORT_JOB_FORCE,
             request_id=42,
-            payload={"download_log_id": 1, "failed_path": failed_path},
-        ).id
+            payload={
+                "download_log_id": download_log_id or 1,
+                "failed_path": failed_path,
+            },
+        )
+        request = db.get_request(42)
+        assert request is not None
+        mb_release_id = request["mb_release_id"]
+        assert isinstance(mb_release_id, str)
+        evidence = make_album_quality_evidence(
+            mb_release_id=mb_release_id,
+            source_path=failed_path,
+            files=snapshot_audio_files(failed_path),
+        )
+        db.upsert_album_quality_evidence(evidence)
+        persisted = db.find_album_quality_evidence(
+            mb_release_id=evidence.mb_release_id,
+            snapshot_fingerprint=evidence.snapshot_fingerprint,
+        )
+        assert persisted is not None and persisted.id is not None
+        db.set_import_job_candidate_evidence(job.id, persisted.id)
+        ready = db.mark_import_job_preview_importable(
+            job.id,
+            preview_result=preview_result or {},
+        )
+        assert ready is not None
+        claimed = db.claim_next_import_job(worker_id="manifest-guard")
+        assert claimed is not None and claimed.id == job.id
+        return job.id
 
     def test_force_import_rejects_audio_not_in_origin_manifest(self):
         import msgspec
@@ -173,15 +221,6 @@ class TestForceImportManifestGuard(unittest.TestCase):
                     "items": [{"path": os.path.join(root, "01 Perth.flac")}],
                 },
             )
-            job = db.enqueue_import_job(
-                IMPORT_JOB_FORCE,
-                request_id=42,
-                payload=force_import_payload(
-                    download_log_id=log_id,
-                    failed_path=root,
-                    source_username="alice",
-                ),
-            )
             audit = SpectralDetail(
                 candidate=SpectralAnalysisDetail(
                     attempted=True, grade="suspect", bitrate_kbps=96),
@@ -191,8 +230,10 @@ class TestForceImportManifestGuard(unittest.TestCase):
             preview_import_result = msgspec.to_builtins(
                 ImportResult(spectral=audit))
             assert isinstance(preview_import_result, dict)
-            db.mark_import_job_preview_importable(
-                job.id,
+            job_id = self._claimed_job(
+                db,
+                root,
+                download_log_id=log_id,
                 preview_result={"import_result": preview_import_result},
             )
 
@@ -200,10 +241,11 @@ class TestForceImportManifestGuard(unittest.TestCase):
                 cast(Any, db),
                 request_id=42,
                 failed_path=root,
-                import_job_id=job.id,
+                import_job_id=job_id,
                 download_log_id=log_id,
             )
 
+        self._persist_deferred_terminal(db, outcome)
         self.assertFalse(outcome.success)
         # Extra/untracked audio: keep the Wrong Matches entry for operator
         # review (the importer skips cleanup on this code).
@@ -250,7 +292,7 @@ class TestForceImportManifestGuard(unittest.TestCase):
                     ],
                 },
             )
-            job_id = self._queued_job(db, root)
+            job_id = self._claimed_job(db, root, download_log_id=log_id)
 
             outcome = dispatch_import_from_db(
                 cast(Any, db),
@@ -260,6 +302,7 @@ class TestForceImportManifestGuard(unittest.TestCase):
                 download_log_id=log_id,
             )
 
+        self._persist_deferred_terminal(db, outcome)
         self.assertFalse(outcome.success)
         self.assertEqual(outcome.code, DISPATCH_CODE_IMPORT_MANIFEST_REJECTED)
         self.assertIn("manifest has 2 audio files", outcome.message)
@@ -284,7 +327,7 @@ class TestForceImportManifestGuard(unittest.TestCase):
             open(os.path.join(root, "01.mp3"), "wb").close()
             open(os.path.join(root, "02.mp3"), "wb").close()
             open(os.path.join(root, "bonus.mp3"), "wb").close()
-            job_id = self._queued_job(db, root)
+            job_id = self._claimed_job(db, root)
 
             outcome = dispatch_import_from_db(
                 cast(Any, db),
@@ -293,6 +336,7 @@ class TestForceImportManifestGuard(unittest.TestCase):
                 import_job_id=job_id,
             )
 
+        self._persist_deferred_terminal(db, outcome)
         self.assertFalse(outcome.success)
         self.assertEqual(outcome.code, DISPATCH_CODE_IMPORT_MANIFEST_REJECTED)
         self.assertIn("3 audio files", outcome.message)
@@ -314,7 +358,7 @@ class TestForceImportManifestGuard(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as root:
             open(os.path.join(root, "01.mp3"), "wb").close()
-            job_id = self._queued_job(db, root)
+            job_id = self._claimed_job(db, root)
 
             outcome = dispatch_import_from_db(
                 cast(Any, db),
@@ -323,6 +367,7 @@ class TestForceImportManifestGuard(unittest.TestCase):
                 import_job_id=job_id,
             )
 
+        self._persist_deferred_terminal(db, outcome)
         self.assertFalse(outcome.success)
         self.assertEqual(outcome.code, DISPATCH_CODE_IMPORT_MANIFEST_REJECTED)
         self.assertIn("requires either an origin audio manifest", outcome.message)
@@ -351,7 +396,7 @@ class TestForceImportManifestGuard(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as root:
             open(os.path.join(root, "01.mp3"), "wb").close()
-            job_id = self._queued_job(db, root)
+            job_id = self._claimed_job(db, root)
 
             outcome = dispatch_import_from_db(
                 cast(Any, db),
@@ -360,6 +405,7 @@ class TestForceImportManifestGuard(unittest.TestCase):
                 import_job_id=job_id,
             )
 
+        self._persist_deferred_terminal(db, outcome)
         self.assertFalse(outcome.success)
         # Preserve-folder code (importer skips deletion) — a non-empty source
         # must never route through the rmtree-ing QUALITY_PIPELINE_REJECTED.
@@ -399,7 +445,7 @@ class TestForceImportManifestGuard(unittest.TestCase):
                     ],
                 },
             )
-            job_id = self._queued_job(db, root)
+            job_id = self._claimed_job(db, root, download_log_id=log_id)
 
             outcome = dispatch_import_from_db(
                 cast(Any, db),
@@ -409,6 +455,7 @@ class TestForceImportManifestGuard(unittest.TestCase):
                 download_log_id=log_id,
             )
 
+        self._persist_deferred_terminal(db, outcome)
         self.assertFalse(outcome.success)
         self.assertEqual(outcome.code, DISPATCH_CODE_IMPORT_MANIFEST_REJECTED)
         self.assertEqual(db.request(42)["status"], "unsearchable")

--- a/tests/test_import_operation_fence.py
+++ b/tests/test_import_operation_fence.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 import unittest
 from unittest.mock import patch
 
+from lib.config import CratediggerConfig
 from lib.dispatch import DispatchOutcome
 from lib.dispatch.types import PostCommitCleanup
 from lib.import_evidence import ensure_candidate_evidence_for_action
@@ -24,6 +25,7 @@ from lib.import_queue import (
 )
 from lib.pipeline_db import PipelineDB
 from lib.quality_evidence import snapshot_audio_files
+from lib.import_preview import force_action_copy_path
 from lib.import_job_recovery_service import resolve_import_job_recovery
 from lib.terminal_outcomes import (
     ImportJobTerminal,
@@ -417,6 +419,79 @@ class TestImportOperationFence(unittest.TestCase):
             "retry",
         )
 
+    def test_recovery_retry_resets_only_force_preview_state(self) -> None:
+        """#853: only force retries lost a disposable action copy."""
+        cases = (
+            (IMPORT_JOB_AUTOMATION, "downloading", "/incoming/automation", {}),
+            (
+                IMPORT_JOB_YOUTUBE,
+                "wanted",
+                "/incoming/youtube",
+                youtube_import_payload(
+                    staged_path="/incoming/youtube",
+                    request_id=42,
+                    browse_id="MPREb_recovery",
+                    download_log_id=77,
+                ),
+            ),
+        )
+        for job_type, status, source_path, payload in cases:
+            with self.subTest(job_type=job_type):
+                db = FakePipelineDB()
+                db.seed_request(make_request_row(
+                    id=42,
+                    mb_release_id="release-42",
+                    status=status,
+                    active_download_state=(
+                        {"current_path": source_path, "files": []}
+                        if job_type == IMPORT_JOB_AUTOMATION else None
+                    ),
+                ))
+                job = db.enqueue_import_job(
+                    job_type,
+                    request_id=42,
+                    dedupe_key=f"{job_type}:recovery-preview",
+                    payload=payload,
+                )
+                _seed_candidate(
+                    db,
+                    job.id,
+                    release_id="release-42",
+                    source_path=source_path,
+                )
+                preview_result = {"verdict": "would_import", "sentinel": job_type}
+                db.mark_import_job_preview_importable(
+                    job.id, preview_result=preview_result,
+                )
+                claimed = db.claim_next_import_job(worker_id="worker")
+                assert claimed is not None
+                candidate_evidence_id = claimed.candidate_evidence_id
+                assert db.authorize_import_job_launch(
+                    claimed.id,
+                    request_id=42,
+                    release_id="release-42",
+                    source_path=source_path,
+                ) is not None
+                recovery = db.mark_import_job_recovery_required(
+                    claimed.id, reason="ambiguous operation",
+                )
+                assert recovery is not None
+
+                result = resolve_import_job_recovery(
+                    db,
+                    recovery.id,
+                    resolution="retry",
+                    reason="Operator reconciled external mutation",
+                )
+
+                assert result.retry_job is not None
+                self.assertEqual(result.retry_job.preview_result, preview_result)
+                self.assertEqual(result.retry_job.candidate_evidence_id, candidate_evidence_id)
+                self.assertEqual(
+                    result.retry_job.beets_launch_snapshot_fingerprint,
+                    None,
+                )
+
     def test_operator_close_never_schedules_replay(self) -> None:
         db, recovery = self._force_recovery_job()
 
@@ -431,6 +506,67 @@ class TestImportOperationFence(unittest.TestCase):
         self.assertIsNone(result.retry_job)
         self.assertEqual(len(db.list_import_jobs()), 1)
         self.assertIsNone(db.claim_next_import_job(worker_id="replay"))
+
+    def test_recovery_resolution_discards_old_force_action_before_close_or_retry(self) -> None:
+        """#853: recovery retains a copy only while reconciliation is pending."""
+        for resolution in ("close", "retry"):
+            with self.subTest(resolution=resolution), tempfile.TemporaryDirectory() as root:
+                downloads = os.path.join(root, "downloads")
+                processing = os.path.join(root, "processing")
+                os.mkdir(downloads, 0o700)
+                os.mkdir(processing, 0o700)
+                os.mkdir(os.path.join(processing, "albums"), 0o700)
+                os.mkdir(os.path.join(processing, "preview"), 0o700)
+                cfg = CratediggerConfig(
+                    slskd_download_dir=downloads,
+                    processing_dir=processing,
+                    audio_check_mode="off",
+                )
+                db = FakePipelineDB()
+                db.seed_request(make_request_row(
+                    id=42, mb_release_id="release-42", status="wanted",
+                ))
+                job = db.enqueue_import_job(
+                    IMPORT_JOB_FORCE,
+                    request_id=42,
+                    dedupe_key=f"force:recovery-action:{resolution}",
+                    payload={"download_log_id": 1, "failed_path": "/operator/raw"},
+                )
+                action_path = force_action_copy_path(cfg, job.id)
+                os.mkdir(action_path, 0o700)
+                with open(os.path.join(action_path, "01.mp3"), "wb") as handle:
+                    handle.write(b"action bytes")
+                _seed_candidate(
+                    db, job.id, release_id="release-42", source_path=action_path,
+                )
+                db.mark_import_job_preview_importable(
+                    job.id, preview_result={"action_path": action_path},
+                )
+                claimed = db.claim_next_import_job(worker_id="worker")
+                assert claimed is not None
+                assert db.authorize_import_job_launch(
+                    claimed.id,
+                    request_id=42,
+                    release_id="release-42",
+                    source_path="/operator/raw",
+                ) is not None
+                recovery = db.mark_import_job_recovery_required(
+                    claimed.id, reason="ambiguous Beets result",
+                )
+                assert recovery is not None
+
+                with patch("lib.config.read_runtime_config", return_value=cfg):
+                    result = resolve_import_job_recovery(
+                        db,
+                        recovery.id,
+                        resolution=resolution,
+                        reason="Operator reconciled Beets and raw source",
+                    )
+
+                self.assertFalse(os.path.exists(action_path))
+                if resolution == "retry":
+                    assert result.retry_job is not None
+                    self.assertIsNone(result.retry_job.preview_result)
 
     def test_operator_retry_refuses_authority_changed_during_inspection(self) -> None:
         db, recovery = self._force_recovery_job()

--- a/tests/test_import_preview.py
+++ b/tests/test_import_preview.py
@@ -2821,6 +2821,64 @@ if TYPE_CHECKING:
     _fake_db_satisfies_preview_protocol: _PreviewDB = cast("FakePipelineDB", None)
 
 
+class TestOwnedProcessingNormalization(unittest.TestCase):
+    """Issue #853: repair belongs after private processing publication."""
+
+    def test_repaired_processing_album_persists_matching_evidence(self):
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=853, mb_release_id="issue-853"))
+        album = tempfile.mkdtemp(
+            prefix="issue-853-",
+            dir=os.path.join(_PREVIEW_PROCESSING_ROOT, "albums"),
+        )
+        track = os.path.join(album, "01.mp3")
+        with open(track, "wb") as handle:
+            handle.write(b"unrepaired")
+        persisted_files: list[object] = []
+
+        def repair(path: str) -> None:
+            self.assertEqual(path, album)
+            with open(track, "wb") as handle:
+                handle.write(b"repaired")
+
+        try:
+            with patch(
+                "lib.import_preview.inspect_local_files",
+                return_value=LocalFileInspection(filetype="mp3"),
+            ), patch(
+                "lib.import_preview.measure_preimport_state",
+                return_value=PreimportMeasurement(
+                    audio_corrupt=True,
+                    folder_layout="flat",
+                    audio_file_count=1,
+                ),
+            ):
+                result = measure_and_persist_candidate_evidence(
+                    db,
+                    request_id=853,
+                    path=album,
+                    runtime_config=_preview_runtime_config(),
+                    current_evidence_loader=lambda *_args, **_kwargs: EvidenceBuildResult(
+                        None, "empty_current",
+                    ),
+                    persist_measurement_fn=lambda *_args, **kwargs: (
+                        persisted_files.extend(kwargs["files"])
+                        or EvidenceBuildResult(
+                            make_album_quality_evidence(mb_release_id="issue-853"),
+                            "ready",
+                        )
+                    ),
+                    repair_fn=repair,
+                )
+            self.assertEqual(result.verdict, "evidence_ready")
+            with open(track, "rb") as handle:
+                self.assertEqual(handle.read(), b"repaired")
+            self.assertEqual(len(persisted_files), 1)
+            self.assertEqual(getattr(persisted_files[0], "size_bytes"), len(b"repaired"))
+        finally:
+            shutil.rmtree(album, ignore_errors=True)
+
+
 class TestEnrichIncompleteCurrentEvidence(unittest.TestCase):
     """Failure-point HAVE enrichment fills only what's missing, once."""
 

--- a/tests/test_import_queue.py
+++ b/tests/test_import_queue.py
@@ -463,7 +463,145 @@ class TestAutomationEvidenceReuse(unittest.TestCase):
         self.assertEqual(handle_valid_calls, [])
 
 
+class TestPreviewCompletionEvidenceOwnership(unittest.TestCase):
+    def _linked_force_job(self) -> tuple[str, str, FakePipelineDB, ImportJob]:
+        root, source = _make_failed_import_source()
+        with open(os.path.join(source, "01.mp3"), "wb") as handle:
+            handle.write(b"audio")
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=42, mb_release_id="mbid-123"))
+        log_id = _force_download_log(db, 42, source)
+        job = db.enqueue_import_job(
+            IMPORT_JOB_FORCE,
+            request_id=42,
+            dedupe_key=force_import_dedupe_key(log_id),
+            payload=force_import_payload(download_log_id=log_id, failed_path=source),
+        )
+        _seed_candidate_for_import_job(
+            db,
+            job.id,
+            mb_release_id="mbid-123",
+            files=snapshot_audio_files(source),
+        )
+        return root, source, db, job
+
+    def test_download_log_evidence_cannot_complete_a_different_job(self):
+        """#853: preview completion requires this job's exact evidence FK."""
+        from scripts.import_preview_worker import _candidate_evidence_ready_for_job
+
+        root, source = _make_failed_import_source()
+        try:
+            with open(os.path.join(source, "01.mp3"), "wb") as handle:
+                handle.write(b"audio")
+            db = FakePipelineDB()
+            db.seed_request(make_request_row(id=42, mb_release_id="mbid-123"))
+            log_id = _force_download_log(db, 42, source)
+            job = db.enqueue_import_job(
+                IMPORT_JOB_FORCE,
+                request_id=42,
+                dedupe_key=force_import_dedupe_key(log_id),
+                payload=force_import_payload(download_log_id=log_id, failed_path=source),
+            )
+            _seed_candidate_for_download_log(
+                db,
+                log_id,
+                mb_release_id="mbid-123",
+                files=snapshot_audio_files(source),
+            )
+
+            ready, reason = _candidate_evidence_ready_for_job(
+                db,
+                job,
+                ImportPreviewResult(
+                    mode="path", source_path=source, verdict="evidence_ready",
+                ),
+            )
+
+            self.assertFalse(ready)
+            self.assertIn("did not link", reason)
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    def test_empty_candidate_fingerprint_cannot_complete_preview(self):
+        """#853: a linked row still needs a non-empty exact fingerprint."""
+        from scripts.import_preview_worker import _candidate_evidence_ready_for_job
+
+        class EmptyFingerprintDB(FakePipelineDB):
+            def load_album_quality_evidence_by_id(self, evidence_id):
+                evidence = super().load_album_quality_evidence_by_id(evidence_id)
+                return (
+                    msgspec.structs.replace(evidence, snapshot_fingerprint="")
+                    if evidence is not None else None
+                )
+
+        root, source, original, job = self._linked_force_job()
+        db = EmptyFingerprintDB()
+        db.__dict__.update(original.__dict__)
+        try:
+            ready, reason = _candidate_evidence_ready_for_job(
+                db,
+                job,
+                ImportPreviewResult(
+                    mode="path", source_path=source, verdict="evidence_ready",
+                ),
+            )
+            self.assertFalse(ready)
+            self.assertIn("empty snapshot fingerprint", reason)
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    def test_wrong_candidate_row_cannot_complete_preview(self):
+        """#853: completion rejects a usable snapshot from another evidence row."""
+        from scripts.import_preview_worker import _candidate_evidence_ready_for_job
+
+        class WrongRowDB(FakePipelineDB):
+            def load_album_quality_evidence_by_id(self, evidence_id):
+                evidence = super().load_album_quality_evidence_by_id(evidence_id)
+                return (
+                    msgspec.structs.replace(evidence, id=(evidence.id or 0) + 1)
+                    if evidence is not None else None
+                )
+
+        root, source, original, job = self._linked_force_job()
+        db = WrongRowDB()
+        db.__dict__.update(original.__dict__)
+        try:
+            ready, reason = _candidate_evidence_ready_for_job(
+                db,
+                job,
+                ImportPreviewResult(
+                    mode="path", source_path=source, verdict="evidence_ready",
+                ),
+            )
+            self.assertFalse(ready)
+            self.assertIn("does not match", reason)
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+
 class TestImporterWorker(unittest.TestCase):
+    def setUp(self) -> None:
+        self._force_root = tempfile.mkdtemp(prefix="cratedigger-force-action-")
+        downloads = os.path.join(self._force_root, "downloads")
+        processing = os.path.join(self._force_root, "processing")
+        os.mkdir(downloads, 0o700)
+        os.mkdir(processing, 0o700)
+        os.mkdir(os.path.join(processing, "albums"), 0o700)
+        os.mkdir(os.path.join(processing, "preview"), 0o700)
+        self._force_cfg = CratediggerConfig(
+            slskd_download_dir=downloads,
+            processing_dir=processing,
+            audio_check_mode="off",
+        )
+        self._runtime_config_patch = patch(
+            "lib.config.read_runtime_config", return_value=self._force_cfg,
+        )
+        self._runtime_config_patch.start()
+
+    def tearDown(self) -> None:
+        self._runtime_config_patch.stop()
+        shutil.rmtree(self._force_root, ignore_errors=True)
+
     def _mark_importable(
         self,
         db: FakePipelineDB,
@@ -471,9 +609,20 @@ class TestImporterWorker(unittest.TestCase):
         *,
         preview_result: dict[str, Any] | None = None,
     ):
+        payload = preview_result or {"verdict": "would_import"}
+        if job.job_type == IMPORT_JOB_FORCE:
+            from lib.import_preview import force_action_copy_path
+
+            action_path = force_action_copy_path(self._force_cfg, job.id)
+            raw_path = job.payload.failed_path
+            if os.path.isdir(raw_path):
+                shutil.copytree(raw_path, action_path)
+            else:
+                os.mkdir(action_path, 0o700)
+            payload = {**payload, "action_path": action_path}
         updated = db.mark_import_job_preview_importable(
             job.id,
-            preview_result=preview_result or {"verdict": "would_import"},
+            preview_result=payload,
             message="ready",
         )
         assert updated is not None
@@ -601,16 +750,71 @@ class TestImporterWorker(unittest.TestCase):
         dispatch.assert_called_once_with(
             db,
             request_id=42,
-            failed_path="/tmp/failed",
+            failed_path=os.path.join(
+                self._force_cfg.processing_dir, "albums", f"force-action-{claimed.id}",
+            ),
             source_username="alice",
             source_dirs=None,
             import_job_id=claimed.id,
             download_log_id=7,
+            source_reference_path="/tmp/failed",
         )
         assert updated is not None
         self.assertEqual(updated.status, "completed")
         self.assertEqual(self._result(updated)["success"], True)
         self.assertEqual(job.id, updated.id)
+        self.assertFalse(os.path.exists(
+            os.path.join(
+                self._force_cfg.processing_dir,
+                "albums",
+                f"force-action-{claimed.id}",
+            ),
+        ))
+
+    def test_acknowledged_force_success_dismisses_only_wrong_match_pointer(self):
+        """#853: success clears review state, not the operator's raw bytes."""
+        from scripts import importer
+
+        db = FakePipelineDB()
+        root, source = _make_failed_import_source()
+        try:
+            raw_bytes = b"archival raw audio"
+            with open(os.path.join(source, "01.mp3"), "wb") as handle:
+                handle.write(raw_bytes)
+            log_id = self._log_wrong_match(db, failed_path=source)
+            job = db.enqueue_import_job(
+                IMPORT_JOB_FORCE,
+                request_id=42,
+                dedupe_key=force_import_dedupe_key(log_id),
+                payload=force_import_payload(
+                    download_log_id=log_id,
+                    failed_path=source,
+                ),
+            )
+            self._mark_importable(db, job)
+            action_path = os.path.join(
+                self._force_cfg.processing_dir, "albums", f"force-action-{job.id}",
+            )
+            claimed = db.claim_next_import_job(worker_id="worker")
+            assert claimed is not None
+
+            updated = importer.process_claimed_job(
+                cast(Any, db),
+                claimed,
+                execute_fn=lambda *_args, **_kwargs: DispatchOutcome(True, "imported"),
+            )
+
+            assert updated is not None
+            self.assertEqual(updated.status, "completed")
+            with open(os.path.join(source, "01.mp3"), "rb") as handle:
+                self.assertEqual(handle.read(), raw_bytes)
+            self.assertEqual(db.get_wrong_matches(), [])
+            self.assertFalse(os.path.exists(action_path))
+            result = self._result(updated)
+            self.assertTrue(result["wrong_match_dismissal"]["success"])
+            self.assertTrue(result["force_action_cleanup"]["removed"])
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
 
     def test_force_import_job_forwards_source_dirs(self):
         from scripts import importer
@@ -640,12 +844,40 @@ class TestImporterWorker(unittest.TestCase):
         dispatch.assert_called_once_with(
             db,
             request_id=42,
-            failed_path="/tmp/failed",
+            failed_path=os.path.join(
+                self._force_cfg.processing_dir, "albums", f"force-action-{claimed.id}",
+            ),
             source_username="alice",
             source_dirs=["alice\\Artist\\Album", "alice\\Artist\\Album\\CD2"],
             import_job_id=claimed.id,
             download_log_id=7,
+            source_reference_path="/tmp/failed",
         )
+
+    def test_force_import_without_private_action_requeues_before_dispatch(self):
+        """A force job must never fall back to the raw quarantine folder."""
+        from scripts import importer
+
+        db = FakePipelineDB()
+        job = db.enqueue_import_job(
+            IMPORT_JOB_FORCE,
+            request_id=42,
+            dedupe_key=force_import_dedupe_key(7),
+            payload=force_import_payload(download_log_id=7, failed_path="/tmp/raw"),
+        )
+        db.mark_import_job_preview_importable(
+            job.id,
+            preview_result={"verdict": "would_import"},
+            message="ready",
+        )
+        claimed = db.claim_next_import_job(worker_id="worker")
+        assert claimed is not None
+
+        updated = importer.process_claimed_job(cast(Any, db), claimed)
+        self.assertIsNone(updated)
+        row = db.get_import_job(job.id)
+        assert row is not None
+        self.assertEqual(row.preview_status, "waiting")
 
     def test_force_import_job_does_not_forward_preview_import_result(self):
         from scripts import importer
@@ -735,7 +967,7 @@ class TestImporterWorker(unittest.TestCase):
             "import must recompute the action decision against current evidence.",
         )
 
-    def test_failed_force_import_quality_pipeline_reject_cleans_without_redeciding(self):
+    def test_failed_force_import_quality_pipeline_reject_preserves_raw_source(self):
         from scripts import importer
 
         db = FakePipelineDB()
@@ -780,19 +1012,199 @@ class TestImporterWorker(unittest.TestCase):
             cleanup_wrong_match.assert_not_called()
             assert updated is not None
             self.assertEqual(updated.status, "failed")
-            self.assertFalse(os.path.exists(source))
-            self.assertEqual(db.get_wrong_matches(), [])
+            self.assertTrue(os.path.exists(source))
+            self.assertEqual(len(db.get_wrong_matches()), 1)
             result = self._result(updated)
             self.assertEqual(result["cleanup"]["success"], True)
-            self.assertEqual(result["cleanup"]["outcome"], "deleted")
-            self.assertEqual(result["cleanup"]["cleared_rows"], 1)
-            self.assertEqual(result["cleanup"]["reason"], "quality_pipeline_rejected")
+            self.assertEqual(
+                result["cleanup"]["outcome"], "preserved_operator_force_source",
+            )
             self.assertEqual(
                 result["cleanup"]["dispatch_code"],
                 DISPATCH_CODE_QUALITY_PIPELINE_REJECTED,
             )
         finally:
             shutil.rmtree(root, ignore_errors=True)
+
+    def test_corrupt_force_action_is_reclaimed_without_protected_quarantine_copy(self):
+        """#853: corrupt force bytes stay private; raw Wrong Match stays intact."""
+        from scripts import importer
+
+        db = FakePipelineDB()
+        root, source = _make_failed_import_source()
+        try:
+            raw_bytes = b"operator raw evidence"
+            with open(os.path.join(source, "01.mp3"), "wb") as handle:
+                handle.write(raw_bytes)
+            db.seed_request(make_request_row(
+                id=42,
+                mb_release_id="mbid-123",
+                status="unsearchable",
+            ))
+            db.set_tracks(42, [{"track_number": 1, "title": "One"}])
+            log_id = self._log_wrong_match(db, failed_path=source)
+            job = db.enqueue_import_job(
+                IMPORT_JOB_FORCE,
+                request_id=42,
+                dedupe_key=force_import_dedupe_key(log_id),
+                payload=force_import_payload(
+                    download_log_id=log_id,
+                    failed_path=source,
+                    source_username="alice",
+                ),
+            )
+            self._mark_importable(db, job)
+            action_path = os.path.join(
+                self._force_cfg.processing_dir, "albums", f"force-action-{job.id}",
+            )
+            _seed_candidate_for_import_job(
+                db,
+                job.id,
+                mb_release_id="mbid-123",
+                files=snapshot_audio_files(action_path),
+                audio_corrupt=True,
+                audio_error="01.mp3: corrupt fixture",
+            )
+            claimed = db.claim_next_import_job(worker_id="worker")
+            assert claimed is not None
+
+            updated = importer.process_claimed_job(cast(Any, db), claimed)
+
+            assert updated is not None
+            self.assertEqual(updated.status, "failed")
+            with open(os.path.join(source, "01.mp3"), "rb") as handle:
+                self.assertEqual(handle.read(), raw_bytes)
+            self.assertTrue(os.path.isdir(source))
+            self.assertEqual(len(db.get_wrong_matches()), 1)
+            self.assertFalse(os.path.exists(action_path))
+            self.assertFalse(os.path.exists(os.path.join(
+                self._force_cfg.slskd_download_dir, "failed_imports", "bad_files",
+            )))
+            result = self._result(updated)
+            self.assertNotIn("post_commit_cleanup", result)
+            self.assertEqual(
+                result["cleanup"]["outcome"], "preserved_operator_force_source",
+            )
+            self.assertTrue(result["force_action_cleanup"]["removed"])
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    def test_stale_rejecting_force_evidence_requeues_before_rejection_audit(self):
+        """#853: action drift invalidates even an initially corrupt reject."""
+        from scripts import importer
+
+        db = FakePipelineDB()
+        root, source = _make_failed_import_source()
+        try:
+            with open(os.path.join(source, "01.mp3"), "wb") as handle:
+                handle.write(b"operator raw evidence")
+            db.seed_request(make_request_row(
+                id=42, mb_release_id="mbid-123", status="unsearchable",
+            ))
+            db.set_tracks(42, [{"track_number": 1, "title": "One"}])
+            log_id = self._log_wrong_match(db, failed_path=source)
+            job = db.enqueue_import_job(
+                IMPORT_JOB_FORCE,
+                request_id=42,
+                dedupe_key=force_import_dedupe_key(log_id),
+                payload=force_import_payload(download_log_id=log_id, failed_path=source),
+            )
+            self._mark_importable(db, job)
+            action_path = os.path.join(
+                self._force_cfg.processing_dir, "albums", f"force-action-{job.id}",
+            )
+            _seed_candidate_for_import_job(
+                db,
+                job.id,
+                mb_release_id="mbid-123",
+                files=snapshot_audio_files(action_path),
+                audio_corrupt=True,
+                audio_error="reject if unchanged",
+            )
+            with open(os.path.join(action_path, "01.mp3"), "ab") as handle:
+                handle.write(b" drift")
+            claimed = db.claim_next_import_job(worker_id="worker")
+            assert claimed is not None
+
+            updated = importer.process_claimed_job(cast(Any, db), claimed)
+
+            self.assertIsNone(updated)
+            row = db.get_import_job(job.id)
+            assert row is not None
+            self.assertEqual(row.status, "queued")
+            self.assertEqual(row.preview_status, "waiting")
+            self.assertEqual(len(db.download_logs), 1)
+            self.assertEqual(len(db.get_wrong_matches()), 1)
+            self.assertTrue(os.path.isdir(action_path))
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    def test_force_action_manifest_drift_requeues_before_terminal_audit(self):
+        """Add/remove/rename drift is stale evidence, never a force reject."""
+        from scripts import importer
+
+        def remove(path: str) -> None:
+            os.unlink(os.path.join(path, "01.mp3"))
+
+        def add(path: str) -> None:
+            with open(os.path.join(path, "bonus.mp3"), "wb") as handle:
+                handle.write(b"unexpected audio")
+
+        def rename(path: str) -> None:
+            os.rename(os.path.join(path, "01.mp3"), os.path.join(path, "02.mp3"))
+
+        for drift, mutate in (("remove", remove), ("add", add), ("rename", rename)):
+            with self.subTest(drift=drift):
+                db = FakePipelineDB()
+                root, source = _make_failed_import_source()
+                try:
+                    raw_bytes = b"operator raw evidence"
+                    with open(os.path.join(source, "01.mp3"), "wb") as handle:
+                        handle.write(raw_bytes)
+                    db.seed_request(make_request_row(
+                        id=42, mb_release_id="mbid-123", status="unsearchable",
+                    ))
+                    db.set_tracks(42, [{"track_number": 1, "title": "One"}])
+                    log_id = self._log_wrong_match(db, failed_path=source)
+                    job = db.enqueue_import_job(
+                        IMPORT_JOB_FORCE,
+                        request_id=42,
+                        dedupe_key=force_import_dedupe_key(log_id),
+                        payload=force_import_payload(
+                            download_log_id=log_id, failed_path=source,
+                        ),
+                    )
+                    action_path = os.path.join(
+                        self._force_cfg.processing_dir,
+                        "albums",
+                        f"force-action-{job.id}",
+                    )
+                    shutil.rmtree(action_path, ignore_errors=True)
+                    self._mark_importable(db, job)
+                    _seed_candidate_for_import_job(
+                        db,
+                        job.id,
+                        mb_release_id="mbid-123",
+                        files=snapshot_audio_files(action_path),
+                    )
+                    mutate(action_path)
+                    claimed = db.claim_next_import_job(worker_id="worker")
+                    assert claimed is not None
+
+                    updated = importer.process_claimed_job(cast(Any, db), claimed)
+
+                    self.assertIsNone(updated)
+                    row = db.get_import_job(job.id)
+                    assert row is not None
+                    self.assertEqual(row.status, "queued")
+                    self.assertEqual(row.preview_status, "waiting")
+                    self.assertEqual(len(db.download_logs), 1)
+                    self.assertEqual(len(db.get_wrong_matches()), 1)
+                    self.assertTrue(os.path.isdir(action_path))
+                    with open(os.path.join(source, "01.mp3"), "rb") as handle:
+                        self.assertEqual(handle.read(), raw_bytes)
+                finally:
+                    shutil.rmtree(root, ignore_errors=True)
 
     def test_failed_force_import_non_pipeline_failure_preserves_wrong_match(self):
         from scripts import importer
@@ -847,7 +1259,7 @@ class TestImporterWorker(unittest.TestCase):
             self.assertTrue(cleanup["skipped"])
             self.assertEqual(
                 cleanup["outcome"],
-                "skipped_non_quality_pipeline_failure",
+                "preserved_operator_force_source",
             )
         finally:
             shutil.rmtree(root, ignore_errors=True)
@@ -890,6 +1302,15 @@ class TestImporterWorker(unittest.TestCase):
                 ),
             )
             self._mark_importable(db, job)
+            action_path = os.path.join(
+                self._force_cfg.processing_dir, "albums", f"force-action-{job.id}",
+            )
+            _seed_candidate_for_import_job(
+                db,
+                job.id,
+                mb_release_id="mbid-123",
+                files=snapshot_audio_files(action_path),
+            )
             claimed = db.claim_next_import_job(worker_id="worker")
             assert claimed is not None
 
@@ -959,6 +1380,15 @@ class TestImporterWorker(unittest.TestCase):
                 ),
             )
             self._mark_importable(db, job)
+            action_path = os.path.join(
+                self._force_cfg.processing_dir, "albums", f"force-action-{job.id}",
+            )
+            _seed_candidate_for_import_job(
+                db,
+                job.id,
+                mb_release_id="mbid-123",
+                files=snapshot_audio_files(action_path),
+            )
             claimed = db.claim_next_import_job(worker_id="worker")
             assert claimed is not None
 
@@ -986,12 +1416,8 @@ class TestImporterWorker(unittest.TestCase):
         finally:
             shutil.rmtree(root, ignore_errors=True)
 
-    def test_force_import_requeued_for_preview_does_not_mark_failed(self):
-        """U2: when dispatch returns DISPATCH_CODE_REQUEUED_FOR_PREVIEW the
-        importer does NOT write a terminal failed status and does NOT run
-        the wrong-match cleanup path. The dispatch-side requeue has already
-        flipped the row back to queued/waiting; the importer just logs and
-        yields."""
+    def test_force_import_requeue_leaves_next_preview_action_copy_intact(self):
+        """A requeued importer cannot reclaim an action a new preview owns."""
         from scripts import importer
         from lib.dispatch import DISPATCH_CODE_REQUEUED_FOR_PREVIEW
 
@@ -1012,15 +1438,32 @@ class TestImporterWorker(unittest.TestCase):
                 ),
             )
             self._mark_importable(db, job)
+            from lib.import_preview import force_action_copy_path
+
+            action_path = force_action_copy_path(self._force_cfg, job.id)
             claimed = db.claim_next_import_job(worker_id="worker")
             assert claimed is not None
             claimed_attempts = claimed.attempts
 
             def fake_dispatch(*_args, **_kwargs):
-                # Simulate the dispatch-side requeue.
+                # The requeue releases the action path to the next preview.
                 db.requeue_import_job_for_preview(
                     job.id,
                     reason="candidate evidence missing",
+                )
+                # Interleave the new preview publishing its fresh private
+                # action copy before this old importer frame returns.
+                shutil.rmtree(action_path)
+                os.mkdir(action_path, 0o700)
+                with open(os.path.join(action_path, "01.mp3"), "wb") as handle:
+                    handle.write(b"fresh preview action")
+                db.mark_import_job_preview_importable(
+                    job.id,
+                    preview_result={
+                        "verdict": "evidence_ready",
+                        "action_path": action_path,
+                    },
+                    message="fresh preview ready",
                 )
                 return DispatchOutcome(
                     False,
@@ -1039,10 +1482,12 @@ class TestImporterWorker(unittest.TestCase):
             # Importer must NOT have written a terminal status.
             cleanup.assert_not_called()
             self.assertTrue(os.path.isdir(source))
-            # Job row is queued/waiting after the requeue.
+            # The fresh preview has republished the job's action copy.
             row = next(r for r in db._import_jobs if r["id"] == job.id)
             self.assertEqual(row["status"], "queued")
-            self.assertEqual(row["preview_status"], "waiting")
+            self.assertEqual(row["preview_status"], "evidence_ready")
+            with open(os.path.join(action_path, "01.mp3"), "rb") as handle:
+                self.assertEqual(handle.read(), b"fresh preview action")
             # Importer did not retry-count: row attempts not bumped beyond
             # the original claim.
             self.assertEqual(row["attempts"], claimed_attempts)
@@ -1158,8 +1603,11 @@ class TestImporterWorker(unittest.TestCase):
 
             assert updated is not None
             self.assertEqual(updated.status, "failed")
-            self.assertEqual(self._result(updated)["cleanup"]["cleared_rows"], 2)
-            self.assertEqual(db.get_wrong_matches(), [])
+            self.assertEqual(
+                self._result(updated)["cleanup"]["outcome"],
+                "preserved_operator_force_source",
+            )
+            self.assertEqual(len(db.get_wrong_matches()), 2)
         finally:
             shutil.rmtree(root, ignore_errors=True)
 
@@ -1208,7 +1656,7 @@ class TestImporterWorker(unittest.TestCase):
             self.assertEqual(len(db.get_wrong_matches()), 1)
             cleanup = self._result(updated)["cleanup"]
             self.assertTrue(cleanup["skipped"])
-            self.assertEqual(cleanup["outcome"], "skipped_active_job")
+            self.assertEqual(cleanup["outcome"], "preserved_operator_force_source")
         finally:
             shutil.rmtree(root, ignore_errors=True)
 
@@ -1526,6 +1974,46 @@ class TestImporterWorker(unittest.TestCase):
 
 
 class TestImportPreviewWorker(unittest.TestCase):
+    def test_terminal_force_preview_failure_reclaims_unpublished_stale_action(self):
+        """A failed preview owns and removes a stale action left by its retry."""
+        from lib.import_preview import force_action_copy_path
+        from scripts import import_preview_worker
+
+        with _force_preview_source() as (source, cfg):
+            db = FakePipelineDB()
+            download_log_id = _force_download_log(db, 42, source)
+            job = db.enqueue_import_job(
+                IMPORT_JOB_FORCE,
+                request_id=42,
+                dedupe_key=force_import_dedupe_key(download_log_id),
+                payload=force_import_payload(
+                    download_log_id=download_log_id,
+                    failed_path=source,
+                ),
+            )
+            claimed = db.claim_next_import_preview_job(worker_id="preview")
+            assert claimed is not None
+            action_path = force_action_copy_path(cfg, job.id)
+            os.mkdir(action_path, 0o700)
+            with open(os.path.join(action_path, "stale.mp3"), "wb") as handle:
+                handle.write(b"prior action")
+
+            terminal = db.mark_import_job_preview_failed(
+                job.id,
+                preview_status="measurement_failed",
+                error="preparation failed",
+            )
+            assert terminal is not None
+            returned = import_preview_worker._cleanup_terminal_preview_force_action(
+                claimed,
+                terminal,
+                action_path=None,
+                runtime_config=cfg,
+            )
+
+            self.assertEqual(returned, terminal)
+            self.assertFalse(os.path.exists(action_path))
+
     def _preview(
         self,
         verdict: str,
@@ -1649,6 +2137,7 @@ class TestImportPreviewWorker(unittest.TestCase):
             download_log_id=download_log_id,
             import_job_id=claimed.id,
             runtime_config=cfg,
+            repair_fn=ANY,
         )
         assert updated is not None
         self.assertEqual(updated.status, "queued")
@@ -1945,7 +2434,7 @@ class TestImportPreviewWorker(unittest.TestCase):
                 ),
             ):
                 updated = import_preview_worker.run_once(
-                    cast(Any, db),
+                    db,
                     worker_id="preview",
                     heartbeat_interval=0.01,
                     runtime_config=cfg,
@@ -2241,7 +2730,7 @@ class TestImportPreviewWorker(unittest.TestCase):
 
         with patch(
             "scripts.import_preview_worker.read_runtime_config",
-        ) as read_config:
+        ):
             updated = import_preview_worker.process_claimed_preview_job(
                 db,
                 claimed,
@@ -2256,7 +2745,6 @@ class TestImportPreviewWorker(unittest.TestCase):
         assert updated is not None
         self.assertEqual(updated.status, "failed")
         self.assertEqual(len(db.download_logs), 1)
-        read_config.assert_not_called()
         prepare.assert_not_called()
         enrich.assert_not_called()
 
@@ -3140,8 +3628,8 @@ class TestImportPreviewWorkerFrontGate(unittest.TestCase):
             def fake_preview(*args: Any, **kwargs: Any) -> ImportPreviewResult:
                 # Simulate production: preview persists candidate evidence
                 # and wires the FK chain that the front-gate reads from.
-                _seed_candidate_for_download_log(
-                    db, download_log_id,
+                _seed_candidate_for_import_job(
+                    db, claimed.id,
                     mb_release_id="mbid-missing-falls-through",
                     files=snapshot_audio_files(source),
                 )
@@ -3218,8 +3706,8 @@ class TestImportPreviewWorkerFrontGate(unittest.TestCase):
             def fake_preview(*args: Any, **kwargs: Any) -> ImportPreviewResult:
                 # Simulate production: preview re-measures and persists fresh
                 # evidence with the actual on-disk snapshot, rewiring the FK.
-                _seed_candidate_for_download_log(
-                    db, download_log_id,
+                _seed_candidate_for_import_job(
+                    db, claimed.id,
                     mb_release_id="mbid-fresh",
                     files=snapshot_audio_files(source),
                 )
@@ -3241,7 +3729,7 @@ class TestImportPreviewWorkerFrontGate(unittest.TestCase):
         self.assertEqual(updated.preview_status, "evidence_ready")
         # The stale evidence row was replaced — the FK now points at fresh
         # content-addressed evidence.
-        evidence_id = db.get_download_log_candidate_evidence_id(download_log_id)
+        evidence_id = db.get_import_job_candidate_evidence_id(claimed.id)
         self.assertIsNotNone(evidence_id)
         evidence = db.load_album_quality_evidence_by_id(evidence_id)
         assert evidence is not None
@@ -4074,7 +4562,7 @@ class TestFrontGateSourcePathYoutubeImport(unittest.TestCase):
         })
 
         result = import_preview_worker._front_gate_source_path(
-            cast(Any, db), job,
+            db, job,
         )
 
         self.assertEqual(result, "/Incoming/auto-import/Artist - Album")
@@ -4117,7 +4605,7 @@ class TestFrontGateSourcePathYoutubeImport(unittest.TestCase):
         })
 
         result = import_preview_worker._front_gate_source_path(
-            cast(Any, db), job,
+            db, job,
         )
 
         # Returns the payload path, not the active_download_state path.
@@ -4154,7 +4642,7 @@ class TestFrontGateSourcePathYoutubeImport(unittest.TestCase):
         })
 
         result = import_preview_worker._front_gate_source_path(
-            cast(Any, db), job,
+            db, job,
         )
 
         self.assertEqual(result, "/slskd/Test Artist - Test Album")
@@ -4200,7 +4688,7 @@ class TestFrontGateSourcePathYoutubeImport(unittest.TestCase):
         })
 
         result = import_preview_worker._preview_input(
-            cast(Any, db), job,
+            db, job,
         )
 
         self.assertEqual(result["path"], "/Incoming/auto-import/Artist - Album")
@@ -4281,7 +4769,7 @@ class TestForcePreviewPathAuthority(unittest.TestCase):
                     seen.append((lookup_path, handle.read()))
                 return EvidenceBuildResult(None, "missing")
 
-            result, display_path = import_preview_worker._front_gate_check(
+            result, display_path, action_path = import_preview_worker._front_gate_check(
                 db,
                 job,
                 runtime_config=cfg,
@@ -4290,6 +4778,7 @@ class TestForcePreviewPathAuthority(unittest.TestCase):
 
             self.assertIsNotNone(result)
             self.assertEqual(display_path, db_source)
+            self.assertIsNotNone(action_path)
             self.assertEqual(len(seen), 1)
             assert_force_preview_authority(
                 lookup_path=seen[0][0],
@@ -4297,7 +4786,7 @@ class TestForcePreviewPathAuthority(unittest.TestCase):
                 payload_failed_path=payload_source,
                 lookup_bytes=seen[0][1],
                 expected_db_bytes=b"database",
-                preview_root=os.path.join(processing, "preview"),
+                preview_root=os.path.join(processing, "albums"),
                 preview_children=os.listdir(os.path.join(processing, "preview")),
             )
 

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -89,6 +89,7 @@ def _preview_worker_config(
             "download_dir": os.path.join(os.path.dirname(staging_dir), "slskd"),
         }
     if processing_dir:
+        os.makedirs(os.path.join(processing_dir, "albums"), mode=0o700, exist_ok=True)
         ini["Paths"] = {"processing_dir": processing_dir}
     ini["Pipeline DB"] = {"enabled": "true"}
     return CratediggerConfig.from_ini(ini)
@@ -6043,6 +6044,7 @@ class TestPreviewFrontGateSlice(unittest.TestCase):
             os.makedirs(source)
             os.makedirs(os.path.join(root, "slskd"))
             os.makedirs(os.path.join(root, "processing"), mode=0o700)
+            os.makedirs(os.path.join(root, "processing", "albums"), mode=0o700)
             os.makedirs(os.path.join(root, "processing", "preview"), mode=0o700)
             with open(os.path.join(source, "01.mp3"), "wb") as handle:
                 handle.write(b"audio")
@@ -6066,7 +6068,6 @@ class TestPreviewFrontGateSlice(unittest.TestCase):
             )
             claimed = db.claim_next_import_preview_job(worker_id="preview")
             assert claimed is not None
-            self._seed_evidence_for_download_log(db, log_id, source)
 
             sentinels = {
                 "preview_called": False,
@@ -6103,6 +6104,13 @@ class TestPreviewFrontGateSlice(unittest.TestCase):
                 staging_dir=staging_dir,
                 processing_dir=os.path.join(root, "processing"),
             )
+            action_path = import_preview_worker._prepare_force_action_path(
+                db,
+                claimed,
+                preview_cfg,
+                raw_path=source,
+            )
+            self._seed_evidence_for_import_job(db, claimed.id, action_path)
             with patch(
                 "scripts.import_preview_worker.measure_and_persist_candidate_evidence",
                 side_effect=_sentinel_preview,
@@ -6863,7 +6871,16 @@ class TestU5PreviewEvidenceReadySlice(unittest.TestCase):
 
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=42, status="downloading"))
-        with tempfile.TemporaryDirectory() as source:
+        with tempfile.TemporaryDirectory() as root:
+            staging_dir = os.path.join(root, "Incoming")
+            source = os.path.join(staging_dir, "failed_imports", "candidate")
+            os.makedirs(source)
+            slskd_dir = os.path.join(root, "slskd")
+            os.mkdir(slskd_dir)
+            processing_dir = os.path.join(root, "processing")
+            os.makedirs(os.path.join(processing_dir, "albums"), mode=0o700)
+            os.makedirs(os.path.join(processing_dir, "preview"), mode=0o700)
+            os.chmod(processing_dir, 0o700)
             with open(os.path.join(source, "01.mp3"), "wb") as handle:
                 handle.write(b"audio")
             download_log_id = db.log_download(
@@ -6883,6 +6900,17 @@ class TestU5PreviewEvidenceReadySlice(unittest.TestCase):
             )
             claimed = db.claim_next_import_preview_job(worker_id="preview")
             assert claimed is not None
+            cfg = CratediggerConfig(
+                beets_staging_dir=staging_dir,
+                slskd_download_dir=slskd_dir,
+                processing_dir=processing_dir,
+            )
+            action_path = import_preview_worker._prepare_force_action_path(
+                db,
+                claimed,
+                cfg,
+                raw_path=source,
+            )
 
             preview_result = ImportPreviewResult(
                 mode="path",
@@ -6891,16 +6919,17 @@ class TestU5PreviewEvidenceReadySlice(unittest.TestCase):
                 reason="import",
                 stage_chain=["stage2_import:import"],
                 source_path=source,
+                action_path=action_path,
                 request_id=42,
             )
 
-            def fake_preview(*args, **kwargs):
+            def fake_preview(*_args: object, **_kwargs: object):
                 # Simulate production: preview persisted candidate evidence
                 # and wired the FK before returning.
-                _seed_candidate_for_download_log(
-                    db, download_log_id,
+                _seed_candidate_for_import_job(
+                    db, claimed.id,
                     mb_release_id="mbid-evidence-ready",
-                    files=snapshot_audio_files(source),
+                    files=snapshot_audio_files(action_path),
                     measurement=AudioQualityMeasurement(
                         min_bitrate_kbps=245,
                         avg_bitrate_kbps=256,
@@ -6921,13 +6950,14 @@ class TestU5PreviewEvidenceReadySlice(unittest.TestCase):
                 updated = import_preview_worker.process_claimed_preview_job(
                     cast(Any, db),
                     claimed,
-                    preview_fn=lambda _db, _job: (
+                    preview_fn=lambda preview_db, _preview_job: (
                         import_preview_worker.measure_and_persist_candidate_evidence(
-                            cast(Any, _db),
+                            cast(Any, preview_db),
                             request_id=42,
-                            path=source,
+                            path=action_path,
                         )
                     ),
+                    runtime_config=cfg,
                 )
 
         assert updated is not None
@@ -7751,6 +7781,7 @@ class TestPreviewWorkerNeverDecidesSlice(unittest.TestCase):
             os.makedirs(source)
             os.makedirs(os.path.join(root, "slskd"))
             os.makedirs(os.path.join(root, "processing"), mode=0o700)
+            os.makedirs(os.path.join(root, "processing", "albums"), mode=0o700)
             os.makedirs(os.path.join(root, "processing", "preview"), mode=0o700)
             with open(os.path.join(source, "01.flac"), "wb") as handle:
                 handle.write(b"lossless-audio")
@@ -7851,6 +7882,7 @@ class TestPreviewWorkerNeverDecidesSlice(unittest.TestCase):
             os.makedirs(source)
             os.makedirs(os.path.join(root, "slskd"))
             os.makedirs(os.path.join(root, "processing"), mode=0o700)
+            os.makedirs(os.path.join(root, "processing", "albums"), mode=0o700)
             os.makedirs(os.path.join(root, "processing", "preview"), mode=0o700)
             with open(os.path.join(source, "01.flac"), "wb") as handle:
                 handle.write(b"lossless-audio")
@@ -7950,6 +7982,7 @@ class TestPreviewWorkerNeverDecidesSlice(unittest.TestCase):
             os.makedirs(source)
             os.makedirs(os.path.join(root, "slskd"))
             os.makedirs(os.path.join(root, "processing"), mode=0o700)
+            os.makedirs(os.path.join(root, "processing", "albums"), mode=0o700)
             os.makedirs(os.path.join(root, "processing", "preview"), mode=0o700)
             with open(os.path.join(source, "01.mp3"), "wb") as h:
                 h.write(b"audio")
@@ -8088,6 +8121,7 @@ class TestPreviewWorkerNeverDecidesSlice(unittest.TestCase):
             os.makedirs(source)
             os.makedirs(os.path.join(root, "slskd"))
             os.makedirs(os.path.join(root, "processing"), mode=0o700)
+            os.makedirs(os.path.join(root, "processing", "albums"), mode=0o700)
             os.makedirs(os.path.join(root, "processing", "preview"), mode=0o700)
             with open(os.path.join(source, "01.mp3"), "wb") as h:
                 h.write(b"audio")
@@ -8168,6 +8202,7 @@ class TestPreviewWorkerNeverDecidesSlice(unittest.TestCase):
             os.makedirs(source)
             os.makedirs(os.path.join(root, "slskd"))
             os.makedirs(os.path.join(root, "processing"), mode=0o700)
+            os.makedirs(os.path.join(root, "processing", "albums"), mode=0o700)
             os.makedirs(os.path.join(root, "processing", "preview"), mode=0o700)
             with open(os.path.join(source, "01.mp3"), "wb") as h:
                 h.write(b"audio")
@@ -8431,6 +8466,7 @@ class TestWrongMatchStaleEvidenceRefreshSlice(unittest.TestCase):
         os.makedirs(source)
         os.makedirs(os.path.join(root, "slskd"))
         os.makedirs(os.path.join(root, "processing"), mode=0o700)
+        os.makedirs(os.path.join(root, "processing", "albums"), mode=0o700)
         os.makedirs(os.path.join(root, "processing", "preview"), mode=0o700)
         try:
             # The track the original evidence describes: a real size that no

--- a/tests/test_normalized_evidence_generated.py
+++ b/tests/test_normalized_evidence_generated.py
@@ -1,0 +1,175 @@
+"""Generated trust-boundary contract for issue #853."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+import unittest
+from typing import TypeGuard
+from unittest.mock import patch
+
+import tests._hypothesis_profiles  # noqa: F401
+from hypothesis import example, given
+from hypothesis import strategies as st
+
+from lib.config import CratediggerConfig
+from lib.import_preview import measure_and_persist_candidate_evidence
+from lib.measurement import LocalFileInspection, PreimportMeasurement
+from lib.quality import AlbumQualityEvidenceFile
+from lib.quality_evidence import EvidenceBuildResult, snapshot_audio_files, snapshot_fingerprint
+from tests.fakes import FakePipelineDB
+from tests.helpers import make_album_quality_evidence, make_request_row
+
+
+def is_album_quality_evidence_file_list(
+    value: object,
+) -> TypeGuard[list[AlbumQualityEvidenceFile]]:
+    """Narrow the deliberately broad persistence seam at the test boundary."""
+    return isinstance(value, list) and all(
+        isinstance(file, AlbumQualityEvidenceFile) for file in value
+    )
+
+
+def assert_normalized_evidence_contract(
+    *,
+    on_disk: bytes,
+    persistence_bytes: bytes,
+    evidence_files: list[AlbumQualityEvidenceFile],
+    evidence_fingerprint: str,
+    normalized: bytes,
+) -> None:
+    """Owned normalization must precede the evidence snapshot.
+
+    The inventory fingerprint deliberately does not include content bytes, so
+    a same-size mutation needs this direct byte assertion too.  Otherwise a
+    pre-repair snapshot can look fresh even though it describes the wrong
+    bytes.
+    """
+    if on_disk != normalized:
+        raise AssertionError("owned processing bytes were not normalized")
+    if persistence_bytes != normalized:
+        raise AssertionError("persistence observed pre-normalization bytes")
+    if evidence_files[0].size_bytes != len(normalized):
+        raise AssertionError("evidence describes pre-normalization bytes")
+    if evidence_fingerprint != snapshot_fingerprint(evidence_files):
+        raise AssertionError("evidence fingerprint does not describe its snapshot")
+
+
+class TestNormalizedEvidenceGenerated(unittest.TestCase):
+    @given(raw=st.binary(min_size=1, max_size=64))
+    @example(raw=b"Styrofoam / Dntel")
+    def test_owned_processing_repair_and_evidence_always_converge(self, raw: bytes):
+        root = tempfile.mkdtemp(prefix="cratedigger-853-gen-")
+        source_root = os.path.join(root, "slskd")
+        processing = os.path.join(root, "processing")
+        albums = os.path.join(processing, "albums")
+        preview = os.path.join(processing, "preview")
+        os.mkdir(source_root)
+        os.mkdir(processing, 0o700)
+        os.mkdir(albums, 0o700)
+        os.mkdir(preview, 0o700)
+        album = tempfile.mkdtemp(prefix="album-", dir=albums)
+        track = os.path.join(album, "01.mp3")
+        # Preserve length to exercise the inventory fingerprint's blind spot:
+        # it intentionally keys file identity by path/size/container, not a
+        # content hash.  The test must therefore prove the bytes persisted
+        # after repair are the bytes on disk, not merely matching-sized bytes.
+        normalized = bytes(byte ^ 0xFF for byte in raw)
+        persisted_files: list[list[AlbumQualityEvidenceFile]] = []
+        persisted_fingerprints: list[str] = []
+        persisted_bytes: list[bytes] = []
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=853, mb_release_id="issue-853"))
+        cfg = CratediggerConfig(
+            slskd_download_dir=source_root,
+            processing_dir=processing,
+            audio_check_mode="off",
+        )
+        try:
+            with open(track, "wb") as handle:
+                handle.write(raw)
+
+            def repair(path: str) -> None:
+                self.assertEqual(path, album)
+                with open(track, "wb") as handle:
+                    handle.write(normalized)
+
+            def persist(*_args: object, **_kwargs: object) -> EvidenceBuildResult:
+                files_value = _kwargs["files"]
+                if not is_album_quality_evidence_file_list(files_value):
+                    raise AssertionError("persistence did not receive an evidence inventory")
+                files = files_value
+                persisted_files.append(files)
+                persisted_fingerprints.append(snapshot_fingerprint(files))
+                with open(track, "rb") as handle:
+                    persisted_bytes.append(handle.read())
+                return EvidenceBuildResult(
+                    make_album_quality_evidence(mb_release_id="issue-853"),
+                    "ready",
+                )
+
+            with patch(
+                "lib.import_preview.inspect_local_files",
+                return_value=LocalFileInspection(filetype="mp3"),
+            ), patch(
+                "lib.import_preview.measure_preimport_state",
+                return_value=PreimportMeasurement(
+                    audio_corrupt=True,
+                    folder_layout="flat",
+                    audio_file_count=1,
+                ),
+            ):
+                result = measure_and_persist_candidate_evidence(
+                    db,
+                    request_id=853,
+                    path=album,
+                    runtime_config=cfg,
+                    current_evidence_loader=lambda *_args, **_kwargs: EvidenceBuildResult(
+                        None, "empty_current",
+                    ),
+                    persist_measurement_fn=persist,
+                    repair_fn=repair,
+                )
+            self.assertEqual(result.verdict, "evidence_ready")
+            with open(track, "rb") as handle:
+                on_disk = handle.read()
+            assert_normalized_evidence_contract(
+                on_disk=on_disk,
+                persistence_bytes=persisted_bytes[0],
+                evidence_files=persisted_files[0],
+                evidence_fingerprint=persisted_fingerprints[0],
+                normalized=normalized,
+            )
+            # Same-size fault injection: the canonical inventory fingerprint
+            # cannot distinguish raw from repaired bytes.  The byte check
+            # above is what makes ordering at the normalization boundary real.
+            self.assertEqual(persisted_files[0], snapshot_audio_files(album))
+            self.assertEqual(
+                persisted_fingerprints[0],
+                snapshot_fingerprint(snapshot_audio_files(album)),
+            )
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+
+class TestNormalizedEvidenceCheckerTripsOnViolation(unittest.TestCase):
+    def test_rejects_pre_normalization_inventory_fault_injection(self):
+        raw = b"raw"
+        normalized = b"normalized"
+        stale_pre_repair_files = [AlbumQualityEvidenceFile(
+            relative_path="01.mp3",
+            size_bytes=len(raw),
+            mtime_ns=0,
+            extension="mp3",
+            container="mp3",
+            codec="mp3",
+        )]
+        with self.assertRaises(AssertionError):
+            assert_normalized_evidence_contract(
+                on_disk=normalized,
+                persistence_bytes=normalized,
+                evidence_files=stale_pre_repair_files,
+                evidence_fingerprint=snapshot_fingerprint(stale_pre_repair_files),
+                normalized=normalized,
+            )

--- a/tests/test_path_authority_generated.py
+++ b/tests/test_path_authority_generated.py
@@ -259,11 +259,11 @@ def assert_force_front_gate_invariant(
     snapshot_root: str,
     preview_children: list[str],
 ) -> None:
-    """Force evidence lookup may consume only the DB-authorized snapshot."""
+    """Force evidence lookup may consume only the DB-authorized action copy."""
     if lookup_path == payload_failed_path or lookup_path == db_failed_path:
         raise AssertionError("force evidence lookup consumed an unisolated path")
     if os.path.commonpath([lookup_path, snapshot_root]) != snapshot_root:
-        raise AssertionError("force evidence lookup escaped private preview")
+        raise AssertionError("force evidence lookup escaped private action root")
     if lookup_bytes != expected_db_bytes:
         raise AssertionError("force evidence lookup did not contain DB-authorized bytes")
     if preview_children:
@@ -639,7 +639,7 @@ class TestGeneratedForceFrontGateAuthority(unittest.TestCase):
                     captured.append((lookup, handle.read()))
                 return EvidenceBuildResult(None, "missing")
 
-            result, display = import_preview_worker._front_gate_check(
+            result, display, action_path = import_preview_worker._front_gate_check(
                 db,
                 job,
                 runtime_config=cfg,
@@ -647,6 +647,7 @@ class TestGeneratedForceFrontGateAuthority(unittest.TestCase):
             )
             self.assertIsNotNone(result)
             self.assertEqual(display, db_path)
+            self.assertIsNotNone(action_path)
             self.assertEqual(len(captured), 1)
             assert_force_front_gate_invariant(
                 lookup_path=captured[0][0],
@@ -654,7 +655,7 @@ class TestGeneratedForceFrontGateAuthority(unittest.TestCase):
                 payload_failed_path=payload_path,
                 lookup_bytes=captured[0][1],
                 expected_db_bytes=db_bytes,
-                snapshot_root=os.path.join(processing, "preview"),
+                snapshot_root=os.path.join(processing, "albums"),
                 preview_children=os.listdir(os.path.join(processing, "preview")),
             )
 

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -22,6 +22,7 @@ from unittest.mock import patch
 
 import msgspec
 import psycopg2
+import psycopg2.extras
 
 # Bootstrap ephemeral PostgreSQL if available
 sys.path.append(os.path.dirname(__file__))
@@ -1241,6 +1242,82 @@ class TestImportJobQueueAPI(unittest.TestCase):
         self.assertIsNone(stored["worker_id"])
         self.assertIsNone(stored["heartbeat_at"])
         self.assertEqual(reread.status, stored["status"])
+
+    def test_recovery_retry_resets_preview_only_for_force_job(self):
+        """#853 Rule A: the retry insert keeps non-force preview authority."""
+        from lib.import_queue import IMPORT_JOB_AUTOMATION, IMPORT_JOB_FORCE
+
+        for job_type, status, source_path in (
+            (IMPORT_JOB_FORCE, "wanted", "/tmp/force-recovery"),
+            (IMPORT_JOB_AUTOMATION, "downloading", "/tmp/automation-recovery"),
+        ):
+            with self.subTest(job_type=job_type):
+                request_id = self.db.add_request(
+                    mb_release_id=f"recovery-{job_type}",
+                    artist_name="Recovery",
+                    album_title=job_type,
+                    source="request",
+                    status=status,
+                )
+                if job_type == IMPORT_JOB_AUTOMATION:
+                    self.db._execute(
+                        "UPDATE album_requests SET active_download_state = %s::jsonb "
+                        "WHERE id = %s",
+                        (psycopg2.extras.Json({
+                            "current_path": source_path,
+                            "files": [],
+                        }), request_id),
+                    )
+                job = self.db.enqueue_import_job(
+                    job_type,
+                    request_id=request_id,
+                    dedupe_key=f"recovery-preview:{job_type}",
+                    payload={"download_log_id": 1, "failed_path": source_path}
+                    if job_type == IMPORT_JOB_FORCE else {},
+                )
+                evidence = make_album_quality_evidence(
+                    mb_release_id=f"recovery-{job_type}", source_path=source_path,
+                )
+                self.db.upsert_album_quality_evidence(evidence)
+                persisted = self.db.find_album_quality_evidence(
+                    mb_release_id=evidence.mb_release_id,
+                    snapshot_fingerprint=evidence.snapshot_fingerprint,
+                )
+                assert persisted is not None and persisted.id is not None
+                self.db.set_import_job_candidate_evidence(job.id, persisted.id)
+                preview_result = {"verdict": "would_import", "case": job_type}
+                self.db.mark_import_job_preview_importable(
+                    job.id, preview_result=preview_result,
+                )
+                claimed = self.db.claim_next_import_job(worker_id="recovery-worker")
+                assert claimed is not None
+                assert self.db.authorize_import_job_launch(
+                    claimed.id,
+                    request_id=request_id,
+                    release_id=f"recovery-{job_type}",
+                    source_path=source_path,
+                ) is not None
+                recovery = self.db.mark_import_job_recovery_required(
+                    claimed.id, reason="ambiguous external mutation",
+                )
+                assert recovery is not None
+
+                resolved = self.db.resolve_import_job_recovery(
+                    recovery.id,
+                    resolution="retry",
+                    reason="operator reconciled mutation",
+                )
+
+                assert resolved is not None
+                _closed, retry = resolved
+                assert retry is not None
+                if job_type == IMPORT_JOB_FORCE:
+                    self.assertEqual(retry.preview_status, "waiting")
+                    self.assertIsNone(retry.preview_result)
+                    self.assertIsNone(retry.candidate_evidence_id)
+                else:
+                    self.assertEqual(retry.preview_result, preview_result)
+                    self.assertEqual(retry.candidate_evidence_id, persisted.id)
 
     def test_two_sessions_cannot_claim_same_job(self):
         from lib.import_queue import IMPORT_JOB_FORCE

--- a/tests/test_preview_failure_evidence_generated.py
+++ b/tests/test_preview_failure_evidence_generated.py
@@ -222,16 +222,15 @@ def assert_preview_failure_have_contract(
             raise AssertionError("force world did not distinguish DB and payload paths")
         if validation.get("source_path") == observation.expected_payload_failed_path:
             raise AssertionError("terminal audit trusted the force payload path")
-        if (
-            observation.force_snapshot_path is None
-            or observation.force_snapshot_path
+        if observation.force_snapshot_path is not None and (
+            observation.force_snapshot_path
             in {
                 observation.expected_failure_source_path,
                 observation.expected_payload_failed_path,
             }
             or observation.force_snapshot_bytes != b"generated database bytes"
         ):
-            raise AssertionError("force preview did not snapshot DB-authorized bytes")
+            raise AssertionError("force preview did not publish DB-authorized bytes")
         if (
             observation.force_preview_children is None
             or observation.force_preview_children
@@ -582,7 +581,7 @@ def _run_world(world: PreviewFailureWorld) -> PreviewFailureObservation:
                     force_snapshot_bytes = handle.read()
                 return EvidenceBuildResult(None, "missing")
 
-            front_gate_result, front_gate_path = (
+            front_gate_result, front_gate_path, _action_path = (
                 import_preview_worker._front_gate_check(
                     db,
                     claimed,
@@ -590,8 +589,8 @@ def _run_world(world: PreviewFailureWorld) -> PreviewFailureObservation:
                     candidate_evidence_loader=capture_snapshot,
                 )
             )
-            assert front_gate_result is not None
-            assert front_gate_path == authoritative_failure_path
+            if front_gate_result is not None:
+                assert front_gate_path == authoritative_failure_path
 
         def prepare_have(db_arg: Any, **kwargs: Any) -> str:
             if world.hook_fault == "prepare":

--- a/tests/test_spectral_attempt_audit_generated.py
+++ b/tests/test_spectral_attempt_audit_generated.py
@@ -147,6 +147,7 @@ def _run_have_boundary_through_both_adapters(
         os.makedirs(slskd_dir)
         processing_dir = os.path.join(root, "processing")
         os.makedirs(processing_dir, mode=0o700)
+        os.makedirs(os.path.join(processing_dir, "albums"), mode=0o700)
         os.makedirs(os.path.join(processing_dir, "preview"), mode=0o700)
         cfg = CratediggerConfig(
             audio_check_mode="off",
@@ -250,10 +251,18 @@ def _run_have_boundary_through_both_adapters(
                 source_username="generated",
             ),
         )
+        from scripts import import_preview_worker
+
+        action_path = import_preview_worker._prepare_force_action_path(
+            db,
+            job,
+            cfg,
+            raw_path=candidate,
+        )
         candidate_evidence = make_album_quality_evidence(
             mb_release_id=mbid,
-            source_path=candidate,
-            files=snapshot_audio_files(candidate),
+            source_path=action_path,
+            files=snapshot_audio_files(action_path),
         )
         db.upsert_album_quality_evidence(candidate_evidence)
         stored_candidate = db.find_album_quality_evidence(
@@ -261,10 +270,7 @@ def _run_have_boundary_through_both_adapters(
             snapshot_fingerprint=candidate_evidence.snapshot_fingerprint,
         )
         assert stored_candidate is not None and stored_candidate.id is not None
-        db.set_download_log_candidate_evidence(
-            download_log_id,
-            stored_candidate.id,
-        )
+        db.set_import_job_candidate_evidence(job.id, stored_candidate.id)
         claimed = db.claim_next_import_preview_job(worker_id="generated")
         assert claimed is not None and claimed.id == job.id
         with _silence_logs(), patch(
@@ -372,7 +378,18 @@ def _run_candidate_snapshot_reuse_world(
         os.makedirs(slskd_dir)
         processing_dir = os.path.join(root, "processing")
         os.makedirs(processing_dir, mode=0o700)
+        os.makedirs(os.path.join(processing_dir, "albums"), mode=0o700)
         os.makedirs(os.path.join(processing_dir, "preview"), mode=0o700)
+        ini = configparser.ConfigParser()
+        ini["Beets Validation"] = {
+            "harness_path": "/fake/harness/run_beets_harness.sh",
+            "audio_check": "off",
+            "staging_dir": staging_dir,
+        }
+        ini["Slskd"] = {"download_dir": slskd_dir}
+        ini["Paths"] = {"processing_dir": processing_dir}
+        ini["Pipeline DB"] = {"enabled": "true"}
+        cfg = CratediggerConfig.from_ini(ini)
         for track in range(1, track_count + 1):
             Path(candidate, f"{track:02d}.mp3").write_bytes(
                 f"candidate-{track}".encode()
@@ -452,10 +469,20 @@ def _run_candidate_snapshot_reuse_world(
                 payload={},
             )
 
+        action_path = candidate
+        if job_mode == "force":
+            from scripts import import_preview_worker
+
+            action_path = import_preview_worker._prepare_force_action_path(
+                db,
+                job,
+                cfg,
+                raw_path=candidate,
+            )
         candidate_evidence = make_album_quality_evidence(
             mb_release_id=mbid,
-            source_path=candidate,
-            files=snapshot_audio_files(candidate),
+            source_path=action_path,
+            files=snapshot_audio_files(action_path),
             measurement=AudioQualityMeasurement(
                 min_bitrate_kbps=245,
                 avg_bitrate_kbps=256,
@@ -472,16 +499,11 @@ def _run_candidate_snapshot_reuse_world(
             snapshot_fingerprint=candidate_evidence.snapshot_fingerprint,
         )
         assert stored_candidate is not None and stored_candidate.id is not None
-        if download_log_id is not None:
-            db.set_download_log_candidate_evidence(
-                download_log_id,
-                stored_candidate.id,
-            )
-        else:
-            db.set_import_job_candidate_evidence(job.id, stored_candidate.id)
+        db.set_import_job_candidate_evidence(job.id, stored_candidate.id)
 
         if snapshot_changed:
-            Path(candidate, f"{track_count:02d}.mp3").write_bytes(
+            changed_path = candidate if job_mode == "force" else action_path
+            Path(changed_path, f"{track_count:02d}.mp3").write_bytes(
                 b"changed-candidate-snapshot"
             )
 
@@ -504,8 +526,8 @@ def _run_candidate_snapshot_reuse_world(
             full_preview_calls += 1
             fresh = make_album_quality_evidence(
                 mb_release_id=mbid,
-                source_path=candidate,
-                files=snapshot_audio_files(candidate),
+                source_path=action_path,
+                files=snapshot_audio_files(action_path),
                 measurement=AudioQualityMeasurement(
                     min_bitrate_kbps=245,
                     avg_bitrate_kbps=256,
@@ -522,19 +544,14 @@ def _run_candidate_snapshot_reuse_world(
                 snapshot_fingerprint=fresh.snapshot_fingerprint,
             )
             assert persisted is not None and persisted.id is not None
-            if download_log_id is not None:
-                db_arg.set_download_log_candidate_evidence(
-                    download_log_id,
-                    persisted.id,
-                )
-            else:
-                db_arg.set_import_job_candidate_evidence(job.id, persisted.id)
+            db_arg.set_import_job_candidate_evidence(job.id, persisted.id)
             return ImportPreviewResult(
                 mode="path",
                 verdict="evidence_ready",
                 decision="import",
                 reason="import",
-                source_path=candidate,
+                source_path=action_path,
+                action_path=(action_path if job_mode == "force" else None),
             )
 
         def load_current(*_args: Any, **_kwargs: Any) -> EvidenceBuildResult:
@@ -546,16 +563,6 @@ def _run_candidate_snapshot_reuse_world(
                 )
             return EvidenceBuildResult(current, "ready")
 
-        ini = configparser.ConfigParser()
-        ini["Beets Validation"] = {
-            "harness_path": "/fake/harness/run_beets_harness.sh",
-            "audio_check": "off",
-            "staging_dir": staging_dir,
-        }
-        ini["Slskd"] = {"download_dir": slskd_dir}
-        ini["Paths"] = {"processing_dir": processing_dir}
-        ini["Pipeline DB"] = {"enabled": "true"}
-        cfg = CratediggerConfig.from_ini(ini)
         updated = process_claimed_preview_job(
             db,
             claimed,
@@ -707,6 +714,7 @@ def _run_dispatch_finalization_world(
     if mode == "manifest_rejection":
         from lib.dispatch import dispatch_import_from_db
         from lib.import_queue import IMPORT_JOB_FORCE
+        from lib.quality_evidence import snapshot_audio_files
 
         db.set_tracks(42, [{"track_number": 1, "title": "One"}])
         with tempfile.TemporaryDirectory() as source:
@@ -723,12 +731,26 @@ def _run_dispatch_finalization_world(
                 builtins = msgspec.to_builtins(ImportResult(spectral=audit))
                 assert isinstance(builtins, dict)
                 preview_result["import_result"] = builtins
+            evidence = make_album_quality_evidence(
+                mb_release_id="generated-mbid",
+                source_path=source,
+                files=snapshot_audio_files(source),
+            )
+            db.upsert_album_quality_evidence(evidence)
+            persisted = db.find_album_quality_evidence(
+                mb_release_id=evidence.mb_release_id,
+                snapshot_fingerprint=evidence.snapshot_fingerprint,
+            )
+            assert persisted is not None and persisted.id is not None
+            db.set_import_job_candidate_evidence(job.id, persisted.id)
             db.mark_import_job_preview_importable(
                 job.id,
                 preview_result=preview_result,
             )
+            claimed = db.claim_next_import_job(worker_id="generated-importer")
+            assert claimed is not None and claimed.id == job.id
             with _silence_logs():
-                dispatch_import_from_db(
+                outcome = dispatch_import_from_db(
                     db,  # type: ignore[arg-type]
                     request_id=42,
                     failed_path=source,
@@ -737,6 +759,7 @@ def _run_dispatch_finalization_world(
                     beets_library_db_path=str(beets.library_db),
                     beets_library_root=str(beets.library_root),
                 )
+                finalize_claimed_dispatch(db, claimed, outcome)
     else:
         from lib.import_queue import IMPORT_JOB_AUTOMATION
         from lib.quality_evidence import snapshot_audio_files

--- a/tests/world_model/support.py
+++ b/tests/world_model/support.py
@@ -39,6 +39,7 @@ from lib.import_preview import (
     ImportPreviewResult,
     enrich_incomplete_current_evidence_for_request,
     persist_exact_current_spectral_from_attempt,
+    force_action_copy_path,
 )
 from lib.import_queue import (
     IMPORT_JOB_AUTOMATION,
@@ -124,7 +125,10 @@ from tests.world_model.census_seeds import (
     WorldCensusSeed,
     assert_missing_current_evidence_seed_anonymized,
 )
-from scripts.import_preview_worker import process_claimed_preview_job
+from scripts.import_preview_worker import (
+    _prepare_force_action_path,
+    process_claimed_preview_job,
+)
 
 
 @dataclass(frozen=True)
@@ -769,7 +773,10 @@ class LifecycleWorld:
                 # the persisted candidate matches the new bytes.
                 fresh = self._persist_candidate_evidence(
                     release=release,
-                    source_path=source_path,
+                    source_path=(
+                        force_action_copy_path(cfg, import_job_id)
+                        if _job.job_type == IMPORT_JOB_FORCE else source_path
+                    ),
                     measurement=measurement,
                     codec=codec,
                     verified_lossless_proof=verified_lossless_proof,
@@ -785,7 +792,14 @@ class LifecycleWorld:
                 verdict="evidence_ready",
                 decision="import",
                 reason="import",
-                source_path=source_path,
+                source_path=(
+                    force_action_copy_path(cfg, import_job_id)
+                    if _job.job_type == IMPORT_JOB_FORCE else source_path
+                ),
+                action_path=(
+                    force_action_copy_path(cfg, import_job_id)
+                    if _job.job_type == IMPORT_JOB_FORCE else None
+                ),
                 request_id=request_id,
                 download_log_id=download_log_id,
             )
@@ -810,6 +824,9 @@ class LifecycleWorld:
         preview_dir = processing_dir / "preview"
         preview_dir.mkdir(mode=0o700, exist_ok=True)
         preview_dir.chmod(0o700)
+        albums_dir = processing_dir / "albums"
+        albums_dir.mkdir(mode=0o700, exist_ok=True)
+        albums_dir.chmod(0o700)
         slskd_dir = self.beets.root / "slskd"
         slskd_dir.mkdir(exist_ok=True)
         cfg = CratediggerConfig(
@@ -820,6 +837,24 @@ class LifecycleWorld:
             slskd_download_dir=str(slskd_dir),
             processing_dir=str(processing_dir),
         )
+        if claimed.job_type == IMPORT_JOB_FORCE and not snapshot_changed:
+            action_path = _prepare_force_action_path(
+                self.db,
+                claimed,
+                cfg,
+                raw_path=source_path,
+            )
+            action_evidence = self._persist_candidate_evidence(
+                release=release,
+                source_path=action_path,
+                measurement=measurement,
+                codec=codec,
+                verified_lossless_proof=verified_lossless_proof,
+            )
+            self.db.set_import_job_candidate_evidence(
+                import_job_id,
+                action_evidence.id,
+            )
         # ``derive_canonical_import_folder`` does a call-time
         # ``from lib.config import read_runtime_config`` for the automation
         # front gate, so patch that binding too — the world never touches the


### PR DESCRIPTION
## Summary

- normalize Cratedigger-owned processing albums before measuring and persisting candidate evidence
- retain one deterministic private normalized action copy for force/quarantine imports while preserving the raw source as audit authority
- remeasure and relink stale evidence, and requeue pre-Beets drift before any terminal quality or manifest decision
- make force action cleanup and recovery ownership explicit without changing non-force retry semantics

## Verification

- `nix-shell --run "pyright --threads 4"`
- `nix-shell --run "bash scripts/run_tests.sh"` (7,006 tests)
- focused deterministic, generated, Fake, and real-PostgreSQL contracts
- fresh Terra implementation; adversarial Sol review converged with no findings

Refs #853

Deployment and live successor-cycle verification are intentionally deferred by operator instruction; this PR must not close #853.
