### PR TITLE
test(audit): every Hypothesis property must use every input it draws

### DIFF
--- a/docs/generated-testing.md
+++ b/docs/generated-testing.md
@@ -75,6 +75,7 @@ Hunting — Generated-First".
 | `tests/test_convergence_runner_generated.py` | `lib/convergence.py::run_convergence_steps` | every registered convergence step is attempted exactly once in declared order even when any arbitrary subset raises; Phase 0 order and the end-of-cycle harvest-before-purge constraint are pinned as registry data rather than source inspection; import failures are isolated like call failures |
 | `tests/test_current_library_quality_generated.py` | `BeetsDB.check_mbids_detail` + `lib.banding.band_from_detail` | current beets projections preserve the positive-track minimum as floor data, expose the positive-track mean explicitly, and select that mean for codec-aware rank; the known-bad min-selected mutant is rejected |
 | `tests/test_unused_import_audit_generated.py` | pinned Ruff `F401`/`F811` source-local analysis plus exact Vulture-whitelist freshness | an import is live only through its own binding in the importing module; same-named peer uses, parameter/comprehension shadows, and rebindings cannot mask it; exact intentional redundant-alias baselines reject expansions, duplicate identities, and stale entries even though Ruff accepts explicit re-exports; unchanged Vulture entries remain valid while any generated source-location move is stale byte-for-byte; planted aggregate-name, baseline-delta, and name-only Vulture faults qualify the checkers |
+| `tests/test_property_input_audit_generated.py` | the bounded drawn-input audit in `tests/test_property_input_audit.py`, which scans every Hypothesis property under `tests/` | a property's unused-input verdict equals an independent oracle across module/method/nested containers, keyword/positional `@given` and stateful `@rule` forms, and call/attribute/f-string/closure/comprehension uses versus `del`/never-mentioned/assign-only inputs; the checker trips exactly when an input is ignored and reports a stale allowlist entry otherwise; bare, `*args`, `**kwargs`, mixed, surplus-positional, unknown-keyword, and variadic shapes fail closed even when allowlisted; a `del`-only checker that misses never-mentioned inputs is known-bad. The #868 shape (`del album, download`) is pinned as an `@example` |
 | `tests/test_import_one_argparse_generated.py` | the bounded `harness/import_one.py` argparse destination/direct-read contract | generated declared/read destination worlds pass exactly on equality and reject either-direction drift; the historical conditional `args.filetype` read is pinned, hyphen normalization and explicit `dest` values come from real argparse actions, and a union-based checker that would hide an undeclared read is known-bad |
 | `tests/test_js_ast_generated.py` | flake-pinned tree-sitter JavaScript structural audits | supported direct payload literals produce exactly the independent field oracle across raw/escaped identifiers, shorthand, quoted/computed, nested, array, comment, string, template, Unicode, and ordering worlds; production payload fixtures use exact local aliases registered from the real renderer module, while raw renderer references, default/namespace/alternate imports, non-top-level or shadowed `__test__` registrations, computed `__test__` fixture calls, spreads, elisions, fixture indirection, and methods fail closed without attempting JavaScript dataflow inference; independent boundary worlds vary lexical scopes, repeated names, `let`/`const`, before/after member mutation, duplicate keys, registration/import shapes, unknown selectors, full browser-global-rooted semantic Object chains, and target expressions; unrelated modules and inert strings remain valid; emitted window handlers preserve ECMAScript raw/cooked escape semantics (including Unicode line continuations and lone surrogates), while bindings normalize escaped keys, treat full member chains rooted at `window`/`globalThis`/`self` as browser globals, reject every computed call rooted at semantic `Object` in a window-binding owner, and accept only exact direct `Object.assign(window, {...})` shapes across multiple blocks; planted quoted-key, template-interpolation, state-boundary, fail-open binding, and missing-binding mutants qualify the checkers |
 | `tests/test_issue_reference_contract_generated.py` | `scripts/audit_issue_references.py` | implementation PR bodies and branch commit messages never use any GitHub auto-closing keyword with same-repo, cross-repo, or full-URL issue references across case, colon, whitespace, and issue-number worlds; canonical `Refs #N` and plain issue URLs remain valid, with the real premature-close shapes for issues #598 and #609 pinned as known-bad examples |
@@ -435,8 +436,53 @@ deeper randomized entropy, 2 survivors fixed in PR #555
 (`assert_below_gate_never_stops_search` and the
 `_SPECTRAL_OVERRIDE_DECISIVE_WORLD` parity pin).
 
