### PR TITLE
test: guard #859 action and pretend source purity

### DIFF
--- a/tests/test_harness_beets2_contract.py
+++ b/tests/test_harness_beets2_contract.py
@@ -173,6 +173,92 @@ print("BAD_RIP_CLEANUP_OK")
 '''
 
 
+# Real wrapper contract for issue #862. This is deliberately a successful
+# dry-run assertion only: it proves the completed ``--pretend`` path leaves
+# the source manifest untouched, not that no transient create/delete event
+# occurred while beets was running.
+_PRETEND_SOURCE_PURITY_CONTRACT = r'''
+import hashlib
+import json
+import os
+import subprocess
+import tempfile
+
+
+def recursive_manifest(root):
+    entries = []
+    for current, dirs, files in os.walk(root):
+        dirs.sort()
+        files.sort()
+        rel_dir = os.path.relpath(current, root)
+        for dirname in dirs:
+            entries.append(("dir", os.path.join(rel_dir, dirname)))
+        for filename in files:
+            path = os.path.join(current, filename)
+            digest = hashlib.sha256()
+            with open(path, "rb") as handle:
+                for chunk in iter(lambda: handle.read(65536), b""):
+                    digest.update(chunk)
+            entries.append(("file", os.path.join(rel_dir, filename), digest.hexdigest()))
+    return entries
+
+
+with tempfile.TemporaryDirectory(prefix="cratedigger-pretend-purity-") as root:
+    source = os.path.join(root, "source")
+    library = os.path.join(root, "library")
+    beetsdir = os.path.join(root, "beets")
+    os.makedirs(source)
+    os.makedirs(library)
+    os.makedirs(beetsdir)
+
+    flac = os.path.join(source, "01 - Source.flac")
+    subprocess.run([
+        "ffmpeg", "-loglevel", "error", "-f", "lavfi", "-i",
+        "sine=frequency=440:duration=0.1", "-metadata", "artist=Purity Artist",
+        "-metadata", "album=Purity Album", "-metadata", "title=Source",
+        "-c:a", "flac", flac,
+    ], check=True)
+    with open(os.path.join(source, "cratedigger-sentinel.json"), "w", encoding="utf-8") as handle:
+        json.dump({"must": "survive"}, handle)
+
+    with open(os.path.join(beetsdir, "config.yaml"), "w", encoding="utf-8") as handle:
+        handle.write("""library: %s\ndirectory: %s\nplugins: scrub\nimport:\n  copy: no\n  write: yes\n  move: yes\n  incremental: no\n  duplicate_keys:\n    album: [mb_albumid, discogs_albumid]\n    item: [artist, title]\n""" % (os.path.join(library, "library.db"), library))
+
+    before = recursive_manifest(source)
+    env = {**os.environ, "BEETSDIR": beetsdir}
+    proc = subprocess.Popen(
+        [os.environ["HARNESS_WRAPPER"], "--pretend", "--noincremental", source],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        env=env,
+    )
+    assert proc.stdin is not None
+    assert proc.stdout is not None
+    saw_choose_match = False
+    saw_session_end = False
+    transcript = []
+    for line in proc.stdout:
+        message = json.loads(line)
+        transcript.append(message)
+        if message["type"] == "choose_match":
+            saw_choose_match = True
+            proc.stdin.write(json.dumps({"action": "skip"}) + "\n")
+            proc.stdin.flush()
+        elif message["type"] == "session_end":
+            saw_session_end = True
+    stderr = proc.stderr.read() if proc.stderr is not None else ""
+    returncode = proc.wait()
+    assert returncode == 0, (returncode, transcript, stderr)
+    assert saw_choose_match, transcript
+    assert saw_session_end, transcript
+    after = recursive_manifest(source)
+    assert after == before, (before, after)
+    print("PRETEND_SOURCE_PURITY_OK")
+'''
+
+
 # Fresh-interpreter sweep of the SHIPPED aunique config against real beets.
 # The Passenger collision class (2026-07-18): beets' %aunique picks the first
 # disambiguator field whose values are all-distinct across the same-key album
@@ -315,6 +401,32 @@ class TestAuniqueCollisionContract(unittest.TestCase):
 
 
 class TestHarnessBeets2Contract(unittest.TestCase):
+    def test_real_harness_pretend_keeps_source_manifest_unchanged(self):
+        """A completed pretend run leaves its source tree unchanged.
+
+        This is not a claim about transient filesystem events during the run;
+        it is the successful dry-run source-purity contract at the real
+        wrapper boundary.
+        """
+        proc = subprocess.run(
+            [sys.executable, "-c", _PRETEND_SOURCE_PURITY_CONTRACT],
+            cwd=_REPO,
+            env={
+                **os.environ,
+                "PYTHONPATH": _REPO + os.pathsep + os.environ.get("PYTHONPATH", ""),
+                "HARNESS_WRAPPER": os.path.join(
+                    _REPO, "harness", "run_beets_harness.sh"),
+            },
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            proc.returncode, 0,
+            f"real harness pretend source-purity contract failed\n"
+            f"STDOUT:\n{proc.stdout}\nSTDERR:\n{proc.stderr}",
+        )
+        self.assertIn("PRETEND_SOURCE_PURITY_OK", proc.stdout)
+
     def test_real_beets_import_library_and_duplicate_action(self):
         proc = subprocess.run(
             [sys.executable, "-c", _CONTRACT],

--- a/tests/test_preview_manifest_generated.py
+++ b/tests/test_preview_manifest_generated.py
@@ -42,6 +42,7 @@ import os
 import sys
 import tempfile
 import unittest
+from dataclasses import dataclass
 from unittest.mock import patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
@@ -215,6 +216,15 @@ def _stub_import_one_run() -> ImportOneRun:
     )
 
 
+@dataclass(frozen=True)
+class PreviewActionFileHandoff:
+    """The real action-file path observed at the harness leaf seam."""
+
+    path: str
+    exists_at_handoff: bool
+    resolved_parent: str
+
+
 def _run_owned_preview_action(
     db: FakePipelineDB,
     ctx: CratediggerContext,
@@ -222,25 +232,39 @@ def _run_owned_preview_action(
     request_id: int,
     canonical_dir: str,
     import_job_id: int = 1,
-) -> ImportPreviewResult:
+) -> tuple[ImportPreviewResult, PreviewActionFileHandoff]:
     """Drive the REAL preview fact-gathering (the #859 fire site) against a
     real owned canonical album. ``_write_preview_spectral_evidence_file``
     runs unmocked — only the harness subprocess and the beets exact-release
     lookup (both legitimate external-edge seams) are stubbed."""
     run = _stub_import_one_run()
+    handoffs: list[PreviewActionFileHandoff] = []
+
+    def _capture_action_file_handoff(**kwargs: object) -> ImportOneRun:
+        action_file = kwargs["quality_evidence_action_file"]
+        assert isinstance(action_file, str)
+        handoffs.append(PreviewActionFileHandoff(
+            path=action_file,
+            exists_at_handoff=os.path.isfile(action_file),
+            resolved_parent=os.path.realpath(os.path.dirname(action_file)),
+        ))
+        return run
+
     with patch("lib.beets_db.BeetsDB", lambda **_kwargs: FakeBeetsDB()):
-        return measure_and_persist_candidate_evidence(
+        result = measure_and_persist_candidate_evidence(
             db,
             request_id=request_id,
             path=canonical_dir,
             runtime_config=ctx.cfg,
             import_job_id=import_job_id,
-            run_import_fn=lambda **_kwargs: run,
+            run_import_fn=_capture_action_file_handoff,
             existing_spectral_resolver=lambda _mbid: ExistingSpectralAuditLookup(),
             spectral_detail_analyzer=lambda _path: SpectralAnalysisDetail(
                 attempted=True, grade="genuine", bitrate_kbps=1000,
             ),
         )
+    assert len(handoffs) == 1, "lossless preview must hand off one action file"
+    return result, handoffs[0]
 
 
 def _expected_basenames(
@@ -284,6 +308,34 @@ def assert_canonical_manifest_pure(
             f"after preview (missing="
             f"{sorted(expected_basenames - actual_basenames)} extra="
             f"{sorted(actual_basenames - expected_basenames)})"
+        )
+
+
+def assert_preview_action_file_handoff_is_safe(
+    handoff: PreviewActionFileHandoff,
+    canonical_dir: str,
+    *,
+    label: str,
+) -> None:
+    """The action file must exist at handoff, outside every album tree.
+
+    The canonical album is itself below the system temporary root in these
+    tests, so checking only that the action file is below ``gettempdir()``
+    would permit the relocation-only #859 regression.
+    """
+    expected_parent = os.path.realpath(tempfile.gettempdir())
+    resolved_album = os.path.realpath(canonical_dir)
+    if not handoff.exists_at_handoff:
+        raise AssertionError(f"{label}: action file did not exist at handoff")
+    if handoff.resolved_parent != expected_parent:
+        raise AssertionError(
+            f"{label}: action file parent {handoff.resolved_parent!r} is not "
+            f"the system tempfile directory {expected_parent!r}"
+        )
+    if os.path.commonpath((os.path.realpath(handoff.path), resolved_album)) == resolved_album:
+        raise AssertionError(
+            f"{label}: action file {handoff.path!r} was inside canonical "
+            f"album {canonical_dir!r}"
         )
 
 
@@ -334,7 +386,7 @@ class TestPreviewSidecarManifestPurityPin(unittest.TestCase):
             canonical_dir = staged_album.current_path
             expected_basenames = _expected_basenames(album, staged_album)
 
-            preview_result = _run_owned_preview_action(
+            preview_result, action_handoff = _run_owned_preview_action(
                 db, ctx, request_id=request_id, canonical_dir=canonical_dir,
             )
             self.assertEqual(
@@ -342,6 +394,14 @@ class TestPreviewSidecarManifestPurityPin(unittest.TestCase):
                 f"preview must reach a real verdict, got "
                 f"decision={preview_result.decision!r} "
                 f"detail={preview_result.detail!r}",
+            )
+
+            assert_preview_action_file_handoff_is_safe(
+                action_handoff, canonical_dir, label="preview action handoff",
+            )
+            self.assertFalse(
+                os.path.exists(action_handoff.path),
+                "preview cleanup must remove the action file after handoff",
             )
 
             # (a) manifest purity: the canonical dir holds ONLY the manifest.
@@ -413,8 +473,16 @@ class TestPreviewManifestPurityProperty(unittest.TestCase):
             canonical_dir = staged_album.current_path
             expected_basenames = _expected_basenames(album, staged_album)
 
-            _run_owned_preview_action(
+            _, action_handoff = _run_owned_preview_action(
                 db, ctx, request_id=request_id, canonical_dir=canonical_dir,
+            )
+
+            assert_preview_action_file_handoff_is_safe(
+                action_handoff, canonical_dir, label="generated world",
+            )
+            self.assertFalse(
+                os.path.exists(action_handoff.path),
+                "preview cleanup must remove the action file after handoff",
             )
 
             actual_basenames = frozenset(os.listdir(canonical_dir))
@@ -452,6 +520,19 @@ class TestPreviewManifestCheckersTripOnViolations(unittest.TestCase):
         with self.assertRaises(AssertionError):
             assert_rematerializes_cleanly(
                 MaterializeGuarded(detail="incomplete_or_unsafe_canonical"),
+                label="known-bad",
+            )
+
+    def test_action_file_checker_trips_on_in_album_handoff(self):
+        canonical_dir = os.path.join(tempfile.gettempdir(), "canonical-album")
+        with self.assertRaises(AssertionError):
+            assert_preview_action_file_handoff_is_safe(
+                PreviewActionFileHandoff(
+                    path=f"{canonical_dir}/action.json",
+                    exists_at_handoff=True,
+                    resolved_parent=os.path.realpath(tempfile.gettempdir()),
+                ),
+                canonical_dir,
                 label="known-bad",
             )
 


### PR DESCRIPTION
## Summary

- capture the real quality-evidence action tempfile at the preview harness seam and require it to live directly in the system temp directory, outside the canonical album, until cleanup removes it
- apply the placement contract to both the deterministic #859 pin and the existing generated manifest-purity property, with a known-bad containment self-test
- add a fresh-process real-beets pretend contract over a synthetic FLAC and sentinel, dangerous write/move/scrub settings, and exact post-run manifest plus content-hash equality

## Validation

- relocation-only action-file mutant: killed by the new placement assertion
- successful-pretend source-mutation mutant: killed by the real-beets contract
- Terra focused tests: 9 passed
- Sol adversarial review: clean
- whole-repository Pyright: 0 errors
- full suite: 7,136 tests passed across 12 workers

The first full-suite attempt lost its terminal status when the execution session detached; no process or receipt remained, so the unchanged reviewed commit was rerun with durable log/status artifacts and passed.

Refs #862.