### PR TITLE
fix(fuzz): make the burst runnable and guard the profile wiring

### DIFF
--- a/docs/generated-testing.md
+++ b/docs/generated-testing.md
@@ -316,27 +316,40 @@ nix-shell --run "bash scripts/fuzz_burst.sh tests.test_quality_generated"  # sub
 ```
 
 Loading a tier is an **import side effect**, so every module that uses
-Hypothesis must import the profile module itself:
+Hypothesis must import the profile module itself — at module level, and
+**above the module's first `class`/`def`**:
 
 ```python
 import tests._hypothesis_profiles  # noqa: F401  (loads the active profile)
 ```
 
-That exact, module-level spelling is the whole grammar, and
-`tests/test_hypothesis_profile_audit.py` fails the suite on anything else —
-an alias, a `from`-import, a statement nested inside a function or an `if`,
-or no import at all. A `@given`/`@settings(...)` resolves every knob it does
-not name from `settings.default` **at decoration time**, so a module without
-that import inherits whichever default happened to be loaded when unittest
-imported it: the registered tier if an earlier module pulled it in, stock
-Hypothesis defaults otherwise. Stock defaults are randomized,
-example-database-backed and carry a 200ms deadline — and a non-`None`
+A `@given`/`@settings(...)` resolves every knob it does not name from
+`settings.default` **at decoration time**, i.e. while the class body runs.
+That makes position load-bearing, not cosmetic: the same statement at the
+BOTTOM of a module is a no-op for every decorator above it. A module without
+the import (or with it too late) inherits whichever default happened to be
+loaded when unittest imported it — the registered tier if an earlier module
+pulled it in, stock Hypothesis defaults otherwise. Stock defaults are
+randomized, example-database-backed and carry a 200ms deadline; a non-`None`
 deadline is a hard failure in `scripts/run_fuzz_tests.py`'s discovery, so a
 single unwired module stops the whole burst before it starts (issue #882).
-The audit scans **every** `.py` under `tests/` recursively, not the
-`test_*_generated.py` glob, because an unwired module outside that glob is
-invisible to the burst while still dragging stock defaults into the
-deterministic suite. `tests/_hypothesis_profiles.py` is the only exclusion.
+
+Two independent gates enforce this:
+
+- `tests/test_hypothesis_profile_audit.py` — the static half. That exact
+  spelling in that position is the whole grammar; an alias, a `from`-import,
+  a statement nested inside a function or an `if`, a canonical statement
+  below the first definition, or no import at all all fail the suite. It
+  scans **every** `.py` under `tests/` recursively, not the
+  `test_*_generated.py` glob, because an unwired module outside that glob is
+  invisible to the burst while still dragging stock defaults into the
+  deterministic suite. `tests/_hypothesis_profiles.py` is the only exclusion.
+- `scripts/run_python_tests.py::assert_hypothesis_deadlines_disabled` — the
+  runtime half, run by every suite target child (and by fuzz discovery, which
+  shares the same owner). It reads resolved settings rather than source, so
+  no spelling or position can evade it. Scoped to `deadline` alone:
+  `derandomize` and `database` are legitimately varied by
+  `tests/world_model/state_machine.py` under `CRATEDIGGER_WORLD_RANDOMIZED=1`.
 
 `scripts/fuzz_burst.sh` discovers the exact unittest IDs and effective
 Hypothesis settings in every generated module. Ordinary deterministic pins run
@@ -472,9 +485,15 @@ deeper randomized entropy, 2 survivors fixed in PR #555
 - Invariant checkers are module-level functions so a known-bad self-test
   can prove each one trips. Every checker owes one — a property that has
   never failed anything is unfalsifiable until proven otherwise.
-- Import `tests._hypothesis_profiles` for the side effect before using
-  `@given` — that is what wires the module into the suite/fuzz tiers, and
-  `tests/test_hypothesis_profile_audit.py` fails the suite without it.
+- Import `tests._hypothesis_profiles` for the side effect **above the first
+  `class`/`def`** — that is what wires the module into the suite/fuzz tiers,
+  and both `tests/test_hypothesis_profile_audit.py` and the suite runner's
+  own `assert_hypothesis_deadlines_disabled` fail without it.
+- Discard an unanswerable world with `assume(...)`, never a bare `return`.
+  A `return` spends the example as a PASS and silently shrinks the real
+  budget; `assume` marks it invalid so Hypothesis refills. Issue #882 found
+  a property burning 29% of a 20,000-example budget this way. If the world
+  has a defined answer, assert it instead of discarding it.
 - Reuse the shared fakes/builders (`tests/fakes/`, `tests/helpers.py`)
   per `.claude/rules/code-quality.md`; leaf-seam mock rules apply to
   generated tests like any other test.

--- a/docs/generated-testing.md
+++ b/docs/generated-testing.md
@@ -315,6 +315,29 @@ nix-shell --run "bash scripts/fuzz_burst.sh"                    # all generated 
 nix-shell --run "bash scripts/fuzz_burst.sh tests.test_quality_generated"  # subset
 ```
 