+## Every property must use every input it draws
+
+Issue #882 item 5. During the #868 series one generated property invoked no
+production symbol at all: it `del`'d its generated input and then asserted a
+relation between two test-local constants, under a "real materialize worlds,
+real filesystem" docstring banner. It survived **0 of 7** planted mutants,
+including one that deleted a containment check outright and failed 25 other
+tests. A property that ignores its world patrols nothing, and nothing stopped
+the next one.
+
+`tests/test_property_input_audit.py` closes that: it walks every `.py` under
+`tests/` with the stdlib `ast` module and requires that each parameter bound
+by `@given`, `@rule`, or `@initialize` is loaded somewhere in that function's
+body. Never mentioned, only `del`'d, or only assigned — all three are the
+defect. `@invariant` is out of scope because it binds no arguments at all.
+
+- The audit **fails closed**: a decorator or signature shape it cannot map
+  (bare decorator, `*args`, `**kwargs`, mixed positional/keyword, surplus
+  positional strategies, a keyword that is not a parameter, a variadic
+  signature) fails rather than passes, and the allowlist cannot excuse it.
+  Aliasing a decorator import (`from hypothesis import given as g`) fails
+  too, since discovery is by decorator name.
+- `PROPERTY_INPUT_ALLOWLIST` carries **one** entry — the deliberate
+  known-bad self-test in `tests/test_quality_generated.py`, whose planted
+  decider must ignore its world for the RED proof to mean anything. The list
+  is the contract: one line of rationale per entry, and a stale entry that no
+  longer flags fails the audit.
+- It is a **bounded syntactic fact**, not a semantic scanner
+  (`.claude/rules/code-quality.md` § "Semantic source scanners are
+  prohibited"). It never infers what the body does with the value. Known
+  misses are documented in the module docstring: `given(...)(func)` call
+  form, a name shadowed by a nested function's own parameter, and a name
+  rebound before it is loaded.
+- The criterion issue #882 originally proposed — "every property must
+  reference at least one production symbol" — was **measured and rejected**:
+  44 of 352 properties (12.5%) flag falsely, because they drive production
+  through a module path inside a string passed to `node`, through a
+  subprocessed script, or through `self.<attr>` in a state machine. Making
+  it work needs a string-path registry plus subprocess argv analysis, which
+  is the prohibited scanner. The module docstring records the measurement so
+  it is not re-proposed.
+
 ## Writing new generated tests
 
+- **Every drawn input must be used.** See the section above; the audit is
+  automatic, so the practical rule is: if a property does not need an input,
+  do not draw it.
 - **Invariants come first.** New features with a generated-testable surface
   (pure decisions, lifecycles/state machines, wire or event ingestion)
   write their policy invariants down in the issue/plan before

--- a/docs/generated-testing.md
+++ b/docs/generated-testing.md
@@ -75,7 +75,7 @@ Hunting — Generated-First".
 | `tests/test_convergence_runner_generated.py` | `lib/convergence.py::run_convergence_steps` | every registered convergence step is attempted exactly once in declared order even when any arbitrary subset raises; Phase 0 order and the end-of-cycle harvest-before-purge constraint are pinned as registry data rather than source inspection; import failures are isolated like call failures |
 | `tests/test_current_library_quality_generated.py` | `BeetsDB.check_mbids_detail` + `lib.banding.band_from_detail` | current beets projections preserve the positive-track minimum as floor data, expose the positive-track mean explicitly, and select that mean for codec-aware rank; the known-bad min-selected mutant is rejected |
 | `tests/test_unused_import_audit_generated.py` | pinned Ruff `F401`/`F811` source-local analysis plus exact Vulture-whitelist freshness | an import is live only through its own binding in the importing module; same-named peer uses, parameter/comprehension shadows, and rebindings cannot mask it; exact intentional redundant-alias baselines reject expansions, duplicate identities, and stale entries even though Ruff accepts explicit re-exports; unchanged Vulture entries remain valid while any generated source-location move is stale byte-for-byte; planted aggregate-name, baseline-delta, and name-only Vulture faults qualify the checkers |
-| `tests/test_property_input_audit_generated.py` | the bounded drawn-input audit in `tests/test_property_input_audit.py`, which scans every Hypothesis property under `tests/` | a property's unused-input verdict equals an independent oracle across module/method/nested containers, keyword/positional `@given` and stateful `@rule` forms, and call/attribute/f-string/closure/comprehension uses versus `del`/never-mentioned/assign-only inputs; the checker trips exactly when an input is ignored and reports a stale allowlist entry otherwise; bare, `*args`, `**kwargs`, mixed, surplus-positional, unknown-keyword, and variadic shapes fail closed even when allowlisted; a `del`-only checker that misses never-mentioned inputs is known-bad. The #868 shape (`del album, download`) is pinned as an `@example` |
+| `tests/test_property_input_audit_generated.py` | the bounded drawn-input audit in `tests/test_property_input_audit.py`, which scans every Hypothesis property under `tests/` | a property's unused-input verdict equals an independent oracle across module/method/nested containers, keyword/positional `@given` and stateful `@rule` forms, and call/attribute/f-string/closure/comprehension uses versus `del`/never-mentioned/assign-only inputs; the checker trips exactly when an input is ignored and reports a stale allowlist entry otherwise; bare, `*args`, `**kwargs`, mixed, surplus-positional, unknown-keyword, and variadic shapes fail closed even when allowlisted; a `del`-only checker that misses never-mentioned inputs is known-bad. The #868 shape (a nested property that discards `album`/`download`) is pinned as an `@example` |
 | `tests/test_import_one_argparse_generated.py` | the bounded `harness/import_one.py` argparse destination/direct-read contract | generated declared/read destination worlds pass exactly on equality and reject either-direction drift; the historical conditional `args.filetype` read is pinned, hyphen normalization and explicit `dest` values come from real argparse actions, and a union-based checker that would hide an undeclared read is known-bad |
 | `tests/test_js_ast_generated.py` | flake-pinned tree-sitter JavaScript structural audits | supported direct payload literals produce exactly the independent field oracle across raw/escaped identifiers, shorthand, quoted/computed, nested, array, comment, string, template, Unicode, and ordering worlds; production payload fixtures use exact local aliases registered from the real renderer module, while raw renderer references, default/namespace/alternate imports, non-top-level or shadowed `__test__` registrations, computed `__test__` fixture calls, spreads, elisions, fixture indirection, and methods fail closed without attempting JavaScript dataflow inference; independent boundary worlds vary lexical scopes, repeated names, `let`/`const`, before/after member mutation, duplicate keys, registration/import shapes, unknown selectors, full browser-global-rooted semantic Object chains, and target expressions; unrelated modules and inert strings remain valid; emitted window handlers preserve ECMAScript raw/cooked escape semantics (including Unicode line continuations and lone surrogates), while bindings normalize escaped keys, treat full member chains rooted at `window`/`globalThis`/`self` as browser globals, reject every computed call rooted at semantic `Object` in a window-binding owner, and accept only exact direct `Object.assign(window, {...})` shapes across multiple blocks; planted quoted-key, template-interpolation, state-boundary, fail-open binding, and missing-binding mutants qualify the checkers |
 | `tests/test_issue_reference_contract_generated.py` | `scripts/audit_issue_references.py` | implementation PR bodies and branch commit messages never use any GitHub auto-closing keyword with same-repo, cross-repo, or full-URL issue references across case, colon, whitespace, and issue-number worlds; canonical `Refs #N` and plain issue URLs remain valid, with the real premature-close shapes for issues #598 and #609 pinned as known-bad examples |
@@ -446,37 +446,57 @@ including one that deleted a containment check outright and failed 25 other
 tests. A property that ignores its world patrols nothing, and nothing stopped
 the next one.
 
-`tests/test_property_input_audit.py` closes that: it walks every `.py` under
-`tests/` with the stdlib `ast` module and requires that each parameter bound
-by `@given`, `@rule`, or `@initialize` is loaded somewhere in that function's
-body. Never mentioned, only `del`'d, or only assigned — all three are the
-defect. `@invariant` is out of scope because it binds no arguments at all.
+`tests/test_property_input_audit.py` catches the detectable tell: it walks
+every `.py` under `tests/` with the stdlib `ast` module and requires that each
+parameter bound by `@given`, `@rule`, or `@initialize` is loaded somewhere in
+that function's body. Never mentioned, only `del`'d, or only assigned over —
+all three are the defect. `@invariant` is out of scope because it binds no
+arguments at all (its pinned signature is
+`invariant(*, check_during_init: bool = False)`).
+
+**Read the guarantee in one direction only.** "Every drawn input is used" does
+NOT mean "every property drives production". The audit run against the pre-fix
+#868 module (`git show 20f309ac^:tests/test_materialize_evidence_generated.py`)
+does flag that property — but on its unused third input, `leaf`. The primary
+defect, indexing two test-local dicts instead of driving production, is
+invisible to this criterion and to any criterion the repository is willing to
+build (see the rejected criterion below). A property that passes this audit
+may still patrol nothing; only review and mutant-kill counts show that.
 
 - The audit **fails closed**: a decorator or signature shape it cannot map
   (bare decorator, `*args`, `**kwargs`, mixed positional/keyword, surplus
   positional strategies, a keyword that is not a parameter, a variadic
   signature) fails rather than passes, and the allowlist cannot excuse it.
   Aliasing a decorator import (`from hypothesis import given as g`) fails
-  too, since discovery is by decorator name.
-- `PROPERTY_INPUT_ALLOWLIST` carries **one** entry — the deliberate
-  known-bad self-test in `tests/test_quality_generated.py`, whose planted
-  decider must ignore its world for the RED proof to mean anything. The list
-  is the contract: one line of rationale per entry, and a stale entry that no
-  longer flags fails the audit.
+  too, since discovery is by decorator name. A future DRY idiom such as
+  `@given(**_COMMON_STRATEGIES)` is therefore a hard build break until the
+  audit is extended — deliberate: an unmappable decorator must not pass.
+- `PROPERTY_INPUT_ALLOWLIST` is **empty and armed**, the same ratchet shape as
+  `WEB_HARNESS_MOCK_BASELINE` in `tests/_mock_audit_scanner.py`. The one
+  property that used to flag — the planted-bad-decider self-test in
+  `tests/test_quality_generated.py` — now passes its world to a decider that
+  ignores it, which models "a decider that ignores its world" more faithfully
+  than discarding the world did. A stale entry that no longer flags also fails
+  the audit.
 - It is a **bounded syntactic fact**, not a semantic scanner
   (`.claude/rules/code-quality.md` § "Semantic source scanners are
-  prohibited"). It never infers what the body does with the value. Known
-  misses are documented in the module docstring: `given(...)(func)` call
-  form, a name shadowed by a nested function's own parameter, and a name
-  rebound before it is loaded.
+  prohibited"). It never infers what the body does with the value. The module
+  docstring names the ceiling — all fail-open, all with zero live instances
+  today, none to be closed case by case: a drawn input loaded only inside an
+  assertion message or `subTest` label (the likeliest escape, and one that
+  reads as better failure text); binding constructs that mask an unused input
+  (`for x in ...`, `with ... as x`, `except E as x`, comprehension targets);
+  non-import decorator aliases (`_g = given`, wrapper functions,
+  `partial(given)`); `given(...)(func)` call form; and shadowing or rebinding
+  before a load.
 - The criterion issue #882 originally proposed — "every property must
   reference at least one production symbol" — was **measured and rejected**:
-  44 of 352 properties (12.5%) flag falsely, because they drive production
-  through a module path inside a string passed to `node`, through a
-  subprocessed script, or through `self.<attr>` in a state machine. Making
-  it work needs a string-path registry plus subprocess argv analysis, which
-  is the prohibited scanner. The module docstring records the measurement so
-  it is not re-proposed.
+  44 of the 352 properties in `tests/test_*_generated.py` (12.5%) flag
+  falsely, because they drive production through a module path inside a
+  string passed to `node`, through a subprocessed script, or through
+  `self.<attr>` in a state machine. Making it work needs a string-path
+  registry plus subprocess argv analysis, which is the prohibited scanner.
+  The module docstring records the measurement so it is not re-proposed.
 
 ## Writing new generated tests
 

--- a/tests/test_property_input_audit.py
+++ b/tests/test_property_input_audit.py
@@ -50,12 +50,19 @@ tuning problem; it is the wrong criterion. Keep this paragraph: the
 measurement is the expensive part of the finding.
 
 The adopted criterion, by contrast, measured over the whole ``tests/`` tree
-at that same revision: 383
-property-shaped functions (351 ``@given``, 23 ``@rule``, 1 ``@initialize``,
-8 ``@invariant``), of which 375 are in scope here; zero unclassifiable
-shapes; and exactly **one** flagged function — the deliberate known-bad
-self-test in ``PROPERTY_INPUT_ALLOWLIST`` below. A one-entry allowlist over
-the whole repository, and it would have caught the #868 defect.
+at that same revision: 383 property-shaped functions (351 ``@given``, 23
+``@rule``, 1 ``@initialize``, 8 ``@invariant``), of which 375 are in scope
+here; zero unclassifiable shapes; and exactly **one** flagged function — the
+deliberate known-bad self-test in ``tests/test_quality_generated.py``, whose
+planted decider now RECEIVES the world it ignores, so it uses its drawn
+inputs and the allowlist below is **permanently empty**.
+
+Independently confirmed against the real defect: the audit run over the
+pre-fix ``tests/test_materialize_evidence_generated.py``
+(``git show 20f309ac^``) flags
+``test_distinct_causes_never_share_a_reason`` on its unused ``leaf`` input.
+Note what that does and does not prove — see the one-directional caveat in
+``docs/generated-testing.md``.
 
 Scope: ``@given``, ``@rule``, ``@initialize``
 --------------------------------------------
@@ -65,32 +72,68 @@ are in scope. ``@rule``/``@initialize``'s ``target=`` / ``targets=`` keywords
 name Bundles for the *return* value and bind no parameter, so they are not
 drawn inputs.
 
-``@invariant`` is deliberately **out** of scope: it binds no arguments at all
-(its only keyword, ``check_during_reuse``, is a setting, not a strategy), so
-an invariant method has no drawn inputs and the check would be vacuous.
-Treating its settings keyword as a drawn input would fail closed on a
-perfectly ordinary member, which is a false positive, not a guard.
+``@invariant`` is deliberately **out** of scope: it binds no arguments at
+all. Its signature in the pinned Hypothesis 6.156.1 is
+``invariant(*, check_during_init: bool = False)`` — one setting, no
+strategies, and passing a strategy (``@invariant(world=st.none())``) raises
+``TypeError``. So an invariant method has no drawn inputs and the check would
+be vacuous, while treating its setting as a drawn input would fail closed on
+a perfectly ordinary member: a false positive, not a guard.
 
-Known limits (documented, not accidental): a property constructed by calling
-``given(...)(func)`` instead of decorating is outside the grammar; a drawn
-name shadowed by a nested function's own parameter of the same name reads as
-used; and a name that is rebound and then loaded reads as used, because
-distinguishing that from an ordinary use needs the flow analysis this audit
-refuses to do. All three are misses, not build breaks — the audit never
-guesses. A name with no ``Load`` at all (never mentioned, only ``del``'d,
-only assigned) is the defect it does catch.
+Known limits — the ceiling, stated so it is not mistaken for coverage
+--------------------------------------------------------------------
+Every one of these is a **miss** (fail-open), never a false build break, and
+each has **zero live instances** in ``tests/`` today. Closing them needs the
+data-flow, scope, or alias tracking that
+``.claude/rules/code-quality.md`` forbids, and its "Good enough is a valid
+stopping condition" clause applies: the production contract is stated
+plainly and behaviour tests pin the known failure modes. Do not extend this
+audit syntax case by syntax case.
 
-Aliasing the decorator import (``from hypothesis import given as g``) would
-also evade discovery, so ``assert_unaliased_property_imports`` fails closed
-on it.
+1. **The diagnostic-position escape — the likeliest one.** A drawn input
+   loaded only inside an assertion message passes:
+   ``assert A == B, f"world={world}"``, ``self.assertEqual(a, b, world)``,
+   ``with self.subTest(world=world):``. It is one keystroke out of a trip
+   and it *reads* as an improvement (better failure text) — the #868 fix
+   itself added exactly such an f-string. A ``Load`` is a ``Load``; this
+   audit does not judge position.
+2. **Binding constructs that mask an unused input**, the same family as the
+   rebind limit: ``for world in ...``, ``with ... as world``,
+   ``except E as world``, and comprehension targets — ``[world for world in
+   xs]`` is a separate scope that never touches the drawn name, yet leaves a
+   ``Load`` of it behind.
+3. **Discovery is by decorator NAME only.** ``assert_unaliased_property_imports``
+   fails closed on ``from hypothesis import given as g``, but a module-level
+   rebind (``_g = given``), a local wrapper (``def my_given(**kw): return
+   given(**kw)``), or ``partial(given)`` evade discovery silently. These are
+   deliberate-circumvention shapes and are outside the grammar by
+   construction.
+4. A property constructed by calling ``given(...)(func)`` instead of
+   decorating is outside the grammar; a drawn name shadowed by a nested
+   function's own parameter reads as used; and a name rebound before it is
+   loaded reads as used.
+
+What it does catch, always: a drawn name with no ``Load`` anywhere in the
+body — never mentioned, only ``del``'d, only assigned over.
+
+The fail-closed edge cuts the other way too: ``@given(*strategies)`` and
+``@given(**strategies)`` are unclassifiable with no allowlist escape, so a
+future DRY idiom such as ``@given(**_COMMON_STRATEGIES)`` is a hard build
+break until this audit is extended to map it. That is the intended trade —
+an unmappable decorator must never pass silently.
 """
 
 from __future__ import annotations
 
 import ast
 from dataclasses import dataclass
+import functools
+import inspect
 from pathlib import Path
 import unittest
+
+from hypothesis import strategies as st
+from hypothesis.stateful import invariant
 
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -112,16 +155,15 @@ _UNALIASABLE_IMPORTS = PROPERTY_DECORATORS | {"invariant"}
 
 _IMPLICIT_FIRST_PARAMETERS = frozenset({"self", "cls"})
 
-# The list is the contract: one line of rationale per entry, keyed by
-# ``<repo-relative path>::<qualname>`` so it survives line shifts.
-PROPERTY_INPUT_ALLOWLIST: dict[str, str] = {
-    "tests/test_quality_generated.py::TestInvariantCheckersTripOnViolations."
-    "test_hypothesis_harness_detects_planted_bad_decider.prop": (
-        "Deliberate known-bad self-test: the planted decider ignores its world, "
-        "so the property must discard its drawn inputs to prove Hypothesis plus "
-        "the checker still trip. Using them would destroy the RED proof."
-    ),
-}
+# EMPTY, and armed — the same ratchet shape as
+# ``WEB_HARNESS_MOCK_BASELINE`` in ``tests/_mock_audit_scanner.py``. The one
+# property that used to flag (the planted-bad-decider self-test in
+# ``tests/test_quality_generated.py``) now passes its world to a decider that
+# ignores it, which models the planted defect more faithfully than discarding
+# the world did. If an entry ever becomes necessary, key it
+# ``<repo-relative path>::<qualname>`` (line shifts must not break it) and give
+# it one line of rationale — the list is the contract.
+PROPERTY_INPUT_ALLOWLIST: dict[str, str] = {}
 
 
 @dataclass(frozen=True)
@@ -267,16 +309,19 @@ def _walk_scopes(
         _walk_scopes(child, qualname, relpath, found)
 
 
-def find_property_functions(source: str, relpath: str) -> tuple[PropertyFunction, ...]:
-    """Return every Hypothesis property declared in one source file."""
+def _find_in_tree(tree: ast.Module, relpath: str) -> tuple[PropertyFunction, ...]:
     found: list[PropertyFunction] = []
-    _walk_scopes(ast.parse(source), "", relpath, found)
+    _walk_scopes(tree, "", relpath, found)
     return tuple(found)
 
 
-def assert_unaliased_property_imports(source: str, relpath: str) -> None:
-    """Reject aliased Hypothesis decorator imports, which evade discovery."""
-    for node in ast.walk(ast.parse(source)):
+def find_property_functions(source: str, relpath: str) -> tuple[PropertyFunction, ...]:
+    """Return every Hypothesis property declared in one source file."""
+    return _find_in_tree(ast.parse(source), relpath)
+
+
+def _check_unaliased_imports(tree: ast.Module, relpath: str) -> None:
+    for node in ast.walk(tree):
         if not isinstance(node, ast.ImportFrom):
             continue
         module = node.module or ""
@@ -290,16 +335,26 @@ def assert_unaliased_property_imports(source: str, relpath: str) -> None:
             )
 
 
+def assert_unaliased_property_imports(source: str, relpath: str) -> None:
+    """Reject aliased Hypothesis decorator imports, which evade discovery."""
+    _check_unaliased_imports(ast.parse(source), relpath)
+
+
+@functools.cache
 def scan_test_tree() -> tuple[PropertyFunction, ...]:
-    """Return every Hypothesis property under ``tests/``, imports checked."""
+    """Return every Hypothesis property under ``tests/``, imports checked.
+
+    Parses each file once and caches the whole sweep: several tests need the
+    live verdict and the tree does not change within a run.
+    """
     found: list[PropertyFunction] = []
     for path in sorted(TESTS_DIR.rglob("*.py")):
         if "__pycache__" in path.parts:
             continue
         relpath = path.relative_to(REPO_ROOT).as_posix()
-        source = path.read_text(encoding="utf-8")
-        assert_unaliased_property_imports(source, relpath)
-        found.extend(find_property_functions(source, relpath))
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        _check_unaliased_imports(tree, relpath)
+        found.extend(_find_in_tree(tree, relpath))
     return tuple(found)
 
 
@@ -338,21 +393,34 @@ def assert_every_drawn_input_used(
 
 
 class TestPropertyInputAudit(unittest.TestCase):
-    def test_live_tree_uses_every_drawn_input_outside_the_allowlist(self) -> None:
+    def test_live_tree_uses_every_drawn_input(self) -> None:
         properties = scan_test_tree()
 
         # A discovery break must not pass vacuously.
         self.assertGreater(len(properties), 300, "property discovery collapsed")
         assert_every_drawn_input_used(properties, PROPERTY_INPUT_ALLOWLIST)
 
-    def test_allowlisted_property_still_discards_its_drawn_inputs(self) -> None:
-        (key,) = PROPERTY_INPUT_ALLOWLIST
+    def test_allowlist_is_an_empty_armed_ratchet(self) -> None:
+        self.assertEqual(
+            PROPERTY_INPUT_ALLOWLIST,
+            {},
+            "the drawn-input allowlist is a permanently empty ratchet: a new "
+            "entry must be keyed '<repo-relative path>::<qualname>' and carry "
+            "one line of rationale, and must be argued for rather than added "
+            "to silence a trip",
+        )
+
+    def test_planted_bad_decider_property_uses_the_world_it_ignores(self) -> None:
+        key = (
+            "tests/test_quality_generated.py::TestInvariantCheckersTripOnViolations."
+            "test_hypothesis_harness_detects_planted_bad_decider.prop"
+        )
         by_key = {prop.key: prop for prop in scan_test_tree()}
 
         self.assertIn(key, by_key)
         self.assertEqual(by_key[key].drawn_inputs, ("album", "download"))
-        self.assertEqual(by_key[key].unused_inputs, ("album", "download"))
-        self.assertEqual(by_key[key].deleted_inputs, ("album", "download"))
+        self.assertEqual(by_key[key].unused_inputs, ())
+        self.assertEqual(by_key[key].deleted_inputs, ())
 
     def test_deleted_drawn_input_is_flagged(self) -> None:
         source = (
@@ -494,12 +562,20 @@ class TestPropertyInputAudit(unittest.TestCase):
     def test_invariant_members_are_deliberately_out_of_scope(self) -> None:
         source = (
             "class Machine(RuleBasedStateMachine):\n"
-            "    @invariant(check_during_reuse=False)\n"
+            "    @invariant(check_during_init=True)\n"
             "    def holds(self):\n"
             "        assert True\n"
         )
 
         self.assertEqual(find_property_functions(source, "tests/test_ok.py"), ())
+
+    def test_invariant_binds_no_strategies_in_the_pinned_hypothesis(self) -> None:
+        """The reason ``@invariant`` is out of scope, checked not asserted."""
+        parameters = inspect.signature(invariant).parameters
+
+        self.assertEqual(list(parameters), ["check_during_init"])
+        with self.assertRaises(TypeError):
+            invariant(world=st.none())  # pyright: ignore[reportCallIssue]
 
     def test_unclassifiable_shapes_fail_closed(self) -> None:
         cases = {

--- a/tests/test_property_input_audit.py
+++ b/tests/test_property_input_audit.py
@@ -1,0 +1,639 @@
+"""Bounded audit: every Hypothesis property must use every input it draws.
+
+Issue #882 item 5 — "unfalsifiable generated properties are undetectable
+today". During the #868 series one generated property invoked no production
+symbol at all: it ``del``'d its generated input and then asserted a relation
+between two test-local constants, under a "real materialize worlds, real
+filesystem" docstring banner. It survived 0 of 7 planted mutants, including
+one that deleted a containment check outright and failed 25 other tests. It
+was fixed in that series and a manual sweep found no second instance —
+nothing prevented the next one.
+
+The invariant this audit enforces
+--------------------------------
+**Every input a Hypothesis property draws must be referenced by that
+property.** A drawn input that is never loaded — never mentioned, only
+``del``'d, or only assigned over — means the generated world cannot reach
+the assertion, so the property patrols nothing. That was exactly the #868
+property's tell.
+
+This is a **bounded syntactic fact** checked with the stdlib ``ast`` module:
+which parameter names does the decorator bind, and does a ``Load`` of each
+name appear anywhere in the function body. There is no data-flow analysis,
+no inference about what the body *does* with the value, and no attempt to
+reproduce Python scoping. It stays inside
+``.claude/rules/code-quality.md`` § "Semantic source scanners are
+prohibited": one local syntactic fact, one deliberately bounded grammar,
+fail-closed on everything outside it.
+
+The criterion that was REJECTED (do not re-propose it)
+------------------------------------------------------
+Issue #882 item 5 proposed a different criterion: *"every property in
+``tests/test_*_generated.py`` must reference at least one production
+symbol."* It was measured over all 352 properties in those modules on
+``origin/main`` before this audit was written (337 ``@given`` + 9 ``@rule``
++ 6 ``@invariant``): **44 of them (12.5%) flag falsely.** They genuinely
+drive production code through channels no symbol-reference scan can see —
+
+* properties that drive production JavaScript by passing a production module
+  path inside a **string** to a ``node`` subprocess
+  (``tests/test_js_ast_generated.py``,
+  ``tests/test_owned_section_expansion_generated.py``);
+* properties that subprocess a production script;
+* ``RuleBasedStateMachine`` rules that reach production only through
+  ``self.<attr>`` (``tests/test_request_lifecycle_generated.py``).
+
+Making that criterion work would require a registry of
+production-paths-embedded-in-strings plus subprocess argv analysis — i.e.
+exactly the repository-wide semantic scanner the rules forbid. It is not a
+tuning problem; it is the wrong criterion. Keep this paragraph: the
+measurement is the expensive part of the finding.
+
+The adopted criterion, by contrast, measured over the whole ``tests/`` tree
+at that same revision: 383
+property-shaped functions (351 ``@given``, 23 ``@rule``, 1 ``@initialize``,
+8 ``@invariant``), of which 375 are in scope here; zero unclassifiable
+shapes; and exactly **one** flagged function — the deliberate known-bad
+self-test in ``PROPERTY_INPUT_ALLOWLIST`` below. A one-entry allowlist over
+the whole repository, and it would have caught the #868 defect.
+
+Scope: ``@given``, ``@rule``, ``@initialize``
+--------------------------------------------
+``@given``, ``hypothesis.stateful.rule`` and ``hypothesis.stateful.initialize``
+all bind drawn values to the decorated function's parameters, so all three
+are in scope. ``@rule``/``@initialize``'s ``target=`` / ``targets=`` keywords
+name Bundles for the *return* value and bind no parameter, so they are not
+drawn inputs.
+
+``@invariant`` is deliberately **out** of scope: it binds no arguments at all
+(its only keyword, ``check_during_reuse``, is a setting, not a strategy), so
+an invariant method has no drawn inputs and the check would be vacuous.
+Treating its settings keyword as a drawn input would fail closed on a
+perfectly ordinary member, which is a false positive, not a guard.
+
+Known limits (documented, not accidental): a property constructed by calling
+``given(...)(func)`` instead of decorating is outside the grammar; a drawn
+name shadowed by a nested function's own parameter of the same name reads as
+used; and a name that is rebound and then loaded reads as used, because
+distinguishing that from an ordinary use needs the flow analysis this audit
+refuses to do. All three are misses, not build breaks — the audit never
+guesses. A name with no ``Load`` at all (never mentioned, only ``del``'d,
+only assigned) is the defect it does catch.
+
+Aliasing the decorator import (``from hypothesis import given as g``) would
+also evade discovery, so ``assert_unaliased_property_imports`` fails closed
+on it.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+from pathlib import Path
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TESTS_DIR = REPO_ROOT / "tests"
+
+#: Decorators that bind generated values to the decorated function's
+#: parameters. See the module docstring for why ``invariant`` is excluded.
+PROPERTY_DECORATORS = frozenset({"given", "rule", "initialize"})
+
+#: Stateful decorators whose ``target``/``targets`` keywords route the return
+#: value to a Bundle instead of binding a parameter.
+_STATEFUL_DECORATORS = frozenset({"rule", "initialize"})
+_BUNDLE_ROUTING_KEYWORDS = frozenset({"target", "targets"})
+
+#: Every Hypothesis name whose import must stay unaliased for discovery to
+#: be honest — the in-scope decorators plus ``invariant``, so an alias cannot
+#: quietly rename a member out of the grammar either.
+_UNALIASABLE_IMPORTS = PROPERTY_DECORATORS | {"invariant"}
+
+_IMPLICIT_FIRST_PARAMETERS = frozenset({"self", "cls"})
+
+# The list is the contract: one line of rationale per entry, keyed by
+# ``<repo-relative path>::<qualname>`` so it survives line shifts.
+PROPERTY_INPUT_ALLOWLIST: dict[str, str] = {
+    "tests/test_quality_generated.py::TestInvariantCheckersTripOnViolations."
+    "test_hypothesis_harness_detects_planted_bad_decider.prop": (
+        "Deliberate known-bad self-test: the planted decider ignores its world, "
+        "so the property must discard its drawn inputs to prove Hypothesis plus "
+        "the checker still trip. Using them would destroy the RED proof."
+    ),
+}
+
+
+@dataclass(frozen=True)
+class PropertyFunction:
+    """One discovered Hypothesis property and its drawn-input verdict."""
+
+    relpath: str
+    qualname: str
+    lineno: int
+    drawn_inputs: tuple[str, ...]
+    unused_inputs: tuple[str, ...]
+    deleted_inputs: tuple[str, ...]
+    unclassified_reason: str | None
+
+    @property
+    def key(self) -> str:
+        return f"{self.relpath}::{self.qualname}"
+
+
+def _decorator_name(node: ast.expr) -> str | None:
+    """Return the trailing attribute/name of a decorator expression."""
+    target = node.func if isinstance(node, ast.Call) else node
+    if isinstance(target, ast.Name):
+        return target.id
+    if isinstance(target, ast.Attribute):
+        return target.attr
+    return None
+
+
+def _eligible_parameters(func: ast.FunctionDef | ast.AsyncFunctionDef) -> list[str]:
+    """Positional parameters Hypothesis can fill, minus ``self``/``cls``."""
+    positional = [arg.arg for arg in (*func.args.posonlyargs, *func.args.args)]
+    if positional and positional[0] in _IMPLICIT_FIRST_PARAMETERS:
+        positional = positional[1:]
+    return positional
+
+
+def _drawn_inputs(
+    func: ast.FunctionDef | ast.AsyncFunctionDef,
+    decorators: list[ast.expr],
+) -> tuple[tuple[str, ...], str | None]:
+    """Return the parameters the decorators bind, or a fail-closed reason."""
+    if func.args.vararg is not None or func.args.kwarg is not None:
+        return (), "variadic signature cannot be mapped to drawn inputs"
+
+    eligible = _eligible_parameters(func)
+    keyword_only = [arg.arg for arg in func.args.kwonlyargs]
+    drawn: list[str] = []
+
+    for decorator in decorators:
+        name = _decorator_name(decorator)
+        if not isinstance(decorator, ast.Call):
+            return (), f"bare @{name} decorator is not a call"
+        if any(isinstance(arg, ast.Starred) for arg in decorator.args):
+            return (), f"@{name} uses *args"
+        if any(kw.arg is None for kw in decorator.keywords):
+            return (), f"@{name} uses **kwargs"
+
+        routing = (
+            _BUNDLE_ROUTING_KEYWORDS
+            if name in _STATEFUL_DECORATORS
+            else frozenset()
+        )
+        keyword_names = [
+            kw.arg
+            for kw in decorator.keywords
+            if kw.arg is not None and kw.arg not in routing
+        ]
+        positional = list(decorator.args)
+
+        if positional and name in _STATEFUL_DECORATORS:
+            return (), f"@{name} takes keyword strategies only"
+        if positional and keyword_names:
+            return (), f"@{name} mixes positional and keyword strategies"
+        if len(positional) > len(eligible):
+            return (), (
+                f"@{name} draws {len(positional)} positional strategies for "
+                f"{len(eligible)} eligible parameters"
+            )
+        if positional:
+            drawn.extend(eligible[len(eligible) - len(positional):])
+        for keyword_name in keyword_names:
+            if keyword_name not in eligible and keyword_name not in keyword_only:
+                return (), f"@{name} draws {keyword_name!r}, which is not a parameter"
+        drawn.extend(keyword_names)
+
+    seen: dict[str, None] = {}
+    for name in drawn:
+        seen.setdefault(name, None)
+    return tuple(seen), None
+
+
+def _names_by_context(
+    func: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> tuple[frozenset[str], frozenset[str]]:
+    """Return ``(loaded, deleted)`` names anywhere in the function body."""
+    loaded: set[str] = set()
+    deleted: set[str] = set()
+    for statement in func.body:
+        for node in ast.walk(statement):
+            if not isinstance(node, ast.Name):
+                continue
+            if isinstance(node.ctx, ast.Load):
+                loaded.add(node.id)
+            elif isinstance(node.ctx, ast.Del):
+                deleted.add(node.id)
+    return frozenset(loaded), frozenset(deleted)
+
+
+def _walk_scopes(
+    node: ast.AST,
+    prefix: str,
+    relpath: str,
+    found: list[PropertyFunction],
+) -> None:
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            qualname = f"{prefix}.{child.name}" if prefix else child.name
+        else:
+            qualname = prefix
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            decorators = [
+                decorator
+                for decorator in child.decorator_list
+                if _decorator_name(decorator) in PROPERTY_DECORATORS
+            ]
+            if decorators:
+                drawn, reason = _drawn_inputs(child, decorators)
+                loaded, deleted = _names_by_context(child)
+                found.append(PropertyFunction(
+                    relpath=relpath,
+                    qualname=qualname,
+                    lineno=child.lineno,
+                    drawn_inputs=drawn,
+                    unused_inputs=tuple(
+                        name for name in drawn if name not in loaded
+                    ),
+                    deleted_inputs=tuple(
+                        name for name in drawn if name in deleted
+                    ),
+                    unclassified_reason=reason,
+                ))
+        _walk_scopes(child, qualname, relpath, found)
+
+
+def find_property_functions(source: str, relpath: str) -> tuple[PropertyFunction, ...]:
+    """Return every Hypothesis property declared in one source file."""
+    found: list[PropertyFunction] = []
+    _walk_scopes(ast.parse(source), "", relpath, found)
+    return tuple(found)
+
+
+def assert_unaliased_property_imports(source: str, relpath: str) -> None:
+    """Reject aliased Hypothesis decorator imports, which evade discovery."""
+    for node in ast.walk(ast.parse(source)):
+        if not isinstance(node, ast.ImportFrom):
+            continue
+        module = node.module or ""
+        if module != "hypothesis" and not module.startswith("hypothesis."):
+            continue
+        for alias in node.names:
+            assert not (alias.name in _UNALIASABLE_IMPORTS and alias.asname), (
+                f"{relpath}: Hypothesis decorator {alias.name!r} is imported as "
+                f"{alias.asname!r}; the drawn-input audit discovers properties by "
+                "decorator name, so aliasing it would hide the property"
+            )
+
+
+def scan_test_tree() -> tuple[PropertyFunction, ...]:
+    """Return every Hypothesis property under ``tests/``, imports checked."""
+    found: list[PropertyFunction] = []
+    for path in sorted(TESTS_DIR.rglob("*.py")):
+        if "__pycache__" in path.parts:
+            continue
+        relpath = path.relative_to(REPO_ROOT).as_posix()
+        source = path.read_text(encoding="utf-8")
+        assert_unaliased_property_imports(source, relpath)
+        found.extend(find_property_functions(source, relpath))
+    return tuple(found)
+
+
+def assert_every_drawn_input_used(
+    properties: tuple[PropertyFunction, ...],
+    allowlist: dict[str, str],
+) -> None:
+    """Require each property to use every input it draws, allowlist exact."""
+    unclassified = [
+        f"{prop.key} (line {prop.lineno}): {prop.unclassified_reason}"
+        for prop in properties
+        if prop.unclassified_reason is not None
+    ]
+    assert not unclassified, (
+        "unclassifiable Hypothesis property shapes (the drawn-input audit fails "
+        f"closed on shapes it cannot map): {unclassified!r}"
+    )
+
+    flagged = {prop.key: prop for prop in properties if prop.unused_inputs}
+    unexpected = sorted(key for key in flagged if key not in allowlist)
+    stale = sorted(key for key in allowlist if key not in flagged)
+    details = [
+        f"{flagged[key].key} (line {flagged[key].lineno}) never uses "
+        f"{list(flagged[key].unused_inputs)!r}"
+        + (
+            f" (discarded by del: {list(flagged[key].deleted_inputs)!r})"
+            if flagged[key].deleted_inputs
+            else ""
+        )
+        for key in unexpected
+    ]
+    assert not unexpected and not stale, (
+        f"Hypothesis properties that ignore a drawn input: {details!r}; "
+        f"stale allowlist entries that no longer flag: {stale!r}"
+    )
+
+
+class TestPropertyInputAudit(unittest.TestCase):
+    def test_live_tree_uses_every_drawn_input_outside_the_allowlist(self) -> None:
+        properties = scan_test_tree()
+
+        # A discovery break must not pass vacuously.
+        self.assertGreater(len(properties), 300, "property discovery collapsed")
+        assert_every_drawn_input_used(properties, PROPERTY_INPUT_ALLOWLIST)
+
+    def test_allowlisted_property_still_discards_its_drawn_inputs(self) -> None:
+        (key,) = PROPERTY_INPUT_ALLOWLIST
+        by_key = {prop.key: prop for prop in scan_test_tree()}
+
+        self.assertIn(key, by_key)
+        self.assertEqual(by_key[key].drawn_inputs, ("album", "download"))
+        self.assertEqual(by_key[key].unused_inputs, ("album", "download"))
+        self.assertEqual(by_key[key].deleted_inputs, ("album", "download"))
+
+    def test_deleted_drawn_input_is_flagged(self) -> None:
+        source = (
+            "@given(album=albums(), download=downloads())\n"
+            "def prop(album, download):\n"
+            "    del album, download\n"
+            "    assert planted()\n"
+        )
+
+        (prop,) = find_property_functions(source, "tests/test_planted.py")
+
+        self.assertEqual(prop.unused_inputs, ("album", "download"))
+        self.assertEqual(prop.deleted_inputs, ("album", "download"))
+        with self.assertRaisesRegex(AssertionError, "discarded by del"):
+            assert_every_drawn_input_used((prop,), {})
+
+    def test_never_mentioned_drawn_input_is_flagged(self) -> None:
+        source = (
+            "@given(world=worlds())\n"
+            "def prop(world):\n"
+            "    assert CONSTANT_A == CONSTANT_B\n"
+        )
+
+        (prop,) = find_property_functions(source, "tests/test_planted.py")
+
+        self.assertEqual(prop.unused_inputs, ("world",))
+        self.assertEqual(prop.deleted_inputs, ())
+        with self.assertRaisesRegex(AssertionError, "never uses"):
+            assert_every_drawn_input_used((prop,), {})
+
+    def test_store_only_drawn_input_is_flagged(self) -> None:
+        source = (
+            "@given(world=worlds())\n"
+            "def prop(world):\n"
+            "    world = fixed_world()\n"
+            "    assert check(FIXED_WORLD)\n"
+        )
+
+        (prop,) = find_property_functions(source, "tests/test_planted.py")
+
+        self.assertEqual(prop.unused_inputs, ("world",))
+        self.assertEqual(prop.deleted_inputs, ())
+
+    def test_rebinding_then_loading_reads_as_used(self) -> None:
+        """Documented limit: a Load anywhere counts, without flow analysis."""
+        source = (
+            "@given(world=worlds())\n"
+            "def prop(world):\n"
+            "    world = fixed_world()\n"
+            "    assert check(world)\n"
+        )
+
+        (prop,) = find_property_functions(source, "tests/test_planted.py")
+
+        self.assertEqual(prop.unused_inputs, ())
+
+    def test_ordinary_properties_use_their_inputs(self) -> None:
+        cases = {
+            "keyword": (
+                "@given(world=worlds())\n"
+                "def prop(world):\n"
+                "    assert check(world)\n"
+            ),
+            "positional": (
+                "@given(worlds(), seeds())\n"
+                "def prop(world, seed):\n"
+                "    assert check(world, seed)\n"
+            ),
+            "method": (
+                "class TestX:\n"
+                "    @given(world=worlds())\n"
+                "    def test_prop(self, world):\n"
+                "        assert check(world)\n"
+            ),
+            "interactive_data": (
+                "@given(data=st.data())\n"
+                "def prop(data):\n"
+                "    assert check(data.draw(worlds()))\n"
+            ),
+            "closure_use": (
+                "@given(world=worlds())\n"
+                "def prop(world):\n"
+                "    def inner():\n"
+                "        return world\n"
+                "    assert check(inner)\n"
+            ),
+            "example_pin": (
+                "@example(world=1)\n"
+                "@given(world=worlds())\n"
+                "def prop(world):\n"
+                "    assert check(world)\n"
+            ),
+            "stateful_rule": (
+                "class Machine(RuleBasedStateMachine):\n"
+                "    @rule(target=rows, world=worlds())\n"
+                "    def add(self, world):\n"
+                "        return self.db.add(world)\n"
+            ),
+            "keyword_only": (
+                "@given(world=worlds())\n"
+                "def prop(*, world):\n"
+                "    assert check(world)\n"
+            ),
+        }
+
+        for label, source in cases.items():
+            with self.subTest(label=label):
+                (prop,) = find_property_functions(source, "tests/test_ok.py")
+
+                self.assertIsNone(prop.unclassified_reason)
+                self.assertEqual(prop.unused_inputs, ())
+                assert_every_drawn_input_used((prop,), {})
+
+    def test_bundle_routing_keywords_are_not_drawn_inputs(self) -> None:
+        source = (
+            "class Machine(RuleBasedStateMachine):\n"
+            "    @rule(target=rows, targets=(rows,), world=worlds())\n"
+            "    def add(self, world):\n"
+            "        return self.db.add(world)\n"
+        )
+
+        (prop,) = find_property_functions(source, "tests/test_ok.py")
+
+        self.assertEqual(prop.drawn_inputs, ("world",))
+        self.assertIsNone(prop.unclassified_reason)
+
+    def test_given_target_keyword_stays_a_drawn_input(self) -> None:
+        source = (
+            "@given(target=worlds())\n"
+            "def prop(target):\n"
+            "    del target\n"
+        )
+
+        (prop,) = find_property_functions(source, "tests/test_planted.py")
+
+        self.assertEqual(prop.drawn_inputs, ("target",))
+        self.assertEqual(prop.unused_inputs, ("target",))
+
+    def test_invariant_members_are_deliberately_out_of_scope(self) -> None:
+        source = (
+            "class Machine(RuleBasedStateMachine):\n"
+            "    @invariant(check_during_reuse=False)\n"
+            "    def holds(self):\n"
+            "        assert True\n"
+        )
+
+        self.assertEqual(find_property_functions(source, "tests/test_ok.py"), ())
+
+    def test_unclassifiable_shapes_fail_closed(self) -> None:
+        cases = {
+            "bare_decorator": (
+                "@given\n"
+                "def prop(world):\n"
+                "    assert check(world)\n",
+                "bare @given",
+            ),
+            "star_args": (
+                "@given(*strategies)\n"
+                "def prop(world):\n"
+                "    assert check(world)\n",
+                r"@given uses \*args",
+            ),
+            "star_star_kwargs": (
+                "@given(**strategies)\n"
+                "def prop(world):\n"
+                "    assert check(world)\n",
+                r"@given uses \*\*kwargs",
+            ),
+            "mixed_positional_keyword": (
+                "@given(worlds(), seed=seeds())\n"
+                "def prop(world, seed):\n"
+                "    assert check(world, seed)\n",
+                "mixes positional and keyword",
+            ),
+            "too_many_positional": (
+                "@given(worlds(), seeds())\n"
+                "def prop(world):\n"
+                "    assert check(world)\n",
+                "2 positional strategies for 1 eligible",
+            ),
+            "keyword_is_not_a_parameter": (
+                "@given(planet=worlds())\n"
+                "def prop(world):\n"
+                "    assert check(world)\n",
+                "'planet', which is not a parameter",
+            ),
+            "variadic_signature": (
+                "@given(worlds())\n"
+                "def prop(*args):\n"
+                "    assert check(args)\n",
+                "variadic signature",
+            ),
+            "positional_stateful_rule": (
+                "class Machine(RuleBasedStateMachine):\n"
+                "    @rule(worlds())\n"
+                "    def add(self, world):\n"
+                "        return self.db.add(world)\n",
+                "keyword strategies only",
+            ),
+        }
+
+        for label, (source, expected) in cases.items():
+            with self.subTest(label=label):
+                (prop,) = find_property_functions(source, "tests/test_odd.py")
+
+                self.assertIsNotNone(prop.unclassified_reason)
+                self.assertRegex(str(prop.unclassified_reason), expected)
+                with self.assertRaisesRegex(AssertionError, "unclassifiable"):
+                    assert_every_drawn_input_used((prop,), {})
+
+    def test_unclassifiable_shape_is_not_excused_by_the_allowlist(self) -> None:
+        source = (
+            "@given\n"
+            "def prop(world):\n"
+            "    assert check(world)\n"
+        )
+        (prop,) = find_property_functions(source, "tests/test_odd.py")
+
+        with self.assertRaisesRegex(AssertionError, "unclassifiable"):
+            assert_every_drawn_input_used((prop,), {prop.key: "excused"})
+
+    def test_stale_allowlist_entry_fails(self) -> None:
+        source = (
+            "@given(world=worlds())\n"
+            "def prop(world):\n"
+            "    assert check(world)\n"
+        )
+        (prop,) = find_property_functions(source, "tests/test_ok.py")
+
+        with self.assertRaisesRegex(AssertionError, "stale allowlist entries"):
+            assert_every_drawn_input_used(
+                (prop,),
+                {"tests/test_ok.py::gone": "no longer flags"},
+            )
+
+    def test_allowlist_entries_carry_a_rationale(self) -> None:
+        for key, rationale in PROPERTY_INPUT_ALLOWLIST.items():
+            with self.subTest(key=key):
+                self.assertIn("::", key)
+                self.assertGreater(len(rationale), 40)
+
+    def test_aliased_decorator_import_fails_closed(self) -> None:
+        cases = {
+            "given": "from hypothesis import given as g\n",
+            "rule": "from hypothesis.stateful import rule as r\n",
+            "invariant": "from hypothesis.stateful import invariant as inv\n",
+        }
+
+        for label, source in cases.items():
+            with self.subTest(label=label):
+                with self.assertRaisesRegex(AssertionError, "imported as"):
+                    assert_unaliased_property_imports(source, "tests/test_alias.py")
+
+    def test_ordinary_hypothesis_imports_are_accepted(self) -> None:
+        source = (
+            "from hypothesis import example, given, settings, strategies as st\n"
+            "from hypothesis.stateful import RuleBasedStateMachine, rule\n"
+            "import tests._hypothesis_profiles\n"
+        )
+
+        assert_unaliased_property_imports(source, "tests/test_ok.py")
+
+    def test_nested_property_is_discovered_by_qualname(self) -> None:
+        source = (
+            "class TestHarness:\n"
+            "    def test_planted_decider(self):\n"
+            "        @given(world=worlds())\n"
+            "        def prop(world):\n"
+            "            del world\n"
+            "        with self.assertRaises(AssertionError):\n"
+            "            prop()\n"
+        )
+
+        (prop,) = find_property_functions(source, "tests/test_planted.py")
+
+        self.assertEqual(
+            prop.key,
+            "tests/test_planted.py::TestHarness.test_planted_decider.prop",
+        )
+        self.assertEqual(prop.unused_inputs, ("world",))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_property_input_audit.py
+++ b/tests/test_property_input_audit.py
@@ -135,6 +135,8 @@ import unittest
 from hypothesis import strategies as st
 from hypothesis.stateful import invariant
 
+import tests._hypothesis_profiles  # noqa: F401 - loads the active profile
+
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 TESTS_DIR = REPO_ROOT / "tests"

--- a/tests/test_property_input_audit_generated.py
+++ b/tests/test_property_input_audit_generated.py
@@ -1,0 +1,243 @@
+"""Generated worlds for the drawn-input audit (issue #882 item 5).
+
+The deterministic pins in ``tests/test_property_input_audit.py`` prove the
+exact #868 shape — a property that ``del``'d its generated input under a
+"real worlds, real filesystem" banner. These properties patrol the space
+around it: any container, any decorator form, any mix of used / discarded /
+never-mentioned / rebound-only drawn inputs, plus the malformed shapes the
+audit must fail closed on.
+
+Profiles and promotion policy: tests/_hypothesis_profiles.py and
+docs/generated-testing.md.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from hypothesis import example, given, strategies as st
+
+import tests._hypothesis_profiles  # noqa: F401 - loads the active profile
+from tests.test_property_input_audit import (
+    PropertyFunction,
+    assert_every_drawn_input_used,
+    find_property_functions,
+)
+
+
+_RELPATH = "tests/test_synthetic_world.py"
+
+_NAMES = st.sampled_from(
+    ["alpha", "beta", "gamma", "delta", "world", "seed", "album", "download"]
+)
+
+#: Modes that leave a ``Load`` of the drawn name in the body, and modes that
+#: do not. The second group is the defect class.
+_USING_MODES = ("call", "attribute", "fstring", "closure", "comprehension")
+_IGNORING_MODES = ("deleted", "absent", "store_only")
+_MODES = st.sampled_from(_USING_MODES + _IGNORING_MODES)
+
+_INPUTS = st.lists(
+    st.tuples(_NAMES, _MODES),
+    min_size=1,
+    max_size=4,
+    unique_by=lambda pair: pair[0],
+)
+_CONTAINERS = st.sampled_from(["module", "method", "nested"])
+_DECORATORS = st.sampled_from(["given_kw", "given_pos", "rule_kw"])
+
+_MALFORMED = st.sampled_from([
+    "bare",
+    "star_args",
+    "star_star_kwargs",
+    "mixed",
+    "surplus_positional",
+    "unknown_keyword",
+    "variadic",
+])
+
+
+def _body_lines(name: str, mode: str) -> list[str]:
+    if mode == "call":
+        return [f"_sink({name})"]
+    if mode == "attribute":
+        return [f"_sink({name}.field)"]
+    if mode == "fstring":
+        return [f'_sink(f"{{{name}}}")']
+    if mode == "closure":
+        return ["def _inner():", f"    return {name}", "_sink(_inner)"]
+    if mode == "comprehension":
+        return [f"_sink([item for item in {name}])"]
+    if mode == "deleted":
+        return [f"del {name}"]
+    if mode == "store_only":
+        return [f"{name} = FIXED"]
+    if mode == "absent":
+        return []
+    raise AssertionError(f"unknown usage mode {mode!r}")
+
+
+def render_property(
+    inputs: list[tuple[str, str]],
+    container: str,
+    decorator: str,
+) -> str:
+    """Render one synthetic Hypothesis property module."""
+    names = [name for name, _mode in inputs]
+    if decorator == "given_pos":
+        decorator_line = "@given(" + ", ".join("st.none()" for _ in names) + ")"
+    elif decorator == "given_kw":
+        decorator_line = "@given(" + ", ".join(f"{n}=st.none()" for n in names) + ")"
+    else:
+        decorator_line = (
+            "@rule(target=rows, " + ", ".join(f"{n}=st.none()" for n in names) + ")"
+        )
+
+    body: list[str] = []
+    for name, mode in inputs:
+        body.extend(_body_lines(name, mode))
+    body.append("assert CHECKED")
+
+    if decorator == "rule_kw":
+        header = ["class Machine(RuleBasedStateMachine):"]
+        signature = "def step(self, " + ", ".join(names) + "):"
+        indent = 4
+    elif container == "module":
+        header = []
+        signature = "def prop(" + ", ".join(names) + "):"
+        indent = 0
+    elif container == "method":
+        header = ["class TestSynthetic:"]
+        signature = "def test_prop(self, " + ", ".join(names) + "):"
+        indent = 4
+    else:
+        header = ["class TestSynthetic:", "    def test_outer(self):"]
+        signature = "def prop(" + ", ".join(names) + "):"
+        indent = 8
+
+    pad = " " * indent
+    lines = [*header, pad + decorator_line, pad + signature]
+    lines.extend(pad + "    " + line for line in body)
+    if container == "nested" and decorator != "rule_kw":
+        lines.append(pad + "prop()")
+    return "\n".join(lines) + "\n"
+
+
+def render_malformed_property(name: str, shape: str) -> str:
+    """Render one shape the bounded grammar must refuse to classify."""
+    if shape == "bare":
+        decorator_line = "@given"
+    elif shape == "star_args":
+        decorator_line = "@given(*strategies)"
+    elif shape == "star_star_kwargs":
+        decorator_line = "@given(**strategies)"
+    elif shape == "mixed":
+        decorator_line = f"@given(st.none(), {name}=st.none())"
+    elif shape == "surplus_positional":
+        decorator_line = "@given(st.none(), st.none())"
+    elif shape == "unknown_keyword":
+        decorator_line = "@given(not_a_parameter=st.none())"
+    elif shape == "variadic":
+        decorator_line = "@given(st.none())"
+    else:
+        raise AssertionError(f"unknown malformed shape {shape!r}")
+
+    if shape == "mixed":
+        signature = f"def prop(other, {name}):"
+        body = f"    _sink(other, {name})"
+    elif shape == "variadic":
+        signature = f"def prop(*{name}):"
+        body = f"    _sink({name})"
+    else:
+        signature = f"def prop({name}):"
+        body = f"    _sink({name})"
+    return f"{decorator_line}\n{signature}\n{body}\n"
+
+
+def assert_no_deleted_drawn_inputs(prop: PropertyFunction) -> None:
+    """Known-bad checker: sees only ``del``, misses never-mentioned inputs."""
+    assert not prop.deleted_inputs, f"{prop.key} deletes {prop.deleted_inputs!r}"
+
+
+class TestGeneratedPropertyInputAudit(unittest.TestCase):
+    @example(
+        inputs=[("album", "deleted"), ("download", "deleted")],
+        container="nested",
+        decorator="given_kw",
+    )
+    @given(inputs=_INPUTS, container=_CONTAINERS, decorator=_DECORATORS)
+    def test_unused_verdict_matches_the_independent_oracle(
+        self,
+        inputs: list[tuple[str, str]],
+        container: str,
+        decorator: str,
+    ) -> None:
+        source = render_property(inputs, container, decorator)
+        expected = tuple(
+            name for name, mode in inputs if mode in _IGNORING_MODES
+        )
+
+        (prop,) = find_property_functions(source, _RELPATH)
+
+        self.assertIsNone(prop.unclassified_reason, source)
+        self.assertEqual(prop.drawn_inputs, tuple(name for name, _ in inputs))
+        self.assertEqual(prop.unused_inputs, expected, source)
+        self.assertEqual(
+            prop.deleted_inputs,
+            tuple(name for name, mode in inputs if mode == "deleted"),
+            source,
+        )
+
+    @given(inputs=_INPUTS, container=_CONTAINERS, decorator=_DECORATORS)
+    def test_checker_trips_exactly_when_an_input_is_ignored(
+        self,
+        inputs: list[tuple[str, str]],
+        container: str,
+        decorator: str,
+    ) -> None:
+        source = render_property(inputs, container, decorator)
+        ignored = [name for name, mode in inputs if mode in _IGNORING_MODES]
+
+        (prop,) = find_property_functions(source, _RELPATH)
+
+        if ignored:
+            with self.assertRaises(AssertionError):
+                assert_every_drawn_input_used((prop,), {})
+            assert_every_drawn_input_used((prop,), {prop.key: "allowlisted"})
+        else:
+            assert_every_drawn_input_used((prop,), {})
+            with self.assertRaisesRegex(AssertionError, "stale allowlist"):
+                assert_every_drawn_input_used((prop,), {prop.key: "stale"})
+
+    @given(name=_NAMES, shape=_MALFORMED)
+    def test_malformed_shapes_fail_closed_even_when_allowlisted(
+        self,
+        name: str,
+        shape: str,
+    ) -> None:
+        source = render_malformed_property(name, shape)
+
+        (prop,) = find_property_functions(source, _RELPATH)
+
+        self.assertIsNotNone(prop.unclassified_reason, source)
+        with self.assertRaisesRegex(AssertionError, "unclassifiable"):
+            assert_every_drawn_input_used((prop,), {prop.key: "excused"})
+
+    @given(inputs=_INPUTS, container=_CONTAINERS)
+    def test_known_bad_del_only_checker_accepts_a_never_mentioned_input(
+        self,
+        inputs: list[tuple[str, str]],
+        container: str,
+    ) -> None:
+        absent = [(name, "absent") for name, _mode in inputs]
+        source = render_property(absent, container, "given_kw")
+
+        (prop,) = find_property_functions(source, _RELPATH)
+
+        assert_no_deleted_drawn_inputs(prop)
+        with self.assertRaisesRegex(AssertionError, "never uses"):
+            assert_every_drawn_input_used((prop,), {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_quality_generated.py
+++ b/tests/test_quality_generated.py
@@ -1967,7 +1967,17 @@ class TestGeneratedEvidenceDecider(unittest.TestCase):
 # decider must be caught end-to-end through the Hypothesis machinery.
 # ===========================================================================
 
-def _planted_bad_import() -> SimResult:
+def _planted_bad_import(
+    album: AlbumState | None = None,
+    download: DownloadScenario | None = None,
+) -> SimResult:
+    """A decider handed a world that it ignores — it always imports.
+
+    The parameters exist so the planted defect is modelled faithfully: the
+    world REACHES this decider and never reaches the decision. Callers that
+    only need the bad result omit them.
+    """
+    del album, download  # the planted defect: the world never reaches the decision
     return SimResult(
         imported=True,
         keep_searching=False,
@@ -2323,9 +2333,9 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
                download=lossy_downloads())
         @settings(max_examples=5, derandomize=True, database=None)
         def prop(album, download):
-            del album, download  # the planted decider ignores its world
+            # The world reaches the planted decider, which ignores it.
             assert_lossy_not_imported_over_verified_lossless(
-                _planted_bad_import())
+                _planted_bad_import(album, download))
 
         with self.assertRaises(AssertionError):
             prop()


### PR DESCRIPTION
Part of #882 (item 5). PR2 of 3.

## The defect class

During the #868 series one generated property invoked no production symbol at all: it `del`'d its generated input and asserted a relation between two test-local constants, under a "real materialize worlds, real filesystem" docstring banner. It survived **0 of 7** mutants, including one that deleted a containment check outright and failed 25 other tests. It was fixed; nothing prevented the next one.

## The criterion the issue proposed is the wrong one — measured, not argued

#882 item 5 proposed "every property must reference at least one production symbol". Measured over all 352 properties in `tests/test_*_generated.py` on `origin/main`: **44 (12.5%) flag falsely.** They drive production through channels no symbol scan can see — production JS paths passed inside **strings** to `node` subprocesses, subprocess'd production scripts, and `RuleBasedStateMachine` rules reaching production only via `self.<attr>`. Making it work needs a registry of production-paths-in-strings plus subprocess argv analysis, i.e. exactly the repository-wide semantic scanner `.claude/rules/code-quality.md` forbids. That measurement is recorded verbatim in the module docstring so it is not re-proposed.

## The criterion that holds

**Every input a Hypothesis property draws must be loaded somewhere in its body.** Three shapes are the defect and all are caught uniformly as "no `Load` anywhere": never mentioned, only `del`'d, only assigned over.

Scope is `@given`, `@rule`, `@initialize` (all bind drawn values to parameters); Bundle `target=`/`targets=` are routing, not draws. `@invariant` is out of scope and the rationale is **checked, not asserted** — a test pins `inspect.signature(invariant)` and that passing a strategy raises `TypeError`, so the exclusion cannot rot.

Fail-closed on bare decorators, `*args`, `**kwargs`, surplus positional strategies, non-parameter keywords, and aliased decorator imports. The allowlist explicitly cannot excuse an unclassifiable shape.

## It catches the real defect

Run against the pre-fix file (`git show 20f309ac^:tests/test_materialize_evidence_generated.py`) it flags `test_distinct_causes_never_share_a_reason` on its unused `leaf` input.

Note the one-directional caveat, stated in both the docstring and the docs: this catches the detectable *tell*. The primary defect — indexing two test-local dicts instead of driving production — stays invisible to this criterion and to any criterion this repo will build.

## Allowlist: permanently empty

The one flagged function was the deliberate known-bad self-test. Rather than allowlist it, `_planted_bad_import()` now **receives** the world it ignores — a more faithful model of "a decider that ignores its world" than one taking no arguments. Verified the RED proof still goes RED: planting `imported=False` makes the property stop raising and the test fail.

Final verdict over the tree: **379 in-scope properties, 94 files, 0 unclassifiable, 0 flagged, allowlist size 0.**

## Known limits, stated so they are not mistaken for coverage

All fail-open, all zero live instances, all documented rather than chased: the diagnostic-position escape (a drawn input loaded only in an assertion message — one keystroke out of a trip, and the #868 fix itself added such an f-string), binding constructs (`for`/`with as`/`except as`/comprehension targets), and discovery being by decorator name only. Closing them needs the data-flow and alias tracking the rules forbid.

## Validation

12 mutants planted, 12 killed (the generated property kills 10 alone). 0 false positives across 16 legitimate idioms. Whole-repo `pyright --threads 4` 0 errors. Module runtime 6.0s → 2.4s via a scan cache.
