### PR TITLE
fix(recents): trace every classify literal to its producer, and fix the copy it exposed

### DIFF
--- a/.claude/rules/test-fidelity.md
+++ b/.claude/rules/test-fidelity.md
@@ -143,7 +143,7 @@ that cannot emit it, which is the whole diagnosis.
 
 ## Stronger enforcement (future work)
 
-The two rules above are guidance. Three layers of stronger enforcement, in order of ROI:
+The three rules above are guidance. Three layers of stronger enforcement, in order of ROI:
 
 ### 1. Struct-typed write interface (high ROI, moderate effort)
 

--- a/.claude/rules/test-fidelity.md
+++ b/.claude/rules/test-fidelity.md
@@ -73,6 +73,74 @@ result = resolve_youtube_album(
 The first form is preferred — if the helper doesn't exist yet, add it to
 `tests/fakes/` with the exception contract documented in its docstring.
 
+## Rule C — A copy pin's input comes from the producer, never from a literal
+
+**When a test pins operator-facing copy, the string that TRIGGERS that copy
+must be derived from the code that produces it — the producing function
+called for real, or the producing module's own exported constant. A
+hand-typed literal in a fixture is not evidence that anything can produce
+it.**
+
+This is Rule B one layer up. Rule B stops a fake from returning a shape
+production never returns; Rule C stops a fixture from feeding an *input*
+production never emits. Both failures look identical from inside the test:
+green, fluent, and describing a world that does not exist.
+
+**Forbidden anti-pattern:**
+
+```python
+# WRONG — the trigger is a string the test author invented. It exists
+# nowhere in the codebase, so the copy behind it is unreachable in
+# production and the assertion is unfalsifiable.
+presentation = present_failure(_evidence(
+    outcome="measurement_failed",
+    error_message="FilesystemAuthorityError: path is outside the library root"))
+self.assertEqual(
+    presentation.verdict,
+    "Measurement failed: installed path is outside the library root")
+```
+
+**Required pattern:**
+
+```python
+# RIGHT — the real authority function raises the real exception, composed
+# exactly the way lib/import_preview.py composes the persisted detail.
+with self.assertRaises(FilesystemAuthorityError) as caught:
+    with open_configured_quarantine_directory(outside, roots):
+        pass
+detail = f"{type(caught.exception).__name__}: {caught.exception}"
+presentation = present_failure(_evidence(
+    outcome="measurement_failed", error_message=detail))
+```
+
+**What this catches:** issue #868's shipped defect. The copy asserted that
+the *installed* path was outside the *library root*; the only string
+production can raise there is about the CANDIDATE's quarantine roots. Every
+fixture fed the invented literal by hand, so the wrong fact shipped fluent
+and nothing failed. Issue #882 found the same shape in `web/classify.py`:
+copy keyed on `no_candidates`, a scenario no producer has ever written,
+while the producing string (`mbid_not_found`, 50 live rows) fell through to
+the raw-token fallback.
+
+**When the trigger genuinely cannot be produced in-process** — a persisted
+enum, a DB column value, a decision name another worker writes — a literal
+is allowed only if a producer audit traces it. The audit owes three things:
+
+- the trigger is **SPELLED** as a string literal by a named production file
+  (parse, don't grep: a mention in a comment or docstring is not a
+  spelling, and that is exactly where a fabricated trigger hides);
+- the set of triggers to trace is **DERIVED** from the module under test by
+  introspection, never hand-listed, and an unrecognised match target
+  **fails closed**;
+- a trigger with no producer is legitimate only as a **HISTORICAL** one,
+  registered as such with the live-row evidence written down.
+
+Canonical implementations: `tests/test_failure_presentation.py::TestEveryTriggerHasAProducer`
+and `tests/test_classify_producer_audit.py`.
+
+**Side effect:** when the audit fails it names the literal and the producer
+that cannot emit it, which is the whole diagnosis.
+
 ## Stronger enforcement (future work)
 
 The two rules above are guidance. Three layers of stronger enforcement, in order of ROI:
@@ -114,7 +182,7 @@ When a new mirror adapter is added, the contract test forces the author to docum
 
 Both bugs from rounds 1 and 2 shipped with passing tests, passing pyright, passing vulture, and a clean review pass. They were only caught by adversarial / api-contract / correctness reviewers reading the code by hand against the migration SQL. That's not a sustainable detection method — the next bug of the same shape will ship.
 
-These rules don't replace review; they make the smell harder to introduce in the first place. If a future PR violates Rule A, the real-PG test will fail at PR time. If a future PR violates Rule B, the fake won't compile against the production exception contract.
+These rules don't replace review; they make the smell harder to introduce in the first place. If a future PR violates Rule A, the real-PG test will fail at PR time. If a future PR violates Rule B, the fake won't compile against the production exception contract. If a future PR violates Rule C, the producer audit names the literal and the module that cannot emit it.
 
 ## Related memory
 

--- a/docs/webui-primer.md
+++ b/docs/webui-primer.md
@@ -257,6 +257,25 @@ Browser → https://music.ablz.au
   Materialize failures render PR1's persisted reason (`download_log.beets_detail`),
   keeping storage errnos and containment refusals in separate vocabularies;
   historical rows without a reason degrade to the generic staging sentence.
+- **Rejection copy is minted only for decision names a producer emits
+  (#882)** — every decision-name literal `web/classify.py` matches is a claim
+  about what some producer writes, so each is traced to the production file
+  that SPELLS it, and a name nothing produces reaches the operator verbatim
+  instead of acquiring an invented sentence. `tests/test_classify_producer_audit.py`
+  derives the match targets from the module itself (inline comparison grammar
+  plus module-level tables) and fails closed on an unregistered one; a literal
+  a past revision emitted and live rows still carry is registered as
+  historical, with the row count written down. The audit's first run convicted
+  `no_candidates` — fluent copy ("No MusicBrainz match found") behind a
+  scenario nothing has ever written, while the real producing literal
+  `mbid_not_found` (50 live rejected rows) fell through to the raw-token
+  fallback; it now renders "Requested release ID not among the match
+  candidates", which is the fact `lib/beets.py` actually determined.
+  The paired generated properties additionally hold every rendered decision
+  claim — verdict and collapsed summary alike — against what the importer
+  really does with that decision (`dispatch_action`, `decision_denylists`), so
+  a proof lock cannot claim the search continues and a no-denylist reject
+  cannot claim the source was banned.
 - **Wrong Matches evidence provenance** — candidate rows keep the downloaded
   source codec, configured target contract, and temporary V0 probe separate.
   A lossless candidate destined for Opus therefore reads `FLAC → OPUS 128

--- a/docs/webui-primer.md
+++ b/docs/webui-primer.md
@@ -260,17 +260,30 @@ Browser → https://music.ablz.au
 - **Rejection copy is minted only for decision names a producer emits
   (#882)** — every decision-name literal `web/classify.py` matches is a claim
   about what some producer writes, so each is traced to the production file
-  that SPELLS it, and a name nothing produces reaches the operator verbatim
-  instead of acquiring an invented sentence. `tests/test_classify_producer_audit.py`
-  derives the match targets from the module itself (inline comparison grammar
-  plus module-level tables) and fails closed on an unregistered one; a literal
-  a past revision emitted and live rows still carry is registered as
-  historical, with the row count written down. The audit's first run convicted
-  `no_candidates` — fluent copy ("No MusicBrainz match found") behind a
-  scenario nothing has ever written, while the real producing literal
-  `mbid_not_found` (50 live rejected rows) fell through to the raw-token
-  fallback; it now renders "Requested release ID not among the match
-  candidates", which is the fact `lib/beets.py` actually determined.
+  that SPELLS it (parsed, not grepped: a mention in a comment or docstring is
+  not a spelling), and an unhandled name is humanized to words rather than
+  acquiring an invented sentence. That is now the module's ONE fallback
+  doctrine — `_rejection_verdict` used to dump the raw machine token while its
+  sibling `_wrong_match_action_label` humanized, so 123 live rows read as
+  `extra_tracks` / `import_failed` / `strong_match`.
+  `tests/test_classify_producer_audit.py`
+  derives the match targets from the module itself (inline comparison grammar,
+  literal containers at ANY scope, and module-level tables) and fails closed on
+  an unregistered one; a literal a past revision emitted and live rows still
+  carry is registered as historical with structured evidence — source
+  expression, row count, last-seen date — so a reviewer has one falsifiable
+  query.
+  The audit's first run convicted `no_candidates`: fluent copy ("No
+  MusicBrainz match found") behind a scenario nothing has ever written, while
+  the real producing literal `mbid_not_found` fell through to the raw token.
+  `lib/beets.py` writes that from `if not result.mbid_found`, whether or not
+  the candidate set was empty, and the two cases send the operator to
+  different places — so the copy splits on the persisted `candidates` list:
+  32 live rows with a populated set read "Requested release ID not among the
+  match candidates" (a pressing mismatch), 18 with an empty one read "Beets
+  returned no match candidates for this folder" (an unmatchable folder, e.g.
+  beets' own `match.ignore_video_tracks` filtering). A row with no readable
+  validation verdict claims neither.
   The paired generated properties additionally hold every rendered decision
   claim — verdict and collapsed summary alike — against what the importer
   really does with that decision (`dispatch_action`, `decision_denylists`), so

--- a/docs/webui-primer.md
+++ b/docs/webui-primer.md
@@ -281,9 +281,21 @@ Browser → https://music.ablz.au
   different places — so the copy splits on the persisted `candidates` list:
   32 live rows with a populated set read "Requested release ID not among the
   match candidates" (a pressing mismatch), 18 with an empty one read "Beets
-  returned no match candidates for this folder" (an unmatchable folder, e.g.
-  beets' own `match.ignore_video_tracks` filtering). A row with no readable
-  validation verdict claims neither.
+  returned no match candidates for the requested release ID". The empty arm
+  names the LOOKUP, not the folder, and asserts no mechanism: `lib/beets.py`
+  always passes `--search-id`, so beets' `tag_album` takes its `if
+  search_ids:` branch and derives candidates from `albums_for_ids` alone —
+  the folder cannot decide whether a candidate exists, and every one of the
+  13 requests behind those 18 rows has sibling attempts on the same release
+  ID that did return candidates. It says "Beets" rather than "MusicBrainz"
+  because two of the 18 requested Discogs release IDs.
+  The empty arm requires positive proof beets actually ran — the `items` and
+  `recommendation` its `choose_match` handler writes — because a synthesized
+  rejection stub carries an empty `candidates` list by default: of every live
+  row with a zero-candidate validation blob, only 18 carry both signals and
+  911 carry neither. A row without that proof falls back to the general
+  sentence, which is the weaker claim and holds of an empty candidate set
+  either way.
   The paired generated properties additionally hold every rendered decision
   claim — verdict and collapsed summary alike — against what the importer
   really does with that decision (`dispatch_action`, `decision_denylists`), so

--- a/lib/validation_envelope.py
+++ b/lib/validation_envelope.py
@@ -89,6 +89,13 @@ class ValidationResultEnvelope(msgspec.Struct, frozen=True):
     source_dirs: list[str] = []
     items: list[dict[str, object]] = []
     candidates: list[dict[str, object]] = []
+    # beets' own confidence for the match it proposed. Written ONLY by
+    # ``lib/beets.py``'s ``choose_match`` handler, from the harness message,
+    # in the same block as ``items`` — so a non-empty value is positive
+    # evidence that beets actually ran on this album, which a synthesized
+    # rejection stub (``ValidationResult(distance=…, scenario=…, detail=…)``)
+    # can never supply. Issue #882 review F4.
+    recommendation: str | None = None
     wrong_match_triage: WrongMatchTriageAudit | None = None
 
 

--- a/tests/test_classify_producer_audit.py
+++ b/tests/test_classify_producer_audit.py
@@ -1,0 +1,736 @@
+#!/usr/bin/env python3
+"""Producer audit for ``web/classify.py``'s decision-name copy (issue #882).
+
+Every decision-name literal the Recents classifier matches against is a
+CLAIM about what some producer emits, and issue #868's defect was exactly
+such a claim going unchecked: copy shipped fluent and wrong because its
+trigger literal existed nowhere in the codebase, and every fixture fed the
+literal by hand (``.claude/rules/test-fidelity.md`` Rule B — the fixture
+was more permissive than production).
+
+``web/classify.py`` had the same shape and no audit. This module supplies
+one:
+
+* **Discovery is derived, never hand-listed.** ``classify_match_targets``
+  reads the module — its inline comparison grammar via AST, its
+  module-level string tables via ``vars`` — so a new match target cannot
+  ship unregistered. Anything discovered and unregistered FAILS.
+* **Evidence is a spelling, not a mention.** A producer proves a literal
+  by SPELLING it as a string literal (``spelled_string_literals`` parses,
+  it does not grep). A mention in a comment is not a spelling, and a
+  docstring that mentions the token is one long literal that never equals
+  it — precisely the hiding place a fabricated trigger would use.
+* **Historical literals are registered as such.** A string a past revision
+  emitted and live rows still carry is legitimate; it just has no producer
+  and must say so, with the live evidence written down.
+
+What it found on the first run (issue #882, verified against the live
+pipeline DB on 2026-07-26):
+
+* ``no_candidates`` — no producer anywhere, zero live rows, yet it carried
+  the fluent sentence "No MusicBrainz match found". The real producing
+  literal is ``lib/beets.py``'s ``mbid_not_found`` (50 live rejected rows),
+  which fell through to the raw-token fallback. Both the key and the claim
+  were wrong: the producer records that the requested ID was absent from
+  the candidate set, not that nothing matched.
+* ``stale_path_cleared`` / ``stale_path_clear_failed`` — planned in a 2026-04
+  plan doc, never produced, zero live rows.
+"""
+
+import ast
+import functools
+import os
+import re
+import sys
+import unittest
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import web.classify as classify
+from lib.quality import dispatch_action
+from lib.quality.dispatch_actions import decision_denylists
+from web.classify import LogEntry, classify_log_entry
+
+_REPO_ROOT = os.path.join(os.path.dirname(__file__), "..")
+_CLASSIFY_RELPATH = "web/classify.py"
+
+
+# ---------------------------------------------------------------------------
+# The registry — what each match target claims, and who can produce it
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class _Producers:
+    """Who can emit the literals compared against one match target."""
+
+    files: tuple[str, ...]
+    """Production files that must SPELL the literal. Empty means the
+    literals are historical and must each carry a live-evidence note."""
+    why: str
+    match: str = "exact"
+    """``exact`` or ``prefix`` — ``prefix`` is for ``.startswith`` targets,
+    where the literal is a fragment of what the producer spells."""
+    casefold: bool = False
+    """Set only where the module itself changes the case before comparing;
+    the reason belongs in ``why``."""
+
+
+_QUALITY_DECISIONS = (
+    "lib/quality/dispatch_actions.py",
+    "lib/quality/decisions.py",
+    "lib/quality/pipeline.py",
+)
+_REJECTION_SCENARIOS = _QUALITY_DECISIONS + (
+    "lib/dispatch/core.py",
+    "lib/beets.py",
+)
+_TRIAGE_ACTIONS = (
+    "lib/wrong_match_cleanup_service.py",
+    "lib/wrong_match_delete_service.py",
+)
+
+MATCH_SUBJECTS: dict[str, _Producers] = {
+    "_entry_decision(entry)": _Producers(
+        _QUALITY_DECISIONS,
+        "the ImportResult decision / beets_scenario a pipeline decision writes",
+    ),
+    "_entry_rejection_decision(entry)": _Producers(
+        _QUALITY_DECISIONS,
+        "a rejection-recording pipeline decision name",
+    ),
+    "ir.decision": _Producers(
+        _QUALITY_DECISIONS, "the persisted ImportResult decision name",
+    ),
+    "triage_preview_decision": _Producers(
+        ("lib/quality/pipeline.py",),
+        "classify_full_pipeline_decision's reason slot",
+    ),
+    "scenario": _Producers(
+        _REJECTION_SCENARIOS,
+        "the rejection scenario persisted on download_log.beets_scenario",
+    ),
+    "scenario.startswith": _Producers(
+        _QUALITY_DECISIONS,
+        "a shared prefix of the suspect-lossless decision names",
+        match="prefix",
+    ),
+    "entry.beets_scenario": _Producers(
+        _QUALITY_DECISIONS, "the transcode decision names",
+    ),
+    "action": _Producers(
+        _TRIAGE_ACTIONS, "a persisted wrong-match triage action",
+    ),
+    "triage_action": _Producers(
+        _TRIAGE_ACTIONS, "a persisted wrong-match triage action",
+    ),
+    "entry.outcome": _Producers(
+        ("lib/pipeline_db/download_log.py",),
+        "the DownloadLogOutcome taxonomy, mirrored by the schema CHECK",
+    ),
+    "entry.request_status": _Producers(
+        ("lib/transitions.py",), "the album_requests lifecycle statuses",
+    ),
+    "job.status": _Producers(
+        ("lib/import_queue.py",), "IMPORT_JOB_STATUSES",
+    ),
+    "preview": _Producers(
+        ("lib/import_queue.py",), "IMPORT_JOB_PREVIEW_STATUSES",
+    ),
+    "basis.branch": _Producers(
+        ("lib/quality/compare.py", "lib/quality/evidence_types.py"),
+        "the branch compare_quality records on QualityComparisonBasis",
+    ),
+    "basis.verdict": _Producers(
+        ("lib/quality/compare.py",), "the verdict compare_quality records",
+    ),
+    "metric": _Producers(
+        ("lib/quality/compare.py",),
+        "the metric label compare_quality selected",
+    ),
+    "entry.spectral_grade": _Producers(
+        ("lib/spectral_check.py",), "a spectral grade the analyser assigns",
+    ),
+    "entry.original_filetype.lower()": _Producers(
+        ("lib/quality/filetypes.py",), "a codec token, already lower-cased",
+    ),
+    "fmt": _Producers(
+        ("lib/quality/filetypes.py",),
+        "a codec token that _quality_label_from_bitrate upper-cases before "
+        "comparing, so the producer's lower-case spelling is the evidence",
+        casefold=True,
+    ),
+    "badge": _Producers(
+        (_CLASSIFY_RELPATH,), "this module's own badge copy",
+    ),
+    "badge.startswith": _Producers(
+        (_CLASSIFY_RELPATH,),
+        "the prefix of this module's own triage badge copy",
+        match="prefix",
+    ),
+}
+
+HISTORICAL_LITERALS: dict[str, str] = {
+    "album_name_mismatch": (
+        "emitted by a pre-2026-03-24 revision; 1 live download_log row "
+        "(2026-03-24), no producer since"
+    ),
+    "preview_backfilled": (
+        "emitted by the 2026-04 preview backfill; 59 live wrong_match_triage "
+        "rows (2026-04-26 to 2026-04-28), no producer since"
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Producer evidence — a spelling, not a mention
+# ---------------------------------------------------------------------------
+
+def spelled_string_literals(source: str) -> frozenset[str]:
+    """Every string a Python source actually SPELLS as a literal.
+
+    Parsed, not grepped. A comment is not a spelling at all, and a
+    docstring mentioning a token is one long literal that never equals it —
+    which is exactly how a fabricated trigger would hide from a whole-file
+    substring check (issue #868).
+    """
+    return frozenset(
+        node.value
+        for node in ast.walk(ast.parse(source))
+        if isinstance(node, ast.Constant) and isinstance(node.value, str)
+    )
+
+
+@functools.cache
+def _spellings(relpath: str) -> frozenset[str]:
+    with open(os.path.join(_REPO_ROOT, relpath), encoding="utf-8") as handle:
+        return spelled_string_literals(handle.read())
+
+
+def producer_spellings(
+    relpaths: "Sequence[str]",
+) -> dict[str, frozenset[str]]:
+    """Read the spellings of each named production file."""
+    return {relpath: _spellings(relpath) for relpath in relpaths}
+
+
+def _is_spelled(
+    literal: str,
+    producers: _Producers,
+    spellings: "Mapping[str, frozenset[str]]",
+) -> bool:
+    needle = literal.casefold() if producers.casefold else literal
+    for relpath in producers.files:
+        for value in spellings.get(relpath, frozenset()):
+            candidate = value.casefold() if producers.casefold else value
+            if producers.match == "prefix":
+                if candidate.startswith(needle):
+                    return True
+            elif candidate == needle:
+                return True
+    return False
+
+
+def check_literal_has_a_producer(
+    literal: str,
+    producers: _Producers,
+    spellings: "Mapping[str, frozenset[str]]",
+    historical: "Mapping[str, str] | None" = None,
+) -> str | None:
+    """Return why this literal is unproducible, or None when it is real.
+
+    Module-level so the known-bad self-tests can hand it the exact
+    fabricated entries that shipped.
+    """
+    known = HISTORICAL_LITERALS if historical is None else historical
+    spelled = _is_spelled(literal, producers, spellings)
+    note = known.get(literal)
+    if note is not None:
+        if len(note) < 20:
+            return f"historical literal {literal!r} carries no live evidence"
+        if spelled:
+            return (
+                f"{literal!r} is registered historical but a producer spells "
+                "it again — retire the historical entry"
+            )
+        return None
+    if not producers.files:
+        return (
+            f"{literal!r} names no producer and is not registered as "
+            "historical with live evidence"
+        )
+    if not spelled:
+        return f"no producer spells {literal!r} ({producers.why})"
+    return None
+
+
+def check_subject_is_registered(
+    subject: str,
+    registry: "Mapping[str, _Producers] | None" = None,
+) -> str | None:
+    """Return why a discovered match target is unaccounted for, or None."""
+    known = MATCH_SUBJECTS if registry is None else registry
+    if subject in known:
+        return None
+    return (
+        f"{subject!r} is matched against string literals but names no "
+        "producer — register it or the copy behind it is unverifiable"
+    )
+
+
+def check_match_target(
+    subject: str,
+    literals: "Sequence[str]",
+    registry: "Mapping[str, _Producers] | None" = None,
+    historical: "Mapping[str, str] | None" = None,
+) -> list[str]:
+    """Everything unaccounted for about one discovered match target.
+
+    The composite the audit runs and the known-bad self-tests plant
+    against: an unregistered subject and an unproducible literal are the
+    two ways a fabricated trigger enters the module, and both answer here.
+    """
+    unregistered = check_subject_is_registered(subject, registry)
+    if unregistered is not None:
+        return [unregistered]
+    producers = (MATCH_SUBJECTS if registry is None else registry)[subject]
+    spellings = producer_spellings(producers.files)
+    return [
+        violation
+        for literal in literals
+        if (violation := check_literal_has_a_producer(
+            literal, producers, spellings, historical)) is not None
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Discovery — derived from the module, never hand-listed
+# ---------------------------------------------------------------------------
+
+_MATCH_OPS = (ast.Eq, ast.NotEq, ast.In, ast.NotIn)
+_PREFIX_METHODS = ("startswith", "endswith")
+
+
+def _constant_strings(node: ast.AST) -> tuple[str, ...]:
+    """Every string constant this operand offers as a match target.
+
+    Deliberately wide: a container mixing names and literals still exposes
+    each literal it spells, so nothing hides behind a sibling.
+    """
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return (node.value,)
+    if isinstance(node, (ast.Tuple, ast.List, ast.Set)):
+        return tuple(
+            element.value
+            for element in node.elts
+            if isinstance(element, ast.Constant)
+            and isinstance(element.value, str)
+        )
+    return ()
+
+
+def inline_match_targets(source: str) -> dict[str, tuple[str, ...]]:
+    """String literals ``web/classify.py`` compares an operand against.
+
+    The module's idiom is an inline ``==`` / ``in`` chain against a local
+    (``scenario``, ``action``, ``preview``), not a module-level table — so
+    that is the grammar this reads, keyed by the operand's source text:
+
+    * ``Compare`` with ``==`` / ``!=`` / ``in`` / ``not in``, either side;
+    * ``.startswith(...)`` / ``.endswith(...)`` with literal arguments;
+    * ``match`` / ``case "literal"``.
+
+    Bounded and syntactic: it collects the literals a comparison spells, it
+    does not try to infer what they mean.
+    """
+    targets: dict[str, tuple[str, ...]] = {}
+
+    def record(subject: str, values: "Sequence[str]") -> None:
+        if values:
+            targets[subject] = tuple(
+                dict.fromkeys(targets.get(subject, ()) + tuple(values)))
+
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Compare):
+            for op, comparator in zip(node.ops, node.comparators):
+                if not isinstance(op, _MATCH_OPS):
+                    continue
+                record(ast.unparse(node.left), _constant_strings(comparator))
+                record(ast.unparse(comparator), _constant_strings(node.left))
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr in _PREFIX_METHODS
+        ):
+            subject = f"{ast.unparse(node.func.value)}.{node.func.attr}"
+            for argument in node.args:
+                record(subject, _constant_strings(argument))
+        elif isinstance(node, ast.Match):
+            subject = ast.unparse(node.subject)
+            for case in node.cases:
+                for pattern in ast.walk(case.pattern):
+                    if isinstance(pattern, ast.MatchValue):
+                        record(subject, _constant_strings(pattern.value))
+    return targets
+
+
+def module_level_match_targets(
+    namespace: "Mapping[str, object]",
+) -> dict[str, tuple[str, ...]]:
+    """String tables a module holds at module level.
+
+    ``web/classify.py`` holds none today — every match target is inline —
+    but a copy table is the shape issue #868's fabricated trigger took, so
+    the scan answers for it in every form it can take: bare ``str``, dict
+    keys, tuple / list / set / frozenset members, and compiled patterns.
+    Anything unrecognised is a match target until it is registered.
+    """
+    targets: dict[str, tuple[str, ...]] = {}
+    for name, value in namespace.items():
+        if name.startswith("__"):
+            continue
+        if isinstance(value, str):
+            targets[name] = (value,)
+        elif isinstance(value, re.Pattern):
+            pattern = value.pattern
+            if isinstance(pattern, str):
+                targets[name] = (pattern,)
+        elif isinstance(value, dict):
+            keys = tuple(key for key in value if isinstance(key, str))
+            if keys:
+                targets[name] = keys
+        elif isinstance(value, (tuple, list, set, frozenset)):
+            items = tuple(item for item in value if isinstance(item, str))
+            if items:
+                targets[name] = items
+    return targets
+
+
+def classify_match_targets(
+    source: str | None = None,
+    namespace: "Mapping[str, object] | None" = None,
+) -> dict[str, tuple[str, ...]]:
+    """Every string ``web/classify.py`` can match a producer value against."""
+    if source is None:
+        with open(
+            os.path.join(_REPO_ROOT, _CLASSIFY_RELPATH), encoding="utf-8",
+        ) as handle:
+            source = handle.read()
+    scope = vars(classify) if namespace is None else namespace
+    targets = inline_match_targets(source)
+    targets.update(module_level_match_targets(scope))
+    return targets
+
+
+# ---------------------------------------------------------------------------
+# The audit
+# ---------------------------------------------------------------------------
+
+class TestEveryClassifyMatchTargetHasAProducer(unittest.TestCase):
+    """The class fix behind issue #868's fabricated-copy defect, applied to
+    the surface issue #882 nominated: ``web/classify.py``."""
+
+    def test_no_match_target_is_unaccounted_for(self) -> None:
+        """The whole contract, through the composite the self-tests plant
+        against. The two tests below are the same audit split for a sharper
+        failure message."""
+        violations = [
+            violation
+            for subject, literals in classify_match_targets().items()
+            for violation in check_match_target(subject, literals)
+        ]
+        self.assertEqual(violations, [])
+
+    def test_every_discovered_subject_is_registered(self) -> None:
+        violations = [
+            violation
+            for subject in classify_match_targets()
+            if (violation := check_subject_is_registered(subject)) is not None
+        ]
+        self.assertEqual(violations, [])
+
+    def test_every_matched_literal_is_spelled_by_its_producer(self) -> None:
+        targets = classify_match_targets()
+        for subject, literals in sorted(targets.items()):
+            producers = MATCH_SUBJECTS[subject]
+            spellings = producer_spellings(producers.files)
+            for literal in literals:
+                with self.subTest(subject=subject, literal=literal):
+                    violation = check_literal_has_a_producer(
+                        literal, producers, spellings)
+                    self.assertIsNone(violation, violation)
+
+    def test_every_registered_subject_is_still_in_the_module(self) -> None:
+        """A registry entry for a target that no longer exists is stale."""
+        targets = classify_match_targets()
+        for subject, producers in MATCH_SUBJECTS.items():
+            with self.subTest(subject):
+                self.assertIn(subject, targets, f"{subject} is registered but gone")
+                self.assertGreater(len(producers.why), 12, "entries carry a reason")
+
+    def test_every_historical_literal_is_still_matched(self) -> None:
+        """A historical exemption for a literal nobody matches is dead."""
+        matched = {
+            literal
+            for literals in classify_match_targets().values()
+            for literal in literals
+        }
+        for literal, note in HISTORICAL_LITERALS.items():
+            with self.subTest(literal):
+                self.assertIn(literal, matched)
+                self.assertGreater(len(note), 20, "historical entries carry evidence")
+
+
+class TestTheAuditIsFailClosed(unittest.TestCase):
+    """Known-bad self-tests: a checker that cannot fail proves nothing."""
+
+    _INVENTED = "the_pressing_went_sideways"
+
+    def _planted_inline_sources(self) -> dict[str, str]:
+        """Every inline form, planted onto the module's REAL subjects.
+
+        Planting under ``scenario`` / ``action`` is the realistic
+        regression: someone adds one more ``if`` to an existing chain.
+        """
+        invented = self._INVENTED
+        return {
+            "equality": f"if scenario == {invented!r}:\n    pass\n",
+            "inequality": f"if scenario != {invented!r}:\n    pass\n",
+            "tuple membership": f"if scenario in ({invented!r},):\n    pass\n",
+            "list membership": f"if scenario in [{invented!r}]:\n    pass\n",
+            "set membership": f"if scenario in {{{invented!r}}}:\n    pass\n",
+            "literal on the left": f"if {invented!r} == scenario:\n    pass\n",
+            "startswith": f"if scenario.startswith({invented!r}):\n    pass\n",
+            "endswith": f"if scenario.endswith({invented!r}):\n    pass\n",
+            "match case": (
+                f"match scenario:\n    case {invented!r}:\n        pass\n"
+            ),
+            "mixed container": (
+                f"if scenario in (OTHER, {invented!r}):\n    pass\n"
+            ),
+        }
+
+    def _planted_module_tables(self) -> dict[str, object]:
+        invented = self._INVENTED
+        return {
+            "_FABRICATED_COPY": {invented: "The pressing is unwell"},
+            "_FABRICATED_PREFIX": invented,
+            "_FABRICATED_TUPLE": (invented,),
+            "_FABRICATED_LIST": [invented],
+            "_FABRICATED_SET": {invented},
+            "_FABRICATED_FROZENSET": frozenset({invented}),
+            "_FABRICATED_RE": re.compile(f"^{invented}$"),
+        }
+
+    def test_every_inline_shape_a_fabricated_trigger_can_take_is_caught(self):
+        """The module's own idiom is inline, so every inline form answers.
+
+        Issue #868 review F3: the narrower scan saw dicts and tuples only,
+        and a bare constant feeding ``.startswith`` shipped silently.
+        """
+        for description, source in self._planted_inline_sources().items():
+            with self.subTest(description):
+                targets = inline_match_targets(source)
+                found = [
+                    (subject, literals)
+                    for subject, literals in targets.items()
+                    if self._INVENTED in literals
+                ]
+                self.assertTrue(found, f"{description} was not discovered")
+                for subject, literals in found:
+                    self.assertTrue(
+                        check_match_target(subject, literals),
+                        f"{description} slipped past the audit",
+                    )
+
+    def test_a_brand_new_inline_subject_fails_closed(self) -> None:
+        """A whole new match chain cannot ship unregistered."""
+        targets = inline_match_targets("if invented_field == 'anything':\n    pass\n")
+        self.assertIn("invented_field", targets)
+        self.assertTrue(check_match_target("invented_field", ("anything",)))
+
+    def test_every_module_table_shape_is_caught(self) -> None:
+        for name, value in self._planted_module_tables().items():
+            with self.subTest(name):
+                targets = module_level_match_targets({name: value})
+                self.assertIn(name, targets, f"{name} was not discovered")
+                self.assertTrue(
+                    any(self._INVENTED in found for found in targets[name]),
+                    f"{name} was discovered without its literal",
+                )
+                self.assertTrue(
+                    check_match_target(name, targets[name]),
+                    f"{name} slipped past the audit",
+                )
+
+    def test_the_composite_scan_fails_closed_on_both_halves(self) -> None:
+        """The entry point the audit uses, not just its halves."""
+        targets = classify_match_targets(
+            source=f"if scenario == {self._INVENTED!r}:\n    pass\n",
+            namespace={"_FABRICATED_COPY": {self._INVENTED: "copy"}},
+        )
+        self.assertIn("_FABRICATED_COPY", targets)
+        self.assertIn("scenario", targets)
+        self.assertTrue(check_match_target(
+            "_FABRICATED_COPY", targets["_FABRICATED_COPY"]))
+        self.assertTrue(check_match_target("scenario", targets["scenario"]))
+
+    def test_the_producer_check_rejects_the_literal_that_shipped(self) -> None:
+        """``no_candidates``: fluent copy, zero rows, no producer (#882)."""
+        producers = MATCH_SUBJECTS["scenario"]
+        spellings = producer_spellings(producers.files)
+        self.assertIsNotNone(check_literal_has_a_producer(
+            "no_candidates", producers, spellings))
+        self.assertIsNotNone(check_literal_has_a_producer(
+            "stale_path_cleared", MATCH_SUBJECTS["action"],
+            producer_spellings(MATCH_SUBJECTS["action"].files)))
+        # …and the literal that replaced it passes.
+        self.assertIsNone(check_literal_has_a_producer(
+            "mbid_not_found", producers, spellings))
+
+    def test_a_mention_in_a_comment_or_docstring_is_not_a_producer(self) -> None:
+        """The evidence bar the #868 substring check could not clear."""
+        source = (
+            '"""A docstring that talks about invented_reason at length."""\n'
+            "# invented_reason is discussed here too\n"
+            "VALUE = 'a_real_literal'\n"
+        )
+        spelled = spelled_string_literals(source)
+        self.assertIn("a_real_literal", spelled)
+        self.assertNotIn("invented_reason", spelled)
+        producers = _Producers(("fake.py",), "planted")
+        self.assertIsNotNone(check_literal_has_a_producer(
+            "invented_reason", producers, {"fake.py": spelled}, historical={}))
+        self.assertIsNone(check_literal_has_a_producer(
+            "a_real_literal", producers, {"fake.py": spelled}, historical={}))
+
+    def test_a_historical_entry_cannot_launder_a_fabricated_literal(self) -> None:
+        producers = _Producers((), "no producer")
+        spellings: dict[str, frozenset[str]] = {}
+        self.assertIsNotNone(check_literal_has_a_producer(
+            "invented", producers, spellings, historical={}))
+        self.assertIsNotNone(check_literal_has_a_producer(
+            "invented", producers, spellings, historical={"invented": "old"}))
+        self.assertIsNone(check_literal_has_a_producer(
+            "invented", producers, spellings,
+            historical={"invented": "12 live rows on 2026-03-24, none since"}))
+        # A "historical" literal a producer spells again is a stale entry.
+        self.assertIsNotNone(check_literal_has_a_producer(
+            "invented",
+            _Producers(("fake.py",), "planted"),
+            {"fake.py": frozenset({"invented"})},
+            historical={"invented": "12 live rows on 2026-03-24, none since"},
+        ))
+
+    def test_prefix_and_casefold_relaxations_still_require_a_spelling(self):
+        prefix = _Producers(("fake.py",), "planted", match="prefix")
+        spellings = {"fake.py": frozenset({"suspect_lossless_downgrade"})}
+        self.assertIsNone(check_literal_has_a_producer(
+            "suspect_lossless", prefix, spellings, historical={}))
+        self.assertIsNotNone(check_literal_has_a_producer(
+            "suspect_flac", prefix, spellings, historical={}))
+        folded = _Producers(("fake.py",), "planted", casefold=True)
+        self.assertIsNone(check_literal_has_a_producer(
+            "FLAC", folded, {"fake.py": frozenset({"flac"})}, historical={}))
+        self.assertIsNotNone(check_literal_has_a_producer(
+            "FLAK", folded, {"fake.py": frozenset({"flac"})}, historical={}))
+
+
+# ---------------------------------------------------------------------------
+# The copy the audit corrected, and the claims it must keep making
+# ---------------------------------------------------------------------------
+
+def _rejected(scenario: str) -> LogEntry:
+    return LogEntry(
+        id=1, request_id=2, outcome="rejected", beets_scenario=scenario)
+
+
+class TestFabricatedCopyIsGone(unittest.TestCase):
+    """Issue #882: the literals the audit convicted, pinned by outcome."""
+
+    def test_the_real_producer_literal_now_carries_the_copy(self) -> None:
+        """50 live rejected rows carry ``mbid_not_found`` (2026-07-26)."""
+        classified = classify_log_entry(_rejected("mbid_not_found"))
+        self.assertEqual(
+            classified.verdict,
+            "Requested release ID not among the match candidates",
+        )
+        # The producer records an absence from the candidate SET, so the
+        # copy must not claim the stronger fact that nothing matched.
+        self.assertNotIn("No MusicBrainz match", classified.verdict)
+
+    def test_the_fabricated_key_no_longer_manufactures_a_sentence(self) -> None:
+        classified = classify_log_entry(_rejected("no_candidates"))
+        self.assertEqual(classified.verdict, "no_candidates")
+
+    def test_the_unproduced_triage_actions_no_longer_have_labels(self) -> None:
+        for action in ("stale_path_cleared", "stale_path_clear_failed"):
+            with self.subTest(action):
+                self.assertEqual(
+                    classify._wrong_match_action_label(action),
+                    action.replace("_", " "),
+                )
+
+    def test_the_historical_literals_keep_their_copy(self) -> None:
+        """One live row from 2026-03-24 still renders as a sentence."""
+        self.assertEqual(
+            classify_log_entry(_rejected("album_name_mismatch")).verdict,
+            "Album name mismatch",
+        )
+        self.assertEqual(
+            classify._wrong_match_action_label("preview_backfilled"),
+            "previewed",
+        )
+
+
+class TestQualityVerdictCopyMatchesTheProducersAction(unittest.TestCase):
+    """Issue #882 item 4, deterministic half.
+
+    Each rejection sentence is checked against the two facts the PRODUCER
+    records for that decision — ``dispatch_action(...).preserve_imported``
+    (does the request stay imported?) and ``decision_denylists(...)`` (is
+    the source banned?). The generated twin in
+    ``tests/test_classify_producer_audit_generated.py`` patrols the world
+    around these.
+    """
+
+    def test_a_proof_lock_says_complete_because_the_request_stays_imported(self):
+        action = dispatch_action("verified_lossless_locked")
+        self.assertTrue(action.preserve_imported)
+        self.assertFalse(decision_denylists("verified_lossless_locked"))
+        verdict = classify_log_entry(_rejected("verified_lossless_locked")).verdict
+        self.assertEqual(
+            verdict,
+            "Verified lossless already on disk; automatic candidate declined "
+            "(no denylist); acquisition is complete",
+        )
+        self.assertNotIn("searching continues", verdict)
+
+    def test_a_source_lock_says_searching_continues_and_admits_the_denylist(self):
+        self.assertFalse(dispatch_action("lossless_source_locked").preserve_imported)
+        self.assertTrue(decision_denylists("lossless_source_locked"))
+        verdict = classify_log_entry(_rejected("lossless_source_locked")).verdict
+        self.assertIn("searching continues", verdict)
+        self.assertNotIn("no denylist", verdict.casefold())
+        self.assertNotIn("acquisition is complete", verdict)
+
+    def test_a_quality_downgrade_never_claims_acquisition_is_complete(self):
+        for scenario in ("downgrade", "quality_downgrade", "transcode_downgrade",
+                         "suspect_lossless_downgrade",
+                         "suspect_lossless_probe_missing"):
+            with self.subTest(scenario):
+                verdict = classify_log_entry(_rejected(scenario)).verdict
+                self.assertIn("searching continues", verdict)
+                self.assertNotIn("acquisition is complete", verdict)
+
+    def test_a_no_denylist_reject_never_claims_the_source_was_denylisted(self):
+        for scenario in ("nested_layout", "high_distance", "album_name_mismatch"):
+            with self.subTest(scenario):
+                self.assertFalse(decision_denylists(scenario))
+                verdict = classify_log_entry(_rejected(scenario)).verdict
+                self.assertNotIn("denylist", verdict.casefold())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_classify_producer_audit.py
+++ b/tests/test_classify_producer_audit.py
@@ -961,13 +961,19 @@ def mbid_not_found_blob(candidate_count: int) -> dict[str, object]:
     """The blob ``lib/beets.py`` writes beside ``mbid_not_found``.
 
     Built from the producer's own Struct, not a hand-rolled dict
-    (``.claude/rules/test-fidelity.md`` Rule C).
+    (``.claude/rules/test-fidelity.md`` Rule C). ``items`` and
+    ``recommendation`` are populated because the ``choose_match`` handler
+    always sets them before it decides ``mbid_found`` — that is exactly
+    what makes them proof beets ran.
     """
     result = ValidationResult(
         valid=False,
         scenario="mbid_not_found",
         mbid_found=False,
         detail="Target MBID rel-1 not in candidates",
+        recommendation="none",
+        local_track_count=3,
+        items=[{"title": f"track {index}"} for index in range(3)],
         candidate_count=candidate_count,
         candidates=[
             CandidateSummary(mbid=f"other-{index}", distance=0.4)
@@ -975,6 +981,20 @@ def mbid_not_found_blob(candidate_count: int) -> dict[str, object]:
         ],
     )
     blob: dict[str, object] = msgspec.to_builtins(result)
+    return blob
+
+
+def synthesized_rejection_blob(scenario: str) -> dict[str, object]:
+    """A rejection stub built WITHOUT beets — the F4 hazard shape.
+
+    Exactly what ``lib/download_rejection.py`` and
+    ``lib/dispatch/outcome_actions.py`` construct: distance, scenario and
+    detail only, leaving ``candidates``/``items``/``recommendation`` at
+    their defaults. On 2026-07-26, 911 of the 929 live rows carrying a
+    zero-candidate validation blob have this shape.
+    """
+    blob: dict[str, object] = msgspec.to_builtins(ValidationResult(
+        distance=0.02, scenario=scenario, detail="synthesized rejection"))
     return blob
 
 
@@ -991,36 +1011,83 @@ class TestFabricatedCopyIsGone(unittest.TestCase):
         )
         self.assertNotIn("No MusicBrainz match", classified.verdict)
 
-    def test_an_empty_candidate_set_says_so_instead(self) -> None:
-        """The other 18 live rows carry an empty set — an unmatchable
-        folder, not a pressing mismatch — so a sentence that reads as
-        though candidates existed is only vacuously true."""
+    def test_an_empty_candidate_set_names_the_release_id_lookup(self) -> None:
+        """The other 18 live rows carry an empty set — a release-ID lookup
+        that came back with nothing, not a pressing mismatch.
+
+        It names the LOOKUP, not the folder: ``lib/beets.py`` always passes
+        ``--search-id``, so beets' ``tag_album`` takes its ``if
+        search_ids:`` branch and derives candidates from
+        ``albums_for_ids`` alone. Live confirmation that the folder is not
+        the discriminator: all 13 requests behind those 18 rows have
+        sibling attempts on the SAME release ID that did return candidates
+        (issue #882 review F1).
+        """
         classified = classify_log_entry(
             _rejected("mbid_not_found", mbid_not_found_blob(0)))
         self.assertEqual(
             classified.verdict,
-            "Beets returned no match candidates for this folder",
+            "Beets returned no match candidates for the requested release ID",
         )
+        lowered = classified.verdict.casefold()
         # The original falsehood must not come back in any form: the
         # producer records an empty CANDIDATE SET, never that no match
-        # exists anywhere. "no match candidates" is the set; "no match
-        # found" / "no MusicBrainz match" are the retracted claim.
-        lowered = classified.verdict.casefold()
+        # exists anywhere.
         for retracted in (
             "no musicbrainz match", "no match found", "no match exists",
             "no matching release",
         ):
             self.assertNotIn(retracted, lowered)
+        # Nor may it point the operator at the folder, which cannot have
+        # decided this, or name MusicBrainz — two of the 18 requested
+        # Discogs release IDs.
+        for misdirection in ("folder", "musicbrainz"):
+            self.assertNotIn(misdirection, lowered)
 
-    def test_without_a_validation_verdict_neither_arm_is_claimed(self) -> None:
-        """Absence of evidence is not evidence of an empty candidate set."""
-        for blob in (None, {"scenario": "mbid_not_found"}):
+    def test_a_row_without_a_beets_verdict_uses_the_general_sentence(self) -> None:
+        """No beets verdict means neither arm is PROVEN, so the general
+        sentence stands — it is the weaker claim and is true of an empty
+        candidate set as well as a populated one."""
+        for blob in (
+            None,
+            {"scenario": "mbid_not_found"},
+            "not json at all",
+            synthesized_rejection_blob("mbid_not_found"),
+        ):
             with self.subTest(blob=blob):
                 classified = classify_log_entry(_rejected("mbid_not_found", blob))
                 self.assertEqual(
                     classified.verdict,
                     "Requested release ID not among the match candidates",
                 )
+
+    def test_a_synthesized_stub_never_claims_beets_returned_nothing(self) -> None:
+        """Review F4: 911 of the 929 live rows with a zero-candidate
+        validation blob carry a beets-shaped rejection stub that beets
+        never produced. An empty ``candidates`` list there is the Struct
+        default, not a verdict.
+
+        The gate therefore requires positive proof beets RAN — the
+        ``items`` and ``recommendation`` its ``choose_match`` handler
+        writes — and each half is load-bearing on its own.
+        """
+        stub = synthesized_rejection_blob("mbid_not_found")
+        self.assertEqual(stub["candidates"], [])
+        self.assertEqual(stub["items"], [])
+        self.assertIsNone(stub["recommendation"])
+        self.assertFalse(classify._beets_returned_no_candidates(
+            _rejected("mbid_not_found", stub)))
+        # A stub dressed up with only one of the two signals still fails.
+        for partial in ({"items": [{"title": "t"}]}, {"recommendation": "none"}):
+            with self.subTest(partial=partial):
+                self.assertFalse(classify._beets_returned_no_candidates(
+                    _rejected("mbid_not_found", {**stub, **partial})))
+        # Both together, with an empty candidate list, is the real thing.
+        self.assertTrue(classify._beets_returned_no_candidates(
+            _rejected("mbid_not_found", mbid_not_found_blob(0))))
+        # …and a real run that DID return candidates is not this arm.
+        self.assertFalse(classify._beets_returned_no_candidates(
+            _rejected("mbid_not_found", mbid_not_found_blob(1))))
 
     def test_the_fabricated_key_no_longer_manufactures_a_sentence(self) -> None:
         classified = classify_log_entry(_rejected("no_candidates"))
@@ -1055,20 +1122,23 @@ class TestUnhandledScenariosReadAsWords(unittest.TestCase):
     no fact — it is the token itself, spelled for a human.
 
     ``changed_rows`` is measured, not assumed: it is how many live rows
-    this change actually re-renders, from replaying both classifiers over
-    all 36,303 ``download_log`` rows on 2026-07-26. It is NOT the count of
-    rows carrying that ``beets_scenario`` — ``_entry_rejection_decision``
-    prefers a rejection-recording ``ImportResult`` decision, so only the
-    rows without one reach this fallback (477 rows carry
-    ``strong_match``; 8 of them render through here).
+    RENDER this text, from replaying both classifiers over all 36,303
+    ``download_log`` rows on 2026-07-26. It is NOT the count of rows
+    carrying that ``beets_scenario`` — ``_entry_rejection_decision``
+    prefers a rejection-recording ``ImportResult`` decision, so a row can
+    render under a different token than its own column holds. 477 rows
+    carry ``strong_match``; 5 render "strong match", and 3 more render
+    "import failed" because their ``ImportResult.decision`` says so
+    (issue #882 review F5 — the same by-scenario-vs-by-rendered-row trap,
+    caught a second time).
     """
 
     CASES = [
         ("extra_tracks", "extra tracks", 45),
-        ("import_failed", "import failed", 44),
+        ("import_failed", "import failed", 47),
         ("untracked_audio", "untracked audio", 14),
         ("mbid_missing", "mbid missing", 10),
-        ("strong_match", "strong match", 8),
+        ("strong_match", "strong match", 5),
         ("quality_evidence_action_failed", "quality evidence action failed", 2),
     ]
 

--- a/tests/test_classify_producer_audit.py
+++ b/tests/test_classify_producer_audit.py
@@ -5,24 +5,25 @@ Every decision-name literal the Recents classifier matches against is a
 CLAIM about what some producer emits, and issue #868's defect was exactly
 such a claim going unchecked: copy shipped fluent and wrong because its
 trigger literal existed nowhere in the codebase, and every fixture fed the
-literal by hand (``.claude/rules/test-fidelity.md`` Rule B — the fixture
+literal by hand (``.claude/rules/test-fidelity.md`` Rule C — the fixture
 was more permissive than production).
 
 ``web/classify.py`` had the same shape and no audit. This module supplies
 one:
 
 * **Discovery is derived, never hand-listed.** ``classify_match_targets``
-  reads the module — its inline comparison grammar via AST, its
-  module-level string tables via ``vars`` — so a new match target cannot
-  ship unregistered. Anything discovered and unregistered FAILS.
+  reads the module — its inline comparison grammar and its literal
+  containers at ANY scope via AST, plus its module-level values via
+  ``vars`` — so a new match target cannot ship unregistered. Anything
+  discovered and neither registered nor exempted FAILS.
 * **Evidence is a spelling, not a mention.** A producer proves a literal
   by SPELLING it as a string literal (``spelled_string_literals`` parses,
-  it does not grep). A mention in a comment is not a spelling, and a
-  docstring that mentions the token is one long literal that never equals
-  it — precisely the hiding place a fabricated trigger would use.
-* **Historical literals are registered as such.** A string a past revision
-  emitted and live rows still carry is legitimate; it just has no producer
-  and must say so, with the live evidence written down.
+  it does not grep). A comment is not a spelling, and a docstring that
+  mentions the token is one long literal that never equals it — precisely
+  the hiding place a fabricated trigger would use.
+* **Historical literals are registered as such**, with structured live
+  evidence (source expression, row count, last-seen date) so a reviewer
+  has one falsifiable query rather than a sentence of prose.
 
 What it found on the first run (issue #882, verified against the live
 pipeline DB on 2026-07-26):
@@ -30,26 +31,42 @@ pipeline DB on 2026-07-26):
 * ``no_candidates`` — no producer anywhere, zero live rows, yet it carried
   the fluent sentence "No MusicBrainz match found". The real producing
   literal is ``lib/beets.py``'s ``mbid_not_found`` (50 live rejected rows),
-  which fell through to the raw-token fallback. Both the key and the claim
-  were wrong: the producer records that the requested ID was absent from
-  the candidate set, not that nothing matched.
+  which fell through to the raw-token fallback.
 * ``stale_path_cleared`` / ``stale_path_clear_failed`` — planned in a 2026-04
   plan doc, never produced, zero live rows.
+
+Two bounds this audit deliberately does NOT close, because closing them
+means inferring runtime semantics from source
+(``.claude/rules/code-quality.md`` § "Semantic source scanners are
+prohibited"):
+
+* Evidence is FILE-level, not field-level. A literal counts as produced
+  when a registered producer FILE spells it, even if the value it spells
+  belongs to a different field's vocabulary. ``scenario == "genuine"``
+  therefore passes, because ``"genuine"`` is a spectral grade spelled in
+  one of the files registered for that subject.
+* A copy table reachable without ever being named (built by a helper call,
+  say) is outside the grammar. Assignments at any scope and literal tables
+  used in place are inside it.
 """
 
 import ast
+import datetime
 import functools
 import os
 import re
 import sys
 import unittest
+from collections import Counter
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
+import msgspec
+
 import web.classify as classify
-from lib.quality import dispatch_action
+from lib.quality import CandidateSummary, ValidationResult, dispatch_action
 from lib.quality.dispatch_actions import decision_denylists
 from web.classify import LogEntry, classify_log_entry
 
@@ -67,7 +84,7 @@ class _Producers:
 
     files: tuple[str, ...]
     """Production files that must SPELL the literal. Empty means the
-    literals are historical and must each carry a live-evidence note."""
+    literals are historical and must each carry structured live evidence."""
     why: str
     match: str = "exact"
     """``exact`` or ``prefix`` — ``prefix`` is for ``.startswith`` targets,
@@ -75,6 +92,11 @@ class _Producers:
     casefold: bool = False
     """Set only where the module itself changes the case before comparing;
     the reason belongs in ``why``."""
+    min_occurrences: int = 1
+    """Raised above 1 for a subject that names ITSELF as its producer,
+    where the comparison site is one of the spellings it would otherwise
+    count as its own evidence — a tautology that lets a typo certify
+    itself."""
 
 
 _QUALITY_DECISIONS = (
@@ -162,23 +184,61 @@ MATCH_SUBJECTS: dict[str, _Producers] = {
         casefold=True,
     ),
     "badge": _Producers(
-        (_CLASSIFY_RELPATH,), "this module's own badge copy",
+        (_CLASSIFY_RELPATH,),
+        "this module's own badge copy — self-produced, so the comparison "
+        "site alone is not evidence and a second spelling is required",
+        min_occurrences=2,
     ),
     "badge.startswith": _Producers(
         (_CLASSIFY_RELPATH,),
-        "the prefix of this module's own triage badge copy",
+        "the prefix of this module's own triage badge copy — self-produced, "
+        "so a second spelling is required",
         match="prefix",
+        min_occurrences=2,
     ),
 }
 
-HISTORICAL_LITERALS: dict[str, str] = {
-    "album_name_mismatch": (
-        "emitted by a pre-2026-03-24 revision; 1 live download_log row "
-        "(2026-03-24), no producer since"
+
+@dataclass(frozen=True)
+class _Historical:
+    """A literal a past revision emitted, kept because live rows carry it.
+
+    Structured rather than prose so a reviewer can falsify the entry with
+    one query instead of trusting a sentence: ``source`` is the exact
+    column or JSON expression, ``row_count`` and ``last_seen`` are what it
+    returned when the entry was written.
+    """
+
+    source: str
+    row_count: int
+    last_seen: str
+
+
+HISTORICAL_LITERALS: dict[str, _Historical] = {
+    "album_name_mismatch": _Historical(
+        source="download_log.beets_scenario",
+        row_count=1,
+        last_seen="2026-03-24",
     ),
-    "preview_backfilled": (
-        "emitted by the 2026-04 preview backfill; 59 live wrong_match_triage "
-        "rows (2026-04-26 to 2026-04-28), no producer since"
+    "preview_backfilled": _Historical(
+        source="download_log.validation_result->'wrong_match_triage'->>'action'",
+        row_count=59,
+        last_seen="2026-04-28",
+    ),
+}
+
+
+NON_MATCH_TARGETS: dict[str, str] = {
+    # Output copy assigned for return, never compared against a producer
+    # value. The badge vocabulary they carry IS audited — as the ``badge``
+    # subject, where this module is its own registered producer.
+    "classify_import_job_display.(badge_class, border_color)": (
+        "output copy: the badge class and border colour this module returns "
+        "for a preview status, not a value it matches against"
+    ),
+    "classify_import_job_display.(badge, badge_class, border_color)": (
+        "output copy: the badge, class and border colour this module returns "
+        "for a preview status, not a value it matches against"
     ),
 }
 
@@ -187,15 +247,17 @@ HISTORICAL_LITERALS: dict[str, str] = {
 # Producer evidence — a spelling, not a mention
 # ---------------------------------------------------------------------------
 
-def spelled_string_literals(source: str) -> frozenset[str]:
-    """Every string a Python source actually SPELLS as a literal.
+def spelled_string_literals(source: str) -> "Counter[str]":
+    """How many times a Python source actually SPELLS each string literal.
 
     Parsed, not grepped. A comment is not a spelling at all, and a
     docstring mentioning a token is one long literal that never equals it —
     which is exactly how a fabricated trigger would hide from a whole-file
-    substring check (issue #868).
+    substring check (issue #868). Counted rather than merely collected so a
+    module that names itself as its own producer cannot certify a literal
+    on the strength of the comparison site alone.
     """
-    return frozenset(
+    return Counter(
         node.value
         for node in ast.walk(ast.parse(source))
         if isinstance(node, ast.Constant) and isinstance(node.value, str)
@@ -203,40 +265,42 @@ def spelled_string_literals(source: str) -> frozenset[str]:
 
 
 @functools.cache
-def _spellings(relpath: str) -> frozenset[str]:
+def _spellings(relpath: str) -> "Counter[str]":
     with open(os.path.join(_REPO_ROOT, relpath), encoding="utf-8") as handle:
         return spelled_string_literals(handle.read())
 
 
 def producer_spellings(
     relpaths: "Sequence[str]",
-) -> dict[str, frozenset[str]]:
+) -> "dict[str, Counter[str]]":
     """Read the spellings of each named production file."""
     return {relpath: _spellings(relpath) for relpath in relpaths}
 
 
-def _is_spelled(
+def spelled_count(
     literal: str,
     producers: _Producers,
-    spellings: "Mapping[str, frozenset[str]]",
-) -> bool:
+    spellings: "Mapping[str, Counter[str]]",
+) -> int:
+    """How many spellings across the registered FILES back this literal."""
     needle = literal.casefold() if producers.casefold else literal
+    total = 0
     for relpath in producers.files:
-        for value in spellings.get(relpath, frozenset()):
+        for value, count in spellings.get(relpath, Counter()).items():
             candidate = value.casefold() if producers.casefold else value
             if producers.match == "prefix":
                 if candidate.startswith(needle):
-                    return True
+                    total += count
             elif candidate == needle:
-                return True
-    return False
+                total += count
+    return total
 
 
 def check_literal_has_a_producer(
     literal: str,
     producers: _Producers,
-    spellings: "Mapping[str, frozenset[str]]",
-    historical: "Mapping[str, str] | None" = None,
+    spellings: "Mapping[str, Counter[str]]",
+    historical: "Mapping[str, _Historical] | None" = None,
 ) -> str | None:
     """Return why this literal is unproducible, or None when it is real.
 
@@ -244,12 +308,22 @@ def check_literal_has_a_producer(
     fabricated entries that shipped.
     """
     known = HISTORICAL_LITERALS if historical is None else historical
-    spelled = _is_spelled(literal, producers, spellings)
-    note = known.get(literal)
-    if note is not None:
-        if len(note) < 20:
-            return f"historical literal {literal!r} carries no live evidence"
-        if spelled:
+    count = spelled_count(literal, producers, spellings)
+    record = known.get(literal)
+    if record is not None:
+        if record.row_count < 1 or not record.source:
+            return (
+                f"historical literal {literal!r} claims no live rows — an "
+                "entry nothing carries is dead copy, not history"
+            )
+        try:
+            datetime.date.fromisoformat(record.last_seen)
+        except ValueError:
+            return (
+                f"historical literal {literal!r} has an unusable last_seen "
+                f"{record.last_seen!r}; a reviewer cannot falsify it"
+            )
+        if count:
             return (
                 f"{literal!r} is registered historical but a producer spells "
                 "it again — retire the historical entry"
@@ -260,18 +334,23 @@ def check_literal_has_a_producer(
             f"{literal!r} names no producer and is not registered as "
             "historical with live evidence"
         )
-    if not spelled:
-        return f"no producer spells {literal!r} ({producers.why})"
+    if count < producers.min_occurrences:
+        return (
+            f"no producer file spells {literal!r} "
+            f"{producers.min_occurrences} time(s) ({producers.why})"
+        )
     return None
 
 
 def check_subject_is_registered(
     subject: str,
     registry: "Mapping[str, _Producers] | None" = None,
+    exemptions: "Mapping[str, str] | None" = None,
 ) -> str | None:
     """Return why a discovered match target is unaccounted for, or None."""
     known = MATCH_SUBJECTS if registry is None else registry
-    if subject in known:
+    exempt = NON_MATCH_TARGETS if exemptions is None else exemptions
+    if subject in known or subject in exempt:
         return None
     return (
         f"{subject!r} is matched against string literals but names no "
@@ -283,7 +362,8 @@ def check_match_target(
     subject: str,
     literals: "Sequence[str]",
     registry: "Mapping[str, _Producers] | None" = None,
-    historical: "Mapping[str, str] | None" = None,
+    historical: "Mapping[str, _Historical] | None" = None,
+    exemptions: "Mapping[str, str] | None" = None,
 ) -> list[str]:
     """Everything unaccounted for about one discovered match target.
 
@@ -291,9 +371,12 @@ def check_match_target(
     against: an unregistered subject and an unproducible literal are the
     two ways a fabricated trigger enters the module, and both answer here.
     """
-    unregistered = check_subject_is_registered(subject, registry)
+    unregistered = check_subject_is_registered(subject, registry, exemptions)
     if unregistered is not None:
         return [unregistered]
+    exempt = NON_MATCH_TARGETS if exemptions is None else exemptions
+    if subject in exempt:
+        return []
     producers = (MATCH_SUBJECTS if registry is None else registry)[subject]
     spellings = producer_spellings(producers.files)
     return [
@@ -310,16 +393,23 @@ def check_match_target(
 
 _MATCH_OPS = (ast.Eq, ast.NotEq, ast.In, ast.NotIn)
 _PREFIX_METHODS = ("startswith", "endswith")
+_INLINE_TABLE = "<inline table>"
 
 
 def _constant_strings(node: ast.AST) -> tuple[str, ...]:
-    """Every string constant this operand offers as a match target.
+    """Every string constant this node offers as a match target.
 
     Deliberately wide: a container mixing names and literals still exposes
     each literal it spells, so nothing hides behind a sibling.
     """
     if isinstance(node, ast.Constant) and isinstance(node.value, str):
         return (node.value,)
+    if isinstance(node, ast.Dict):
+        return tuple(
+            key.value
+            for key in node.keys
+            if isinstance(key, ast.Constant) and isinstance(key.value, str)
+        )
     if isinstance(node, (ast.Tuple, ast.List, ast.Set)):
         return tuple(
             element.value
@@ -330,60 +420,136 @@ def _constant_strings(node: ast.AST) -> tuple[str, ...]:
     return ()
 
 
-def inline_match_targets(source: str) -> dict[str, tuple[str, ...]]:
-    """String literals ``web/classify.py`` compares an operand against.
+def _is_literal_container(node: ast.AST | None) -> bool:
+    return isinstance(node, (ast.Dict, ast.Tuple, ast.List, ast.Set))
+
+
+class _MatchTargetScan(ast.NodeVisitor):
+    """The bounded grammar of "a literal this module can match against".
+
+    Keyed by the operand's source text for comparisons, and by the
+    enclosing scope plus the assigned name for containers — so a
+    function-local table is a DIFFERENT subject from a module constant of
+    the same name, and neither can hide behind the other.
+    """
+
+    def __init__(self) -> None:
+        self.targets: dict[str, tuple[str, ...]] = {}
+        self._scope: list[str] = []
+
+    # -- recording ----------------------------------------------------
+    def _record(self, subject: str, values: "Sequence[str]") -> None:
+        if values:
+            self.targets[subject] = tuple(dict.fromkeys(
+                self.targets.get(subject, ()) + tuple(values)))
+
+    def _qualified(self, name: str) -> str:
+        return ".".join([*self._scope, name])
+
+    def _scoped(self, name: str, node: ast.AST) -> None:
+        self._scope.append(name)
+        self.generic_visit(node)
+        self._scope.pop()
+
+    # -- scopes -------------------------------------------------------
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._scoped(node.name, node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._scoped(node.name, node)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._scoped(node.name, node)
+
+    # -- inline comparisons -------------------------------------------
+    def visit_Compare(self, node: ast.Compare) -> None:
+        for op, comparator in zip(node.ops, node.comparators):
+            if isinstance(op, _MATCH_OPS):
+                self._record(
+                    ast.unparse(node.left), _constant_strings(comparator))
+                self._record(
+                    ast.unparse(comparator), _constant_strings(node.left))
+        self.generic_visit(node)
+
+    def visit_Call(self, node: ast.Call) -> None:
+        func = node.func
+        if isinstance(func, ast.Attribute) and func.attr in _PREFIX_METHODS:
+            subject = f"{ast.unparse(func.value)}.{func.attr}"
+            for argument in node.args:
+                self._record(subject, _constant_strings(argument))
+        self.generic_visit(node)
+
+    def visit_Match(self, node: ast.Match) -> None:
+        subject = ast.unparse(node.subject)
+        for case in node.cases:
+            for pattern in ast.walk(case.pattern):
+                if isinstance(pattern, ast.MatchValue):
+                    self._record(subject, _constant_strings(pattern.value))
+        self.generic_visit(node)
+
+    # -- literal containers, at ANY scope -----------------------------
+    def visit_Assign(self, node: ast.Assign) -> None:
+        if _is_literal_container(node.value):
+            values = _constant_strings(node.value)
+            for target in node.targets:
+                self._record(self._qualified(ast.unparse(target)), values)
+        self.generic_visit(node)
+
+    def visit_AnnAssign(self, node: ast.AnnAssign) -> None:
+        if node.value is not None and _is_literal_container(node.value):
+            self._record(
+                self._qualified(ast.unparse(node.target)),
+                _constant_strings(node.value),
+            )
+        self.generic_visit(node)
+
+    def visit_Subscript(self, node: ast.Subscript) -> None:
+        if _is_literal_container(node.value):
+            self._record(
+                self._qualified(_INLINE_TABLE), _constant_strings(node.value))
+        self.generic_visit(node)
+
+    def visit_Attribute(self, node: ast.Attribute) -> None:
+        if _is_literal_container(node.value):
+            self._record(
+                self._qualified(_INLINE_TABLE), _constant_strings(node.value))
+        self.generic_visit(node)
+
+
+def source_match_targets(source: str) -> dict[str, tuple[str, ...]]:
+    """String literals ``web/classify.py`` can match a producer value against.
 
     The module's idiom is an inline ``==`` / ``in`` chain against a local
-    (``scenario``, ``action``, ``preview``), not a module-level table — so
-    that is the grammar this reads, keyed by the operand's source text:
+    (``scenario``, ``action``, ``preview``), so that is the primary
+    grammar, keyed by the operand's source text:
 
     * ``Compare`` with ``==`` / ``!=`` / ``in`` / ``not in``, either side;
     * ``.startswith(...)`` / ``.endswith(...)`` with literal arguments;
     * ``match`` / ``case "literal"``.
 
-    Bounded and syntactic: it collects the literals a comparison spells, it
-    does not try to infer what they mean.
+    A copy table is the OTHER shape a fabricated trigger takes, so literal
+    dict / tuple / list / set containers are read too — at ANY scope, not
+    just module level. Collapsing part of a long ``if``-chain into a
+    function-local table is the single most obvious refactor in this file,
+    and a module-scope-only scan walks straight past it (issue #882 review
+    B2).
+
+    Bounded and syntactic throughout: it collects the literals a
+    comparison or a container spells; it does not infer what they mean.
     """
-    targets: dict[str, tuple[str, ...]] = {}
-
-    def record(subject: str, values: "Sequence[str]") -> None:
-        if values:
-            targets[subject] = tuple(
-                dict.fromkeys(targets.get(subject, ()) + tuple(values)))
-
-    for node in ast.walk(ast.parse(source)):
-        if isinstance(node, ast.Compare):
-            for op, comparator in zip(node.ops, node.comparators):
-                if not isinstance(op, _MATCH_OPS):
-                    continue
-                record(ast.unparse(node.left), _constant_strings(comparator))
-                record(ast.unparse(comparator), _constant_strings(node.left))
-        elif (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Attribute)
-            and node.func.attr in _PREFIX_METHODS
-        ):
-            subject = f"{ast.unparse(node.func.value)}.{node.func.attr}"
-            for argument in node.args:
-                record(subject, _constant_strings(argument))
-        elif isinstance(node, ast.Match):
-            subject = ast.unparse(node.subject)
-            for case in node.cases:
-                for pattern in ast.walk(case.pattern):
-                    if isinstance(pattern, ast.MatchValue):
-                        record(subject, _constant_strings(pattern.value))
-    return targets
+    scan = _MatchTargetScan()
+    scan.visit(ast.parse(source))
+    return scan.targets
 
 
 def module_level_match_targets(
     namespace: "Mapping[str, object]",
 ) -> dict[str, tuple[str, ...]]:
-    """String tables a module holds at module level.
+    """String tables a module holds at module level, by runtime value.
 
-    ``web/classify.py`` holds none today — every match target is inline —
-    but a copy table is the shape issue #868's fabricated trigger took, so
-    the scan answers for it in every form it can take: bare ``str``, dict
-    keys, tuple / list / set / frozenset members, and compiled patterns.
+    Complements the AST scan rather than duplicating it: this half sees a
+    module constant however it was built — a comprehension, an import, a
+    ``frozenset(get_args(...))`` — where the AST half only sees literals.
     Anything unrecognised is a match target until it is registered.
     """
     targets: dict[str, tuple[str, ...]] = {}
@@ -418,8 +584,12 @@ def classify_match_targets(
         ) as handle:
             source = handle.read()
     scope = vars(classify) if namespace is None else namespace
-    targets = inline_match_targets(source)
-    targets.update(module_level_match_targets(scope))
+    targets = source_match_targets(source)
+    # Merge, never replace: a module constant sharing a name with an inline
+    # subject would otherwise silently drop that subject's literals
+    # (issue #882 review N8).
+    for name, literals in module_level_match_targets(scope).items():
+        targets[name] = tuple(dict.fromkeys(targets.get(name, ()) + literals))
     return targets
 
 
@@ -453,6 +623,8 @@ class TestEveryClassifyMatchTargetHasAProducer(unittest.TestCase):
     def test_every_matched_literal_is_spelled_by_its_producer(self) -> None:
         targets = classify_match_targets()
         for subject, literals in sorted(targets.items()):
+            if subject in NON_MATCH_TARGETS:
+                continue
             producers = MATCH_SUBJECTS[subject]
             spellings = producer_spellings(producers.files)
             for literal in literals:
@@ -469,6 +641,13 @@ class TestEveryClassifyMatchTargetHasAProducer(unittest.TestCase):
                 self.assertIn(subject, targets, f"{subject} is registered but gone")
                 self.assertGreater(len(producers.why), 12, "entries carry a reason")
 
+    def test_every_exemption_is_still_in_the_module_and_carries_a_reason(self):
+        targets = classify_match_targets()
+        for subject, reason in NON_MATCH_TARGETS.items():
+            with self.subTest(subject):
+                self.assertIn(subject, targets, f"{subject} is exempt but gone")
+                self.assertGreater(len(reason), 20, "exemptions carry a reason")
+
     def test_every_historical_literal_is_still_matched(self) -> None:
         """A historical exemption for a literal nobody matches is dead."""
         matched = {
@@ -476,10 +655,12 @@ class TestEveryClassifyMatchTargetHasAProducer(unittest.TestCase):
             for literals in classify_match_targets().values()
             for literal in literals
         }
-        for literal, note in HISTORICAL_LITERALS.items():
+        for literal, record in HISTORICAL_LITERALS.items():
             with self.subTest(literal):
                 self.assertIn(literal, matched)
-                self.assertGreater(len(note), 20, "historical entries carry evidence")
+                self.assertGreaterEqual(record.row_count, 1)
+                self.assertTrue(record.source)
+                datetime.date.fromisoformat(record.last_seen)
 
 
 class TestTheAuditIsFailClosed(unittest.TestCase):
@@ -490,8 +671,8 @@ class TestTheAuditIsFailClosed(unittest.TestCase):
     def _planted_inline_sources(self) -> dict[str, str]:
         """Every inline form, planted onto the module's REAL subjects.
 
-        Planting under ``scenario`` / ``action`` is the realistic
-        regression: someone adds one more ``if`` to an existing chain.
+        Planting under ``scenario`` is the realistic regression: someone
+        adds one more ``if`` to an existing chain.
         """
         invented = self._INVENTED
         return {
@@ -511,6 +692,67 @@ class TestTheAuditIsFailClosed(unittest.TestCase):
             ),
         }
 
+    def _planted_local_tables(self) -> dict[str, str]:
+        """The refactor shape a module-scope-only scan walks straight past.
+
+        ``_rejection_verdict`` is a long ``if``-chain; collapsing part of
+        it into a function-local table is the obvious tidy-up, and an
+        ADDITIVE local table leaves every module-scope check green — three
+        of these survived the earlier scan (issue #882 review B2).
+        """
+        invented = self._INVENTED
+        return {
+            "function-local dict": (
+                "def _rejection_verdict(entry):\n"
+                f"    _LOCAL_COPY = {{{invented!r}: 'The pressing is unwell'}}\n"
+                "    if scenario in _LOCAL_COPY:\n"
+                "        return _LOCAL_COPY[scenario]\n"
+            ),
+            "function-local tuple": (
+                "def _rejection_verdict(entry):\n"
+                f"    _LOCAL_NAMES = ({invented!r},)\n"
+                "    if scenario in _LOCAL_NAMES:\n"
+                "        return 'The pressing is unwell'\n"
+            ),
+            "function-local dict.get": (
+                "def _rejection_verdict(entry):\n"
+                f"    _LOCAL_COPY = {{{invented!r}: 'The pressing is unwell'}}\n"
+                "    hit = _LOCAL_COPY.get(scenario)\n"
+                "    if hit:\n"
+                "        return hit\n"
+            ),
+            "annotated function-local table": (
+                "def _rejection_verdict(entry):\n"
+                "    _LOCAL_COPY: dict[str, str] = "
+                f"{{{invented!r}: 'The pressing is unwell'}}\n"
+                "    return _LOCAL_COPY.get(scenario)\n"
+            ),
+            "function-local list": (
+                "def _rejection_verdict(entry):\n"
+                f"    _LOCAL_NAMES = [{invented!r}]\n"
+                "    if scenario in _LOCAL_NAMES:\n"
+                "        return 'unwell'\n"
+            ),
+            "unassigned table subscripted in place": (
+                "def _rejection_verdict(entry):\n"
+                f"    return {{{invented!r}: 'unwell'}}[scenario]\n"
+            ),
+            "unassigned table with .get": (
+                "def _rejection_verdict(entry):\n"
+                f"    return {{{invented!r}: 'unwell'}}.get(scenario)\n"
+            ),
+            "nested-scope table": (
+                "def _rejection_verdict(entry):\n"
+                "    def _inner():\n"
+                f"        _LOCAL_COPY = {{{invented!r}: 'unwell'}}\n"
+                "        return _LOCAL_COPY\n"
+                "    return _inner().get(scenario)\n"
+            ),
+            "module-level control": (
+                f"_MODULE_COPY = {{{invented!r}: 'unwell'}}\n"
+            ),
+        }
+
     def _planted_module_tables(self) -> dict[str, object]:
         invented = self._INVENTED
         return {
@@ -523,6 +765,22 @@ class TestTheAuditIsFailClosed(unittest.TestCase):
             "_FABRICATED_RE": re.compile(f"^{invented}$"),
         }
 
+    def _assert_planted_source_is_caught(
+        self, description: str, source: str,
+    ) -> None:
+        targets = source_match_targets(source)
+        found = [
+            (subject, literals)
+            for subject, literals in targets.items()
+            if self._INVENTED in literals
+        ]
+        self.assertTrue(found, f"{description} was not discovered")
+        for subject, literals in found:
+            self.assertTrue(
+                check_match_target(subject, literals),
+                f"{description} slipped past the audit as {subject!r}",
+            )
+
     def test_every_inline_shape_a_fabricated_trigger_can_take_is_caught(self):
         """The module's own idiom is inline, so every inline form answers.
 
@@ -531,22 +789,17 @@ class TestTheAuditIsFailClosed(unittest.TestCase):
         """
         for description, source in self._planted_inline_sources().items():
             with self.subTest(description):
-                targets = inline_match_targets(source)
-                found = [
-                    (subject, literals)
-                    for subject, literals in targets.items()
-                    if self._INVENTED in literals
-                ]
-                self.assertTrue(found, f"{description} was not discovered")
-                for subject, literals in found:
-                    self.assertTrue(
-                        check_match_target(subject, literals),
-                        f"{description} slipped past the audit",
-                    )
+                self._assert_planted_source_is_caught(description, source)
+
+    def test_a_copy_table_at_any_scope_is_caught(self) -> None:
+        """Issue #882 review B2."""
+        for description, source in self._planted_local_tables().items():
+            with self.subTest(description):
+                self._assert_planted_source_is_caught(description, source)
 
     def test_a_brand_new_inline_subject_fails_closed(self) -> None:
         """A whole new match chain cannot ship unregistered."""
-        targets = inline_match_targets("if invented_field == 'anything':\n    pass\n")
+        targets = source_match_targets("if invented_field == 'anything':\n    pass\n")
         self.assertIn("invented_field", targets)
         self.assertTrue(check_match_target("invented_field", ("anything",)))
 
@@ -576,6 +829,17 @@ class TestTheAuditIsFailClosed(unittest.TestCase):
             "_FABRICATED_COPY", targets["_FABRICATED_COPY"]))
         self.assertTrue(check_match_target("scenario", targets["scenario"]))
 
+    def test_a_name_collision_never_drops_the_inline_subject(self) -> None:
+        """Review N8: the halves merge, so a module constant sharing a name
+        with an inline subject cannot hide that subject's literals."""
+        targets = classify_match_targets(
+            source=f"if fmt == {self._INVENTED!r}:\n    pass\n",
+            namespace={"fmt": "FLAC"},
+        )
+        self.assertIn(self._INVENTED, targets["fmt"])
+        self.assertIn("FLAC", targets["fmt"])
+        self.assertTrue(check_match_target("fmt", targets["fmt"]))
+
     def test_the_producer_check_rejects_the_literal_that_shipped(self) -> None:
         """``no_candidates``: fluent copy, zero rows, no producer (#882)."""
         producers = MATCH_SUBJECTS["scenario"]
@@ -597,72 +861,170 @@ class TestTheAuditIsFailClosed(unittest.TestCase):
             "VALUE = 'a_real_literal'\n"
         )
         spelled = spelled_string_literals(source)
-        self.assertIn("a_real_literal", spelled)
-        self.assertNotIn("invented_reason", spelled)
+        self.assertEqual(spelled["a_real_literal"], 1)
+        self.assertEqual(spelled["invented_reason"], 0)
         producers = _Producers(("fake.py",), "planted")
         self.assertIsNotNone(check_literal_has_a_producer(
             "invented_reason", producers, {"fake.py": spelled}, historical={}))
         self.assertIsNone(check_literal_has_a_producer(
             "a_real_literal", producers, {"fake.py": spelled}, historical={}))
 
-    def test_a_historical_entry_cannot_launder_a_fabricated_literal(self) -> None:
+    def test_a_self_registered_subject_cannot_certify_its_own_typo(self) -> None:
+        """Review N4: with the comparison site as the only spelling, a
+        badge typo would prove itself."""
+        typo = _Producers(
+            (_CLASSIFY_RELPATH,), "self-produced", min_occurrences=2)
+        spellings = producer_spellings((_CLASSIFY_RELPATH,))
+        self.assertIsNotNone(check_literal_has_a_producer(
+            "Triaged · download delted", typo, spellings, historical={}))
+        self.assertIsNone(check_literal_has_a_producer(
+            "Imported", typo, spellings, historical={}))
+        # One spelling is enough for a subject produced elsewhere — the
+        # raised bar is specific to self-certification.
+        loose = _Producers(("fake.py",), "planted")
+        self.assertIsNone(check_literal_has_a_producer(
+            "Triaged · download delted", loose,
+            {"fake.py": Counter({"Triaged · download delted": 1})},
+            historical={}))
+
+    def test_a_historical_entry_needs_structured_falsifiable_evidence(self):
+        """Review N5: prose is not evidence — a plausible sentence let a
+        brand-new invention register as history."""
         producers = _Producers((), "no producer")
-        spellings: dict[str, frozenset[str]] = {}
+        spellings: "dict[str, Counter[str]]" = {}
         self.assertIsNotNone(check_literal_has_a_producer(
             "invented", producers, spellings, historical={}))
+        # No live rows: the entry describes copy nothing can reach.
         self.assertIsNotNone(check_literal_has_a_producer(
-            "invented", producers, spellings, historical={"invented": "old"}))
+            "invented", producers, spellings,
+            historical={"invented": _Historical(
+                source="download_log.beets_scenario", row_count=0,
+                last_seen="2026-03-24")},
+        ))
+        # No queryable source expression.
+        self.assertIsNotNone(check_literal_has_a_producer(
+            "invented", producers, spellings,
+            historical={"invented": _Historical(
+                source="", row_count=12, last_seen="2026-03-24")},
+        ))
+        # A date a reviewer cannot check against.
+        self.assertIsNotNone(check_literal_has_a_producer(
+            "invented", producers, spellings,
+            historical={"invented": _Historical(
+                source="download_log.beets_scenario", row_count=12,
+                last_seen="a while back")},
+        ))
         self.assertIsNone(check_literal_has_a_producer(
             "invented", producers, spellings,
-            historical={"invented": "12 live rows on 2026-03-24, none since"}))
+            historical={"invented": _Historical(
+                source="download_log.beets_scenario", row_count=12,
+                last_seen="2026-03-24")},
+        ))
         # A "historical" literal a producer spells again is a stale entry.
         self.assertIsNotNone(check_literal_has_a_producer(
             "invented",
             _Producers(("fake.py",), "planted"),
-            {"fake.py": frozenset({"invented"})},
-            historical={"invented": "12 live rows on 2026-03-24, none since"},
+            {"fake.py": Counter({"invented": 1})},
+            historical={"invented": _Historical(
+                source="download_log.beets_scenario", row_count=12,
+                last_seen="2026-03-24")},
         ))
 
     def test_prefix_and_casefold_relaxations_still_require_a_spelling(self):
         prefix = _Producers(("fake.py",), "planted", match="prefix")
-        spellings = {"fake.py": frozenset({"suspect_lossless_downgrade"})}
+        spellings = {"fake.py": Counter({"suspect_lossless_downgrade": 1})}
         self.assertIsNone(check_literal_has_a_producer(
             "suspect_lossless", prefix, spellings, historical={}))
         self.assertIsNotNone(check_literal_has_a_producer(
             "suspect_flac", prefix, spellings, historical={}))
         folded = _Producers(("fake.py",), "planted", casefold=True)
         self.assertIsNone(check_literal_has_a_producer(
-            "FLAC", folded, {"fake.py": frozenset({"flac"})}, historical={}))
+            "FLAC", folded, {"fake.py": Counter({"flac": 1})}, historical={}))
         self.assertIsNotNone(check_literal_has_a_producer(
-            "FLAK", folded, {"fake.py": frozenset({"flac"})}, historical={}))
+            "FLAK", folded, {"fake.py": Counter({"flac": 1})}, historical={}))
 
 
 # ---------------------------------------------------------------------------
 # The copy the audit corrected, and the claims it must keep making
 # ---------------------------------------------------------------------------
 
-def _rejected(scenario: str) -> LogEntry:
+def _rejected(scenario: str, validation_result: object = None) -> LogEntry:
     return LogEntry(
-        id=1, request_id=2, outcome="rejected", beets_scenario=scenario)
+        id=1, request_id=2, outcome="rejected", beets_scenario=scenario,
+        validation_result=(
+            validation_result  # pyright: ignore[reportArgumentType]
+        ),
+    )
+
+
+def mbid_not_found_blob(candidate_count: int) -> dict[str, object]:
+    """The blob ``lib/beets.py`` writes beside ``mbid_not_found``.
+
+    Built from the producer's own Struct, not a hand-rolled dict
+    (``.claude/rules/test-fidelity.md`` Rule C).
+    """
+    result = ValidationResult(
+        valid=False,
+        scenario="mbid_not_found",
+        mbid_found=False,
+        detail="Target MBID rel-1 not in candidates",
+        candidate_count=candidate_count,
+        candidates=[
+            CandidateSummary(mbid=f"other-{index}", distance=0.4)
+            for index in range(candidate_count)
+        ],
+    )
+    blob: dict[str, object] = msgspec.to_builtins(result)
+    return blob
 
 
 class TestFabricatedCopyIsGone(unittest.TestCase):
     """Issue #882: the literals the audit convicted, pinned by outcome."""
 
-    def test_the_real_producer_literal_now_carries_the_copy(self) -> None:
-        """50 live rejected rows carry ``mbid_not_found`` (2026-07-26)."""
-        classified = classify_log_entry(_rejected("mbid_not_found"))
+    def test_a_populated_candidate_set_reads_as_a_pressing_mismatch(self) -> None:
+        """32 of the 50 live rows (2026-07-26): one candidate, not ours."""
+        classified = classify_log_entry(
+            _rejected("mbid_not_found", mbid_not_found_blob(1)))
         self.assertEqual(
             classified.verdict,
             "Requested release ID not among the match candidates",
         )
-        # The producer records an absence from the candidate SET, so the
-        # copy must not claim the stronger fact that nothing matched.
         self.assertNotIn("No MusicBrainz match", classified.verdict)
+
+    def test_an_empty_candidate_set_says_so_instead(self) -> None:
+        """The other 18 live rows carry an empty set — an unmatchable
+        folder, not a pressing mismatch — so a sentence that reads as
+        though candidates existed is only vacuously true."""
+        classified = classify_log_entry(
+            _rejected("mbid_not_found", mbid_not_found_blob(0)))
+        self.assertEqual(
+            classified.verdict,
+            "Beets returned no match candidates for this folder",
+        )
+        # The original falsehood must not come back in any form: the
+        # producer records an empty CANDIDATE SET, never that no match
+        # exists anywhere. "no match candidates" is the set; "no match
+        # found" / "no MusicBrainz match" are the retracted claim.
+        lowered = classified.verdict.casefold()
+        for retracted in (
+            "no musicbrainz match", "no match found", "no match exists",
+            "no matching release",
+        ):
+            self.assertNotIn(retracted, lowered)
+
+    def test_without_a_validation_verdict_neither_arm_is_claimed(self) -> None:
+        """Absence of evidence is not evidence of an empty candidate set."""
+        for blob in (None, {"scenario": "mbid_not_found"}):
+            with self.subTest(blob=blob):
+                classified = classify_log_entry(_rejected("mbid_not_found", blob))
+                self.assertEqual(
+                    classified.verdict,
+                    "Requested release ID not among the match candidates",
+                )
 
     def test_the_fabricated_key_no_longer_manufactures_a_sentence(self) -> None:
         classified = classify_log_entry(_rejected("no_candidates"))
-        self.assertEqual(classified.verdict, "no_candidates")
+        self.assertEqual(classified.verdict, "no candidates")
 
     def test_the_unproduced_triage_actions_no_longer_have_labels(self) -> None:
         for action in ("stale_path_cleared", "stale_path_clear_failed"):
@@ -682,6 +1044,52 @@ class TestFabricatedCopyIsGone(unittest.TestCase):
             classify._wrong_match_action_label("preview_backfilled"),
             "previewed",
         )
+
+
+class TestUnhandledScenariosReadAsWords(unittest.TestCase):
+    """One module, one fallback doctrine (#882 review).
+
+    ``_wrong_match_action_label`` has always humanized its unhandled
+    tokens; ``_rejection_verdict`` dumped the raw machine token, so live
+    rows read as ``extra_tracks`` / ``import_failed``. Humanizing invents
+    no fact — it is the token itself, spelled for a human.
+
+    ``changed_rows`` is measured, not assumed: it is how many live rows
+    this change actually re-renders, from replaying both classifiers over
+    all 36,303 ``download_log`` rows on 2026-07-26. It is NOT the count of
+    rows carrying that ``beets_scenario`` — ``_entry_rejection_decision``
+    prefers a rejection-recording ``ImportResult`` decision, so only the
+    rows without one reach this fallback (477 rows carry
+    ``strong_match``; 8 of them render through here).
+    """
+
+    CASES = [
+        ("extra_tracks", "extra tracks", 45),
+        ("import_failed", "import failed", 44),
+        ("untracked_audio", "untracked audio", 14),
+        ("mbid_missing", "mbid missing", 10),
+        ("strong_match", "strong match", 8),
+        ("quality_evidence_action_failed", "quality evidence action failed", 2),
+    ]
+
+    # Single tokens humanize to themselves: no change, and no new claim.
+    # These carry 19 and 11 live rejected rows and re-render identically.
+    UNCHANGED = [("exception", 19), ("crash", 11)]
+
+    def test_live_raw_token_scenarios_now_read_as_words(self) -> None:
+        for scenario, expected, changed_rows in self.CASES:
+            with self.subTest(scenario, changed_rows=changed_rows):
+                self.assertEqual(
+                    classify_log_entry(_rejected(scenario)).verdict, expected)
+
+    def test_single_token_scenarios_are_unchanged(self) -> None:
+        for scenario, live_rows in self.UNCHANGED:
+            with self.subTest(scenario, live_rows=live_rows):
+                self.assertEqual(
+                    classify_log_entry(_rejected(scenario)).verdict, scenario)
+
+    def test_an_empty_scenario_still_says_rejected(self) -> None:
+        self.assertEqual(classify_log_entry(_rejected("")).verdict, "Rejected")
 
 
 class TestQualityVerdictCopyMatchesTheProducersAction(unittest.TestCase):

--- a/tests/test_classify_producer_audit_generated.py
+++ b/tests/test_classify_producer_audit_generated.py
@@ -1,0 +1,472 @@
+#!/usr/bin/env python3
+"""Generated properties for ``web/classify.py``'s decision copy (issue #882).
+
+The pins in ``tests/test_classify_producer_audit.py`` prove the exact
+scenarios; these properties patrol the world space around them, per
+``.claude/rules/code-quality.md`` § "Pin+fuzz PAIR rule".
+
+Invariants:
+
+C1. **Every string that renders a decision claim is true of what the
+    PRODUCER actually does with that decision.** The expectations are
+    derived from ``lib.quality.dispatch_action`` and
+    ``lib.quality.dispatch_actions.decision_denylists`` — the real
+    importer's own policy — never from the presenter's copy, so the two
+    must independently agree. Applied to the verdict AND the summary, and
+    through both renderers of the same claim (``_rejection_verdict`` and
+    ``_quality_verdict_from_import_result``): issue #868's lesson is that
+    a retracted claim survives in the OTHER renderer and in the adjective
+    form ("could not read" fixed, "unreadable" shipped), so a
+    verdict-scoped check proves nothing.
+
+C2. **A decision name no producer emits is never rewritten into operator
+    copy.** It reaches the operator as itself. This is the property twin
+    of the producer audit: the audit proves no fabricated literal is
+    matched today, this proves the module does not manufacture a sentence
+    for one tomorrow. It is the invariant ``no_candidates`` violated —
+    fluent copy for a string nothing produces, while the producing string
+    (``mbid_not_found``, 50 live rows) fell through to the raw token.
+
+C3. **A decision name classify DOES match renders words, not its own raw
+    token.** The other half of the same defect.
+
+Every checker is a module-level function returning a violation string (or
+``None``), so ``TestInvariantCheckersTripOnViolations`` can call it
+directly with a planted violation.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import unittest
+
+import msgspec
+from hypothesis import assume, example, given, strategies as st
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import tests._hypothesis_profiles  # noqa: F401  (loads the active profile)
+
+from lib.quality import dispatch_action
+from lib.quality.dispatch_actions import decision_denylists
+from tests.helpers import make_import_result
+from tests.test_classify_producer_audit import classify_match_targets
+from web.classify import LogEntry, classify_log_entry
+
+# ---------------------------------------------------------------------------
+# Worlds — derived from the audit's own discovery, never hand-listed
+# ---------------------------------------------------------------------------
+
+# The subjects whose literals are pipeline decision names. Each is a key
+# the producer audit has already traced to a producing module; taking the
+# world space from the same discovery means a new decision literal enters
+# these properties the moment it enters the module.
+DECISION_SUBJECTS = (
+    "scenario",
+    "ir.decision",
+    "_entry_decision(entry)",
+    "_entry_rejection_decision(entry)",
+    "entry.beets_scenario",
+    "triage_preview_decision",
+)
+
+
+def classify_decision_literals() -> tuple[str, ...]:
+    """Every decision name ``web/classify.py`` claims to render copy for."""
+    targets = classify_match_targets()
+    return tuple(sorted({
+        literal
+        for subject in DECISION_SUBJECTS
+        for literal in targets.get(subject, ())
+    }))
+
+
+DECISION_LITERALS = classify_decision_literals()
+REJECTION_SCENARIO_LITERALS = tuple(sorted(
+    classify_match_targets().get("scenario", ())))
+
+# Peer names from an alphabet no claim word contains, so "does the summary
+# repeat a claim?" stays a decidable question.
+_PEER_NAMES = st.text(alphabet="QXZJKVW0123456789", min_size=5, max_size=12)
+
+
+# ---------------------------------------------------------------------------
+# Claim families — derived from the producer's action, not from the copy
+# ---------------------------------------------------------------------------
+
+FAMILY_ACQUISITION_COMPLETE = "acquisition_complete"
+FAMILY_SEARCH_CONTINUES = "search_continues"
+FAMILY_DENYLISTS_THE_SOURCE = "denylists_the_source"
+FAMILY_LEAVES_THE_SOURCE_ALONE = "leaves_the_source_alone"
+FAMILY_ACCEPTED_THE_CANDIDATE = "accepted_the_candidate"
+
+
+def decision_claim_families(decision: str) -> frozenset[str]:
+    """The claim families a decision belongs to, per the PRODUCER.
+
+    ``dispatch_action`` is what the importer really does; whether the
+    request stays imported and whether the source is banned are facts, not
+    presentation choices, so the copy has to agree with them.
+    """
+    action = dispatch_action(decision)
+    families: set[str] = set()
+    if action.preserve_imported:
+        families.add(FAMILY_ACQUISITION_COMPLETE)
+    elif action.record_rejection:
+        families.add(FAMILY_SEARCH_CONTINUES)
+    if action.mark_done:
+        families.add(FAMILY_ACCEPTED_THE_CANDIDATE)
+    if decision_denylists(decision):
+        families.add(FAMILY_DENYLISTS_THE_SOURCE)
+    else:
+        families.add(FAMILY_LEAVES_THE_SOURCE_ALONE)
+    return frozenset(families)
+
+
+# Each family declares the words it may NOT use, paired with the member
+# that contradicts each one. Grammatical variants are listed separately and
+# deliberately: "could not read" was fixed in one renderer while the
+# adjective "unreadable" shipped in another (issue #868 review F1), so a
+# family that bans a claim bans every form the module can spell it in.
+FORBIDDEN_FAMILY_CLAIMS: dict[str, tuple[tuple[str, str], ...]] = {
+    FAMILY_ACQUISITION_COMPLETE: (
+        ("searching continues",
+         "verified_lossless_locked sets preserve_imported: the request stays "
+         "imported and no search is open"),
+        ("searching for better", "the participle form of the same claim"),
+        ("still searching", "the progressive form of the same claim"),
+        ("returned to the queue",
+         "nothing is requeued when the import is preserved"),
+    ),
+    FAMILY_SEARCH_CONTINUES: (
+        ("acquisition is complete",
+         "downgrade returns the request to wanted — the search is still open"),
+        ("acquisition complete", "the bare-adjective form of the same claim"),
+        ("no further search", "the negative form of the same claim"),
+    ),
+    FAMILY_LEAVES_THE_SOURCE_ALONE: (
+        ("denylisted",
+         "nested_layout is a folder-shape reject: dispatch_action bans nobody"),
+        ("denylisting", "the gerund form of the same claim"),
+        ("source banned", "the plain-English form of the same claim"),
+    ),
+    FAMILY_DENYLISTS_THE_SOURCE: (
+        ("no denylist",
+         "downgrade denylists the source, so the reassuring parenthetical "
+         "verified_lossless_locked earns would be false here"),
+        ("without denylisting", "the participle form of the same claim"),
+        ("source kept", "the plain-English form of the same claim"),
+    ),
+    FAMILY_ACCEPTED_THE_CANDIDATE: (
+        ("not better than",
+         "transcode_upgrade sets mark_done: the candidate was imported, not "
+         "out-ranked"),
+        ("declined", "the passive form of the same retracted claim"),
+        ("rejected", "the blunt form of the same retracted claim"),
+    ),
+}
+
+
+def check_decision_claim(
+    decision: str,
+    claim: str,
+    *,
+    where: str,
+) -> str | None:
+    """C1 — any string that speaks for a decision must be action-true.
+
+    ``claim`` is deliberately not "the verdict": the same sentence reaches
+    the operator through ``_rejection_verdict``, through
+    ``_quality_verdict_from_import_result``, and again through the
+    collapsed summary line — which is the line they actually read. Every
+    string that speaks for the decision answers here.
+    """
+    lowered = claim.casefold()
+    for family in sorted(decision_claim_families(decision)):
+        for forbidden, why in FORBIDDEN_FAMILY_CLAIMS.get(family, ()):
+            if forbidden in lowered:
+                return (
+                    f"{where} for {decision} ({family}) claims "
+                    f"{forbidden!r} ({why}): {claim!r}"
+                )
+    return None
+
+
+def check_unproduced_name_is_not_rewritten(
+    scenario: str,
+    verdict: str,
+) -> str | None:
+    """C2 — copy is invented only for names a producer actually emits.
+
+    The defect this patrols: a branch keyed on a string no producer emits
+    replaced the operator's own evidence with a different, wrong fact.
+    Anything the module does not claim must reach them unedited.
+    """
+    if verdict != scenario:
+        return (
+            f"an unregistered decision name was rewritten: {scenario!r} -> "
+            f"{verdict!r}"
+        )
+    return None
+
+
+def check_matched_name_renders_words(
+    scenario: str,
+    verdict: str,
+) -> str | None:
+    """C3 — a name the module matches never renders as its own raw token."""
+    if verdict.strip() == scenario:
+        return (
+            f"{scenario!r} is matched by the module but still renders as its "
+            f"own machine token: {verdict!r}"
+        )
+    return None
+
+
+# ---------------------------------------------------------------------------
+# World builders
+# ---------------------------------------------------------------------------
+
+def _entry_for(
+    decision: str,
+    *,
+    outcome: str,
+    username: str | None = None,
+    with_import_result: bool = False,
+) -> LogEntry:
+    import_result = (
+        msgspec.to_builtins(make_import_result(decision=decision))
+        if with_import_result
+        else None
+    )
+    return LogEntry(
+        id=1,
+        request_id=2,
+        outcome=outcome,
+        beets_scenario=decision,
+        soulseek_username=username,
+        import_result=import_result,
+    )
+
+
+def _outcomes_for(decision: str) -> tuple[str, ...]:
+    """The download_log outcomes this decision can actually be logged under."""
+    action = dispatch_action(decision)
+    if action.mark_done:
+        return ("success",)
+    # A rejection is recorded as ``rejected``; the import-phase failures
+    # that carry the same decision are logged as ``failed`` and reach the
+    # SECOND renderer of the same claim.
+    return ("rejected", "failed")
+
+
+# ---------------------------------------------------------------------------
+# Properties
+# ---------------------------------------------------------------------------
+
+class TestDecisionClaimsMatchTheProducersAction(unittest.TestCase):
+    """C1 — issue #882 item 4."""
+
+    def test_the_world_space_is_derived_and_non_trivial(self) -> None:
+        self.assertGreater(len(DECISION_LITERALS), 10)
+        self.assertIn("verified_lossless_locked", DECISION_LITERALS)
+        self.assertIn("provisional_lossless_upgrade", DECISION_LITERALS)
+
+    @given(
+        decision=st.sampled_from(DECISION_LITERALS),
+        data=st.data(),
+        username=st.one_of(st.none(), _PEER_NAMES),
+        with_import_result=st.booleans(),
+    )
+    @example(
+        decision="verified_lossless_locked", data=None,
+        username="QXZJK", with_import_result=False,
+    )
+    @example(
+        decision="lossless_source_locked", data=None,
+        username=None, with_import_result=True,
+    )
+    @example(
+        decision="provisional_lossless_upgrade", data=None,
+        username="QXZJK", with_import_result=True,
+    )
+    def test_no_rendered_claim_contradicts_the_producers_action(
+        self,
+        decision: str,
+        data: st.DataObject | None,
+        username: str | None,
+        with_import_result: bool,
+    ) -> None:
+        outcomes = _outcomes_for(decision)
+        chosen = (
+            outcomes if data is None else (data.draw(st.sampled_from(outcomes)),)
+        )
+        for outcome in chosen:
+            classified = classify_log_entry(_entry_for(
+                decision,
+                outcome=outcome,
+                username=username,
+                with_import_result=with_import_result,
+            ))
+            for where, claim in (
+                (f"{outcome} verdict", classified.verdict),
+                (f"{outcome} summary", classified.summary),
+            ):
+                violation = check_decision_claim(decision, claim, where=where)
+                self.assertIsNone(violation, violation)
+
+    @given(
+        decision=st.sampled_from(DECISION_LITERALS),
+        username=st.one_of(st.none(), _PEER_NAMES),
+    )
+    def test_the_collapsed_summary_carries_the_verdict(
+        self, decision: str, username: str | None,
+    ) -> None:
+        """The list row is the line the operator reads (issue #868 #12)."""
+        for outcome in _outcomes_for(decision):
+            classified = classify_log_entry(
+                _entry_for(decision, outcome=outcome, username=username))
+            if classified.badge == "Imported":
+                continue
+            self.assertIn(classified.verdict, classified.summary)
+
+
+class TestUnproducedNamesAreNeverRewritten(unittest.TestCase):
+    """C2 — the property twin of the producer audit."""
+
+    @given(scenario=st.text(min_size=1, max_size=60))
+    @example(scenario="no_candidates")
+    @example(scenario="stale_path_cleared")
+    def test_an_unmatched_decision_name_reaches_the_operator_verbatim(
+        self, scenario: str,
+    ) -> None:
+        assume(scenario not in DECISION_LITERALS)
+        assume(scenario.strip() == scenario and scenario.strip())
+        classified = classify_log_entry(
+            LogEntry(id=1, request_id=2, outcome="rejected",
+                     beets_scenario=scenario))
+        violation = check_unproduced_name_is_not_rewritten(
+            scenario, classified.verdict)
+        self.assertIsNone(violation, violation)
+
+
+class TestMatchedNamesRenderWords(unittest.TestCase):
+    """C3 — the other half of the ``no_candidates`` defect."""
+
+    @given(scenario=st.sampled_from(REJECTION_SCENARIO_LITERALS))
+    @example(scenario="mbid_not_found")
+    def test_every_matched_rejection_scenario_renders_a_sentence(
+        self, scenario: str,
+    ) -> None:
+        classified = classify_log_entry(
+            LogEntry(id=1, request_id=2, outcome="rejected",
+                     beets_scenario=scenario))
+        violation = check_matched_name_renders_words(
+            scenario, classified.verdict)
+        self.assertIsNone(violation, violation)
+
+
+# ---------------------------------------------------------------------------
+# Known-bad self-tests — a checker that cannot fail proves nothing
+# ---------------------------------------------------------------------------
+
+class TestInvariantCheckersTripOnViolations(unittest.TestCase):
+
+    def test_family_derivation_follows_the_producer(self) -> None:
+        self.assertIn(
+            FAMILY_ACQUISITION_COMPLETE,
+            decision_claim_families("verified_lossless_locked"),
+        )
+        self.assertIn(
+            FAMILY_LEAVES_THE_SOURCE_ALONE,
+            decision_claim_families("verified_lossless_locked"),
+        )
+        self.assertIn(
+            FAMILY_SEARCH_CONTINUES, decision_claim_families("downgrade"))
+        self.assertIn(
+            FAMILY_DENYLISTS_THE_SOURCE, decision_claim_families("downgrade"))
+        self.assertIn(
+            FAMILY_ACCEPTED_THE_CANDIDATE,
+            decision_claim_families("transcode_upgrade"),
+        )
+
+    def test_claim_checker_trips_on_a_lock_that_claims_to_keep_searching(self):
+        self.assertIsNotNone(check_decision_claim(
+            "verified_lossless_locked",
+            "Verified lossless already on disk; searching continues",
+            where="planted verdict",
+        ))
+        # …and on the participle form that would survive a literal fix.
+        self.assertIsNotNone(check_decision_claim(
+            "verified_lossless_locked",
+            "Verified lossless already on disk; searching for better",
+            where="planted verdict",
+        ))
+        self.assertIsNone(check_decision_claim(
+            "verified_lossless_locked",
+            "Verified lossless already on disk; automatic candidate declined "
+            "(no denylist); acquisition is complete",
+            where="real verdict",
+        ))
+
+    def test_claim_checker_trips_on_a_reject_that_claims_completion(self) -> None:
+        self.assertIsNotNone(check_decision_claim(
+            "downgrade",
+            "Quality not better than on-disk copy; acquisition is complete",
+            where="planted verdict",
+        ))
+
+    def test_claim_checker_trips_on_both_denylist_claims(self) -> None:
+        self.assertIsNotNone(check_decision_claim(
+            "nested_layout",
+            "Nested folder layout; source denylisted",
+            where="planted verdict",
+        ))
+        self.assertIsNotNone(check_decision_claim(
+            "downgrade",
+            "Quality not better than on-disk copy (no denylist)",
+            where="planted verdict",
+        ))
+        self.assertIsNone(check_decision_claim(
+            "downgrade",
+            "Quality not better than on-disk copy; searching continues",
+            where="real verdict",
+        ))
+
+    def test_claim_checker_trips_on_an_accepted_candidate_called_rejected(self):
+        self.assertIsNotNone(check_decision_claim(
+            "transcode_upgrade",
+            "Transcode at 245kbps — rejected as not better than on-disk copy",
+            where="planted verdict",
+        ))
+        self.assertIsNone(check_decision_claim(
+            "transcode_upgrade",
+            "Transcode at 245kbps — imported as upgrade, searching for better",
+            where="real verdict",
+        ))
+
+    def test_claim_checker_reads_the_summary_too(self) -> None:
+        """The verdict-only version of this check would pass here."""
+        self.assertIsNotNone(check_decision_claim(
+            "verified_lossless_locked",
+            "Verified lossless already on disk · searching continues · QXZJK",
+            where="planted summary",
+        ))
+
+    def test_passthrough_checker_trips_on_a_manufactured_sentence(self) -> None:
+        self.assertIsNotNone(check_unproduced_name_is_not_rewritten(
+            "no_candidates", "No MusicBrainz match found"))
+        self.assertIsNone(check_unproduced_name_is_not_rewritten(
+            "no_candidates", "no_candidates"))
+
+    def test_raw_token_checker_trips_on_the_other_half_of_the_defect(self) -> None:
+        self.assertIsNotNone(check_matched_name_renders_words(
+            "mbid_not_found", "mbid_not_found"))
+        self.assertIsNone(check_matched_name_renders_words(
+            "mbid_not_found",
+            "Requested release ID not among the match candidates"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_classify_producer_audit_generated.py
+++ b/tests/test_classify_producer_audit_generated.py
@@ -19,16 +19,30 @@ C1. **Every string that renders a decision claim is true of what the
     form ("could not read" fixed, "unreadable" shipped), so a
     verdict-scoped check proves nothing.
 
-C2. **A decision name no producer emits is never rewritten into operator
-    copy.** It reaches the operator as itself. This is the property twin
-    of the producer audit: the audit proves no fabricated literal is
-    matched today, this proves the module does not manufacture a sentence
-    for one tomorrow. It is the invariant ``no_candidates`` violated —
-    fluent copy for a string nothing produces, while the producing string
-    (``mbid_not_found``, 50 live rows) fell through to the raw token.
+C2. **A decision name no producer emits is never rewritten into a
+    different FACT.** It reaches the operator as the token itself, spelled
+    for a human. This is the property twin of the producer audit: the
+    audit proves no fabricated literal is matched today, this proves the
+    module does not manufacture a sentence for one tomorrow. It is the
+    invariant ``no_candidates`` violated — fluent copy for a string
+    nothing produces, while the producing string (``mbid_not_found``, 50
+    live rows) fell through to the raw token.
+
+    The comparison is against an INDEPENDENT restatement of the
+    presentation-only transform (``humanized``), not against
+    ``_humanize_token`` itself; comparing production to production would
+    make the property follow a producer that started inventing.
 
 C3. **A decision name classify DOES match renders words, not its own raw
     token.** The other half of the same defect.
+
+Known limitation (issue #882 review N6): C1's forbidden vocabulary is a
+DENYLIST of phrasings, so a novel wording of a false claim — "…; the hunt
+goes on" for a proof-locked request — escapes it. That is inherent to
+checking prose; the backstop is the exact-string pins in
+``tests/test_classify_producer_audit.py``, which fail the moment the
+sentence changes at all. Widen the denylist when a new phrasing ships;
+do not mistake it for a semantic check.
 
 Every checker is a module-level function returning a violation string (or
 ``None``), so ``TestInvariantCheckersTripOnViolations`` can call it
@@ -193,6 +207,17 @@ def check_decision_claim(
     return None
 
 
+def humanized(token: str) -> str:
+    """The presentation-only transform, restated independently.
+
+    Deliberately not a call to ``web.classify._humanize_token``: a checker
+    that asks production what production should have said cannot catch
+    production inventing. Separators become spaces; nothing else changes,
+    so no new fact can enter.
+    """
+    return token.replace("_", " ").replace("-", " ").strip()
+
+
 def check_unproduced_name_is_not_rewritten(
     scenario: str,
     verdict: str,
@@ -200,10 +225,13 @@ def check_unproduced_name_is_not_rewritten(
     """C2 — copy is invented only for names a producer actually emits.
 
     The defect this patrols: a branch keyed on a string no producer emits
-    replaced the operator's own evidence with a different, wrong fact.
-    Anything the module does not claim must reach them unedited.
+    replaced the operator's own evidence with a different, wrong fact. The
+    bar is the FACT, not the exact bytes — spelling ``import_failed`` as
+    "import failed" adds no claim, which is why this compares against the
+    independent ``humanized`` restatement rather than the raw token
+    (issue #882 review N1).
     """
-    if verdict != scenario:
+    if verdict != humanized(scenario):
         return (
             f"an unregistered decision name was rewritten: {scenario!r} -> "
             f"{verdict!r}"
@@ -215,8 +243,13 @@ def check_matched_name_renders_words(
     scenario: str,
     verdict: str,
 ) -> str | None:
-    """C3 — a name the module matches never renders as its own raw token."""
-    if verdict.strip() == scenario:
+    """C3 — a name the module matches renders copy, not the token itself.
+
+    A matched name is one the module claims to have something to say
+    about; falling through to the humanized token means the claim is
+    missing (``mbid_not_found``, 50 live rows, before #882).
+    """
+    if verdict.strip() in (scenario, humanized(scenario)):
         return (
             f"{scenario!r} is matched by the module but still renders as its "
             f"own machine token: {verdict!r}"
@@ -338,11 +371,15 @@ class TestUnproducedNamesAreNeverRewritten(unittest.TestCase):
     @given(scenario=st.text(min_size=1, max_size=60))
     @example(scenario="no_candidates")
     @example(scenario="stale_path_cleared")
-    def test_an_unmatched_decision_name_reaches_the_operator_verbatim(
+    @example(scenario="extra_tracks")
+    def test_an_unmatched_decision_name_reaches_the_operator_unedited(
         self, scenario: str,
     ) -> None:
         assume(scenario not in DECISION_LITERALS)
         assume(scenario.strip() == scenario and scenario.strip())
+        # A token that humanizes away entirely ("___") legitimately falls
+        # back to the generic "Rejected"; there is no fact to preserve.
+        assume(humanized(scenario))
         classified = classify_log_entry(
             LogEntry(id=1, request_id=2, outcome="rejected",
                      beets_scenario=scenario))
@@ -457,12 +494,27 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
     def test_passthrough_checker_trips_on_a_manufactured_sentence(self) -> None:
         self.assertIsNotNone(check_unproduced_name_is_not_rewritten(
             "no_candidates", "No MusicBrainz match found"))
+        # Spelling the token for a human adds no fact, so it passes …
         self.assertIsNone(check_unproduced_name_is_not_rewritten(
-            "no_candidates", "no_candidates"))
+            "no_candidates", "no candidates"))
+        # … while any other sentence, however plausible, does not.
+        self.assertIsNotNone(check_unproduced_name_is_not_rewritten(
+            "no_candidates", "Rejected: no usable candidate was found"))
+
+    def test_the_humanize_restatement_is_independent_of_production(self) -> None:
+        """N1: comparing production to production proves nothing."""
+        self.assertEqual(humanized("quality_evidence_action_failed"),
+                         "quality evidence action failed")
+        self.assertEqual(humanized("exception"), "exception")
+        self.assertEqual(humanized("stale-path"), "stale path")
+        self.assertEqual(humanized("  x_y  "), "x y")
 
     def test_raw_token_checker_trips_on_the_other_half_of_the_defect(self) -> None:
         self.assertIsNotNone(check_matched_name_renders_words(
             "mbid_not_found", "mbid_not_found"))
+        # The humanized token is still no claim — a matched name owes copy.
+        self.assertIsNotNone(check_matched_name_renders_words(
+            "mbid_not_found", "mbid not found"))
         self.assertIsNone(check_matched_name_renders_words(
             "mbid_not_found",
             "Requested release ID not among the match candidates"))

--- a/tests/test_web_recents.py
+++ b/tests/test_web_recents.py
@@ -1049,6 +1049,9 @@ class TestClassifyVerdict(unittest.TestCase):
     def test_mbid_not_found_verdict(self):
         """The producer's own fact: the requested ID was not in the set.
 
+        ``lib/beets.py`` writes this from ``if not result.mbid_found``,
+        whether or not that set was empty; the empty case gets its own
+        sentence (pinned in ``tests/test_classify_producer_audit.py``).
         The copy this replaces was keyed on ``no_candidates`` — a literal
         ``lib/beets.py`` has never emitted — and claimed the stronger,
         false fact that no match existed at all (issue #882).

--- a/tests/test_web_recents.py
+++ b/tests/test_web_recents.py
@@ -780,9 +780,9 @@ class TestClassifyBadge(unittest.TestCase):
             outcome="rejected", beets_scenario="audio_corrupt"))
         self.assertEqual(result.badge, "Rejected")
 
-    def test_rejected_no_candidates(self):
+    def test_rejected_mbid_not_found(self):
         result = classify_log_entry(_entry(
-            outcome="rejected", beets_scenario="no_candidates"))
+            outcome="rejected", beets_scenario="mbid_not_found"))
         self.assertEqual(result.badge, "Rejected")
 
     def test_rejected_album_name_mismatch(self):
@@ -1046,11 +1046,19 @@ class TestClassifyVerdict(unittest.TestCase):
         self.assertIn("duplicate remove guard failed", result.verdict.lower())
         self.assertIn("2 duplicates", result.verdict.lower())
 
-    def test_no_candidates_verdict(self):
+    def test_mbid_not_found_verdict(self):
+        """The producer's own fact: the requested ID was not in the set.
+
+        The copy this replaces was keyed on ``no_candidates`` — a literal
+        ``lib/beets.py`` has never emitted — and claimed the stronger,
+        false fact that no match existed at all (issue #882).
+        """
         result = classify_log_entry(_entry(
-            outcome="rejected", beets_scenario="no_candidates"))
-        self.assertIn("no", result.verdict.lower())
-        self.assertIn("match", result.verdict.lower())
+            outcome="rejected", beets_scenario="mbid_not_found"))
+        self.assertEqual(
+            result.verdict,
+            "Requested release ID not among the match candidates",
+        )
 
     def test_album_name_mismatch_verdict(self):
         result = classify_log_entry(_entry(

--- a/web/classify.py
+++ b/web/classify.py
@@ -903,21 +903,35 @@ def _extract_wrong_match_triage(entry: LogEntry) -> dict[str, Any]:
 
 
 def _beets_returned_no_candidates(entry: LogEntry) -> bool:
-    """Whether the persisted validation POSITIVELY records an empty candidate set.
+    """Whether a real beets run POSITIVELY recorded an empty candidate set.
 
     ``lib/beets.py`` writes ``mbid_not_found`` whenever the requested release
-    ID is absent from ``cm.candidates``, empty set or not. Only the blob it
-    wrote alongside distinguishes the two, so this answers ``True`` solely on
-    positive evidence: a real ``ValidationResult`` verdict (``valid`` is a
-    bool on every envelope its writer produced — ``None`` marks the
-    curator-ban/legacy envelopes that never carried one) whose ``candidates``
-    list is empty. Absence of evidence is not an empty candidate set.
+    ID is absent from ``cm.candidates``, empty set or not, so only the blob it
+    wrote alongside separates "beets returned nothing" from "beets returned
+    siblings". The discriminator has to prove beets RAN, not merely that the
+    blob is ValidationResult-shaped: ``valid`` defaults to ``False`` and is
+    always emitted, so most rejection blobs on disk are synthesized stubs
+    (``ValidationResult(distance=…, scenario=…, detail=…)`` in
+    ``lib/download_rejection.py`` / ``lib/dispatch/outcome_actions.py``) that
+    carry an empty ``candidates`` list purely because beets was never
+    consulted (issue #882 review F4).
+
+    ``items`` and ``recommendation`` are written together, and only, by the
+    ``choose_match`` handler in ``lib/beets.py`` — the local tracks the
+    harness reported and beets' own confidence in the match it proposed — so
+    both non-empty is positive evidence of a real run. Live on 2026-07-26 the
+    two populations separate cleanly: of every row carrying a zero-candidate
+    validation blob, the 18 with both signals all have
+    ``recommendation='none'`` and 2-20 items, and the other 911 have neither.
+    Anything short of both fails closed to the general sentence, which is
+    true of an empty candidate set anyway.
     """
     try:
         envelope = decode_validation_envelope(entry.validation_result)
     except (msgspec.ValidationError, json.JSONDecodeError):
         return False
-    return envelope.valid is not None and not envelope.candidates
+    beets_ran = bool(envelope.items) and bool(envelope.recommendation)
+    return beets_ran and not envelope.candidates
 
 
 def _candidate_audio_is_corrupt(
@@ -1525,9 +1539,21 @@ def _rejection_verdict(entry: LogEntry) -> str:
     # ``lib/beets.py`` sets this from ``if not result.mbid_found``: the
     # requested release ID is not in the candidate set beets emitted. That
     # fires whether or not the set was empty — 18 of the 50 live rows carry
-    # an empty one (beets' own filtering, e.g. ``match.ignore_video_tracks``)
-    # — and the two cases send the operator to different places, so each
-    # gets the sentence its own evidence supports.
+    # an empty one — and the two cases send the operator to different
+    # places, so each gets the sentence its own evidence supports.
+    #
+    # The empty arm names the release-ID LOOKUP, not the folder, because
+    # the folder cannot be the discriminator: ``lib/beets.py`` always
+    # passes ``--search-id``, the harness maps it to
+    # ``config["import"]["search_ids"]``, and beets' ``tag_album`` then
+    # takes its ``if search_ids:`` branch — deriving candidates from
+    # ``albums_for_ids`` alone and skipping the metadata/text search
+    # entirely. Live confirmation: every one of the 13 requests behind
+    # those 18 rows has sibling attempts on the SAME release ID that did
+    # return candidates (1 to 115 each). It says "Beets" rather than
+    # "MusicBrainz" because the ID is not always an MBID — two of the 18
+    # requested Discogs release IDs, which ``albums_for_ids`` dispatches
+    # across metadata plugins.
     #
     # The copy this replaced was keyed on ``no_candidates``, a string no
     # producer has ever emitted (issue #882): the 50 live rows carrying the
@@ -1535,7 +1561,10 @@ def _rejection_verdict(entry: LogEntry) -> str:
     # sentence sat behind a key nothing could reach.
     if scenario == "mbid_not_found":
         if _beets_returned_no_candidates(entry):
-            return "Beets returned no match candidates for this folder"
+            return (
+                "Beets returned no match candidates for the requested "
+                "release ID"
+            )
         return "Requested release ID not among the match candidates"
 
     # Historical: emitted by a pre-2026-03-24 revision, one live row, no

--- a/web/classify.py
+++ b/web/classify.py
@@ -766,16 +766,21 @@ def _humanize_token(value: str | None) -> str | None:
 
 
 def _wrong_match_action_label(action: str | None) -> str | None:
+    """Operator label for a persisted wrong-match triage action.
+
+    Every literal matched here is one ``lib/wrong_match_cleanup_service.py``
+    or ``lib/wrong_match_delete_service.py`` actually writes, except
+    ``preview_backfilled`` which is historical (59 live rows, 2026-04-26 to
+    2026-04-28). Anything else falls through to the humanized token, so an
+    unhandled producer action still reads as words rather than inventing a
+    fact. Audited by ``tests/test_classify_producer_audit.py``.
+    """
     if action == "deleted_reject":
         return "download deleted"
     if action == "deleted_verified_lossless_parent":
         return "download deleted: verified-lossless parent"
     if action == "delete_failed":
         return "delete failed"
-    if action == "stale_path_cleared":
-        return "stale path cleared"
-    if action == "stale_path_clear_failed":
-        return "stale path clear failed"
     if action == "kept_would_import":
         return "download kept: would import"
     if action == "kept_uncertain":
@@ -1505,9 +1510,17 @@ def _rejection_verdict(entry: LogEntry) -> str:
             return f"Duplicate remove guard failed: {entry.beets_detail}"
         return "Duplicate remove guard failed"
 
-    if scenario == "no_candidates":
-        return "No MusicBrainz match found"
+    # ``lib/beets.py`` sets this when the requested release ID is absent from
+    # the candidate set beets returned — NOT when beets found nothing. The
+    # copy this replaced was keyed on ``no_candidates``, a string no producer
+    # has ever emitted (issue #882): 50 live rows carrying the real
+    # ``mbid_not_found`` fell through to the raw-token fallback while the
+    # fluent sentence sat behind a key nothing could reach.
+    if scenario == "mbid_not_found":
+        return "Requested release ID not among the match candidates"
 
+    # Historical: emitted by a pre-2026-03-24 revision, one live row, no
+    # current producer — which is why the audit registers it as historical.
     if scenario == "album_name_mismatch":
         return "Album name mismatch"
 

--- a/web/classify.py
+++ b/web/classify.py
@@ -902,6 +902,24 @@ def _extract_wrong_match_triage(entry: LogEntry) -> dict[str, Any]:
     }
 
 
+def _beets_returned_no_candidates(entry: LogEntry) -> bool:
+    """Whether the persisted validation POSITIVELY records an empty candidate set.
+
+    ``lib/beets.py`` writes ``mbid_not_found`` whenever the requested release
+    ID is absent from ``cm.candidates``, empty set or not. Only the blob it
+    wrote alongside distinguishes the two, so this answers ``True`` solely on
+    positive evidence: a real ``ValidationResult`` verdict (``valid`` is a
+    bool on every envelope its writer produced — ``None`` marks the
+    curator-ban/legacy envelopes that never carried one) whose ``candidates``
+    list is empty. Absence of evidence is not an empty candidate set.
+    """
+    try:
+        envelope = decode_validation_envelope(entry.validation_result)
+    except (msgspec.ValidationError, json.JSONDecodeError):
+        return False
+    return envelope.valid is not None and not envelope.candidates
+
+
 def _candidate_audio_is_corrupt(
     entry: LogEntry,
     triage_preview_decision: str | None,
@@ -1454,12 +1472,6 @@ def _rejection_verdict(entry: LogEntry) -> str:
     # evidence in the row payload.
     scenario = _entry_rejection_decision(entry)
 
-    # Proof lock: the decision is current-proof-driven, so the quality
-    # comparison sentence built from the ImportResult would mislabel it —
-    # return the dedicated policy sentence before any delegation.
-    if scenario == "verified_lossless_locked":
-        return _verified_lossless_locked_verdict()
-
     # Quality comparison scenarios — delegate to ImportResult when available
     if scenario in (
         "downgrade",
@@ -1510,13 +1522,20 @@ def _rejection_verdict(entry: LogEntry) -> str:
             return f"Duplicate remove guard failed: {entry.beets_detail}"
         return "Duplicate remove guard failed"
 
-    # ``lib/beets.py`` sets this when the requested release ID is absent from
-    # the candidate set beets returned — NOT when beets found nothing. The
-    # copy this replaced was keyed on ``no_candidates``, a string no producer
-    # has ever emitted (issue #882): 50 live rows carrying the real
-    # ``mbid_not_found`` fell through to the raw-token fallback while the
-    # fluent sentence sat behind a key nothing could reach.
+    # ``lib/beets.py`` sets this from ``if not result.mbid_found``: the
+    # requested release ID is not in the candidate set beets emitted. That
+    # fires whether or not the set was empty — 18 of the 50 live rows carry
+    # an empty one (beets' own filtering, e.g. ``match.ignore_video_tracks``)
+    # — and the two cases send the operator to different places, so each
+    # gets the sentence its own evidence supports.
+    #
+    # The copy this replaced was keyed on ``no_candidates``, a string no
+    # producer has ever emitted (issue #882): the 50 live rows carrying the
+    # real literal fell through to the raw-token fallback while the fluent
+    # sentence sat behind a key nothing could reach.
     if scenario == "mbid_not_found":
+        if _beets_returned_no_candidates(entry):
+            return "Beets returned no match candidates for this folder"
         return "Requested release ID not among the match candidates"
 
     # Historical: emitted by a pre-2026-03-24 revision, one live row, no
@@ -1527,7 +1546,11 @@ def _rejection_verdict(entry: LogEntry) -> str:
     if scenario == "nested_layout":
         return "Nested folder layout (flatten first)"
 
-    return str(scenario) if scenario else "Rejected"
+    # An unhandled producer scenario reads as words, not as a machine token —
+    # the same doctrine ``_wrong_match_action_label`` has always applied, and
+    # the one this module had two answers to before #882. Humanizing invents
+    # no fact: it is the token itself, spelled for a human.
+    return _humanize_token(scenario) or "Rejected"
 
 
 def _upgrade_verdict(prev_br: Optional[int], cur_br: Optional[int],


### PR DESCRIPTION
Part of #882 (items 3 and 4). PR3 of 3. **Changes live operator copy — 173 rows.**

## The audit found what it was built to find

`web/classify.py` carried the fluent sentence **"No MusicBrainz match found"** behind the scenario key `no_candidates` — a literal that exists nowhere in the codebase, with **zero** live rows. The real producing literal, `mbid_not_found` from `lib/beets.py`, has **50 live rejected rows** and fell through to the raw-token fallback, so those rows rendered as the bare machine token `mbid_not_found`. Exactly the #868 shape, one module over: fluent copy on an unreachable key, the reachable key unhandled.

The claim was wrong too, not just the key. The producer fires on `not result.mbid_found` — beets returned candidates, the *requested release ID* wasn't among them. Under strict pressing identity that is materially different from "nothing matched".

## The copy, split by what the evidence actually supports

| rows | copy |
|---|---|
| 32 (one candidate) | `Requested release ID not among the match candidates` |
| 18 (zero candidates) | `Beets returned no match candidates for the requested release ID` |

**"Beets", not "MusicBrainz"** — two of the 18 rows requested *Discogs* IDs (`5159` → `1838462`, `15969` → `28229`), so naming MusicBrainz would have been flatly wrong; `albums_for_ids` fans across enabled metadata plugins.

**"for the requested release ID", not "for this folder"** — `harness/beets_harness.py:798` sets `import.search_ids`, so beets 2.12's `tag_album` takes the `if search_ids:` branch and skips the text search entirely. The folder cannot affect whether candidates *exist*. All 13 requests behind those 18 rows have sibling attempts on the same release ID that **did** return candidates (1–115 each). The earlier wording would have sent the operator to inspect tags and filenames when the release-ID lookup was what failed.

The empty arm only fires where beets demonstrably ran: gated on `items` **and** `recommendation`, written together by a single producer. Live separation: of **929** rows with a zero-candidate blob, **18 carry both signals, 911 carry neither** (those are synthesized rejection stubs whose `candidates=[]` is a struct default, not evidence).

## The one-line fallback

`_rejection_verdict` ended `return str(scenario)` while its sibling `_wrong_match_action_label` ended `return _humanize_token(action)` — one module, two fallbacks, two doctrines. Unified: **123 more rows** stop showing machine tokens (`extra_tracks` 45, `import_failed` 47, `untracked_audio` 14, `mbid_missing` 10, `strong_match` 5, `quality_evidence_action_failed` 2). It invents nothing — a token in words is not a new fact-claim.

Deliberately **not** done: bespoke sentences for those ~10 scenarios. That means reading 10 producers, and getting one wrong reintroduces the defect class. Registering producible-but-uncopied names so the audit *names* them is separate work.

## The guards

- **Producer audit** — discovery is derived, never hand-listed: classify's inline comparison grammar (`==`/`in`/`startswith`/`match`-`case`) by AST, plus literal containers at **any scope** (a table declared inside a function was invisible to the first version; three planted mutants survived it and now die). Evidence is a **spelling**, not a mention: the producer must spell the literal as an AST `Constant`, so a comment or docstring mention cannot satisfy it. Unregistered target → fails closed.
- **Claim checkers (item 4)** — families derived from the *producer's* own action (`dispatch_action(...).preserve_imported`/`.mark_done`, `decision_denylists(...)`), never from classify's copy, so the two must independently agree. Applied to both renderers and the collapsed summary, in every grammatical form.
- **`historical` entries** now carry structured falsifiable evidence (`source`, `row_count`, `last_seen`) instead of prose, so the hatch cannot launder an invention behind a plausible sentence.
- **`.claude/rules/test-fidelity.md` Rule C** — a copy pin's input comes from the producer, never from a literal.

## Live evidence

Replayed `origin/main`'s classifier against this tree over **all 36,303 `download_log` rows**: **173 rows change, every one in `verdict` + `summary` only.** `badge`, `badge_class`, `border_color`, `downloaded_label` byte-identical on every row. The removed `verified_lossless_locked` branch is proven unreachable (0 live rows); the `stale_path_*` deletions are byte-identical to `_humanize_token` output.

## Review history

Three rounds, and rounds 2 and 3 each found a **new falsehood introduced while fixing the old one** — the same pattern #868 recorded. Round 2: the comment justifying the new copy claimed the producer fires "NOT when beets found nothing", falsified by 18 live zero-candidate rows. Round 3: the cited cause (`match.ignore_video_tracks`) was fabricated — that option drops video tracks from a track list, never a candidate, and it is `false` in the deployed config. Both are recorded here because the pattern is the point: gates were green for all of it; only driving the real classifier over real rows found any of it.