+Loading a tier is an **import side effect**, so every module that uses
+Hypothesis must import the profile module itself:
+
+```python
+import tests._hypothesis_profiles  # noqa: F401  (loads the active profile)
+```
+
+That exact, module-level spelling is the whole grammar, and
+`tests/test_hypothesis_profile_audit.py` fails the suite on anything else —
+an alias, a `from`-import, a statement nested inside a function or an `if`,
+or no import at all. A `@given`/`@settings(...)` resolves every knob it does
+not name from `settings.default` **at decoration time**, so a module without
+that import inherits whichever default happened to be loaded when unittest
+imported it: the registered tier if an earlier module pulled it in, stock
+Hypothesis defaults otherwise. Stock defaults are randomized,
+example-database-backed and carry a 200ms deadline — and a non-`None`
+deadline is a hard failure in `scripts/run_fuzz_tests.py`'s discovery, so a
+single unwired module stops the whole burst before it starts (issue #882).
+The audit scans **every** `.py` under `tests/` recursively, not the
+`test_*_generated.py` glob, because an unwired module outside that glob is
+invisible to the burst while still dragging stock defaults into the
+deterministic suite. `tests/_hypothesis_profiles.py` is the only exclusion.
+
 `scripts/fuzz_burst.sh` discovers the exact unittest IDs and effective
 Hypothesis settings in every generated module. Ordinary deterministic pins run
 once as a batch, and fixed per-test `@settings(max_examples=...)` budgets remain
@@ -450,7 +473,8 @@ deeper randomized entropy, 2 survivors fixed in PR #555
   can prove each one trips. Every checker owes one — a property that has
   never failed anything is unfalsifiable until proven otherwise.
 - Import `tests._hypothesis_profiles` for the side effect before using
-  `@given` — that is what wires the module into the suite/fuzz tiers.
+  `@given` — that is what wires the module into the suite/fuzz tiers, and
+  `tests/test_hypothesis_profile_audit.py` fails the suite without it.
 - Reuse the shared fakes/builders (`tests/fakes/`, `tests/helpers.py`)
   per `.claude/rules/code-quality.md`; leaf-seam mock rules apply to
   generated tests like any other test.

--- a/scripts/run_fuzz_tests.py
+++ b/scripts/run_fuzz_tests.py
@@ -12,13 +12,13 @@ import tempfile
 import time
 import unittest
 from collections import Counter
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
 
 import msgspec
-from hypothesis import is_hypothesis_test, settings
+from hypothesis import settings
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(REPO_ROOT) not in sys.path:
@@ -27,6 +27,8 @@ if str(REPO_ROOT) not in sys.path:
 from scripts.run_python_tests import (  # noqa: E402
     ChildTargetResult,
     _iter_test_cases,
+    assert_hypothesis_deadlines_disabled,
+    resolve_hypothesis_settings,
 )
 
 
@@ -278,15 +280,6 @@ def assert_exact_fuzz_coverage(
             raise ValueError(f"changed fuzz property budget: {test_id}")
 
 
-def _test_method(test: unittest.TestCase) -> Callable[..., object] | None:
-    method_name = test._testMethodName
-    for owner in type(test).__mro__:
-        candidate = vars(owner).get(method_name)
-        if callable(candidate):
-            return candidate
-    return None
-
-
 def _settings_max_examples(configured: settings) -> int:
     raw_max_examples: object = getattr(configured, "max_examples", None)
     if isinstance(raw_max_examples, bool) or not isinstance(
@@ -295,11 +288,6 @@ def _settings_max_examples(configured: settings) -> int:
     ):
         raise TypeError("Hypothesis max_examples is not an integer")
     return raw_max_examples
-
-
-def _settings_deadline(configured: settings) -> object:
-    """Return the effective deadline so fuzz work never depends on timing."""
-    return getattr(configured, "deadline", None)
 
 
 def _discover_module_child(module_name: str, result_path: Path) -> int:
@@ -311,51 +299,19 @@ def _discover_module_child(module_name: str, result_path: Path) -> int:
     if default_settings is None:
         raise RuntimeError("Hypothesis has no active default settings")
     default_max_examples = _settings_max_examples(default_settings)
+    # One owner for the deadline contract, shared with the deterministic
+    # suite runner so neither tier can drift from the other (#882 B1b).
+    assert_hypothesis_deadlines_disabled(suite)
     for test in cases:
-        method = _test_method(test)
-        if method is None or not is_hypothesis_test(method):
+        resolved = resolve_hypothesis_settings(test)
+        if resolved is None:
             continue
-        raw_configured: object | None = getattr(
-            method,
-            "_hypothesis_internal_use_settings",
-            None,
+        configured = resolved.configured
+        uses_default_settings = (
+            _settings_max_examples(configured) == default_max_examples
+            if resolved.from_state_machine_class
+            else configured is default_settings
         )
-        if raw_configured is not None and not isinstance(
-            raw_configured,
-            settings,
-        ):
-            raise TypeError(f"Hypothesis test has invalid settings: {test.id()}")
-        configured: settings | None = raw_configured
-        uses_default_settings = configured is default_settings
-        if configured is None and hasattr(
-            method,
-            "_hypothesis_state_machine_class",
-        ):
-            raw_stateful_settings: object | None = getattr(
-                type(test),
-                "settings",
-                None,
-            )
-            if raw_stateful_settings is not None and not isinstance(
-                raw_stateful_settings,
-                settings,
-            ):
-                raise TypeError(
-                    f"State-machine test has invalid settings: {test.id()}"
-                )
-            configured = raw_stateful_settings
-            uses_default_settings = (
-                configured is not None
-                and _settings_max_examples(configured) == default_max_examples
-            )
-        if configured is None:
-            raise TypeError(f"Hypothesis test has no settings: {test.id()}")
-        deadline = _settings_deadline(configured)
-        if deadline is not None:
-            raise RuntimeError(
-                "Hypothesis test has non-None deadline: "
-                f"{test.id()}: {deadline!r}"
-            )
         configured_max_examples = _settings_max_examples(configured)
         hypothesis_tests.append(
             FuzzPropertyManifest(

--- a/scripts/run_python_tests.py
+++ b/scripts/run_python_tests.py
@@ -13,12 +13,13 @@ import tempfile
 import time
 import unittest
 from collections import Counter
-from collections.abc import Iterator, Mapping, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
 
 import msgspec
+from hypothesis import is_hypothesis_test, settings
 
 
 DEFAULT_MAX_WORKERS = 12
@@ -428,6 +429,87 @@ def _iter_test_cases(suite: unittest.TestSuite) -> Iterator[unittest.TestCase]:
             yield test
 
 
+@dataclass(frozen=True)
+class ResolvedHypothesisSettings:
+    """The settings object one Hypothesis test will actually run under."""
+
+    configured: settings
+    from_state_machine_class: bool
+
+
+def _test_method(test: unittest.TestCase) -> Callable[..., object] | None:
+    method_name = test._testMethodName
+    for owner in type(test).__mro__:
+        candidate = vars(owner).get(method_name)
+        if callable(candidate):
+            return candidate
+    return None
+
+
+def resolve_hypothesis_settings(
+    test: unittest.TestCase,
+) -> ResolvedHypothesisSettings | None:
+    """Resolve one test's effective Hypothesis settings, or ``None``.
+
+    ``None`` means the test is not a Hypothesis test. A Hypothesis test whose
+    settings cannot be resolved raises: an unclassifiable shape fails closed
+    rather than escaping the deadline contract below.
+    """
+    method = _test_method(test)
+    if method is None or not is_hypothesis_test(method):
+        return None
+    raw_configured: object | None = getattr(
+        method,
+        "_hypothesis_internal_use_settings",
+        None,
+    )
+    if raw_configured is not None and not isinstance(raw_configured, settings):
+        raise TypeError(f"Hypothesis test has invalid settings: {test.id()}")
+    if raw_configured is not None:
+        return ResolvedHypothesisSettings(raw_configured, False)
+    if hasattr(method, "_hypothesis_state_machine_class"):
+        raw_stateful: object | None = getattr(type(test), "settings", None)
+        if raw_stateful is not None and not isinstance(raw_stateful, settings):
+            raise TypeError(
+                f"State-machine test has invalid settings: {test.id()}"
+            )
+        if raw_stateful is not None:
+            return ResolvedHypothesisSettings(raw_stateful, True)
+    raise TypeError(f"Hypothesis test has no settings: {test.id()}")
+
+
+def assert_hypothesis_deadlines_disabled(suite: unittest.TestSuite) -> None:
+    """Every Hypothesis test in this suite must resolve ``deadline=None``.
+
+    This is the RUNTIME half of the profile-tier invariant (issue #882): a
+    module that never imports ``tests._hypothesis_profiles`` — or imports it
+    below the decorators that snapshot ``settings.default`` — inherits stock
+    Hypothesis defaults, including a 200ms per-example deadline that flakes
+    under load. ``scripts/run_fuzz_tests.py`` has always asserted this during
+    fuzz discovery; asserting it here means the deterministic suite enforces
+    the same fact, and neither spelling nor import position can evade it.
+
+    Deliberately scoped to ``deadline`` alone. ``derandomize`` and ``database``
+    are legitimately varied by ``tests/world_model/state_machine.py`` under
+    ``CRATEDIGGER_WORLD_RANDOMIZED=1`` (which ``scripts/world_model_burst.sh``
+    exports), so asserting those would fail correctly-pinned tests.
+    """
+    offenders: list[str] = []
+    for test in _iter_test_cases(suite):
+        resolved = resolve_hypothesis_settings(test)
+        if resolved is None:
+            continue
+        deadline: object = getattr(resolved.configured, "deadline", None)
+        if deadline is not None:
+            offenders.append(f"{test.id()}: {deadline!r}")
+    if offenders:
+        raise RuntimeError(
+            "Hypothesis test has non-None deadline (its module never ran "
+            "`import tests._hypothesis_profiles` before the decorator): "
+            + ", ".join(sorted(offenders))
+        )
+
+
 def _list_module_test_ids_child(module_name: str, result_path: Path) -> int:
     """Discover exact unittest IDs in a disposable interpreter."""
     suite = unittest.defaultTestLoader.loadTestsFromName(module_name)
@@ -502,6 +584,7 @@ def _run_test_target_child(
         suite = unittest.TestSuite(
             discovered_by_id[test_id] for test_id in selected_test_ids
         )
+    assert_hypothesis_deadlines_disabled(suite)
     result = unittest.TextTestRunner(
         stream=stream,
         verbosity=2,

--- a/tests/test_album_source.py
+++ b/tests/test_album_source.py
@@ -17,6 +17,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from album_source import AlbumRecord, DatabaseSource, MB_API_BASE
 from lib.grab_list import GrabListEntry, DownloadFile
 from lib.quality import DownloadInfo, ValidationResult
+import tests._hypothesis_profiles  # noqa: F401  (loads the active profile)
 from tests.fakes import FakePipelineDB
 from tests.helpers import make_request_row
 

--- a/tests/test_dispatch_quarantine_root_generated.py
+++ b/tests/test_dispatch_quarantine_root_generated.py
@@ -6,6 +6,7 @@ import unittest
 
 from hypothesis import given, strategies as st
 
+import tests._hypothesis_profiles  # noqa: F401  (loads the active profile)
 from tests.test_dispatch_core import TestDispatchCoreOrchestration
 
 

--- a/tests/test_dispatch_quarantine_root_generated.py
+++ b/tests/test_dispatch_quarantine_root_generated.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import unittest
 
-from hypothesis import given, strategies as st
+from hypothesis import assume, given, strategies as st
 
 import tests._hypothesis_profiles  # noqa: F401  (loads the active profile)
 from tests.test_dispatch_core import TestDispatchCoreOrchestration
@@ -24,8 +24,12 @@ class TestDispatchQuarantineRootGenerated(unittest.TestCase):
     def test_real_dispatch_uses_staging_for_distinct_configured_roots(
         self, staging_name: str, slskd_name: str,
     ) -> None:
-        if staging_name == slskd_name:
-            return
+        # Identical roots are discarded, not asserted: the oracle's claim is
+        # "staging was chosen INSTEAD OF slskd", which is unanswerable when
+        # they are the same directory. A bare ``return`` spent the example as
+        # a PASS; ``assume`` marks it invalid so Hypothesis refills the budget
+        # with worlds that actually reach dispatch (#882).
+        assume(staging_name != slskd_name)
         staging = f"/configured/{staging_name}"
         slskd = f"/configured/{slskd_name}"
         world = TestDispatchCoreOrchestration()._dispatch(

--- a/tests/test_final_gate_receipt_generated.py
+++ b/tests/test_final_gate_receipt_generated.py
@@ -12,6 +12,7 @@ import unittest
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
+import tests._hypothesis_profiles  # noqa: F401  (loads the active profile)
 from tests.test_final_gate_receipt import HELPER, _FAKE_NIX_SHELL
 
 

--- a/tests/test_force_import_service_generated.py
+++ b/tests/test_force_import_service_generated.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 from hypothesis import given, strategies as st
 
 from lib.force_import_service import RESULT_QUEUED, enqueue_force_import
+import tests._hypothesis_profiles  # noqa: F401  (loads the active profile)
 from tests.fakes import FakePipelineDB
 from tests.helpers import make_request_row
 

--- a/tests/test_force_import_service_generated.py
+++ b/tests/test_force_import_service_generated.py
@@ -7,12 +7,27 @@ import tempfile
 import unittest
 from types import SimpleNamespace
 
-from hypothesis import given, strategies as st
+from hypothesis import example, given, strategies as st
 
 from lib.force_import_service import RESULT_QUEUED, enqueue_force_import
+from lib.processing_paths import processing_albums_dir
 import tests._hypothesis_profiles  # noqa: F401  (loads the active profile)
 from tests.fakes import FakePipelineDB
 from tests.helpers import make_request_row
+
+
+# Stated here rather than imported from lib.fs_authority: an oracle derived
+# from the production table cannot detect that table widening. The three
+# configured quarantine roots carry DELIBERATELY ASYMMETRIC marker sets —
+# staging authorizes ``failed_imports`` only, because a wrong-match rejection
+# is never staged there.
+MARKERS_BY_ROOT: dict[str, frozenset[str]] = {
+    "slskd": frozenset({"failed_imports", "wrong_matches"}),
+    "staging": frozenset({"failed_imports"}),
+    "processing": frozenset({"failed_imports", "wrong_matches"}),
+}
+
+_MARKERS = ("failed_imports", "wrong_matches", "failed_imports-lookalike")
 
 
 def assert_force_import_authority_invariant(
@@ -26,22 +41,46 @@ def assert_force_import_authority_invariant(
 
 
 class TestForceImportAuthorityGenerated(unittest.TestCase):
-    @given(authorized=st.booleans(), missing=st.booleans())
+    @given(
+        root=st.sampled_from(sorted(MARKERS_BY_ROOT)),
+        marker=st.sampled_from(_MARKERS),
+        missing=st.booleans(),
+        nested=st.booleans(),
+    )
+    @example(
+        # The asymmetry itself: staging must NOT authorize a wrong-match
+        # quarantine, however the path is shaped.
+        root="staging", marker="wrong_matches", missing=False, nested=False,
+    )
+    @example(
+        # Must-still-work: the ordinary authorized world.
+        root="staging", marker="failed_imports", missing=False, nested=False,
+    )
+    @example(
+        # Marker is a path COMPONENT, not a prefix — the lookalike is refused
+        # from every root.
+        root="slskd", marker="failed_imports-lookalike", missing=False,
+        nested=True,
+    )
     def test_only_existing_configured_quarantine_sources_enqueue(
-        self, authorized: bool, missing: bool,
+        self, root: str, marker: str, missing: bool, nested: bool,
     ) -> None:
-        with tempfile.TemporaryDirectory() as root:
-            staging = os.path.join(root, "Incoming")
-            slskd = os.path.join(root, "slskd")
-            processing = os.path.join(root, "processing")
+        with tempfile.TemporaryDirectory() as tmp:
+            staging = os.path.join(tmp, "Incoming")
+            slskd = os.path.join(tmp, "slskd")
+            processing = os.path.join(tmp, "processing")
             os.makedirs(staging)
             os.makedirs(slskd)
-            os.makedirs(processing)
-            path = os.path.join(
-                staging,
-                "failed_imports" if authorized else "failed_imports-lookalike",
-                "Album",
-            )
+            # The processing quarantine root is the albums/ child, not the
+            # processing dir itself.
+            os.makedirs(processing_albums_dir(processing))
+            root_path = {
+                "slskd": slskd,
+                "staging": staging,
+                "processing": processing_albums_dir(processing),
+            }[root]
+            prefix = ("auto-import", "Artist") if nested else ()
+            path = os.path.join(root_path, *prefix, marker, "Album")
             if not missing:
                 os.makedirs(path)
             db = FakePipelineDB()
@@ -58,7 +97,7 @@ class TestForceImportAuthorityGenerated(unittest.TestCase):
             )
             result = enqueue_force_import(db, cfg, log_id)
             assert_force_import_authority_invariant(
-                authorized=authorized and not missing,
+                authorized=marker in MARKERS_BY_ROOT[root] and not missing,
                 outcome=result.outcome,
                 job_count=len(db.list_import_jobs()),
             )
@@ -67,4 +106,10 @@ class TestForceImportAuthorityGenerated(unittest.TestCase):
         with self.assertRaisesRegex(AssertionError, "unauthorized"):
             assert_force_import_authority_invariant(
                 authorized=False, outcome=RESULT_QUEUED, job_count=1,
+            )
+
+    def test_invariant_checker_rejects_a_refused_authorized_source(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "did not enqueue exactly once"):
+            assert_force_import_authority_invariant(
+                authorized=True, outcome="not_found", job_count=0,
             )

--- a/tests/test_hypothesis_profile_audit.py
+++ b/tests/test_hypothesis_profile_audit.py
@@ -1,0 +1,304 @@
+"""Audit: every Hypothesis-using module under tests/ loads the shared tiers.
+
+``tests/_hypothesis_profiles.py`` registers the ``suite`` and ``fuzz`` tiers
+and loads the selected one **as an import side effect**. A ``@given`` or
+``@settings(...)`` resolves every knob it does not name from
+``settings.default`` at decoration time, so a module that never imports the
+profile module gets whatever default happened to be loaded when it was
+imported — the registered tier if some earlier module pulled it in, stock
+Hypothesis defaults if not. That makes the effective budget, determinism and
+deadline of those tests a function of unittest's module load order.
+
+Two real consequences were live on ``main`` before this audit:
+
+* ``tests/test_dispatch_quarantine_root_generated.py`` and
+  ``tests/test_force_import_service_generated.py`` carried bare ``@given``
+  decorators, so they inherited the stock 200ms deadline. That is a hard
+  failure in ``scripts/run_fuzz_tests.py::_discover_module_child``, which
+  refuses any Hypothesis test with a non-``None`` effective deadline — the
+  default fuzz burst could not run at all.
+* ``tests/test_final_gate_receipt_generated.py`` pinned ``deadline=None``
+  explicitly, so it was not a burst blocker, but it still ran
+  non-derandomized and example-database-backed inside the ``suite`` tier,
+  whose whole promise is machine-identical runs.
+
+**Scope is every ``.py`` under ``tests/`` recursively, not the
+``test_*_generated.py`` glob.** ``tests/test_album_source.py`` is the reason:
+it carries a bare ``@given`` while sitting outside that glob, so the burst
+runner never even sees it, yet it drags the stock 200ms deadline into the
+ordinary suite. The same argument covers the non-``test_``-prefixed helper
+modules (``tests/world_model/``) — they construct ``settings`` objects at
+import time and are subject to the identical ordering hazard. The single
+structural exclusion is the profile module itself, which cannot import
+itself.
+
+The grammar is deliberately small: one canonical, module-level
+``import tests._hypothesis_profiles`` statement. Anything else — an alias, a
+``from``-import, a statement nested inside a function or an ``if`` — fails
+closed and is reported as non-canonical rather than silently accepted. This
+audit reads import statements with the stdlib ``ast`` and nothing else: no
+data flow, no alias tracking, no inference about runtime behaviour (see
+``.claude/rules/code-quality.md`` § "Semantic source scanners are
+prohibited").
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import unittest
+from dataclasses import dataclass
+
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+
+#: The one sanctioned spelling. Everything else fails closed.
+CANONICAL_PROFILE_MODULE = "tests._hypothesis_profiles"
+
+#: Relative path of the profile module itself — the only structural exclusion.
+PROFILE_MODULE_RELPATH = "_hypothesis_profiles.py"
+
+_PROFILE_LEAF = "_hypothesis_profiles"
+
+
+class HypothesisProfileAuditError(Exception):
+    """A tests-tree module could not be classified, so the audit fails."""
+
+
+@dataclass(frozen=True)
+class ModuleProfileFacts:
+    """Bounded syntactic facts about one module's import statements."""
+
+    uses_hypothesis: bool
+    canonical_profile_import: bool
+    other_profile_import: bool
+
+
+def _imports_hypothesis(node: ast.stmt) -> bool:
+    """True when this statement imports the third-party ``hypothesis``."""
+    if isinstance(node, ast.Import):
+        return any(
+            alias.name == "hypothesis" or alias.name.startswith("hypothesis.")
+            for alias in node.names
+        )
+    if isinstance(node, ast.ImportFrom):
+        module = node.module or ""
+        return node.level == 0 and (
+            module == "hypothesis" or module.startswith("hypothesis.")
+        )
+    return False
+
+
+def _mentions_profile_module(node: ast.stmt) -> bool:
+    """True when this import statement names the profile module at all."""
+    if isinstance(node, ast.Import):
+        return any(
+            alias.name.split(".")[-1] == _PROFILE_LEAF for alias in node.names
+        )
+    if isinstance(node, ast.ImportFrom):
+        module = node.module or ""
+        if module.split(".")[-1] == _PROFILE_LEAF:
+            return True
+        return any(alias.name == _PROFILE_LEAF for alias in node.names)
+    return False
+
+
+def _is_canonical_profile_import(node: ast.stmt) -> bool:
+    """True for exactly ``import tests._hypothesis_profiles`` (no alias)."""
+    return isinstance(node, ast.Import) and any(
+        alias.name == CANONICAL_PROFILE_MODULE and alias.asname is None
+        for alias in node.names
+    )
+
+
+def module_profile_facts(source: str, *, label: str) -> ModuleProfileFacts:
+    """Classify one module source by its import statements alone.
+
+    Hypothesis usage counts wherever it appears; the canonical profile import
+    counts only as a direct child of the module body, because a statement
+    nested in a function or an ``if`` does not necessarily run at import time.
+    A source that does not parse raises — the audit never passes a module it
+    could not read.
+    """
+    try:
+        tree = ast.parse(source, filename=label)
+    except SyntaxError as exc:
+        raise HypothesisProfileAuditError(
+            f"{label}: could not be parsed, so its Hypothesis profile "
+            f"wiring cannot be audited: {exc}"
+        ) from exc
+
+    statements = [node for node in ast.walk(tree) if isinstance(node, ast.stmt)]
+    uses_hypothesis = any(_imports_hypothesis(node) for node in statements)
+    canonical = any(_is_canonical_profile_import(node) for node in tree.body)
+    mentions_profile = any(_mentions_profile_module(node) for node in statements)
+    return ModuleProfileFacts(
+        uses_hypothesis=uses_hypothesis,
+        canonical_profile_import=canonical,
+        other_profile_import=mentions_profile and not canonical,
+    )
+
+
+def profile_import_violation(facts: ModuleProfileFacts) -> str | None:
+    """Return the violation for these facts, or ``None`` when compliant."""
+    if not facts.uses_hypothesis:
+        return None
+    if facts.canonical_profile_import:
+        return None
+    if facts.other_profile_import:
+        return (
+            "non-canonical profile import — use a module-level "
+            f"`import {CANONICAL_PROFILE_MODULE}`"
+        )
+    return (
+        "imports hypothesis without a module-level "
+        f"`import {CANONICAL_PROFILE_MODULE}`"
+    )
+
+
+def iter_tests_tree_modules(root: str = TESTS_DIR) -> list[tuple[str, str]]:
+    """Yield ``(relpath, abspath)`` for every auditable .py under ``root``."""
+    found: list[tuple[str, str]] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = sorted(d for d in dirnames if d != "__pycache__")
+        for filename in sorted(filenames):
+            if not filename.endswith(".py"):
+                continue
+            path = os.path.join(dirpath, filename)
+            relpath = os.path.relpath(path, root)
+            if relpath == PROFILE_MODULE_RELPATH:
+                continue
+            found.append((relpath, path))
+    return found
+
+
+def audit_tests_tree(root: str = TESTS_DIR) -> list[str]:
+    """Return one offender line per non-compliant module, sorted by path."""
+    offenders: list[str] = []
+    for relpath, path in iter_tests_tree_modules(root):
+        with open(path, encoding="utf-8") as handle:
+            source = handle.read()
+        facts = module_profile_facts(source, label=relpath)
+        violation = profile_import_violation(facts)
+        if violation is not None:
+            offenders.append(f"{relpath}: {violation}")
+    return offenders
+
+
+class TestHypothesisProfileImportAudit(unittest.TestCase):
+    """Every Hypothesis-using tests module wires itself into the tiers."""
+
+    def test_every_hypothesis_module_loads_the_shared_profiles(self) -> None:
+        offenders = audit_tests_tree()
+        self.assertEqual(
+            offenders, [],
+            "A Hypothesis test whose module never imports "
+            f"`{CANONICAL_PROFILE_MODULE}` resolves its unnamed settings from "
+            "an import-order-dependent global default: stock Hypothesis "
+            "defaults (200ms deadline, randomized, example-database backed) "
+            "instead of the suite/fuzz tier. A stock deadline also aborts "
+            "`scripts/run_fuzz_tests.py` in discovery. Offenders "
+            "(paths relative to tests/):\n  "
+            + "\n  ".join(offenders),
+        )
+
+    def test_scan_reaches_every_tests_subpackage(self) -> None:
+        """Pin the recursive walk: a revert to a glob or ``os.listdir``
+        would silently drop the subpackages that motivated this scope."""
+        relpaths = {relpath for relpath, _ in iter_tests_tree_modules()}
+        self.assertIn("test_album_source.py", relpaths)
+        self.assertIn(os.path.join("web", "_harness.py"), relpaths)
+        self.assertIn(os.path.join("world_model", "state_machine.py"), relpaths)
+
+    def test_the_profile_module_is_the_only_exclusion(self) -> None:
+        relpaths = {relpath for relpath, _ in iter_tests_tree_modules()}
+        self.assertNotIn(PROFILE_MODULE_RELPATH, relpaths)
+        self.assertIn(os.path.basename(__file__), relpaths)
+
+
+class TestHypothesisProfileCheckerTripsOnViolations(unittest.TestCase):
+    """Known-bad self-tests: the checker must reject planted module shapes."""
+
+    HYPOTHESIS_FORMS = (
+        "import hypothesis\n",
+        "import hypothesis.strategies as st\n",
+        "from hypothesis import given\n",
+        "from hypothesis.strategies import integers\n",
+        "from hypothesis.stateful import rule\n",
+    )
+
+    def _violation(self, source: str) -> str | None:
+        return profile_import_violation(
+            module_profile_facts(source, label="planted.py"),
+        )
+
+    def test_hypothesis_without_the_profile_import_is_rejected(self) -> None:
+        for form in self.HYPOTHESIS_FORMS:
+            with self.subTest(form=form.strip()):
+                violation = self._violation(f"{form}\nVALUE = 1\n")
+                self.assertIsNotNone(violation)
+                assert violation is not None
+                self.assertIn("without a module-level", violation)
+
+    def test_hypothesis_with_the_canonical_profile_import_passes(self) -> None:
+        for form in self.HYPOTHESIS_FORMS:
+            with self.subTest(form=form.strip()):
+                self.assertIsNone(
+                    self._violation(
+                        f"{form}import {CANONICAL_PROFILE_MODULE}  # noqa: F401\n",
+                    ),
+                )
+
+    def test_a_module_without_hypothesis_needs_no_profile_import(self) -> None:
+        self.assertIsNone(self._violation("import os\nimport unittest\n"))
+
+    def test_non_canonical_profile_imports_fail_closed(self) -> None:
+        non_canonical = (
+            f"import {CANONICAL_PROFILE_MODULE} as profiles\n",
+            "from tests import _hypothesis_profiles\n",
+            f"from {CANONICAL_PROFILE_MODULE} import settings\n",
+            f"def wire():\n    import {CANONICAL_PROFILE_MODULE}\n",
+            f"if True:\n    import {CANONICAL_PROFILE_MODULE}\n",
+        )
+        for form in non_canonical:
+            with self.subTest(form=form.replace("\n", " ").strip()):
+                violation = self._violation(
+                    f"from hypothesis import given\n{form}",
+                )
+                self.assertIsNotNone(violation)
+                assert violation is not None
+                self.assertIn("non-canonical", violation)
+
+    def test_a_mention_inside_a_string_is_not_an_import(self) -> None:
+        """A regex/substring checker would pass this planted source."""
+        source = (
+            '"""This module explains `import tests._hypothesis_profiles`."""\n'
+            "from hypothesis import given\n"
+            'SNIPPET = "import tests._hypothesis_profiles  # noqa: F401"\n'
+        )
+        self.assertIn("import tests._hypothesis_profiles", source)
+
+        violation = self._violation(source)
+
+        self.assertIsNotNone(violation)
+        assert violation is not None
+        self.assertIn("without a module-level", violation)
+
+    def test_an_unparseable_module_fails_closed(self) -> None:
+        with self.assertRaises(HypothesisProfileAuditError):
+            module_profile_facts("def broken(:\n", label="planted.py")
+
+    def test_a_deferred_hypothesis_import_is_still_in_scope(self) -> None:
+        """Hypothesis usage counts wherever it appears; the profile import
+        must still be module-level."""
+        facts = module_profile_facts(
+            "def build():\n    from hypothesis import strategies as st\n"
+            "    return st\n",
+            label="planted.py",
+        )
+        self.assertTrue(facts.uses_hypothesis)
+        self.assertIsNotNone(profile_import_violation(facts))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hypothesis_profile_audit.py
+++ b/tests/test_hypothesis_profile_audit.py
@@ -32,12 +32,25 @@ import time and are subject to the identical ordering hazard. The single
 structural exclusion is the profile module itself, which cannot import
 itself.
 
-The grammar is deliberately small: one canonical, module-level
-``import tests._hypothesis_profiles`` statement. Anything else — an alias, a
-``from``-import, a statement nested inside a function or an ``if`` — fails
-closed and is reported as non-canonical rather than silently accepted. This
-audit reads import statements with the stdlib ``ast`` and nothing else: no
-data flow, no alias tracking, no inference about runtime behaviour (see
+The grammar is deliberately small: one canonical
+``import tests._hypothesis_profiles`` statement, at module level and **above
+the module's first ``class``/``def``**. Anything else — an alias, a
+``from``-import, a statement nested inside a function or an ``if``, or the
+canonical statement placed below the first definition — fails closed rather
+than being silently accepted.
+
+The position half is not cosmetic. Decorators run at class-body execution
+time, so a canonical import at the BOTTOM of a module is a no-op for every
+``@given``/``@settings`` above it: the audit would see the statement and pass
+the module while discovery still rejects it for a stock deadline, or worse,
+the module silently runs non-derandomized in the ``suite`` tier. The runtime
+half of that invariant is enforced independently by
+``scripts/run_python_tests.py::assert_hypothesis_deadlines_disabled``, which
+cannot be fooled by spelling or position at all; this audit is the cheap
+static half that names the fix.
+
+This audit reads import statements with the stdlib ``ast`` and nothing else:
+no data flow, no alias tracking, no inference about runtime behaviour (see
 ``.claude/rules/code-quality.md`` § "Semantic source scanners are
 prohibited").
 """
@@ -71,6 +84,7 @@ class ModuleProfileFacts:
 
     uses_hypothesis: bool
     canonical_profile_import: bool
+    late_canonical_profile_import: bool
     other_profile_import: bool
 
 
@@ -114,11 +128,15 @@ def _is_canonical_profile_import(node: ast.stmt) -> bool:
 def module_profile_facts(source: str, *, label: str) -> ModuleProfileFacts:
     """Classify one module source by its import statements alone.
 
-    Hypothesis usage counts wherever it appears; the canonical profile import
-    counts only as a direct child of the module body, because a statement
-    nested in a function or an ``if`` does not necessarily run at import time.
-    A source that does not parse raises — the audit never passes a module it
-    could not read.
+    Hypothesis usage counts wherever it appears. The canonical profile import
+    counts only as a direct child of the module body AND above the module's
+    first ``class``/``def``: a statement nested in a function or an ``if`` does
+    not necessarily run at import time, and one placed below a decorated class
+    runs *after* the ``@given``/``@settings`` above it have already snapshotted
+    ``settings.default``. Both are the same runtime fact — the import must have
+    run before anything reads the default — expressed as a bounded position
+    rule. A source that does not parse raises; the audit never passes a module
+    it could not read.
     """
     try:
         tree = ast.parse(source, filename=label)
@@ -130,12 +148,33 @@ def module_profile_facts(source: str, *, label: str) -> ModuleProfileFacts:
 
     statements = [node for node in ast.walk(tree) if isinstance(node, ast.stmt)]
     uses_hypothesis = any(_imports_hypothesis(node) for node in statements)
-    canonical = any(_is_canonical_profile_import(node) for node in tree.body)
+    first_definition = next(
+        (
+            index
+            for index, node in enumerate(tree.body)
+            if isinstance(
+                node,
+                (ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef),
+            )
+        ),
+        len(tree.body),
+    )
+    canonical = any(
+        _is_canonical_profile_import(node)
+        for node in tree.body[:first_definition]
+    )
+    late_canonical = not canonical and any(
+        _is_canonical_profile_import(node)
+        for node in tree.body[first_definition:]
+    )
     mentions_profile = any(_mentions_profile_module(node) for node in statements)
     return ModuleProfileFacts(
         uses_hypothesis=uses_hypothesis,
         canonical_profile_import=canonical,
-        other_profile_import=mentions_profile and not canonical,
+        late_canonical_profile_import=late_canonical,
+        other_profile_import=(
+            mentions_profile and not canonical and not late_canonical
+        ),
     )
 
 
@@ -145,9 +184,19 @@ def profile_import_violation(facts: ModuleProfileFacts) -> str | None:
         return None
     if facts.canonical_profile_import:
         return None
+    if facts.late_canonical_profile_import:
+        return (
+            "profile import is below the first class/function — every "
+            "`@given`/`@settings` above it already snapshotted "
+            f"`settings.default`; move `import {CANONICAL_PROFILE_MODULE}` "
+            "above the first definition"
+        )
     if facts.other_profile_import:
         return (
-            "non-canonical profile import — use a module-level "
+            "non-canonical profile import (an alias, a `from`-import, or a "
+            "nested statement). Some of these do load the tier at runtime and "
+            "some do not; the audit accepts exactly one spelling so the "
+            "guarantee never depends on which you picked — rewrite it as "
             f"`import {CANONICAL_PROFILE_MODULE}`"
         )
     return (
@@ -251,6 +300,55 @@ class TestHypothesisProfileCheckerTripsOnViolations(unittest.TestCase):
 
     def test_a_module_without_hypothesis_needs_no_profile_import(self) -> None:
         self.assertIsNone(self._violation("import os\nimport unittest\n"))
+
+    def test_a_canonical_import_below_the_first_class_is_rejected(self) -> None:
+        """The exact module the #882 PR1 review planted and drove through
+        real discovery: the audit passed it, discovery still raised
+        ``non-None deadline``. Position is part of the grammar."""
+        source = (
+            "import unittest\n"
+            "from hypothesis import given, strategies as st\n"
+            "\n"
+            "class TestBottomImport(unittest.TestCase):\n"
+            "    @given(n=st.integers())\n"
+            "    def test_property(self, n): self.assertIsInstance(n, int)\n"
+            "\n"
+            f"import {CANONICAL_PROFILE_MODULE}  # noqa: E402, F401\n"
+        )
+
+        violation = self._violation(source)
+
+        self.assertIsNotNone(violation)
+        assert violation is not None
+        self.assertIn("below the first class/function", violation)
+
+    def test_a_canonical_import_below_the_first_function_is_rejected(self) -> None:
+        source = (
+            "from hypothesis import given\n"
+            "def helper():\n    return 1\n"
+            f"import {CANONICAL_PROFILE_MODULE}\n"
+        )
+
+        violation = self._violation(source)
+
+        self.assertIsNotNone(violation)
+        assert violation is not None
+        self.assertIn("below the first class/function", violation)
+
+    def test_a_canonical_import_above_the_first_definition_passes(self) -> None:
+        """Must-still-work guard: the position rule must not reject the
+        ordinary shape every repository module already uses."""
+        source = (
+            "import unittest\n"
+            "from hypothesis import given, strategies as st\n"
+            f"import {CANONICAL_PROFILE_MODULE}  # noqa: F401\n"
+            "\n"
+            "class TestWorld(unittest.TestCase):\n"
+            "    @given(n=st.integers())\n"
+            "    def test_property(self, n): self.assertIsInstance(n, int)\n"
+        )
+
+        self.assertIsNone(self._violation(source))
 
     def test_non_canonical_profile_imports_fail_closed(self) -> None:
         non_canonical = (

--- a/tests/test_hypothesis_profile_audit_generated.py
+++ b/tests/test_hypothesis_profile_audit_generated.py
@@ -1,0 +1,268 @@
+"""Generated patrol for the tests-tree Hypothesis profile-import audit.
+
+The deterministic pins in ``test_hypothesis_profile_audit.py`` name the exact
+module shapes that were live on ``main``. This property ranges over the whole
+cross product of hypothesis-import forms, profile-import forms, surrounding
+noise and tree depth, driving the REAL audit entry point (``audit_tests_tree``)
+over a planted tree: only a canonical, module-level
+``import tests._hypothesis_profiles`` may satisfy it, and every other shape —
+including one that merely mentions the phrase in a docstring, comment or string
+constant — must fail closed.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+
+from hypothesis import example, given
+from hypothesis import strategies as st
+
+import tests._hypothesis_profiles  # noqa: F401  (loads the active profile)
+from tests.test_hypothesis_profile_audit import (
+    CANONICAL_PROFILE_MODULE,
+    PROFILE_MODULE_RELPATH,
+    audit_tests_tree,
+)
+
+
+_HYPOTHESIS_FORMS: dict[str, str] = {
+    "none": "",
+    "import_root": "import hypothesis\n",
+    "import_submodule_alias": "import hypothesis.strategies as st\n",
+    "from_root": "from hypothesis import given\n",
+    "from_submodule": "from hypothesis.strategies import integers\n",
+    "from_stateful": "from hypothesis.stateful import rule\n",
+    "deferred_in_function": (
+        "def build():\n    import hypothesis\n    return hypothesis\n"
+    ),
+}
+
+_PROFILE_FORMS: dict[str, str] = {
+    "none": "",
+    "canonical": f"import {CANONICAL_PROFILE_MODULE}\n",
+    "canonical_noqa": f"import {CANONICAL_PROFILE_MODULE}  # noqa: F401\n",
+    "aliased": f"import {CANONICAL_PROFILE_MODULE} as profiles\n",
+    "from_package": "from tests import _hypothesis_profiles\n",
+    "from_module": f"from {CANONICAL_PROFILE_MODULE} import settings\n",
+    "nested_function": f"def wire():\n    import {CANONICAL_PROFILE_MODULE}\n",
+    "nested_if": f"if True:\n    import {CANONICAL_PROFILE_MODULE}\n",
+}
+
+#: Only these spellings run the profile side effect at module import time.
+CANONICAL_FORMS = frozenset({"canonical", "canonical_noqa"})
+
+_NOISE: dict[str, str] = {
+    "none": "",
+    "docstring": (
+        f'"""Mentions `import {CANONICAL_PROFILE_MODULE}` and '
+        '`from hypothesis import given` in prose."""\n'
+    ),
+    "string_constant": (
+        f'SNIPPET = "import {CANONICAL_PROFILE_MODULE}"\n'
+        'OTHER = "from hypothesis import given"\n'
+    ),
+    "comment": (
+        f"# import {CANONICAL_PROFILE_MODULE}\n"
+        "# from hypothesis import given\n"
+    ),
+    "unrelated_imports": "import os\nimport unittest\nfrom pathlib import Path\n",
+}
+
+_SUBDIRECTORIES = ("", "web", os.path.join("world_model", "deep"))
+
+#: A module shape that must never be reported, whatever it contains.
+_EXCLUDED_SOURCE = "from hypothesis import given\n"
+
+
+def assert_audit_verdict(
+    *,
+    offenders: tuple[str, ...],
+    relpath: str,
+    hypothesis_form: str,
+    profile_form: str,
+) -> None:
+    """Independent oracle for one planted module's audit outcome.
+
+    Derived from the chosen construction, deliberately not by re-parsing the
+    source the audit already read.
+    """
+    expects_violation = (
+        hypothesis_form != "none" and profile_form not in CANONICAL_FORMS
+    )
+    reported = [line for line in offenders if line.startswith(f"{relpath}:")]
+    if len(reported) > 1:
+        raise AssertionError(f"module reported more than once: {reported!r}")
+    if expects_violation and not reported:
+        raise AssertionError(
+            f"audit accepted {hypothesis_form}/{profile_form} without a "
+            "canonical module-level profile import",
+        )
+    if not expects_violation and reported:
+        raise AssertionError(
+            f"audit rejected compliant {hypothesis_form}/{profile_form}: "
+            f"{reported!r}",
+        )
+    if not reported:
+        return
+    expected_phrase = (
+        "non-canonical" if profile_form != "none" else "without a module-level"
+    )
+    if expected_phrase not in reported[0]:
+        raise AssertionError(
+            f"violation for {profile_form} was not named {expected_phrase!r}: "
+            f"{reported[0]!r}",
+        )
+
+
+def write_planted_module(root: str, relpath: str, source: str) -> None:
+    """Write one synthetic module into a planted tests tree."""
+    path = os.path.join(root, relpath)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(source)
+
+
+def substring_offenders(sources: dict[str, str]) -> tuple[str, ...]:
+    """Known-bad mutant: classify by substring instead of import syntax."""
+    return tuple(
+        f"{relpath}: imports hypothesis without a module-level import"
+        for relpath, source in sorted(sources.items())
+        if "hypothesis" in source
+        and f"import {CANONICAL_PROFILE_MODULE}" not in source
+    )
+
+
+class TestGeneratedProfileImportAudit(unittest.TestCase):
+    @given(
+        hypothesis_form=st.sampled_from(sorted(_HYPOTHESIS_FORMS)),
+        profile_form=st.sampled_from(sorted(_PROFILE_FORMS)),
+        noise=st.sampled_from(sorted(_NOISE)),
+        subdirectory=st.sampled_from(_SUBDIRECTORIES),
+    )
+    @example(
+        # The two burst blockers live on main: a bare ``@given`` module with
+        # no profile import at all.
+        hypothesis_form="from_root",
+        profile_form="none",
+        noise="none",
+        subdirectory="",
+    )
+    @example(
+        # A module that only talks about the import in its docstring.
+        hypothesis_form="from_root",
+        profile_form="none",
+        noise="docstring",
+        subdirectory="",
+    )
+    @example(
+        # Compliant: the canonical spelling every repository site uses.
+        hypothesis_form="from_root",
+        profile_form="canonical_noqa",
+        noise="unrelated_imports",
+        subdirectory="web",
+    )
+    def test_only_a_canonical_module_level_import_satisfies_the_audit(
+        self,
+        hypothesis_form: str,
+        profile_form: str,
+        noise: str,
+        subdirectory: str,
+    ) -> None:
+        source = (
+            _NOISE[noise]
+            + _HYPOTHESIS_FORMS[hypothesis_form]
+            + _PROFILE_FORMS[profile_form]
+            + "VALUE = 1\n"
+        )
+        relpath = os.path.join(subdirectory, "test_planted.py")
+        with tempfile.TemporaryDirectory() as root:
+            write_planted_module(root, relpath, source)
+            # Never reported: the profile module itself is the one structural
+            # exclusion, and __pycache__ is pruned from the walk.
+            write_planted_module(root, PROFILE_MODULE_RELPATH, _EXCLUDED_SOURCE)
+            write_planted_module(
+                root,
+                os.path.join("__pycache__", "test_cached.py"),
+                _EXCLUDED_SOURCE,
+            )
+
+            offenders = tuple(audit_tests_tree(root))
+
+        assert_audit_verdict(
+            offenders=offenders,
+            relpath=relpath,
+            hypothesis_form=hypothesis_form,
+            profile_form=profile_form,
+        )
+        self.assertEqual(
+            [line for line in offenders if not line.startswith(f"{relpath}:")],
+            [],
+            "an excluded or pruned path was audited",
+        )
+
+
+class TestProfileAuditCheckerTripsOnViolations(unittest.TestCase):
+    """Known-bad self-tests: the oracle and the syntax basis must both trip."""
+
+    def test_oracle_trips_when_a_violating_module_is_accepted(self) -> None:
+        with self.assertRaises(AssertionError):
+            assert_audit_verdict(
+                offenders=(),
+                relpath="test_planted.py",
+                hypothesis_form="from_root",
+                profile_form="none",
+            )
+
+    def test_oracle_trips_when_a_compliant_module_is_rejected(self) -> None:
+        with self.assertRaises(AssertionError):
+            assert_audit_verdict(
+                offenders=("test_planted.py: imports hypothesis",),
+                relpath="test_planted.py",
+                hypothesis_form="from_root",
+                profile_form="canonical",
+            )
+
+    def test_oracle_trips_when_a_non_canonical_import_is_misnamed(self) -> None:
+        with self.assertRaises(AssertionError):
+            assert_audit_verdict(
+                offenders=(
+                    "test_planted.py: imports hypothesis without a "
+                    "module-level import",
+                ),
+                relpath="test_planted.py",
+                hypothesis_form="from_root",
+                profile_form="aliased",
+            )
+
+    def test_substring_mutant_is_fooled_by_a_string_constant(self) -> None:
+        """The real audit is AST-based; prove that basis is load-bearing."""
+        relpath = "test_planted.py"
+        source = (
+            _NOISE["string_constant"]
+            + _HYPOTHESIS_FORMS["from_root"]
+            + "VALUE = 1\n"
+        )
+        with tempfile.TemporaryDirectory() as root:
+            write_planted_module(root, relpath, source)
+            offenders = tuple(audit_tests_tree(root))
+
+        self.assertEqual(substring_offenders({relpath: source}), ())
+        assert_audit_verdict(
+            offenders=offenders,
+            relpath=relpath,
+            hypothesis_form="from_root",
+            profile_form="none",
+        )
+        with self.assertRaises(AssertionError):
+            assert_audit_verdict(
+                offenders=substring_offenders({relpath: source}),
+                relpath=relpath,
+                hypothesis_form="from_root",
+                profile_form="none",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hypothesis_profile_audit_generated.py
+++ b/tests/test_hypothesis_profile_audit_generated.py
@@ -48,10 +48,26 @@ _PROFILE_FORMS: dict[str, str] = {
     "from_module": f"from {CANONICAL_PROFILE_MODULE} import settings\n",
     "nested_function": f"def wire():\n    import {CANONICAL_PROFILE_MODULE}\n",
     "nested_if": f"if True:\n    import {CANONICAL_PROFILE_MODULE}\n",
+    "canonical_after_class": (
+        "class _Planted:\n    pass\n"
+        f"import {CANONICAL_PROFILE_MODULE}\n"
+    ),
+    "canonical_after_function": (
+        "def _planted():\n    return None\n"
+        f"import {CANONICAL_PROFILE_MODULE}\n"
+    ),
 }
 
-#: Only these spellings run the profile side effect at module import time.
+#: Only these spellings run the profile side effect before any decorator
+#: below them snapshots ``settings.default``.
 CANONICAL_FORMS = frozenset({"canonical", "canonical_noqa"})
+
+#: Canonical spelling, module level, but below the first class/function — the
+#: shape the #882 PR1 review drove through real discovery and reproduced the
+#: burst blocker with.
+LATE_CANONICAL_FORMS = frozenset(
+    {"canonical_after_class", "canonical_after_function"},
+)
 
 _NOISE: dict[str, str] = {
     "none": "",
@@ -106,9 +122,12 @@ def assert_audit_verdict(
         )
     if not reported:
         return
-    expected_phrase = (
-        "non-canonical" if profile_form != "none" else "without a module-level"
-    )
+    if profile_form in LATE_CANONICAL_FORMS:
+        expected_phrase = "below the first class/function"
+    elif profile_form != "none":
+        expected_phrase = "non-canonical"
+    else:
+        expected_phrase = "without a module-level"
     if expected_phrase not in reported[0]:
         raise AssertionError(
             f"violation for {profile_form} was not named {expected_phrase!r}: "
@@ -163,6 +182,14 @@ class TestGeneratedProfileImportAudit(unittest.TestCase):
         noise="unrelated_imports",
         subdirectory="web",
     )
+    @example(
+        # The review's planted probe: canonical spelling, module level, but
+        # below the decorated class it was supposed to wire.
+        hypothesis_form="from_root",
+        profile_form="canonical_after_class",
+        noise="none",
+        subdirectory="",
+    )
     def test_only_a_canonical_module_level_import_satisfies_the_audit(
         self,
         hypothesis_form: str,
@@ -170,10 +197,13 @@ class TestGeneratedProfileImportAudit(unittest.TestCase):
         noise: str,
         subdirectory: str,
     ) -> None:
+        # The profile form precedes the hypothesis form so each form owns its
+        # own position: the late-canonical forms carry the definition they must
+        # sit below, and no other form is accidentally pushed past one.
         source = (
             _NOISE[noise]
-            + _HYPOTHESIS_FORMS[hypothesis_form]
             + _PROFILE_FORMS[profile_form]
+            + _HYPOTHESIS_FORMS[hypothesis_form]
             + "VALUE = 1\n"
         )
         relpath = os.path.join(subdirectory, "test_planted.py")
@@ -234,6 +264,21 @@ class TestProfileAuditCheckerTripsOnViolations(unittest.TestCase):
                 relpath="test_planted.py",
                 hypothesis_form="from_root",
                 profile_form="aliased",
+            )
+
+    def test_oracle_trips_when_a_late_import_is_reported_as_missing(self) -> None:
+        """A late canonical import must be named as a POSITION problem — the
+        author has the statement, and 'missing' would send them looking for
+        one they already wrote."""
+        with self.assertRaises(AssertionError):
+            assert_audit_verdict(
+                offenders=(
+                    "test_planted.py: imports hypothesis without a "
+                    "module-level import",
+                ),
+                relpath="test_planted.py",
+                hypothesis_form="from_root",
+                profile_form="canonical_after_class",
             )
 
     def test_substring_mutant_is_fooled_by_a_string_constant(self) -> None:

--- a/tests/test_import_one_argparse_generated.py
+++ b/tests/test_import_one_argparse_generated.py
@@ -6,7 +6,7 @@ import argparse
 import keyword
 import unittest
 
-from hypothesis import example, given, strategies as st
+from hypothesis import assume, example, given, strategies as st
 
 import tests._hypothesis_profiles  # noqa: F401 - loads the active profile
 from tests.test_import_one_argparse_audit import (
@@ -63,8 +63,7 @@ class TestGeneratedImportOneArgparseAudit(unittest.TestCase):
         declared: set[str],
         read: set[str],
     ) -> None:
-        if declared == read:
-            return
+        assume(declared != read)
         with self.assertRaises(AssertionError):
             assert_argparse_destinations_match_reads(
                 _parser_for(declared),

--- a/tests/test_mb_api.py
+++ b/tests/test_mb_api.py
@@ -16,7 +16,7 @@ from unittest.mock import MagicMock, patch
 
 from hypothesis import given, strategies as st
 
-from tests import _hypothesis_profiles  # noqa: F401 — registers active profile
+import tests._hypothesis_profiles  # noqa: F401 — registers active profile
 from lib.va_identity import MB_VA_ARTIST_MBID
 from web.mb import (
     _quote_mb_identifier,

--- a/tests/test_parallel_test_runner.py
+++ b/tests/test_parallel_test_runner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import datetime
 import os
 import subprocess
 import sys
@@ -9,16 +10,23 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+import tests._hypothesis_profiles  # noqa: F401  (loads the active profile)
 from scripts.run_python_tests import (
     HOTSPOT_SHARD_POLICIES,
     WORLD_MODEL_MODULE,
     TestModule,
+    _iter_test_cases,
     assert_exact_target_coverage,
     assert_exact_schedule,
+    assert_hypothesis_deadlines_disabled,
     complete_test_modules,
     discover_test_modules,
     list_module_test_ids,
     recommended_worker_count,
+    resolve_hypothesis_settings,
     schedule_modules,
     shard_test_ids,
     test_subprocess_environment,
@@ -364,6 +372,181 @@ class TestRunnerProcessContract(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertIn("Ran 0 tests", result.stdout)
+
+
+def _planted_case(
+    deadline: int | datetime.timedelta | None,
+) -> type[unittest.TestCase]:
+    """One real Hypothesis TestCase class carrying exactly this deadline."""
+
+    @settings(deadline=deadline, max_examples=1)
+    @given(value=st.integers())
+    def test_property(self: unittest.TestCase, value: int) -> None:
+        self.assertIsInstance(value, int)
+
+    return type("PlantedWorld", (unittest.TestCase,), {
+        "test_property": test_property,
+    })
+
+
+def _plain_case() -> type[unittest.TestCase]:
+    def test_ordinary(self: unittest.TestCase) -> None:
+        self.assertTrue(True)
+
+    return type("PlainWorld", (unittest.TestCase,), {
+        "test_ordinary": test_ordinary,
+    })
+
+
+# Held in a dict, never bound as module attributes, so unittest never collects
+# them — the deadline-bearing ones would otherwise fail this very module under
+# the contract they exist to test. Built here rather than loaded from a temp
+# package because an arbitrary ``sys.path`` insert is the #95/#445 dual-load
+# hazard the sys.path audit forbids.
+PLANTED_CASES: dict[str, type[unittest.TestCase]] = {
+    "none": _planted_case(None),
+    "ms_1": _planted_case(1),
+    "ms_200": _planted_case(200),
+    "ms_60000": _planted_case(60_000),
+    "timedelta": _planted_case(datetime.timedelta(milliseconds=200)),
+    "plain": _plain_case(),
+}
+
+#: Planted kinds whose Hypothesis tests carry a deadline the contract rejects.
+DEADLINE_BEARING_KINDS = frozenset({"ms_1", "ms_200", "ms_60000", "timedelta"})
+
+#: Planted kinds that are Hypothesis tests at all.
+HYPOTHESIS_KINDS = frozenset(set(PLANTED_CASES) - {"plain"})
+
+
+def planted_suite(kinds: tuple[str, ...]) -> unittest.TestSuite:
+    """Compose one suite from the planted catalogue, in order."""
+    suite = unittest.TestSuite()
+    for kind in kinds:
+        suite.addTests(
+            unittest.defaultTestLoader.loadTestsFromTestCase(PLANTED_CASES[kind]),
+        )
+    return suite
+
+
+class TestSuiteDeadlineContract(unittest.TestCase):
+    """Issue #882 B1b: the suite tier enforces what fuzz discovery already did.
+
+    A source audit can only police one spelling in one position. This is the
+    runtime fact itself — resolved settings, not source text — so a module
+    that imports the profile tier below its decorators (which the static audit
+    catches) and any shape it does NOT catch both fail here.
+    """
+
+    # An "unwired module" cannot be reproduced IN THIS PROCESS: something has
+    # already imported tests._hypothesis_profiles, and load_profile mutates
+    # settings.default globally, so a freshly loaded unwired module inherits
+    # the tier anyway. That process-global inheritance IS the #882 defect. The
+    # unwired case is therefore pinned end-to-end below, in a fresh child that
+    # loads nothing else; the in-process pins cover the contract itself.
+
+    def test_a_deadline_pinned_to_none_passes_the_runtime_contract(self) -> None:
+        """Must-still-work guard: the ordinary shape is not rejected."""
+        assert_hypothesis_deadlines_disabled(planted_suite(("none",)))
+
+    def test_an_explicit_deadline_is_rejected_however_the_module_is_wired(
+        self,
+    ) -> None:
+        """Spelling and position cannot buy an explicit deadline back."""
+        with self.assertRaisesRegex(RuntimeError, "non-None deadline"):
+            assert_hypothesis_deadlines_disabled(planted_suite(("ms_200",)))
+
+    def test_one_deadline_condemns_an_otherwise_clean_suite(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "non-None deadline"):
+            assert_hypothesis_deadlines_disabled(
+                planted_suite(("none", "plain", "timedelta")),
+            )
+
+    def test_a_suite_without_hypothesis_tests_is_accepted(self) -> None:
+        suite = planted_suite(("plain", "plain"))
+
+        assert_hypothesis_deadlines_disabled(suite)
+        for test in _iter_test_cases(suite):
+            self.assertIsNone(resolve_hypothesis_settings(test))
+
+    def test_an_unclassifiable_hypothesis_test_fails_closed(self) -> None:
+        """A Hypothesis test whose settings cannot be read must raise, not be
+        quietly skipped past the deadline contract."""
+        broken = _planted_case(None)
+        setattr(
+            getattr(broken, "test_property"),
+            "_hypothesis_internal_use_settings",
+            object(),
+        )
+        suite = unittest.defaultTestLoader.loadTestsFromTestCase(broken)
+
+        with self.assertRaisesRegex(TypeError, "invalid settings"):
+            assert_hypothesis_deadlines_disabled(suite)
+
+    def test_planted_cases_are_never_collected_from_this_module(self) -> None:
+        """The deadline-bearing plants must stay out of unittest discovery —
+        otherwise this module fails the very contract it defines."""
+        suite = unittest.defaultTestLoader.loadTestsFromName(__name__)
+        collected = {type(test).__name__ for test in _iter_test_cases(suite)}
+
+        self.assertNotIn("PlantedWorld", collected)
+        self.assertNotIn("PlainWorld", collected)
+        assert_hypothesis_deadlines_disabled(suite)
+
+    def test_the_child_runner_refuses_to_run_an_unwired_module(self) -> None:
+        """End-to-end: the real ``--_run-target`` child, not just the helper.
+
+        A fresh interpreter that loads ONLY this module has never imported the
+        profile tier, so the bare ``@given`` really does resolve the stock
+        200ms deadline — the exact #882 item-1 shape.
+        """
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            package = root / "child_deadline_fixture"
+            package.mkdir()
+            (package / "__init__.py").write_text("", encoding="utf-8")
+            (package / "test_unwired.py").write_text(
+                "import unittest\n"
+                "from hypothesis import given\n"
+                "from hypothesis import strategies as st\n"
+                "\n"
+                "class Planted(unittest.TestCase):\n"
+                "    @given(value=st.integers())\n"
+                "    def test_property(self, value):\n"
+                "        self.assertIsInstance(value, int)\n",
+                encoding="utf-8",
+            )
+            env = {
+                **os.environ,
+                "PYTHONPATH": os.pathsep.join(
+                    part
+                    for part in (
+                        str(root),
+                        str(REPO_ROOT),
+                        os.environ.get("PYTHONPATH", ""),
+                    )
+                    if part
+                ),
+            }
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(RUNNER),
+                    "--_run-target",
+                    '["child_deadline_fixture.test_unwired"]',
+                    "0",
+                    str(root / "result.json"),
+                ],
+                cwd=REPO_ROOT,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("non-None deadline", completed.stderr)
+        self.assertFalse((root / "result.json").exists())
 
 
 class TestRunTestsWiring(unittest.TestCase):

--- a/tests/test_parallel_test_runner_generated.py
+++ b/tests/test_parallel_test_runner_generated.py
@@ -5,18 +5,27 @@ from __future__ import annotations
 import unittest
 from pathlib import Path
 
-from hypothesis import given
+from hypothesis import example, given
 from hypothesis import strategies as st
 
 import tests._hypothesis_profiles  # noqa: F401 - registers active profile
 from scripts.run_python_tests import (
     DEFAULT_MAX_WORKERS,
     TestModule,
+    _iter_test_cases,
     assert_exact_target_coverage,
     assert_exact_schedule,
+    assert_hypothesis_deadlines_disabled,
     recommended_worker_count,
+    resolve_hypothesis_settings,
     schedule_modules,
     shard_test_ids,
+)
+from tests.test_parallel_test_runner import (
+    DEADLINE_BEARING_KINDS,
+    HYPOTHESIS_KINDS,
+    PLANTED_CASES,
+    planted_suite,
 )
 
 
@@ -107,6 +116,104 @@ class TestGeneratedTargetSharding(unittest.TestCase):
         )
         self.assertEqual(set(scheduled_ids), set(test_ids))
         self.assertEqual(len(scheduled_ids), len(test_ids))
+
+
+def assert_deadline_contract(
+    *,
+    accepted: bool,
+    kinds: tuple[str, ...],
+) -> None:
+    """A suite is admissible iff no Hypothesis test carries a deadline.
+
+    Stated from the planted construction rather than by re-reading the
+    settings the checker itself read (#882 B1b).
+    """
+    expected = not any(kind in DEADLINE_BEARING_KINDS for kind in kinds)
+    if accepted != expected:
+        verdict = "accepted" if accepted else "rejected"
+        raise AssertionError(
+            f"suite of {kinds!r} was {verdict}; deadlines present="
+            f"{not expected}",
+        )
+
+
+class TestGeneratedSuiteDeadlineContract(unittest.TestCase):
+    """#882 B1b: the runtime half of the profile-tier invariant.
+
+    Ranges over mixed suites of Hypothesis and ordinary tests with assorted
+    deadlines, driving the real ``assert_hypothesis_deadlines_disabled``.
+    """
+
+    @given(
+        kinds=st.lists(
+            st.sampled_from(sorted(PLANTED_CASES)),
+            min_size=1,
+            max_size=6,
+        ),
+    )
+    @example(kinds=["none"])
+    @example(kinds=["ms_200"])
+    @example(kinds=["plain"])
+    @example(kinds=["none", "plain", "ms_200"])
+    @example(kinds=["timedelta"])
+    def test_only_a_deadline_free_suite_is_admissible(
+        self,
+        kinds: list[str],
+    ) -> None:
+        planted = tuple(kinds)
+        suite = planted_suite(planted)
+        try:
+            assert_hypothesis_deadlines_disabled(suite)
+        except RuntimeError:
+            accepted = False
+        else:
+            accepted = True
+
+        assert_deadline_contract(accepted=accepted, kinds=planted)
+
+    @given(
+        kinds=st.lists(
+            st.sampled_from(sorted(PLANTED_CASES)),
+            min_size=1,
+            max_size=6,
+        ),
+    )
+    def test_every_planted_property_resolves_its_own_settings(
+        self,
+        kinds: list[str],
+    ) -> None:
+        """The resolver never silently returns ``None`` for a real property —
+        that would let a deadline slip past the contract unexamined."""
+        planted = tuple(kinds)
+        resolved = [
+            resolve_hypothesis_settings(test)
+            for test in _iter_test_cases(planted_suite(planted))
+        ]
+
+        self.assertEqual(
+            sum(item is not None for item in resolved),
+            sum(kind in HYPOTHESIS_KINDS for kind in planted),
+        )
+
+
+class TestSuiteDeadlineCheckerKnownBad(unittest.TestCase):
+    def test_contract_trips_when_a_deadline_suite_is_accepted(self) -> None:
+        with self.assertRaises(AssertionError):
+            assert_deadline_contract(accepted=True, kinds=("ms_200",))
+
+    def test_contract_trips_when_a_clean_suite_is_rejected(self) -> None:
+        with self.assertRaises(AssertionError):
+            assert_deadline_contract(accepted=False, kinds=("none", "plain"))
+
+    def test_planted_cases_are_never_collected_from_this_module(self) -> None:
+        """The deadline-bearing plants must stay out of unittest discovery —
+        otherwise this module fails the very contract it patrols."""
+        suite = unittest.defaultTestLoader.loadTestsFromName(__name__)
+        collected = {type(test).__name__ for test in _iter_test_cases(suite)}
+
+        self.assertNotIn("PlantedWorld", collected)
+        self.assertNotIn("PlainWorld", collected)
+        assert_hypothesis_deadlines_disabled(suite)
 
 
 if __name__ == "__main__":

--- a/tests/test_path_authority.py
+++ b/tests/test_path_authority.py
@@ -956,6 +956,26 @@ class TestAuthorityInvariantCheckers(unittest.TestCase):
                 allowed_result_types=(MaterializeFailed,),
             )
 
+    def test_publication_checker_default_refuses_a_failed_materialize(self) -> None:
+        """Issue #882 item 6: the DEFAULT tuple is itself a proof surface.
+
+        Callers that omit ``allowed_result_types`` rely on the default, and
+        every other known-bad pin here passes an explicit tuple — so a mutant
+        widening the default to admit ``MaterializeFailed`` survived the whole
+        suite. It must not: a refusal reaching a call site that asserts
+        publication is a finding, not an accepted outcome.
+        """
+        with self.assertRaises(AssertionError):
+            assert_publication_invariant(
+                result=MaterializeFailed(reason="slskd_root_missing"),
+                source_exists=True,
+                expected_source_exists=True,
+                destination_names=set(),
+                expected_names=set(),
+                artifact_names=[],
+                name_max=255,
+            )
+
     def test_publication_checker_still_refuses_an_unexpected_result_type(self) -> None:
         with self.assertRaises(AssertionError):
             assert_publication_invariant(

--- a/tests/test_path_authority_generated.py
+++ b/tests/test_path_authority_generated.py
@@ -30,6 +30,7 @@ from lib.import_preview import (
     remove_preview_snapshot,
 )
 from lib.download_materialization import (
+    MaterializeFailed,
     MaterializeGuarded,
     Materialized,
     _materialize_processing_dir,
@@ -42,6 +43,7 @@ from lib.quality_evidence import EvidenceBuildResult
 from lib.staged_album import StagedAlbum
 from tests.fakes import FakePipelineDB
 from tests.helpers import make_ctx_with_fake_db, make_grab_list_entry
+from tests.test_path_authority import assert_publication_invariant
 from web.wrong_match_file_service import (
     WrongMatchExplorerLimits,
     build_wrong_match_explorer,
@@ -185,6 +187,49 @@ def assert_generated_publication_invariant(
         raise AssertionError("materialize lock is not a bounded shard lock")
     if len({name.rsplit("-", 1)[-1] for name in lock_names}) > 256:
         raise AssertionError("materialize used more than 256 lock shards")
+
+
+_RESULT_TYPES: dict[str, type] = {
+    "materialized": Materialized,
+    "guarded": MaterializeGuarded,
+    "failed": MaterializeFailed,
+}
+
+_RESULT_FACTORIES: dict[str, Callable[[], object]] = {
+    "materialized": Materialized,
+    "guarded": lambda: MaterializeGuarded(detail="incomplete_or_unsafe_canonical"),
+    "failed": lambda: MaterializeFailed(reason="slskd_root_missing"),
+}
+
+# Stated here rather than read off the production default, for the same
+# reason as #868 I3: an assertion derived from the thing under test cannot
+# detect that thing widening.
+DEFAULT_PUBLICATION_RESULT_KINDS = frozenset({"materialized", "guarded"})
+
+
+def assert_result_type_gate(
+    *,
+    accepted: bool,
+    result_kind: str,
+    allowed_kinds: frozenset[str] | None,
+) -> None:
+    """The publication checker's result-type gate, stated independently.
+
+    ``allowed_kinds is None`` means the call site took the DEFAULT tuple,
+    which admits exactly a publication and a guard — never a refusal (#882
+    item 6: the default was the one arm no known-bad pin exercised).
+    """
+    effective = (
+        DEFAULT_PUBLICATION_RESULT_KINDS
+        if allowed_kinds is None
+        else allowed_kinds
+    )
+    if accepted != (result_kind in effective):
+        verdict = "accepted" if accepted else "rejected"
+        raise AssertionError(
+            f"materialize result {result_kind!r} was {verdict} against "
+            f"allowed kinds {sorted(effective)!r}",
+        )
 
 
 def assert_generated_preview_invariant(
@@ -763,8 +808,92 @@ class TestGeneratedRootRelocation(unittest.TestCase):
             )
 
 
+class TestGeneratedPublicationResultTypeGate(unittest.TestCase):
+    """#882 item 6: patrol every (result kind × allowed tuple) world.
+
+    The deterministic pin in ``test_path_authority.py`` proves the default
+    rejects a ``MaterializeFailed``; this ranges over the whole cross product
+    so a widening of the default — or of any explicit tuple — is killed
+    wherever it lands.
+    """
+
+    @given(
+        result_kind=st.sampled_from(sorted(_RESULT_FACTORIES)),
+        allowed_kinds=st.one_of(
+            st.none(),
+            st.frozensets(
+                st.sampled_from(sorted(_RESULT_FACTORIES)),
+                min_size=1,
+            ),
+        ),
+    )
+    @example(result_kind="failed", allowed_kinds=None)
+    @example(result_kind="materialized", allowed_kinds=None)
+    @example(result_kind="guarded", allowed_kinds=None)
+    def test_only_allowed_result_kinds_pass_the_publication_checker(
+        self,
+        result_kind: str,
+        allowed_kinds: frozenset[str] | None,
+    ) -> None:
+        # Every other arm of the checker is satisfied, so the result-type
+        # gate is the only thing that can refuse this world.
+        result = _RESULT_FACTORIES[result_kind]()
+        try:
+            if allowed_kinds is None:
+                assert_publication_invariant(
+                    result=result,
+                    source_exists=True,
+                    expected_source_exists=True,
+                    destination_names=set(),
+                    expected_names=set(),
+                    artifact_names=[],
+                    name_max=255,
+                )
+            else:
+                assert_publication_invariant(
+                    result=result,
+                    source_exists=True,
+                    expected_source_exists=True,
+                    destination_names=set(),
+                    expected_names=set(),
+                    artifact_names=[],
+                    name_max=255,
+                    allowed_result_types=tuple(
+                        _RESULT_TYPES[kind] for kind in sorted(allowed_kinds)
+                    ),
+                )
+        except AssertionError:
+            accepted = False
+        else:
+            accepted = True
+
+        assert_result_type_gate(
+            accepted=accepted,
+            result_kind=result_kind,
+            allowed_kinds=allowed_kinds,
+        )
+
+
 class TestPathAuthorityProofCheckers(unittest.TestCase):
     """Known-bad proof checks: every invariant checker must reject a lie."""
+
+    def test_result_type_gate_trips_when_the_default_admits_a_refusal(
+        self,
+    ) -> None:
+        with self.assertRaises(AssertionError):
+            assert_result_type_gate(
+                accepted=True, result_kind="failed", allowed_kinds=None,
+            )
+
+    def test_result_type_gate_trips_when_an_allowed_kind_is_refused(
+        self,
+    ) -> None:
+        with self.assertRaises(AssertionError):
+            assert_result_type_gate(
+                accepted=False,
+                result_kind="failed",
+                allowed_kinds=frozenset({"failed"}),
+            )
 
     def test_publication_checker_rejects_overwrite_source_loss(self) -> None:
         with self.assertRaises(AssertionError):

--- a/tests/test_unused_import_audit_generated.py
+++ b/tests/test_unused_import_audit_generated.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import keyword
 import unittest
 
-from hypothesis import example, given, strategies as st
+from hypothesis import assume, example, given, strategies as st
 
 import tests._hypothesis_profiles  # noqa: F401 - registers suite/fuzz tiers
 from tests.test_unused_import_audit import (
@@ -250,8 +250,7 @@ class TestGeneratedVultureWhitelistFreshness(unittest.TestCase):
         old_line: int,
         new_line: int,
     ) -> None:
-        if old_line == new_line:
-            return
+        assume(old_line != new_line)
         committed = (_vulture_entry(symbol, old_line),)
         generated = (_vulture_entry(symbol, new_line),)
 

--- a/tests/test_world_invariants_generated.py
+++ b/tests/test_world_invariants_generated.py
@@ -7,7 +7,7 @@ import tempfile
 import unittest
 
 import msgspec
-from hypothesis import given, strategies as st
+from hypothesis import assume, given, strategies as st
 
 import tests._hypothesis_profiles  # noqa: F401  (loads active profile)
 from lib.beets_db import (
@@ -256,9 +256,7 @@ class TestWorldInvariantGenerated(unittest.TestCase):
         evidence_fingerprint: str,
         actual_fingerprint: str,
     ) -> None:
-        assume_distinct = evidence_fingerprint != actual_fingerprint
-        if not assume_distinct:
-            return
+        assume(evidence_fingerprint != actual_fingerprint)
         violations = check_evidence_disk_coherence((EvidenceDiskSnapshot(
             request_id=request_id,
             release_id=release_id,

--- a/tests/web/test_server_endpoints.py
+++ b/tests/web/test_server_endpoints.py
@@ -22,7 +22,7 @@ from urllib.error import HTTPError
 
 from hypothesis import example, given, settings, strategies as st
 
-from tests import _hypothesis_profiles  # noqa: F401 — registers active profile
+import tests._hypothesis_profiles  # noqa: F401 — registers active profile
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
 

--- a/tests/world_model/mirror_harness.py
+++ b/tests/world_model/mirror_harness.py
@@ -19,6 +19,7 @@ from hypothesis.stateful import RuleBasedStateMachine, invariant, precondition, 
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 import conftest  # noqa: E402, F401
 
+import tests._hypothesis_profiles  # noqa: E402, F401  (loads the active profile)
 from tests.beets_world import BeetsWorldRelease  # noqa: E402
 from tests.world_model.census_seeds import (  # noqa: E402
     STATEFUL_WORLD_CENSUS_SEEDS,

--- a/tests/world_model/state_machine.py
+++ b/tests/world_model/state_machine.py
@@ -39,6 +39,7 @@ from hypothesis.stateful import (
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 import conftest  # noqa: E402, F401
 
+import tests._hypothesis_profiles  # noqa: E402, F401  (loads the active profile)
 from tests.beets_world import (  # noqa: E402
     BeetsWorldRelease,
     HISTORICAL_PASSENGER_PATH_TEMPLATE,


### PR DESCRIPTION
Part of #882 (items 1 and 6). PR1 of 3.

## The burst could not run at all

`scripts/run_fuzz_tests.py::_discover_module_child` rejects any Hypothesis test whose effective `deadline` is not `None`. Two modules never imported `tests._hypothesis_profiles` — the module whose import side effect calls `settings.load_profile` — so they ran under the stock 200 ms deadline and **aborted discovery for the whole burst**:

```
RuntimeError: Hypothesis test has non-None deadline:
  tests.test_dispatch_quarantine_root_generated…: timedelta(milliseconds=200)
```

`scripts/fuzz_burst.sh` is the randomized burst the repo requires after quality-policy changes. It was not slow or flaky — it was structurally impossible, so it was either skipped or hand-scoped.

## The unwired set was 8 modules, not 2

The two blockers, plus `test_final_gate_receipt_generated.py` and `test_album_source.py` (both pin or inherit a deadline that hides the abort while still running non-derandomized and example-DB-backed inside the *deterministic* suite tier), plus `test_mb_api.py` and `tests/web/test_server_endpoints.py` (non-canonical `from tests import …` spelling), plus the two `world_model` helpers — included with a knob-by-knob proof that it is a no-op today (all 11 settings knobs compared under stock vs both tiers: zero difference).

`test_album_source.py` is outside the `test_*_generated.py` glob, which is why the guard is scoped to **every** test module that imports `hypothesis`.

## Two gates, because one of them is not enough

- **Source audit** (`tests/test_hypothesis_profile_audit.py`) — stdlib `ast` over import statements. Fails closed on a missing, aliased, `from`-form, or nested import, **and on an import placed below the module's first `class`/`def`**: decorators snapshot `settings.default` at decoration time, so a late import is a no-op. Review caught this — a module with the import at the bottom passed the audit and still reproduced the original blocker.
- **Runtime assertion** — `assert_hypothesis_deadlines_disabled` now lives in `scripts/run_python_tests.py` and runs on every suite target, so the suite tier enforces what only the fuzz tier did. `run_fuzz_tests.py` imports it instead of keeping its own copy (~60 duplicated lines deleted).

Enumeration behind the assertion, whole tree under the suite tier: **281 modules, 355 Hypothesis tests, 0 with a non-`None` deadline, 0 unresolvable.** Scoped to `deadline` only — `scripts/world_model_burst.sh` exports `CRATEDIGGER_WORLD_RANDOMIZED=1`, which legitimately flips `derandomize` and attaches a real example database.

## Two properties that were patrolling almost nothing

- `test_force_import_service_generated` drew two booleans: **4 distinct worlds against a 20,000-example budget**, never requested. A mutant widening `beets_staging_dir`'s marker set to also authorize `wrong_matches` — a real widening of a quarantine authority boundary — **survived 215 tests**. Widened to `root × marker × missing × nested` (36 worlds, oracle from the marker table); the mutant now dies on the explicit staging/`wrong_matches` example while the other 213 tests still pass, so the kill is attributable to the widening.
- `test_dispatch_quarantine_root_generated` discarded colliding worlds with a bare `return`, which spends the budget as a **pass**: 31.3% of the suite tier and 28.7% of the fuzz tier were vacuous. Now `assume()`; both tiers run 100% real worlds. Three more generated modules had the same defect (one discarded a local literally named `assume_distinct`) — found by manual pass, no scanner built.

## Item 6

`assert_publication_invariant`'s `allowed_result_types` default was itself unguarded: a mutant widening it to admit `MaterializeFailed` survived the suite. Now pinned bidirectionally — three coordinated edits are required to move it undetected.

## Validation

Whole-repo `pyright --threads 4` **0 errors**; production strict config **0 errors**. Full burst on the integrated tree: **ALL GREEN, 88 modules / 946 tests / 2,704 targets / 819.7s** — the first completed run in this repo's history.
