### PR TITLE
Report per-property generated depth in the fuzz burst

### DIFF
--- a/docs/generated-testing.md
+++ b/docs/generated-testing.md
@@ -371,6 +371,57 @@ host-scaled entropy fan-out. On doc1's 30-core VM on 2026-07-23, the complete
 seconds. The worst subprocess-heavy generated module completed alone in 142.7
 seconds; its unsharded properties had still not completed after ten minutes.
 
+### Per-property depth report
+
+Issue #888 item 1. A budget is not depth: `@given(authorized=st.booleans(),
+missing=st.booleans())` has four distinct worlds, so Hypothesis exhausts it in
+four examples and stops — whether the budget is 150 or 20,000. A mutant that
+widens a quarantine authority boundary survived 215 tests across seven modules
+for exactly that reason, and nothing in the burst output said so.
+
+After the `SLOW` lines, every burst now prints what each property actually
+generated, measured from Hypothesis' own `statistics` collector in the child
+that ran it:
+
+```
+DEPTH 351 properties measured, 68 exhausted their strategy space, 6 discarded at least 10% of their examples
+SHALLOW 2 worlds of 150 examples (1 shards) tests.test_pin_retention_generated.TestGeneratedPinRetention.test_every_status_is_pending_or_terminal
+SHALLOW ... 48 more exhausted
+DISCARD 51% of 307 examples (157 discarded, 150 worlds) tests.test_world_invariants_generated.TestWorldInvariantGenerated.test_any_evidence_fingerprint_drift_is_rejected
+```
+
+- **SHALLOW** — the property ran out of distinct worlds before it ran out of
+  budget (`stopped-because: nothing left to do`), ranked by world count
+  ascending, top 20. Entropy shards are folded into one row first: a
+  default-budget property runs as up to eight children of `budget / shards`
+  examples, so a raw per-shard verdict would flag every sharded property.
+  The reported world count is the largest single shard, because shards
+  re-explore the same space.
+- **DISCARD** — the property threw away at least 10% of its examples through
+  `assume()` or a strategy filter, ranked by rate descending. This is a cost
+  and shape signal, not a defect: `assume` marks a world invalid and
+  Hypothesis refills the budget, which is exactly why it is the correct way
+  to drop an unanswerable world.
+
+**It reports; it never gates.** A small strategy space is often exactly
+right — the 36-world force-import authority property is correct — so a
+threshold would either be trivially satisfiable or block legitimate work. Two
+carve-outs keep the verdict honest: a run that reached an `interesting` case
+stopped because it found its planted bug (every known-bad self-test looks
+exhausted otherwise), and a property whose worlds reach its budget wasted
+nothing.
+
+**It cannot see a bare `return`.** A `return` spends the example as a PASS, so
+a vacuously-discarding property reads as a full budget of valid worlds. That
+is unchanged by this report and is why the `assume`-not-`return` rule below
+still has to be followed by hand.
+
+On doc1 on 2026-07-26, the deterministic-tier burst over all 89 generated
+modules measured 351 properties, of which 68 exhaust their space — the
+smallest at two worlds against 150 examples. Those are the properties for
+which a deeper burst buys nothing at all; widening their strategies is
+separate work this report exists to aim.
+
 All active logs, property tempdirs, and Hypothesis database writes stay in the
 private per-shell tmpfs. A database named by
 `HYPOTHESIS_STORAGE_DIRECTORY` seeds the run read-only. A green run discards
@@ -559,7 +610,12 @@ may still patrol nothing; only review and mutant-kill counts show that.
   A `return` spends the example as a PASS and silently shrinks the real
   budget; `assume` marks it invalid so Hypothesis refills. Issue #882 found
   a property burning 29% of a 20,000-example budget this way. If the world
-  has a defined answer, assert it instead of discarding it.
+  has a defined answer, assert it instead of discarding it. The burst's
+  `DISCARD` lines price the `assume` cost; a `return` shows up nowhere, so
+  this one is still enforced by hand.
+- **Check the burst's `SHALLOW` lines for the property you just wrote.** A
+  strategy space smaller than the budget is a fact worth knowing before the
+  next mutant hunt reports a survivor.
 - Reuse the shared fakes/builders (`tests/fakes/`, `tests/helpers.py`)
   per `.claude/rules/code-quality.md`; leaf-seam mock rules apply to
   generated tests like any other test.

--- a/docs/generated-testing.md
+++ b/docs/generated-testing.md
@@ -384,43 +384,60 @@ generated, measured from Hypothesis' own `statistics` collector in the child
 that ran it:
 
 ```
-DEPTH 351 properties measured, 68 exhausted their strategy space, 6 discarded at least 10% of their examples
-SHALLOW 2 worlds of 150 examples (1 shards) tests.test_pin_retention_generated.TestGeneratedPinRetention.test_every_status_is_pending_or_terminal
-SHALLOW ... 48 more exhausted
+DEPTH 351 properties measured, 68 shallow (space exhausted below budget), 6 discarding at least 10% of their examples
+SHALLOW 2 worlds vs 150 examples per shard (1 shard, 150 total) tests.test_pin_retention_generated.TestGeneratedPinRetention.test_every_status_is_pending_or_terminal
+SHALLOW ... 48 more shallow
 DISCARD 51% of 307 examples (157 discarded, 150 worlds) tests.test_world_invariants_generated.TestWorldInvariantGenerated.test_any_evidence_fingerprint_drift_is_rejected
 ```
 
 - **SHALLOW** — the property ran out of distinct worlds before it ran out of
   budget (`stopped-because: nothing left to do`), ranked by world count
-  ascending, top 20. Entropy shards are folded into one row first: a
-  default-budget property runs as up to eight children of `budget / shards`
-  examples, so a raw per-shard verdict would flag every sharded property.
-  The reported world count is the largest single shard, because shards
-  re-explore the same space.
+  ascending, top 20. Entropy shards are folded into one row first. That
+  folding does not change WHICH properties are flagged — a shard that stops
+  at its own budget reports `settings.max_examples=…`, never exhaustion, so
+  an unfolded verdict picks out the same set. It de-duplicates eight
+  identical rows out of the ranked list and reports the property's real total
+  budget against one distinct-world bound: the largest single shard, since
+  shards re-explore the same space.
 - **DISCARD** — the property threw away at least 10% of its examples through
   `assume()` or a strategy filter, ranked by rate descending. This is a cost
   and shape signal, not a defect: `assume` marks a world invalid and
   Hypothesis refills the budget, which is exactly why it is the correct way
   to drop an unanswerable world.
 
+Only properties are counted. A plain test whose body declares and calls its
+own `@given` — the shape every known-bad self-test uses — emits statistics
+too, under the enclosing test's id; those are dropped, so the denominator is
+exactly the number of real `@given` property tests.
+
 **It reports; it never gates.** A small strategy space is often exactly
 right — the 36-world force-import authority property is correct — so a
 threshold would either be trivially satisfiable or block legitimate work. Two
 carve-outs keep the verdict honest: a run that reached an `interesting` case
-stopped because it found its planted bug (every known-bad self-test looks
-exhausted otherwise), and a property whose worlds reach its budget wasted
-nothing.
+stopped because it found its planted bug, and a property whose worlds reach
+its budget wasted nothing. The first is defensive rather than load-bearing
+today: no repository property reaches that state, precisely because the
+known-bad self-tests plant their bug in a dropped inner `@given`.
+
+**The ceiling is the per-child budget.** Only a space smaller than the
+`N examples per shard` figure — 150 at the deterministic tier, `budget /
+shards` (2,500 on a 30-core host) at the fuzz tier — can be observed at all.
+A 5,000-world property never exhausts, so it is reported as deep at both
+tiers, and every non-shallow property's worlds are bounded by that per-shard
+budget rather than by its real space. An empty SHALLOW section means "none
+found below the ceiling", never "no shallow properties".
 
 **It cannot see a bare `return`.** A `return` spends the example as a PASS, so
 a vacuously-discarding property reads as a full budget of valid worlds. That
 is unchanged by this report and is why the `assume`-not-`return` rule below
 still has to be followed by hand.
 
-On doc1 on 2026-07-26, the deterministic-tier burst over all 89 generated
-modules measured 351 properties, of which 68 exhaust their space — the
-smallest at two worlds against 150 examples. Those are the properties for
-which a deeper burst buys nothing at all; widening their strategies is
-separate work this report exists to aim.
+Measured on doc1, 2026-07-26, deterministic tier, all 89 generated modules
+(963 tests, 58.3s): 351 properties, 68 of them shallow — the smallest at two
+worlds against 150 examples. Those are the properties for which a deeper
+burst buys nothing at all; widening their strategies is separate work this
+report exists to aim. Every figure here moves with each property added or
+strategy widened, so re-run the burst rather than trusting these numbers.
 
 All active logs, property tempdirs, and Hypothesis database writes stay in the
 private per-shell tmpfs. A database named by

--- a/scripts/run_fuzz_tests.py
+++ b/scripts/run_fuzz_tests.py
@@ -97,10 +97,15 @@ class PropertyDepth:
     reached. Shards re-explore the same strategy space with different entropy,
     so summing them would overcount distinct worlds; the maximum is the honest
     bound on how much of its space the property can reach.
+
+    ``shard_budget_bound`` is the largest budget any single child ran under.
+    That, not ``budget``, is the number Hypothesis compared the worlds
+    against, and it is therefore the report's detection ceiling.
     """
 
     test_id: str
     budget: int
+    shard_budget_bound: int
     shards: int
     exhausted_shards: int
     distinct_world_bound: int
@@ -318,10 +323,16 @@ def aggregate_property_depth(
 ) -> tuple[PropertyDepth, ...]:
     """Fold every entropy shard's statistics into one row per property.
 
-    Sharding is invisible to depth: a default-budget property runs as up to
-    eight children of ``budget / shards`` examples each, so judging a raw
-    record would flag every sharded property as under-run. Budgets and case
-    counts sum; the distinct-world bound is the maximum single shard.
+    A default-budget property runs as up to eight children of
+    ``budget / shards`` examples each. Folding does NOT change which
+    properties are flagged — a shard that stops at its own budget reports
+    ``settings.max_examples=...``, never exhaustion, so an unfolded verdict
+    picks out the same set (measured on a real 8-shard run: 185 shard records,
+    24 properties, same three flagged either way). It changes the report:
+    one row instead of eight identical ones eating the ranked list, the
+    property's real total budget, and one distinct-world bound (the maximum
+    shard, since shards re-explore the same space and summing would
+    overcount).
     """
     grouped: dict[str, list[HypothesisPropertyStats]] = {}
     for record in records:
@@ -332,6 +343,9 @@ def aggregate_property_depth(
                 PropertyDepth(
                     test_id=test_id,
                     budget=sum(shard.max_examples for shard in shards),
+                    shard_budget_bound=max(
+                        shard.max_examples for shard in shards
+                    ),
                     shards=len(shards),
                     exhausted_shards=sum(
                         shard.stopped_because == STRATEGY_SPACE_EXHAUSTED
@@ -371,11 +385,21 @@ def is_structurally_shallow(depth: PropertyDepth) -> bool:
     worlds, so a mutant outside those four worlds survives however deep the
     burst runs.
 
+    **Detection ceiling.** Only a space smaller than ``shard_budget_bound``
+    can be observed at all — 150 at the deterministic tier, ``budget /
+    shards`` (2,500 on a 30-core host) at the fuzz tier. A property with more
+    worlds than that never exhausts, so it is reported as deep whatever its
+    real space is, and an empty SHALLOW section means "none found below the
+    ceiling", never "no shallow properties".
+
     Two carve-outs keep the verdict honest:
 
     * a run that reached an ``interesting`` case stopped early BECAUSE it
-      found what it was looking for — every known-bad self-test in the
-      repository looks exactly like an exhausted run otherwise;
+      found what it was looking for. This is defensive: no repository
+      property produces interesting cases today, because the known-bad
+      self-tests run their planted property in an inner ``@given`` whose
+      statistics ``HypothesisStatsRecorder`` drops. It exists so a future
+      property that does report them is not mislabelled;
     * a property whose worlds reach its budget spent everything it was given,
       whatever the tier's budget happens to be.
 
@@ -389,6 +413,10 @@ def is_structurally_shallow(depth: PropertyDepth) -> bool:
     if depth.exhausted_shards != depth.shards:
         return False
     return depth.distinct_world_bound < depth.budget
+
+
+def _shard_count(shards: int) -> str:
+    return f"{shards} shard" if shards == 1 else f"{shards} shards"
 
 
 def format_depth_report(depths: Sequence[PropertyDepth]) -> tuple[str, ...]:
@@ -409,18 +437,20 @@ def format_depth_report(depths: Sequence[PropertyDepth]) -> tuple[str, ...]:
     )
     lines = [
         f"DEPTH {len(depths)} properties measured, "
-        f"{len(shallow)} exhausted their strategy space, "
-        f"{len(discarding)} discarded at least "
+        f"{len(shallow)} shallow (space exhausted below budget), "
+        f"{len(discarding)} discarding at least "
         f"{DISCARD_RATE_THRESHOLD:.0%} of their examples"
     ]
     for depth in shallow[:DEPTH_REPORT_LIMIT]:
         lines.append(
-            f"SHALLOW {depth.distinct_world_bound} worlds of "
-            f"{depth.budget} examples ({depth.shards} shards) {depth.test_id}"
+            f"SHALLOW {depth.distinct_world_bound} worlds vs "
+            f"{depth.shard_budget_bound} examples per shard "
+            f"({_shard_count(depth.shards)}, {depth.budget} total) "
+            f"{depth.test_id}"
         )
     if len(shallow) > DEPTH_REPORT_LIMIT:
         lines.append(
-            f"SHALLOW ... {len(shallow) - DEPTH_REPORT_LIMIT} more exhausted"
+            f"SHALLOW ... {len(shallow) - DEPTH_REPORT_LIMIT} more shallow"
         )
     for depth in discarding[:DEPTH_REPORT_LIMIT]:
         lines.append(

--- a/scripts/run_fuzz_tests.py
+++ b/scripts/run_fuzz_tests.py
@@ -25,16 +25,27 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from scripts.run_python_tests import (  # noqa: E402
+    STRATEGY_SPACE_EXHAUSTED,
     ChildTargetResult,
+    HypothesisPropertyStats,
     _iter_test_cases,
     assert_hypothesis_deadlines_disabled,
     resolve_hypothesis_settings,
+    settings_max_examples,
 )
 
 
 TARGET_RUNNER = REPO_ROOT / "scripts" / "run_python_tests.py"
 DEFAULT_PROFILE = "fuzz"
 DEFAULT_DURATIONS = 5
+
+#: Ranked depth-report lines printed per section before truncation.
+DEPTH_REPORT_LIMIT = 20
+
+#: Discard rate at which a property's ``assume()`` cost is worth naming. Not a
+#: defect: ``assume`` marks a world invalid and Hypothesis refills the budget,
+#: which is exactly why it is the correct way to drop an unanswerable world.
+DISCARD_RATE_THRESHOLD = 0.10
 
 
 class FuzzPropertyManifest(msgspec.Struct, frozen=True):
@@ -75,6 +86,28 @@ class FuzzRunResult:
     tests_run: int
     elapsed_seconds: float
     log_path: Path
+    hypothesis_stats: tuple[HypothesisPropertyStats, ...] = ()
+
+
+@dataclass(frozen=True)
+class PropertyDepth:
+    """One property's generated depth, aggregated across its entropy shards.
+
+    ``distinct_world_bound`` is the largest world count any single shard
+    reached. Shards re-explore the same strategy space with different entropy,
+    so summing them would overcount distinct worlds; the maximum is the honest
+    bound on how much of its space the property can reach.
+    """
+
+    test_id: str
+    budget: int
+    shards: int
+    exhausted_shards: int
+    distinct_world_bound: int
+    valid: int
+    invalid: int
+    overrun: int
+    interesting: int
 
 
 @dataclass(frozen=True)
@@ -280,14 +313,126 @@ def assert_exact_fuzz_coverage(
             raise ValueError(f"changed fuzz property budget: {test_id}")
 
 
-def _settings_max_examples(configured: settings) -> int:
-    raw_max_examples: object = getattr(configured, "max_examples", None)
-    if isinstance(raw_max_examples, bool) or not isinstance(
-        raw_max_examples,
-        int,
-    ):
-        raise TypeError("Hypothesis max_examples is not an integer")
-    return raw_max_examples
+def aggregate_property_depth(
+    records: Sequence[HypothesisPropertyStats],
+) -> tuple[PropertyDepth, ...]:
+    """Fold every entropy shard's statistics into one row per property.
+
+    Sharding is invisible to depth: a default-budget property runs as up to
+    eight children of ``budget / shards`` examples each, so judging a raw
+    record would flag every sharded property as under-run. Budgets and case
+    counts sum; the distinct-world bound is the maximum single shard.
+    """
+    grouped: dict[str, list[HypothesisPropertyStats]] = {}
+    for record in records:
+        grouped.setdefault(record.test_id, []).append(record)
+    return tuple(
+        sorted(
+            (
+                PropertyDepth(
+                    test_id=test_id,
+                    budget=sum(shard.max_examples for shard in shards),
+                    shards=len(shards),
+                    exhausted_shards=sum(
+                        shard.stopped_because == STRATEGY_SPACE_EXHAUSTED
+                        for shard in shards
+                    ),
+                    distinct_world_bound=max(shard.valid for shard in shards),
+                    valid=sum(shard.valid for shard in shards),
+                    invalid=sum(shard.invalid for shard in shards),
+                    overrun=sum(shard.overrun for shard in shards),
+                    interesting=sum(shard.interesting for shard in shards),
+                )
+                for test_id, shards in grouped.items()
+            ),
+            key=lambda depth: depth.test_id,
+        )
+    )
+
+
+def attempted_examples(depth: PropertyDepth) -> int:
+    """Every example Hypothesis actually spent on this property."""
+    return depth.valid + depth.invalid + depth.overrun
+
+
+def discard_rate(depth: PropertyDepth) -> float:
+    """Share of spent examples that ``assume()`` (or a filter) threw away."""
+    attempted = attempted_examples(depth)
+    if attempted == 0:
+        return 0.0
+    return depth.invalid / attempted
+
+
+def is_structurally_shallow(depth: PropertyDepth) -> bool:
+    """True when a property ran out of worlds long before it ran out of budget.
+
+    The disclosure #888 item 1 exists for: ``@given(a=st.booleans(),
+    b=st.booleans())`` against a 20,000-example budget is exhausted in four
+    worlds, so a mutant outside those four worlds survives however deep the
+    burst runs.
+
+    Two carve-outs keep the verdict honest:
+
+    * a run that reached an ``interesting`` case stopped early BECAUSE it
+      found what it was looking for — every known-bad self-test in the
+      repository looks exactly like an exhausted run otherwise;
+    * a property whose worlds reach its budget spent everything it was given,
+      whatever the tier's budget happens to be.
+
+    It reports; it never gates. A small strategy space can be exactly right
+    (the 36-world force-import authority property is correct), and a
+    ``return``-based discard is invisible here by construction — a bare
+    ``return`` spends the example as a PASS, so it counts as a valid world.
+    """
+    if depth.interesting:
+        return False
+    if depth.exhausted_shards != depth.shards:
+        return False
+    return depth.distinct_world_bound < depth.budget
+
+
+def format_depth_report(depths: Sequence[PropertyDepth]) -> tuple[str, ...]:
+    """Render the ranked per-property depth disclosure for one burst."""
+    if not depths:
+        return ()
+    shallow = sorted(
+        (depth for depth in depths if is_structurally_shallow(depth)),
+        key=lambda depth: (depth.distinct_world_bound, depth.test_id),
+    )
+    discarding = sorted(
+        (
+            depth
+            for depth in depths
+            if discard_rate(depth) >= DISCARD_RATE_THRESHOLD
+        ),
+        key=lambda depth: (-discard_rate(depth), depth.test_id),
+    )
+    lines = [
+        f"DEPTH {len(depths)} properties measured, "
+        f"{len(shallow)} exhausted their strategy space, "
+        f"{len(discarding)} discarded at least "
+        f"{DISCARD_RATE_THRESHOLD:.0%} of their examples"
+    ]
+    for depth in shallow[:DEPTH_REPORT_LIMIT]:
+        lines.append(
+            f"SHALLOW {depth.distinct_world_bound} worlds of "
+            f"{depth.budget} examples ({depth.shards} shards) {depth.test_id}"
+        )
+    if len(shallow) > DEPTH_REPORT_LIMIT:
+        lines.append(
+            f"SHALLOW ... {len(shallow) - DEPTH_REPORT_LIMIT} more exhausted"
+        )
+    for depth in discarding[:DEPTH_REPORT_LIMIT]:
+        lines.append(
+            f"DISCARD {discard_rate(depth):.0%} of {attempted_examples(depth)} "
+            f"examples ({depth.invalid} discarded, {depth.valid} worlds) "
+            f"{depth.test_id}"
+        )
+    if len(discarding) > DEPTH_REPORT_LIMIT:
+        lines.append(
+            f"DISCARD ... {len(discarding) - DEPTH_REPORT_LIMIT} more discarding"
+        )
+    return tuple(lines)
 
 
 def _discover_module_child(module_name: str, result_path: Path) -> int:
@@ -298,7 +443,7 @@ def _discover_module_child(module_name: str, result_path: Path) -> int:
     default_settings = settings.default
     if default_settings is None:
         raise RuntimeError("Hypothesis has no active default settings")
-    default_max_examples = _settings_max_examples(default_settings)
+    default_max_examples = settings_max_examples(default_settings)
     # One owner for the deadline contract, shared with the deterministic
     # suite runner so neither tier can drift from the other (#882 B1b).
     assert_hypothesis_deadlines_disabled(suite)
@@ -308,11 +453,11 @@ def _discover_module_child(module_name: str, result_path: Path) -> int:
             continue
         configured = resolved.configured
         uses_default_settings = (
-            _settings_max_examples(configured) == default_max_examples
+            settings_max_examples(configured) == default_max_examples
             if resolved.from_state_machine_class
             else configured is default_settings
         )
-        configured_max_examples = _settings_max_examples(configured)
+        configured_max_examples = settings_max_examples(configured)
         hypothesis_tests.append(
             FuzzPropertyManifest(
                 test_id=test.id(),
@@ -458,6 +603,7 @@ def _execute_fuzz_target(
         tests_run=child.tests_run,
         elapsed_seconds=elapsed_seconds,
         log_path=log_path,
+        hypothesis_stats=child.hypothesis_stats,
     )
 
 
@@ -744,6 +890,16 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(
                 f"SLOW {result.elapsed_seconds:.1f}s {result.target.label}"
             )
+        for line in format_depth_report(
+            aggregate_property_depth(
+                tuple(
+                    record
+                    for result in results
+                    for record in result.hypothesis_stats
+                )
+            )
+        ):
+            print(line)
         if failed_results or infrastructure_failures:
             for result in sorted(
                 failed_results,

--- a/scripts/run_python_tests.py
+++ b/scripts/run_python_tests.py
@@ -149,10 +149,19 @@ class HypothesisStatsRecorder:
     started — ``RecordingTextTestResult.startTest`` — which the child bridges
     into :meth:`start`.
 
+    Only tests that ARE properties are recorded. A plain test whose body
+    declares and calls its own ``@given`` function also emits statistics, and
+    the running test is then the enclosing plain test — the repository's
+    known-bad self-test shape. Absence from the budget map is exactly the
+    "not a property test method" signal, so those runs are dropped: filing
+    them under the enclosing test would inflate the property count and, when
+    one body runs two inner properties, fold them into a single row whose
+    shard count and world bound are both fiction.
+
     The recorder never raises and never fails a run: a burst depth report is a
-    disclosure, not a gate. A callback with no running test, an unrecognised
-    budget, or an unreadable statistics shape degrades to a dropped or
-    zero-budget record instead of breaking the suite that produced it.
+    disclosure, not a gate. A callback with no running test, a test that is
+    not a property, or an unreadable statistics shape degrades to a dropped
+    record instead of breaking the suite that produced it.
     """
 
     def __init__(self, budgets: Mapping[str, int]) -> None:
@@ -170,9 +179,9 @@ class HypothesisStatsRecorder:
         self._current_test_id = test_id
 
     def note(self, statistics: Mapping[str, object]) -> None:
-        """Record one Hypothesis run's generate-phase case statuses."""
+        """Record one property's generate-phase case statuses."""
         test_id = self._current_test_id
-        if test_id is None:
+        if test_id is None or test_id not in self._budgets:
             return
         generate_phase = json_dict(statistics.get("generate-phase"))
         statuses = [
@@ -186,7 +195,7 @@ class HypothesisStatsRecorder:
         self._records.append(
             HypothesisPropertyStats(
                 test_id=test_id,
-                max_examples=self._budgets.get(test_id, 0),
+                max_examples=self._budgets[test_id],
                 valid=counts["valid"],
                 invalid=counts["invalid"],
                 overrun=counts["overrun"],

--- a/scripts/run_python_tests.py
+++ b/scripts/run_python_tests.py
@@ -20,6 +20,13 @@ from pathlib import Path
 
 import msgspec
 from hypothesis import is_hypothesis_test, settings
+from hypothesis.statistics import collector
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from lib.json_narrow import json_dict, json_list  # noqa: E402 - after path setup
 
 
 DEFAULT_MAX_WORKERS = 12
@@ -33,6 +40,17 @@ HOTSPOT_SHARD_POLICIES = {
 }
 HOTSPOT_CLASS_BATCHES = 8
 HOTSPOT_METHOD_BATCHES = 12
+
+#: Hypothesis' ``stopped-because`` reason when a strategy space ran out of
+#: distinct worlds before the example budget ran out
+#: (``ExitReason.finished``). This is the signal that a property is
+#: structurally incapable of spending its budget, however large that budget is.
+STRATEGY_SPACE_EXHAUSTED = "nothing left to do"
+
+#: The generate-phase case statuses Hypothesis reports, lower-cased. Pinned by
+#: ``tests/test_parallel_test_runner.py`` against the live ``Status`` enum: a
+#: new status would otherwise be silently uncounted in the depth report.
+HYPOTHESIS_CASE_STATUSES = ("valid", "invalid", "overrun", "interesting")
 
 
 @dataclass(frozen=True)
@@ -77,6 +95,23 @@ class TargetInfrastructureFailure:
     detail: str
 
 
+class HypothesisPropertyStats(msgspec.Struct, frozen=True):
+    """One Hypothesis property's generate-phase depth in one child process.
+
+    ``max_examples`` is the budget that child actually ran under — the
+    per-shard budget when ``scripts/run_fuzz_tests.py`` split a property
+    across entropy shards, so the shards sum back to the property's total.
+    """
+
+    test_id: str
+    max_examples: int
+    valid: int
+    invalid: int
+    overrun: int
+    interesting: int
+    stopped_because: str
+
+
 class ChildTargetResult(msgspec.Struct, frozen=True):
     """Wire result written by one fresh target interpreter."""
 
@@ -84,6 +119,7 @@ class ChildTargetResult(msgspec.Struct, frozen=True):
     tests_run: int
     test_ids: tuple[str, ...]
     output: str
+    hypothesis_stats: tuple[HypothesisPropertyStats, ...] = ()
 
 
 class ListedTestIds(msgspec.Struct, frozen=True):
@@ -102,6 +138,64 @@ class RecordingTextTestResult(unittest.TextTestResult):
             self.test_ids = []
         self.test_ids.append(test.id())
         super().startTest(test)
+
+
+class HypothesisStatsRecorder:
+    """Attribute each Hypothesis statistics callback to its running test.
+
+    Hypothesis reports one statistics mapping per property run through
+    ``hypothesis.statistics.collector``, and that mapping names no test. The
+    running test is therefore read from the one canonical record of what
+    started — ``RecordingTextTestResult.startTest`` — which the child bridges
+    into :meth:`start`.
+
+    The recorder never raises and never fails a run: a burst depth report is a
+    disclosure, not a gate. A callback with no running test, an unrecognised
+    budget, or an unreadable statistics shape degrades to a dropped or
+    zero-budget record instead of breaking the suite that produced it.
+    """
+
+    def __init__(self, budgets: Mapping[str, int]) -> None:
+        self._budgets = budgets
+        self._current_test_id: str | None = None
+        self._records: list[HypothesisPropertyStats] = []
+
+    @property
+    def records(self) -> tuple[HypothesisPropertyStats, ...]:
+        """Every property's statistics, in the order Hypothesis reported them."""
+        return tuple(self._records)
+
+    def start(self, test_id: str) -> None:
+        """Mark the test whose statistics arrive next."""
+        self._current_test_id = test_id
+
+    def note(self, statistics: Mapping[str, object]) -> None:
+        """Record one Hypothesis run's generate-phase case statuses."""
+        test_id = self._current_test_id
+        if test_id is None:
+            return
+        generate_phase = json_dict(statistics.get("generate-phase"))
+        statuses = [
+            json_dict(case).get("status")
+            for case in json_list(generate_phase.get("test-cases"))
+        ]
+        counts = {
+            status: statuses.count(status) for status in HYPOTHESIS_CASE_STATUSES
+        }
+        stopped_because = statistics.get("stopped-because")
+        self._records.append(
+            HypothesisPropertyStats(
+                test_id=test_id,
+                max_examples=self._budgets.get(test_id, 0),
+                valid=counts["valid"],
+                invalid=counts["invalid"],
+                overrun=counts["overrun"],
+                interesting=counts["interesting"],
+                stopped_because=(
+                    stopped_because if isinstance(stopped_because, str) else ""
+                ),
+            )
+        )
 
 
 def _line_weight(path: Path) -> int:
@@ -478,6 +572,28 @@ def resolve_hypothesis_settings(
     raise TypeError(f"Hypothesis test has no settings: {test.id()}")
 
 
+def settings_max_examples(configured: settings) -> int:
+    """Read one resolved settings object's integer example budget."""
+    raw_max_examples: object = getattr(configured, "max_examples", None)
+    if isinstance(raw_max_examples, bool) or not isinstance(
+        raw_max_examples,
+        int,
+    ):
+        raise TypeError("Hypothesis max_examples is not an integer")
+    return raw_max_examples
+
+
+def hypothesis_example_budgets(suite: unittest.TestSuite) -> dict[str, int]:
+    """Map each Hypothesis test in this suite to the budget it will run under."""
+    budgets: dict[str, int] = {}
+    for test in _iter_test_cases(suite):
+        resolved = resolve_hypothesis_settings(test)
+        if resolved is None:
+            continue
+        budgets[test.id()] = settings_max_examples(resolved.configured)
+    return budgets
+
+
 def assert_hypothesis_deadlines_disabled(suite: unittest.TestSuite) -> None:
     """Every Hypothesis test in this suite must resolve ``deadline=None``.
 
@@ -585,12 +701,27 @@ def _run_test_target_child(
             discovered_by_id[test_id] for test_id in selected_test_ids
         )
     assert_hypothesis_deadlines_disabled(suite)
-    result = unittest.TextTestRunner(
-        stream=stream,
-        verbosity=2,
-        durations=durations,
-        resultclass=RecordingTextTestResult,  # pyright: ignore[reportArgumentType]
-    ).run(suite)
+    recorder = HypothesisStatsRecorder(hypothesis_example_budgets(suite))
+
+    class _StatsRecordingResult(RecordingTextTestResult):
+        """Bridge the canonical started-test record to the stats recorder."""
+
+        def startTest(self, test: unittest.TestCase) -> None:
+            super().startTest(test)
+            recorder.start(test.id())
+
+    # Hypothesis types the collector as ``DynamicVariable[None]``, so pyright
+    # reads any callback as a bad argument; the runtime contract is a callable
+    # taking one statistics mapping (``hypothesis.statistics.note_statistics``).
+    with collector.with_value(
+        recorder.note,  # pyright: ignore[reportArgumentType]
+    ):
+        result = unittest.TextTestRunner(
+            stream=stream,
+            verbosity=2,
+            durations=durations,
+            resultclass=_StatsRecordingResult,  # pyright: ignore[reportArgumentType]
+        ).run(suite)
     if not isinstance(result, RecordingTextTestResult):
         raise TypeError("unittest runner returned an unexpected result type")
     result_path.write_bytes(
@@ -600,6 +731,7 @@ def _run_test_target_child(
                 tests_run=result.testsRun,
                 test_ids=tuple(result.test_ids or ()),
                 output=stream.getvalue(),
+                hypothesis_stats=recorder.records,
             )
         )
     )

--- a/tests/test_fuzz_burst.py
+++ b/tests/test_fuzz_burst.py
@@ -270,8 +270,9 @@ class TestBurstDepthReport(unittest.TestCase):
     def test_entropy_shards_are_aggregated_before_depth_is_judged(self) -> None:
         """One property split eight ways is one row, judged once.
 
-        Without aggregation every sharded property reads as under-run: each
-        shard receives budget/shards examples and reports only its own worlds.
+        Folding does not change WHICH properties are flagged — it de-duplicates
+        eight identical rows out of the ranked list and reports the property's
+        real total budget against one distinct-world bound.
         """
         records = tuple(
             _shard(self.PROPERTY, budget=2_500, valid=4) for _ in range(8)
@@ -285,6 +286,7 @@ class TestBurstDepthReport(unittest.TestCase):
                 PropertyDepth(
                     test_id=self.PROPERTY,
                     budget=20_000,
+                    shard_budget_bound=2_500,
                     shards=8,
                     exhausted_shards=8,
                     distinct_world_bound=4,
@@ -298,27 +300,23 @@ class TestBurstDepthReport(unittest.TestCase):
         self.assertTrue(is_structurally_shallow(depths[0]))
         self.assertEqual(
             [line for line in format_depth_report(depths) if "SHALLOW" in line],
-            [f"SHALLOW 4 worlds of 20000 examples (8 shards) {self.PROPERTY}"],
+            [
+                "SHALLOW 4 worlds vs 2500 examples per shard "
+                f"(8 shards, 20000 total) {self.PROPERTY}"
+            ],
         )
 
-    def test_a_run_that_found_its_planted_bug_is_never_shallow(self) -> None:
-        """Known-bad self-test: every known-bad self-test looks exhausted.
+    def test_a_single_shard_line_names_one_shard(self) -> None:
+        depths = aggregate_property_depth(
+            (_shard(self.PROPERTY, budget=50, valid=4),)
+        )
 
-        A checker without this carve-out flags every deliberately failing
-        property in the repository as structurally shallow.
-        """
-        found_its_bug = aggregate_property_depth(
-            (_shard(self.PROPERTY, budget=20_000, valid=26, interesting=2),)
-        )[0]
-        same_world_without_the_bug = aggregate_property_depth(
-            (_shard(self.PROPERTY, budget=20_000, valid=26),)
-        )[0]
-
-        self.assertFalse(is_structurally_shallow(found_its_bug))
-        self.assertTrue(is_structurally_shallow(same_world_without_the_bug))
-        self.assertNotIn(
-            "SHALLOW",
-            "\n".join(format_depth_report((found_its_bug,))),
+        self.assertEqual(
+            [line for line in format_depth_report(depths) if "SHALLOW" in line],
+            [
+                "SHALLOW 4 worlds vs 50 examples per shard "
+                f"(1 shard, 50 total) {self.PROPERTY}"
+            ],
         )
 
     def test_a_property_that_spends_its_whole_budget_is_not_shallow(self) -> None:
@@ -400,14 +398,50 @@ class TestBurstDepthReport(unittest.TestCase):
         self.assertEqual(
             lines[0],
             f"DEPTH {DEPTH_REPORT_LIMIT + 5} properties measured, "
-            f"{DEPTH_REPORT_LIMIT + 5} exhausted their strategy space, "
-            "0 discarded at least 10% of their examples",
+            f"{DEPTH_REPORT_LIMIT + 5} shallow (space exhausted below budget), "
+            "0 discarding at least 10% of their examples",
         )
         self.assertEqual(
             [line.split()[1] for line in lines[1 : DEPTH_REPORT_LIMIT + 1]],
             [str(index) for index in range(DEPTH_REPORT_LIMIT)],
         )
-        self.assertEqual(lines[-1], "SHALLOW ... 5 more exhausted")
+        self.assertEqual(lines[-1], "SHALLOW ... 5 more shallow")
+
+    def test_discarding_properties_rank_by_rate_and_truncate(self) -> None:
+        records = tuple(
+            _shard(
+                f"{self.PROPERTY}_{index:02d}",
+                budget=150,
+                valid=150,
+                invalid=20 + index,
+                stopped_because="settings.max_examples=150",
+            )
+            for index in range(DEPTH_REPORT_LIMIT + 3)
+        )
+
+        lines = format_depth_report(aggregate_property_depth(records))
+        discard_lines = [
+            line for line in lines if line.startswith("DISCARD ") and "..." not in line
+        ]
+
+        self.assertEqual(
+            lines[0],
+            f"DEPTH {DEPTH_REPORT_LIMIT + 3} properties measured, "
+            "0 shallow (space exhausted below budget), "
+            f"{DEPTH_REPORT_LIMIT + 3} discarding at least 10% of their examples",
+        )
+        self.assertEqual(
+            [line.split()[-1][-2:] for line in discard_lines],
+            [
+                f"{index:02d}"
+                for index in range(
+                    DEPTH_REPORT_LIMIT + 2,
+                    DEPTH_REPORT_LIMIT + 2 - DEPTH_REPORT_LIMIT,
+                    -1,
+                )
+            ],
+        )
+        self.assertEqual(lines[-1], "DISCARD ... 3 more discarding")
 
     def test_a_burst_without_properties_reports_nothing(self) -> None:
         self.assertEqual(format_depth_report(aggregate_property_depth(())), ())
@@ -457,6 +491,35 @@ class TestFuzzRunnerProcess(unittest.TestCase):
             "    @given(value=st.integers())\n"
             "    def test_property(self, value):\n"
             "        self.assertEqual(value, value)\n",
+            encoding="utf-8",
+        )
+        (package / "test_mixed_generated.py").write_text(
+            "import unittest\n"
+            "from hypothesis import given, settings\n"
+            "from hypothesis import strategies as st\n"
+            "from hypothesis.stateful import RuleBasedStateMachine, rule\n"
+            "import tests._hypothesis_profiles\n\n"
+            "class MixedWorld(unittest.TestCase):\n"
+            "    @settings(max_examples=50, database=None)\n"
+            "    @given(value=st.booleans())\n"
+            "    def test_property(self, value):\n"
+            "        self.assertIsInstance(value, bool)\n\n"
+            "    def test_pin(self):\n"
+            "        self.assertTrue(True)\n\n"
+            "    def test_pin_running_an_inner_property(self):\n"
+            "        @settings(max_examples=50, database=None)\n"
+            "        @given(first=st.booleans(), second=st.booleans())\n"
+            "        def planted(first, second):\n"
+            "            raise AssertionError('planted')\n"
+            "        with self.assertRaises(AssertionError):\n"
+            "            planted()\n\n"
+            "@settings(max_examples=5, stateful_step_count=3,\n"
+            "          database=None, deadline=None)\n"
+            "class Machine(RuleBasedStateMachine):\n"
+            "    @rule(value=st.integers())\n"
+            "    def step(self, value):\n"
+            "        assert isinstance(value, int)\n\n"
+            "TestMachine = Machine.TestCase\n",
             encoding="utf-8",
         )
         (package / "test_shallow_generated.py").write_text(
@@ -602,14 +665,75 @@ class TestFuzzRunnerProcess(unittest.TestCase):
 
         self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
         self.assertIn(
-            "DEPTH 1 properties measured, 1 exhausted their strategy space",
+            "DEPTH 1 properties measured, 1 shallow "
+            "(space exhausted below budget)",
             completed.stdout,
         )
         self.assertIn(
-            "SHALLOW 4 worlds of 50 examples (1 shards) "
+            "SHALLOW 4 worlds vs 50 examples per shard (1 shard, 50 total) "
             "fuzz_fixture.test_shallow_generated.ShallowWorld.test_property",
             completed.stdout,
         )
+
+    def test_reported_property_count_equals_the_discovered_property_count(
+        self,
+    ) -> None:
+        """The denominator is derived, never hand-counted.
+
+        The fixture mixes a property, a plain pin, a pin whose body declares
+        and calls its own ``@given`` (the known-bad self-test shape, which
+        emits statistics under the enclosing test's id), and a stateful
+        machine (whose id comes from ``hypothesis.stateful``, not the module).
+        Only the two real properties may be counted.
+        """
+        module = "fuzz_fixture.test_mixed_generated"
+        env = {
+            **os.environ,
+            "PYTHONPATH": os.pathsep.join(
+                (str(self.root), str(REPO_ROOT), os.environ.get("PYTHONPATH", ""))
+            ),
+            "HYPOTHESIS_STORAGE_DIRECTORY": str(self.database),
+            "CRATEDIGGER_HYPOTHESIS_PROFILE": "suite",
+        }
+        with tempfile.TemporaryDirectory() as discovery:
+            manifest = discover_fuzz_manifests(
+                (module,),
+                worker_count=1,
+                environment=env,
+                work_directory=Path(discovery),
+            )[0]
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(RUNNER),
+                "--jobs",
+                "2",
+                "--profile",
+                "suite",
+                module,
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+        discovered = tuple(item.test_id for item in manifest.hypothesis_tests)
+        self.assertEqual(
+            sorted(discovered),
+            [
+                "fuzz_fixture.test_mixed_generated.MixedWorld.test_property",
+                "hypothesis.stateful.Machine.TestCase.runTest",
+            ],
+        )
+        self.assertIn(
+            f"DEPTH {len(discovered)} properties measured,",
+            completed.stdout,
+        )
+        self.assertNotIn("test_pin_running_an_inner_property", completed.stdout)
 
     def test_deterministic_profile_rejects_entropy_sharding(self) -> None:
         completed = subprocess.run(

--- a/tests/test_fuzz_burst.py
+++ b/tests/test_fuzz_burst.py
@@ -10,12 +10,22 @@ import unittest
 from pathlib import Path
 
 from scripts.run_fuzz_tests import (
+    DEPTH_REPORT_LIMIT,
     FuzzModuleManifest,
     FuzzPropertyManifest,
+    PropertyDepth,
+    aggregate_property_depth,
     assert_exact_fuzz_coverage,
     build_fuzz_targets,
+    discard_rate,
     discover_fuzz_manifests,
+    format_depth_report,
+    is_structurally_shallow,
     recommended_property_shards,
+)
+from scripts.run_python_tests import (
+    STRATEGY_SPACE_EXHAUSTED,
+    HypothesisPropertyStats,
 )
 
 
@@ -230,6 +240,179 @@ class TestFuzzTargetPlanning(unittest.TestCase):
         self.assertEqual(state_machine.max_examples, 150)
 
 
+def _shard(
+    test_id: str,
+    *,
+    budget: int,
+    valid: int,
+    invalid: int = 0,
+    overrun: int = 0,
+    interesting: int = 0,
+    stopped_because: str = STRATEGY_SPACE_EXHAUSTED,
+) -> HypothesisPropertyStats:
+    """One child's statistics, in the shape the real child encodes."""
+    return HypothesisPropertyStats(
+        test_id=test_id,
+        max_examples=budget,
+        valid=valid,
+        invalid=invalid,
+        overrun=overrun,
+        interesting=interesting,
+        stopped_because=stopped_because,
+    )
+
+
+class TestBurstDepthReport(unittest.TestCase):
+    """Per-property depth disclosure (#888 item 1)."""
+
+    PROPERTY = "tests.test_example_generated.TestWorld.test_property"
+
+    def test_entropy_shards_are_aggregated_before_depth_is_judged(self) -> None:
+        """One property split eight ways is one row, judged once.
+
+        Without aggregation every sharded property reads as under-run: each
+        shard receives budget/shards examples and reports only its own worlds.
+        """
+        records = tuple(
+            _shard(self.PROPERTY, budget=2_500, valid=4) for _ in range(8)
+        )
+
+        depths = aggregate_property_depth(records)
+
+        self.assertEqual(
+            depths,
+            (
+                PropertyDepth(
+                    test_id=self.PROPERTY,
+                    budget=20_000,
+                    shards=8,
+                    exhausted_shards=8,
+                    distinct_world_bound=4,
+                    valid=32,
+                    invalid=0,
+                    overrun=0,
+                    interesting=0,
+                ),
+            ),
+        )
+        self.assertTrue(is_structurally_shallow(depths[0]))
+        self.assertEqual(
+            [line for line in format_depth_report(depths) if "SHALLOW" in line],
+            [f"SHALLOW 4 worlds of 20000 examples (8 shards) {self.PROPERTY}"],
+        )
+
+    def test_a_run_that_found_its_planted_bug_is_never_shallow(self) -> None:
+        """Known-bad self-test: every known-bad self-test looks exhausted.
+
+        A checker without this carve-out flags every deliberately failing
+        property in the repository as structurally shallow.
+        """
+        found_its_bug = aggregate_property_depth(
+            (_shard(self.PROPERTY, budget=20_000, valid=26, interesting=2),)
+        )[0]
+        same_world_without_the_bug = aggregate_property_depth(
+            (_shard(self.PROPERTY, budget=20_000, valid=26),)
+        )[0]
+
+        self.assertFalse(is_structurally_shallow(found_its_bug))
+        self.assertTrue(is_structurally_shallow(same_world_without_the_bug))
+        self.assertNotIn(
+            "SHALLOW",
+            "\n".join(format_depth_report((found_its_bug,))),
+        )
+
+    def test_a_property_that_spends_its_whole_budget_is_not_shallow(self) -> None:
+        depth = aggregate_property_depth(
+            (
+                _shard(
+                    self.PROPERTY,
+                    budget=150,
+                    valid=150,
+                    stopped_because="settings.max_examples=150",
+                ),
+            )
+        )[0]
+
+        self.assertFalse(is_structurally_shallow(depth))
+
+    def test_an_exactly_exhausted_budget_is_not_shallow(self) -> None:
+        """Exhausting a space that is exactly the budget wastes nothing."""
+        depth = aggregate_property_depth(
+            (_shard(self.PROPERTY, budget=4, valid=4),)
+        )[0]
+
+        self.assertFalse(is_structurally_shallow(depth))
+
+    def test_one_unexhausted_shard_withholds_the_shallow_verdict(self) -> None:
+        depths = aggregate_property_depth(
+            (
+                _shard(self.PROPERTY, budget=2_500, valid=4),
+                _shard(
+                    self.PROPERTY,
+                    budget=2_500,
+                    valid=2_500,
+                    stopped_because="settings.max_examples=2500",
+                ),
+            )
+        )
+
+        self.assertEqual(depths[0].exhausted_shards, 1)
+        self.assertEqual(depths[0].shards, 2)
+        self.assertFalse(is_structurally_shallow(depths[0]))
+
+    def test_discard_rate_measures_assume_cost_against_spent_examples(self) -> None:
+        depth = aggregate_property_depth(
+            (
+                _shard(
+                    self.PROPERTY,
+                    budget=150,
+                    valid=150,
+                    invalid=150,
+                    stopped_because="settings.max_examples=150",
+                ),
+            )
+        )[0]
+
+        self.assertEqual(discard_rate(depth), 0.5)
+        self.assertEqual(
+            [line for line in format_depth_report((depth,)) if "DISCARD" in line],
+            [
+                f"DISCARD 50% of 300 examples (150 discarded, 150 worlds) "
+                f"{self.PROPERTY}"
+            ],
+        )
+
+    def test_a_property_that_ran_nothing_has_no_discard_rate(self) -> None:
+        depth = aggregate_property_depth(
+            (_shard(self.PROPERTY, budget=150, valid=0, stopped_because=""),)
+        )[0]
+
+        self.assertEqual(discard_rate(depth), 0.0)
+
+    def test_shallow_properties_rank_by_world_count_and_truncate(self) -> None:
+        records = tuple(
+            _shard(f"{self.PROPERTY}_{index:02d}", budget=20_000, valid=index)
+            for index in range(DEPTH_REPORT_LIMIT + 5)
+        )
+
+        lines = format_depth_report(aggregate_property_depth(records))
+
+        self.assertEqual(
+            lines[0],
+            f"DEPTH {DEPTH_REPORT_LIMIT + 5} properties measured, "
+            f"{DEPTH_REPORT_LIMIT + 5} exhausted their strategy space, "
+            "0 discarded at least 10% of their examples",
+        )
+        self.assertEqual(
+            [line.split()[1] for line in lines[1 : DEPTH_REPORT_LIMIT + 1]],
+            [str(index) for index in range(DEPTH_REPORT_LIMIT)],
+        )
+        self.assertEqual(lines[-1], "SHALLOW ... 5 more exhausted")
+
+    def test_a_burst_without_properties_reports_nothing(self) -> None:
+        self.assertEqual(format_depth_report(aggregate_property_depth(())), ())
+
+
 class TestFuzzRunnerProcess(unittest.TestCase):
     def setUp(self) -> None:
         self.tempdir = tempfile.TemporaryDirectory()
@@ -274,6 +457,19 @@ class TestFuzzRunnerProcess(unittest.TestCase):
             "    @given(value=st.integers())\n"
             "    def test_property(self, value):\n"
             "        self.assertEqual(value, value)\n",
+            encoding="utf-8",
+        )
+        (package / "test_shallow_generated.py").write_text(
+            "import unittest\n"
+            "from hypothesis import given, settings\n"
+            "from hypothesis import strategies as st\n"
+            "import tests._hypothesis_profiles\n\n"
+            "class ShallowWorld(unittest.TestCase):\n"
+            "    @settings(max_examples=50, database=None)\n"
+            "    @given(first=st.booleans(), second=st.booleans())\n"
+            "    def test_property(self, first, second):\n"
+            "        self.assertIsInstance(first, bool)\n"
+            "        self.assertIsInstance(second, bool)\n",
             encoding="utf-8",
         )
         self.module = "fuzz_fixture.test_example_generated"
@@ -376,6 +572,44 @@ class TestFuzzRunnerProcess(unittest.TestCase):
         self.assertIn("4 targets", completed.stdout)
         self.assertIn("1 tests", completed.stdout)
         self.assertIn("ALL GREEN", completed.stdout)
+
+    def test_burst_discloses_a_structurally_shallow_property(self) -> None:
+        """End-to-end: real runner, real child, real Hypothesis statistics."""
+        env = {
+            **os.environ,
+            "PYTHONPATH": os.pathsep.join(
+                (str(self.root), str(REPO_ROOT), os.environ.get("PYTHONPATH", ""))
+            ),
+            "HYPOTHESIS_STORAGE_DIRECTORY": str(self.database),
+        }
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(RUNNER),
+                "--jobs",
+                "1",
+                "--profile",
+                "suite",
+                "fuzz_fixture.test_shallow_generated",
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+        self.assertIn(
+            "DEPTH 1 properties measured, 1 exhausted their strategy space",
+            completed.stdout,
+        )
+        self.assertIn(
+            "SHALLOW 4 worlds of 50 examples (1 shards) "
+            "fuzz_fixture.test_shallow_generated.ShallowWorld.test_property",
+            completed.stdout,
+        )
 
     def test_deterministic_profile_rejects_entropy_sharding(self) -> None:
         completed = subprocess.run(

--- a/tests/test_fuzz_runner_generated.py
+++ b/tests/test_fuzz_runner_generated.py
@@ -9,18 +9,20 @@ import os
 from pathlib import Path
 import tempfile
 
-from hypothesis import given
+from hypothesis import example, given
 from hypothesis import strategies as st
 
 import tests._hypothesis_profiles  # noqa: F401 - registers active profile
 from scripts.run_fuzz_tests import (
     DEPTH_REPORT_LIMIT,
+    DISCARD_RATE_THRESHOLD,
     FuzzModuleManifest,
     FuzzPropertyManifest,
     PropertyDepth,
     aggregate_property_depth,
     assert_exact_fuzz_coverage,
     build_fuzz_targets,
+    discard_rate,
     discover_fuzz_manifests,
     format_depth_report,
     is_structurally_shallow,
@@ -83,6 +85,7 @@ def assert_shard_aggregation(
         expected = PropertyDepth(
             test_id=depth.test_id,
             budget=sum(shard.max_examples for shard in shards),
+            shard_budget_bound=max(shard.max_examples for shard in shards),
             shards=len(shards),
             exhausted_shards=sum(
                 shard.stopped_because == STRATEGY_SPACE_EXHAUSTED
@@ -123,17 +126,40 @@ def assert_shallow_verdict_is_conservative(
         )
 
 
+def _named_by_section(lines: Sequence[str], prefix: str) -> list[str]:
+    return [
+        line.split()[-1]
+        for line in lines
+        if line.startswith(f"{prefix} ") and not line.startswith(f"{prefix} ...")
+    ]
+
+
+def _assert_section_truncation(
+    lines: Sequence[str],
+    prefix: str,
+    total: int,
+    suffix: str,
+) -> None:
+    expected = (
+        [f"{prefix} ... {total - DEPTH_REPORT_LIMIT} more {suffix}"]
+        if total > DEPTH_REPORT_LIMIT
+        else []
+    )
+    actual = [line for line in lines if line.startswith(f"{prefix} ...")]
+    if actual != expected:
+        raise AssertionError(
+            f"{prefix} truncation line is {actual}, expected {expected} "
+            f"for {total} properties"
+        )
+
+
 def assert_report_names_exactly_the_shallow_properties(
     depths: Sequence[PropertyDepth],
     lines: Sequence[str],
 ) -> None:
     """Every ranked SHALLOW line names a shallow property, smallest first."""
     shallow = {depth.test_id for depth in depths if is_structurally_shallow(depth)}
-    named = [
-        line.split()[-1]
-        for line in lines
-        if line.startswith("SHALLOW") and not line.startswith("SHALLOW ...")
-    ]
+    named = _named_by_section(lines, "SHALLOW")
     if len(named) != len(set(named)):
         raise AssertionError(f"a property is reported twice: {named}")
     unexpected = sorted(set(named) - shallow)
@@ -151,6 +177,40 @@ def assert_report_names_exactly_the_shallow_properties(
     ]
     if bounds != sorted(bounds):
         raise AssertionError(f"shallow ranking is not ascending: {bounds}")
+    _assert_section_truncation(lines, "SHALLOW", len(shallow), "shallow")
+
+
+def assert_report_names_exactly_the_discarding_properties(
+    depths: Sequence[PropertyDepth],
+    lines: Sequence[str],
+) -> None:
+    """Every ranked DISCARD line names a discarding property, worst first."""
+    discarding = {
+        depth.test_id
+        for depth in depths
+        if discard_rate(depth) >= DISCARD_RATE_THRESHOLD
+    }
+    named = _named_by_section(lines, "DISCARD")
+    if len(named) != len(set(named)):
+        raise AssertionError(f"a property is reported twice: {named}")
+    unexpected = sorted(set(named) - discarding)
+    if unexpected:
+        raise AssertionError(
+            f"report names properties below the discard threshold: {unexpected}"
+        )
+    if len(named) != min(len(discarding), DEPTH_REPORT_LIMIT):
+        raise AssertionError(
+            f"report names {len(named)} of {len(discarding)} discarding properties"
+        )
+    rates = [
+        discard_rate(depth)
+        for name in named
+        for depth in depths
+        if depth.test_id == name
+    ]
+    if rates != sorted(rates, reverse=True):
+        raise AssertionError(f"discard ranking is not descending: {rates}")
+    _assert_section_truncation(lines, "DISCARD", len(discarding), "discarding")
 
 
 class TestGeneratedFuzzTargetPlanning(unittest.TestCase):
@@ -234,17 +294,32 @@ class TestGeneratedBurstDepthReport(unittest.TestCase):
                 is_structurally_shallow(depth),
             )
 
+    @example(
+        records=tuple(
+            HypothesisPropertyStats(
+                test_id=(
+                    f"tests.test_world_{index:02d}_generated.World.test_property"
+                ),
+                max_examples=20_000,
+                valid=100,
+                invalid=10 + index,
+                overrun=0,
+                interesting=0,
+                stopped_because="settings.max_examples=20000",
+            )
+            for index in range(25)
+        ),
+    )
     @given(records=property_stats(id_count=40, max_size=60))
-    def test_report_ranks_exactly_the_shallow_properties(
+    def test_report_ranks_exactly_the_shallow_and_discarding_properties(
         self,
         records: tuple[HypothesisPropertyStats, ...],
     ) -> None:
         depths = aggregate_property_depth(records)
+        lines = format_depth_report(depths)
 
-        assert_report_names_exactly_the_shallow_properties(
-            depths,
-            format_depth_report(depths),
-        )
+        assert_report_names_exactly_the_shallow_properties(depths, lines)
+        assert_report_names_exactly_the_discarding_properties(depths, lines)
 
 
 class TestDepthCheckersTripOnViolations(unittest.TestCase):
@@ -318,6 +393,78 @@ class TestDepthCheckersTripOnViolations(unittest.TestCase):
                 (self._depth(),),
                 ("DEPTH 1 properties measured",),
             )
+
+    def test_report_checker_rejects_a_missing_shallow_truncation_line(self) -> None:
+        depths = tuple(
+            replace(self._depth(), test_id=f"module.World.test_{index:02d}")
+            for index in range(DEPTH_REPORT_LIMIT + 1)
+        )
+        lines = format_depth_report(depths)
+
+        with self.assertRaisesRegex(AssertionError, "truncation line"):
+            assert_report_names_exactly_the_shallow_properties(
+                depths,
+                [line for line in lines if not line.startswith("SHALLOW ...")],
+            )
+
+    def _discarding(self, invalid: int, index: int) -> PropertyDepth:
+        return replace(
+            self._depth(),
+            test_id=f"module.World.test_{index:02d}",
+            valid=100,
+            invalid=invalid,
+            exhausted_shards=0,
+        )
+
+    def test_discard_checker_rejects_a_reversed_ranking(self) -> None:
+        depths = (self._discarding(20, 0), self._discarding(60, 1))
+        ascending = tuple(
+            sorted(depths, key=lambda depth: discard_rate(depth))
+        )
+
+        assert_report_names_exactly_the_discarding_properties(
+            depths,
+            format_depth_report(depths),
+        )
+        with self.assertRaisesRegex(AssertionError, "not descending"):
+            assert_report_names_exactly_the_discarding_properties(
+                depths,
+                tuple(
+                    f"DISCARD x of y examples (a discarded, b worlds) "
+                    f"{depth.test_id}"
+                    for depth in ascending
+                ),
+            )
+
+    def test_discard_checker_rejects_a_line_below_the_threshold(self) -> None:
+        quiet = self._discarding(1, 0)
+
+        self.assertLess(discard_rate(quiet), DISCARD_RATE_THRESHOLD)
+        with self.assertRaisesRegex(AssertionError, "below the discard threshold"):
+            assert_report_names_exactly_the_discarding_properties(
+                (quiet,),
+                (f"DISCARD 1% of 101 examples (1 discarded, 100 worlds) "
+                 f"{quiet.test_id}",),
+            )
+
+    def test_discard_checker_rejects_an_omitted_discarding_property(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "names 0 of 1"):
+            assert_report_names_exactly_the_discarding_properties(
+                (self._discarding(60, 0),),
+                ("DEPTH 1 properties measured",),
+            )
+
+    def test_discard_checker_accepts_the_real_report(self) -> None:
+        """Must-still-work: the production report satisfies its own checker."""
+        depths = tuple(
+            self._discarding(20 + index, index)
+            for index in range(DEPTH_REPORT_LIMIT + 2)
+        )
+
+        assert_report_names_exactly_the_discarding_properties(
+            depths,
+            format_depth_report(depths),
+        )
 
 
 class TestFuzzCoverageCheckerKnownBad(unittest.TestCase):

--- a/tests/test_fuzz_runner_generated.py
+++ b/tests/test_fuzz_runner_generated.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import unittest
+from collections.abc import Sequence
 from dataclasses import replace
 import os
 from pathlib import Path
@@ -13,12 +14,143 @@ from hypothesis import strategies as st
 
 import tests._hypothesis_profiles  # noqa: F401 - registers active profile
 from scripts.run_fuzz_tests import (
+    DEPTH_REPORT_LIMIT,
     FuzzModuleManifest,
     FuzzPropertyManifest,
+    PropertyDepth,
+    aggregate_property_depth,
     assert_exact_fuzz_coverage,
     build_fuzz_targets,
     discover_fuzz_manifests,
+    format_depth_report,
+    is_structurally_shallow,
 )
+from scripts.run_python_tests import (
+    STRATEGY_SPACE_EXHAUSTED,
+    HypothesisPropertyStats,
+)
+
+
+#: Reasons Hypothesis reports, exhaustion plus the ordinary budget endings.
+STOPPED_BECAUSE = (
+    STRATEGY_SPACE_EXHAUSTED,
+    "settings.max_examples=2500",
+    "settings.max_examples=2500, but < 1% of examples satisfied assumptions",
+    "",
+)
+
+
+def property_stats(id_count: int, max_size: int) -> st.SearchStrategy[
+    tuple[HypothesisPropertyStats, ...]
+]:
+    """Child statistics over a small ID pool, so shards of one property collide."""
+    return st.lists(
+        st.builds(
+            HypothesisPropertyStats,
+            test_id=st.sampled_from(
+                [
+                    f"tests.test_world_{index:02d}_generated.World.test_property"
+                    for index in range(id_count)
+                ]
+            ),
+            max_examples=st.integers(min_value=1, max_value=20_000),
+            valid=st.integers(min_value=0, max_value=20_000),
+            invalid=st.integers(min_value=0, max_value=20_000),
+            overrun=st.integers(min_value=0, max_value=500),
+            interesting=st.integers(min_value=0, max_value=10),
+            stopped_because=st.sampled_from(STOPPED_BECAUSE),
+        ),
+        min_size=1,
+        max_size=max_size,
+    ).map(tuple)
+
+
+def assert_shard_aggregation(
+    records: Sequence[HypothesisPropertyStats],
+    depths: Sequence[PropertyDepth],
+) -> None:
+    """One row per property, conserving every shard's budget and cases."""
+    shards_by_id: dict[str, list[HypothesisPropertyStats]] = {}
+    for record in records:
+        shards_by_id.setdefault(record.test_id, []).append(record)
+    if sorted(depth.test_id for depth in depths) != sorted(shards_by_id):
+        raise AssertionError(
+            f"depth rows {[depth.test_id for depth in depths]} do not cover "
+            f"exactly {sorted(shards_by_id)}"
+        )
+    for depth in depths:
+        shards = shards_by_id[depth.test_id]
+        expected = PropertyDepth(
+            test_id=depth.test_id,
+            budget=sum(shard.max_examples for shard in shards),
+            shards=len(shards),
+            exhausted_shards=sum(
+                shard.stopped_because == STRATEGY_SPACE_EXHAUSTED
+                for shard in shards
+            ),
+            distinct_world_bound=max(shard.valid for shard in shards),
+            valid=sum(shard.valid for shard in shards),
+            invalid=sum(shard.invalid for shard in shards),
+            overrun=sum(shard.overrun for shard in shards),
+            interesting=sum(shard.interesting for shard in shards),
+        )
+        if depth != expected:
+            raise AssertionError(f"{depth} does not aggregate its shards: {expected}")
+
+
+def assert_shallow_verdict_is_conservative(
+    depth: PropertyDepth,
+    shallow: bool,
+) -> None:
+    """A shallow verdict claims wasted budget, and nothing else."""
+    if not shallow:
+        return
+    if depth.interesting:
+        raise AssertionError(
+            f"{depth.test_id} stopped early because it found "
+            f"{depth.interesting} interesting cases, not because it ran out "
+            "of worlds"
+        )
+    if depth.exhausted_shards != depth.shards:
+        raise AssertionError(
+            f"{depth.test_id} exhausted only {depth.exhausted_shards} of "
+            f"{depth.shards} shards"
+        )
+    if depth.distinct_world_bound >= depth.budget:
+        raise AssertionError(
+            f"{depth.test_id} reached {depth.distinct_world_bound} worlds "
+            f"against a {depth.budget}-example budget: nothing was wasted"
+        )
+
+
+def assert_report_names_exactly_the_shallow_properties(
+    depths: Sequence[PropertyDepth],
+    lines: Sequence[str],
+) -> None:
+    """Every ranked SHALLOW line names a shallow property, smallest first."""
+    shallow = {depth.test_id for depth in depths if is_structurally_shallow(depth)}
+    named = [
+        line.split()[-1]
+        for line in lines
+        if line.startswith("SHALLOW") and not line.startswith("SHALLOW ...")
+    ]
+    if len(named) != len(set(named)):
+        raise AssertionError(f"a property is reported twice: {named}")
+    unexpected = sorted(set(named) - shallow)
+    if unexpected:
+        raise AssertionError(f"report names non-shallow properties: {unexpected}")
+    if len(named) != min(len(shallow), DEPTH_REPORT_LIMIT):
+        raise AssertionError(
+            f"report names {len(named)} of {len(shallow)} shallow properties"
+        )
+    bounds = [
+        depth.distinct_world_bound
+        for name in named
+        for depth in depths
+        if depth.test_id == name
+    ]
+    if bounds != sorted(bounds):
+        raise AssertionError(f"shallow ranking is not ascending: {bounds}")
 
 
 class TestGeneratedFuzzTargetPlanning(unittest.TestCase):
@@ -84,6 +216,107 @@ class TestGeneratedFuzzTargetPlanning(unittest.TestCase):
             self.assertEqual(
                 sum(pin_id in target.expected_test_ids for target in targets),
                 1,
+            )
+
+
+class TestGeneratedBurstDepthReport(unittest.TestCase):
+    @given(records=property_stats(id_count=3, max_size=16))
+    def test_depth_aggregates_shards_and_never_overclaims_shallowness(
+        self,
+        records: tuple[HypothesisPropertyStats, ...],
+    ) -> None:
+        depths = aggregate_property_depth(records)
+
+        assert_shard_aggregation(records, depths)
+        for depth in depths:
+            assert_shallow_verdict_is_conservative(
+                depth,
+                is_structurally_shallow(depth),
+            )
+
+    @given(records=property_stats(id_count=40, max_size=60))
+    def test_report_ranks_exactly_the_shallow_properties(
+        self,
+        records: tuple[HypothesisPropertyStats, ...],
+    ) -> None:
+        depths = aggregate_property_depth(records)
+
+        assert_report_names_exactly_the_shallow_properties(
+            depths,
+            format_depth_report(depths),
+        )
+
+
+class TestDepthCheckersTripOnViolations(unittest.TestCase):
+    """Known-bad self-tests: each depth checker must reject a planted world."""
+
+    RECORDS = (
+        HypothesisPropertyStats(
+            test_id="tests.test_world_00_generated.World.test_property",
+            max_examples=2_500,
+            valid=4,
+            invalid=0,
+            overrun=0,
+            interesting=0,
+            stopped_because=STRATEGY_SPACE_EXHAUSTED,
+        ),
+    ) * 2
+
+    def _depth(self, **overrides: int) -> PropertyDepth:
+        base = aggregate_property_depth(self.RECORDS)[0]
+        return replace(base, **overrides)
+
+    def test_aggregation_checker_rejects_one_row_per_shard(self) -> None:
+        per_shard = tuple(
+            aggregate_property_depth((record,))[0] for record in self.RECORDS
+        )
+
+        with self.assertRaisesRegex(AssertionError, "do not cover exactly"):
+            assert_shard_aggregation(self.RECORDS, per_shard)
+
+    def test_aggregation_checker_rejects_a_dropped_shard_budget(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "does not aggregate its shards"):
+            assert_shard_aggregation(self.RECORDS, (self._depth(budget=2_500),))
+
+    def test_shallow_checker_rejects_a_verdict_over_an_interesting_run(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "interesting cases"):
+            assert_shallow_verdict_is_conservative(self._depth(interesting=2), True)
+
+    def test_shallow_checker_rejects_a_verdict_over_partial_exhaustion(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "exhausted only"):
+            assert_shallow_verdict_is_conservative(
+                self._depth(exhausted_shards=1),
+                True,
+            )
+
+    def test_shallow_checker_rejects_a_verdict_over_a_spent_budget(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "nothing was wasted"):
+            assert_shallow_verdict_is_conservative(
+                self._depth(distinct_world_bound=5_000),
+                True,
+            )
+
+    def test_shallow_checker_accepts_the_real_shallow_world(self) -> None:
+        """Must-still-work: the four-world property is genuinely shallow."""
+        depth = self._depth()
+
+        self.assertTrue(is_structurally_shallow(depth))
+        assert_shallow_verdict_is_conservative(depth, True)
+
+    def test_report_checker_rejects_a_line_for_a_deep_property(self) -> None:
+        deep = self._depth(interesting=2)
+
+        with self.assertRaisesRegex(AssertionError, "non-shallow properties"):
+            assert_report_names_exactly_the_shallow_properties(
+                (deep,),
+                (f"SHALLOW 4 worlds of 5000 examples (2 shards) {deep.test_id}",),
+            )
+
+    def test_report_checker_rejects_an_omitted_shallow_property(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "names 0 of 1"):
+            assert_report_names_exactly_the_shallow_properties(
+                (self._depth(),),
+                ("DEPTH 1 properties measured",),
             )
 
 

--- a/tests/test_parallel_test_runner.py
+++ b/tests/test_parallel_test_runner.py
@@ -8,15 +8,24 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from collections.abc import Callable
 from pathlib import Path
 
-from hypothesis import given, settings
+import msgspec
+from hypothesis import HealthCheck, assume, given, settings
 from hypothesis import strategies as st
+from hypothesis.internal.conjecture.data import Status
+from hypothesis.statistics import collector
 
 import tests._hypothesis_profiles  # noqa: F401  (loads the active profile)
 from scripts.run_python_tests import (
     HOTSPOT_SHARD_POLICIES,
+    HYPOTHESIS_CASE_STATUSES,
+    STRATEGY_SPACE_EXHAUSTED,
     WORLD_MODEL_MODULE,
+    ChildTargetResult,
+    HypothesisPropertyStats,
+    HypothesisStatsRecorder,
     TestModule,
     _iter_test_cases,
     assert_exact_target_coverage,
@@ -24,6 +33,7 @@ from scripts.run_python_tests import (
     assert_hypothesis_deadlines_disabled,
     complete_test_modules,
     discover_test_modules,
+    hypothesis_example_budgets,
     list_module_test_ids,
     recommended_worker_count,
     resolve_hypothesis_settings,
@@ -547,6 +557,209 @@ class TestSuiteDeadlineContract(unittest.TestCase):
         self.assertNotEqual(completed.returncode, 0)
         self.assertIn("non-None deadline", completed.stderr)
         self.assertFalse((root / "result.json").exists())
+
+
+@settings(deadline=None, max_examples=50, database=None)
+@given(first=st.booleans(), second=st.booleans())
+def _tiny_space_property(first: bool, second: bool) -> None:
+    """Four distinct worlds against a fifty-example budget (#888 item 1)."""
+    assert isinstance(first, bool)
+    assert isinstance(second, bool)
+
+
+@settings(
+    deadline=None,
+    max_examples=50,
+    database=None,
+    suppress_health_check=[HealthCheck.filter_too_much],
+)
+@given(value=st.integers())
+def _discarding_property(value: int) -> None:
+    """Half of every generated world is discarded by ``assume``."""
+    assume(value % 2 == 0)
+    assert value % 2 == 0
+
+
+@settings(deadline=None, max_examples=50, database=None, print_blob=False)
+@given(value=st.integers(min_value=0, max_value=3))
+def _planted_failing_property(value: int) -> None:
+    """The known-bad shape every self-test has: it finds its planted bug."""
+    raise AssertionError(f"planted failure for {value}")
+
+
+class TestHypothesisStatsRecorder(unittest.TestCase):
+    """Per-property depth measured from real Hypothesis statistics (#888).
+
+    Every statistics mapping under test is produced by Hypothesis itself
+    through the real ``collector`` seam — a hand-typed statistics literal
+    would prove nothing about what the engine emits (`.claude/rules/
+    test-fidelity.md` Rule C).
+    """
+
+    def _record(
+        self,
+        prop: Callable[[], None],
+        *,
+        budget: int,
+        test_id: str = "planted.Property.test_property",
+        expect_failure: bool = False,
+    ) -> HypothesisPropertyStats:
+        recorder = HypothesisStatsRecorder({test_id: budget})
+        recorder.start(test_id)
+        with collector.with_value(recorder.note):  # pyright: ignore[reportArgumentType]
+            if expect_failure:
+                with self.assertRaises(AssertionError):
+                    prop()
+            else:
+                prop()
+        self.assertEqual(len(recorder.records), 1, recorder.records)
+        return recorder.records[0]
+
+    def test_an_exhausted_strategy_space_is_measured_below_its_budget(self) -> None:
+        record = self._record(_tiny_space_property, budget=50)
+
+        self.assertEqual(record.stopped_because, STRATEGY_SPACE_EXHAUSTED)
+        self.assertEqual(record.valid, 4)
+        self.assertEqual(record.interesting, 0)
+        self.assertEqual(record.max_examples, 50)
+
+    def test_assume_discards_are_measured_as_invalid_worlds(self) -> None:
+        record = self._record(_discarding_property, budget=50)
+
+        self.assertEqual(record.valid, 50)
+        self.assertGreater(record.invalid, 0)
+
+    def test_a_planted_bug_is_measured_as_an_interesting_case(self) -> None:
+        record = self._record(
+            _planted_failing_property,
+            budget=50,
+            expect_failure=True,
+        )
+
+        self.assertGreater(record.interesting, 0)
+
+    def test_statistics_arriving_with_no_started_test_are_dropped(self) -> None:
+        """Impossible by construction; a report must never break its own run."""
+        recorder = HypothesisStatsRecorder({})
+        with collector.with_value(recorder.note):  # pyright: ignore[reportArgumentType]
+            _tiny_space_property()
+
+        self.assertEqual(recorder.records, ())
+
+    def test_an_unbudgeted_test_records_a_zero_budget(self) -> None:
+        recorder = HypothesisStatsRecorder({})
+        recorder.start("planted.Property.test_property")
+        with collector.with_value(recorder.note):  # pyright: ignore[reportArgumentType]
+            _tiny_space_property()
+
+        self.assertEqual(recorder.records[0].max_examples, 0)
+
+    def test_counted_statuses_match_the_hypothesis_vocabulary(self) -> None:
+        """A new engine status must not silently vanish from the report."""
+        self.assertEqual(
+            set(HYPOTHESIS_CASE_STATUSES),
+            {status.name.lower() for status in Status},
+        )
+
+    def test_budget_map_covers_every_hypothesis_test_and_nothing_else(self) -> None:
+        suite = planted_suite(("none", "plain"))
+
+        budgets = hypothesis_example_budgets(suite)
+
+        hypothesis_ids = [
+            test.id()
+            for test in _iter_test_cases(suite)
+            if resolve_hypothesis_settings(test) is not None
+        ]
+        self.assertEqual(sorted(budgets), sorted(hypothesis_ids))
+        self.assertEqual(set(budgets.values()), {1})
+
+    def test_the_child_runner_reports_per_property_generated_depth(self) -> None:
+        """End-to-end: the real ``--_run-target`` child, over the real wire.
+
+        Proves the collected depth survives ``ChildTargetResult`` — the fake
+        cannot show that, because the runner reads what the child encoded.
+        """
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            package = root / "child_depth_fixture"
+            package.mkdir()
+            (package / "__init__.py").write_text("", encoding="utf-8")
+            (package / "test_tiny_generated.py").write_text(
+                "import unittest\n"
+                "from hypothesis import given, settings\n"
+                "from hypothesis import strategies as st\n"
+                "\n"
+                "import tests._hypothesis_profiles  # noqa: F401\n"
+                "\n"
+                "class Tiny(unittest.TestCase):\n"
+                "    @settings(max_examples=50, database=None)\n"
+                "    @given(first=st.booleans(), second=st.booleans())\n"
+                "    def test_property(self, first, second):\n"
+                "        self.assertIsInstance(first, bool)\n"
+                "        self.assertIsInstance(second, bool)\n"
+                "\n"
+                "    def test_pin(self):\n"
+                "        self.assertTrue(True)\n",
+                encoding="utf-8",
+            )
+            result_path = root / "result.json"
+            env = {
+                **os.environ,
+                "PYTHONPATH": os.pathsep.join(
+                    part
+                    for part in (
+                        str(root),
+                        str(REPO_ROOT),
+                        os.environ.get("PYTHONPATH", ""),
+                    )
+                    if part
+                ),
+            }
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(RUNNER),
+                    "--_run-target",
+                    '["child_depth_fixture.test_tiny_generated"]',
+                    "0",
+                    str(result_path),
+                ],
+                cwd=REPO_ROOT,
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(
+                completed.returncode,
+                0,
+                completed.stdout + completed.stderr,
+            )
+            child = msgspec.json.decode(
+                result_path.read_bytes(),
+                type=ChildTargetResult,
+            )
+
+        self.assertEqual(child.tests_run, 2)
+        self.assertEqual(
+            tuple(record.test_id for record in child.hypothesis_stats),
+            ("child_depth_fixture.test_tiny_generated.Tiny.test_property",),
+        )
+        self.assertEqual(
+            child.hypothesis_stats[0],
+            HypothesisPropertyStats(
+                test_id=(
+                    "child_depth_fixture.test_tiny_generated.Tiny.test_property"
+                ),
+                max_examples=50,
+                valid=4,
+                invalid=0,
+                overrun=0,
+                interesting=0,
+                stopped_because=STRATEGY_SPACE_EXHAUSTED,
+            ),
+        )
 
 
 class TestRunTestsWiring(unittest.TestCase):

--- a/tests/test_parallel_test_runner.py
+++ b/tests/test_parallel_test_runner.py
@@ -9,6 +9,7 @@ import sys
 import tempfile
 import unittest
 from collections.abc import Callable
+from dataclasses import replace
 from pathlib import Path
 
 import msgspec
@@ -18,6 +19,10 @@ from hypothesis.internal.conjecture.data import Status
 from hypothesis.statistics import collector
 
 import tests._hypothesis_profiles  # noqa: F401  (loads the active profile)
+from scripts.run_fuzz_tests import (
+    aggregate_property_depth,
+    is_structurally_shallow,
+)
 from scripts.run_python_tests import (
     HOTSPOT_SHARD_POLICIES,
     HYPOTHESIS_CASE_STATUSES,
@@ -638,6 +643,29 @@ class TestHypothesisStatsRecorder(unittest.TestCase):
 
         self.assertGreater(record.interesting, 0)
 
+    def test_a_real_interesting_run_is_never_reported_as_shallow(self) -> None:
+        """The carve-out, driven by the producer that makes interesting cases.
+
+        A property that fails on its first world stops with ``nothing left to
+        do`` and zero valid worlds — indistinguishable from an exhausted tiny
+        space unless the interesting cases are read. No repository property
+        reaches this state today (the known-bad self-tests plant their bug in
+        an inner ``@given`` whose statistics are dropped), so the carve-out is
+        defensive; this pin proves the shape is producible and handled.
+        """
+        record = self._record(
+            _planted_failing_property,
+            budget=50,
+            expect_failure=True,
+        )
+        depth = aggregate_property_depth((record,))[0]
+
+        self.assertGreater(depth.interesting, 0)
+        self.assertEqual(depth.exhausted_shards, depth.shards)
+        self.assertLess(depth.distinct_world_bound, depth.budget)
+        self.assertFalse(is_structurally_shallow(depth))
+        self.assertTrue(is_structurally_shallow(replace(depth, interesting=0)))
+
     def test_statistics_arriving_with_no_started_test_are_dropped(self) -> None:
         """Impossible by construction; a report must never break its own run."""
         recorder = HypothesisStatsRecorder({})
@@ -646,13 +674,20 @@ class TestHypothesisStatsRecorder(unittest.TestCase):
 
         self.assertEqual(recorder.records, ())
 
-    def test_an_unbudgeted_test_records_a_zero_budget(self) -> None:
-        recorder = HypothesisStatsRecorder({})
-        recorder.start("planted.Property.test_property")
+    def test_an_inner_property_is_not_filed_under_its_enclosing_test(self) -> None:
+        """The known-bad self-test shape: a plain test that runs a property.
+
+        Attributing those statistics to the enclosing test would inflate the
+        property count, and a body running two inner properties would fold
+        into one row claiming two entropy shards it never had.
+        """
+        recorder = HypothesisStatsRecorder({"module.World.test_property": 150})
+        recorder.start("module.World.test_plain_pin")
         with collector.with_value(recorder.note):  # pyright: ignore[reportArgumentType]
             _tiny_space_property()
+            _discarding_property()
 
-        self.assertEqual(recorder.records[0].max_examples, 0)
+        self.assertEqual(recorder.records, ())
 
     def test_counted_statuses_match_the_hypothesis_vocabulary(self) -> None:
         """A new engine status must not silently vanish from the report."""


### PR DESCRIPTION
Part of #888 (item 1). Report only — no gate.

> **Revision 2** addresses all seven findings from the review of the first
> commit. Three of them were the exact defect class #888 is about — fluent,
> green documentation describing a world that does not exist — so every claim
> below is re-measured on the pushed tree. See "What changed in revision 2".

## The problem

A budget is not depth. `test_force_import_service_generated` drew
`@given(authorized=st.booleans(), missing=st.booleans())` — a 4-point strategy
space against a 20,000-example budget. Hypothesis exhausted it in four examples
and stopped, so a mutant widening a quarantine authority boundary
(`lib/fs_authority.py`, the staging root's marker set) survived 215 tests across
seven modules. #883 widened that one property. This PR makes the whole class
visible: every burst now says which properties are structurally incapable of
spending their budget.

## What ships

After the `SLOW` lines, `scripts/run_fuzz_tests.py` prints what each property
actually generated, measured from Hypothesis' own `statistics` collector in the
child that ran it:

- **SHALLOW** — the property ran out of distinct worlds before it ran out of
  budget (`stopped-because: nothing left to do`), ranked ascending by world
  count, top 20. Entropy shards are folded into one row first. Folding does
  **not** change which properties are flagged (measured: a real 8-shard run,
  185 shard records, 24 properties — the unfolded verdict picks the same three,
  because a shard that stops at its own budget reports
  `settings.max_examples=…`, never exhaustion). It de-duplicates eight
  identical rows out of the ranked list and reports the real total budget
  against one distinct-world bound — the largest single shard, since shards
  re-explore the same space.
- **DISCARD** — the property threw away >= 10% of its examples through
  `assume()` or a filter, ranked descending. A cost and shape signal, not a
  defect: `assume` marks a world invalid and Hypothesis refills the budget.

Only properties are counted. A plain test whose body declares and calls its own
`@given` — the shape every known-bad self-test uses — emits statistics too,
under the enclosing test's id; those are dropped, so the denominator is exactly
the number of real `@given` property tests.

**It reports; it never gates.** A small strategy space is often exactly right —
the 36-world force-import authority property is correct — so a threshold would
either be trivially satisfiable or block legitimate work. Two carve-outs keep
the verdict honest: a run that reached an `interesting` case stopped because it
found its planted bug, and a property whose worlds reach its budget wasted
nothing. The first is **defensive rather than load-bearing today**: no
repository property reaches that state, precisely because the known-bad
self-tests plant their bug in a dropped inner `@given`.

**The ceiling is the per-child budget** — 150 at the deterministic tier,
`budget / shards` (2,500 on a 30-core host) at the fuzz tier. A 5,000-world
property never exhausts, so it reads as deep at both tiers, and every
non-shallow property's world count is bounded by that per-shard budget rather
than by its real space. An empty SHALLOW section means "none found below the
ceiling", never "no shallow properties".

**A bare `return` is invisible by construction** — it spends the example as a
PASS, so it counts as a valid world. The `assume`-not-`return` rule is still
enforced by hand; the docs say so explicitly.

## First finding — doc1, 2026-07-26, pushed tree `f6521b2d`

Deterministic tier (budget 150) over all 89 generated modules, 963 tests, 58.3s.
`DEPTH 351` matches the 351 `@given` property tests real discovery finds:

```
DEPTH 351 properties measured, 68 shallow (space exhausted below budget), 6 discarding at least 10% of their examples
SHALLOW 2 worlds vs 150 examples per shard (1 shard, 150 total) tests.test_deploy_hold_generated.TestGeneratedHoldLifecycle.test_atomic_receipt_publication_retry_precedes_hold_mutation
SHALLOW 2 worlds vs 150 examples per shard (1 shard, 150 total) tests.test_destructive_authority_generated.TestGeneratedDestructiveAuthority.test_successful_ban_preserves_searchability
SHALLOW 2 worlds vs 150 examples per shard (1 shard, 150 total) tests.test_evidence_generated.TestGeneratedTwoAxisFingerprintCarry.test_fingerprint_flip_carries_only_source_facts
SHALLOW 2 worlds vs 150 examples per shard (1 shard, 150 total) tests.test_path_authority_generated.TestGeneratedDescriptorAuthority.test_private_root_acceptance_tracks_ancestor_writability
SHALLOW 2 worlds vs 150 examples per shard (1 shard, 150 total) tests.test_path_authority_generated.TestGeneratedRootRelocation.test_real_publish_relocation_never_commits_to_replacement
SHALLOW 2 worlds vs 150 examples per shard (1 shard, 150 total) tests.test_pin_retention_generated.TestGeneratedPinRetention.test_every_status_is_pending_or_terminal
SHALLOW 2 worlds vs 150 examples per shard (1 shard, 150 total) tests.test_quality_generated.TestGeneratedSimulatorInvariants.test_lossless_narrowing_is_subject_blind_for_genuine_transparent
SHALLOW 3 worlds vs 150 examples per shard (1 shard, 150 total) tests.test_evidence_generated.TestGeneratedPoisonedCurrentLink.test_mismatched_exact_identity_carries_no_linked_facts
SHALLOW 3 worlds vs 150 examples per shard (1 shard, 150 total) tests.test_import_operation_fence_generated.TestGeneratedImportOperationFence.test_definitely_not_started_recovery_may_retry
SHALLOW 3 worlds vs 150 examples per shard (1 shard, 150 total) tests.test_import_operation_fence_generated.TestGeneratedImportOperationFence.test_may_have_started_recovery_never_replays
SHALLOW 3 worlds vs 150 examples per shard (1 shard, 150 total) tests.test_import_operation_fence_generated.TestGeneratedImportOperationFence.test_terminal_acknowledgement_prevents_recovery
SHALLOW 3 worlds vs 150 examples per shard (1 shard, 150 total) tests.test_js_ast_generated.TestJsAstGenerated.test_dynamic_window_callee_worlds_fail_closed
SHALLOW 3 worlds vs 150 examples per shard (1 shard, 150 total) tests.test_js_ast_generated.TestJsAstGenerated.test_unrelated_computed_calls_and_inert_strings_remain_supported
SHALLOW 3 worlds vs 150 examples per shard (1 shard, 150 total) tests.test_quality_generated.TestGeneratedSimulatorInvariants.test_real_quality_gate_matches_post_import_action_table
SHALLOW 3 worlds vs 150 examples per shard (1 shard, 150 total) tests.test_quality_lineage_generated.TestQualityLineageGenerated.test_source_measurement_never_carries_output_lineage
SHALLOW 4 worlds vs 150 examples per shard (1 shard, 150 total) tests.test_deploy_hold_generated.TestGeneratedHoldLifecycle.test_any_incomplete_release_phase_can_recover_to_strict_hold
SHALLOW 4 worlds vs 12 examples per shard (1 shard, 12 total) tests.test_deploy_pin_generated.TestGeneratedDeployPinLifecycle.test_divergent_sibling_receipt_is_superseded_only_by_equivalent_verified_remote
SHALLOW 4 worlds vs 150 examples per shard (1 shard, 150 total) tests.test_destructive_authority_generated.TestGeneratedDestructiveAuthority.test_delete_configuration_authority_requires_both_exact_paths
SHALLOW 4 worlds vs 150 examples per shard (1 shard, 150 total) tests.test_evidence_generated.TestGeneratedEvidenceLifecycle.test_changed_snapshot_retry_waits_for_surviving_or_new_facts
SHALLOW 4 worlds vs 150 examples per shard (1 shard, 150 total) tests.test_js_ast_generated.TestJsAstGenerated.test_unicode_line_continuations_preserve_static_window_handler
SHALLOW ... 48 more shallow
DISCARD 51% of 307 examples (157 discarded, 150 worlds) tests.test_world_invariants_generated.TestWorldInvariantGenerated.test_any_evidence_fingerprint_drift_is_rejected
DISCARD 51% of 304 examples (154 discarded, 150 worlds) tests.test_failure_presentation_generated.TestFamilyClausesHoldForEveryMember.test_no_breakdown_claims_what_a_member_contradicts
DISCARD 42% of 289 examples (120 discarded, 150 worlds) tests.test_dispatch_quarantine_root_generated.TestDispatchQuarantineRootGenerated.test_real_dispatch_uses_staging_for_distinct_configured_roots
DISCARD 31% of 226 examples (69 discarded, 150 worlds) tests.test_unused_import_audit_generated.TestGeneratedVultureWhitelistFreshness.test_moved_exact_entries_are_stale
DISCARD 14% of 212 examples (30 discarded, 150 worlds) tests.test_materialize_generated.TestFingerprintProperties.test_distinguishes_different_sets
DISCARD 13% of 187 examples (24 discarded, 150 worlds) hypothesis.stateful.RequestLifecycleMachine.TestCase.runTest
```

Fixing those 68 is deliberately NOT in this PR — the report is the deliverable
and it aims that work.

## Proof the real runner still works — deep tier, pushed tree

`nix-shell --run "python3 scripts/run_fuzz_tests.py tests.test_force_import_service_generated tests.test_quality_generated"` -> `exit=0`:

```
fuzz burst: 2 generated modules, 186 targets (184 property targets, up to 8 entropy shards), up to 30 parallel (30 host cores), profile=fuzz
DEPTH 23 properties measured, 3 shallow (space exhausted below budget), 0 discarding at least 10% of their examples
SHALLOW 2 worlds vs 2500 examples per shard (8 shards, 20000 total) tests.test_quality_generated.TestGeneratedSimulatorInvariants.test_lossless_narrowing_is_subject_blind_for_genuine_transparent
SHALLOW 3 worlds vs 2500 examples per shard (8 shards, 20000 total) tests.test_quality_generated.TestGeneratedSimulatorInvariants.test_real_quality_gate_matches_post_import_action_table
SHALLOW 36 worlds vs 2500 examples per shard (8 shards, 20000 total) tests.test_force_import_service_generated.TestForceImportAuthorityGenerated.test_only_existing_configured_quarantine_sources_enqueue
```

Eight shards of one property collapse to one row with the total budget, the
per-shard comparison Hypothesis actually made, and one world bound. (23, not
24, properties: the inner-`@given` known-bad self-test in
`test_quality_generated` is no longer counted as a property.)

## What changed in revision 2

1. **Inner-`@given` mis-attribution.** A plain test whose body declares and
   calls its own `@given` emitted statistics under the ENCLOSING test's id.
   Two exist, so the report printed **353**, not 351; worse, a body running two
   inner properties folded into one row claiming two entropy shards it never
   had, and the smaller property vanished. `HypothesisStatsRecorder.note` now
   drops records whose test id is not in the budget map — absence IS the "not a
   property test method" signal. **Verified no legitimate property is lost:**
   real discovery finds 351 `@given` property tests and the one stateful
   machine (`hypothesis.stateful.RequestLifecycleMachine.TestCase.runTest`) IS
   in the budget map. The burst now prints `DEPTH 351`, matching discovery.
2. **The denominator is self-verifying**, not hand-checked: a fixture module
   mixing a property, a plain pin, a pin that runs an inner `@given`, and a
   stateful machine asserts the reported count equals what
   `discover_fuzz_manifests` finds. The docs' evidence block (captured before
   the previous commit, hence its drift) is re-measured on this tree.
3. **The sharding rationale was false** and is corrected in the code, docs, and
   above — measured, not asserted.
4. **The `interesting > 0` carve-out claim was false.** It said it protects
   "every deliberately failing property in the repository"; after fix 1 no
   repository property reaches that state at all. It stays as defensive
   future-proofing and now says so. Its hand-typed, unproducible world
   (Rule C applied to a rationale) is replaced by a **composed pin driving
   REAL Hypothesis** through the real recorder and real aggregator: a property
   that fails on its first world really does report `interesting=4, valid=0,
   "nothing left to do"` under a 50-example budget, and the same record with
   `interesting` zeroed IS shallow.
5. **Detection ceiling** documented, and `PropertyDepth` carries
   `shard_budget_bound` so the line no longer implies a 36-vs-20,000
   comparison Hypothesis never made.
6. **DISCARD now ships the pair.** Reversing its ranking previously survived
   all 36 tests and its truncation line had no assertion anywhere. Adds
   `assert_report_names_exactly_the_discarding_properties` (membership, count,
   descending rank, truncation) with known-bad self-tests and a decisive
   `@example`, truncation assertions for the SHALLOW half, and a deterministic
   ranking pin.
7. **DEPTH headline** says what its number is: `68 shallow (space exhausted
   below budget)` rather than labelling `len(shallow)` "exhausted their
   strategy space" (70 rows exhaust every shard; 68 are shallow).

### Mutants planted after the fixes (one-shots, not committed)

| Mutant | Before | After |
|---|---|---|
| Reverse DISCARD ranking (`-discard_rate` → `discard_rate`) | survived all 36 | **4 tests fail** |
| Delete the `DISCARD ... N more discarding` truncation line | survived | **3 tests fail** |
| Revert the budget-map drop rule | n/a | **2 tests fail** (`DEPTH 3` vs `DEPTH 2`) |

## Implementation

- `scripts/run_python_tests.py` — `HypothesisPropertyStats` (msgspec, wire) plus
  `HypothesisStatsRecorder`, which attributes each `collector` callback to the
  running test through the EXISTING `RecordingTextTestResult.startTest` record
  (no second recording mechanism) and records only real properties. The counts
  ride home on a **defaulted** `ChildTargetResult.hypothesis_stats`, so the
  deterministic suite tier is unchanged. `_settings_max_examples` moves here as
  `settings_max_examples` rather than growing a second copy; the budget map
  reuses the existing `resolve_hypothesis_settings` owner. The recorder never
  raises: an unattributable callback, a non-property test, or an unreadable
  statistics shape degrades to a dropped record rather than breaking the suite
  that produced it (`lib/json_narrow.py` narrowing, per the "never a
  re-convert" rule).
- `scripts/run_fuzz_tests.py` — pure `aggregate_property_depth` /
  `is_structurally_shallow` / `discard_rate` / `format_depth_report`; `main`
  prints the lines after SLOW.
- `docs/generated-testing.md` — "Per-property depth report" section (rationale,
  ceiling, carve-outs, what it cannot see), plus the `SHALLOW`-check bullet in
  "Writing new generated tests".

## Tests (pin + property pair for both halves)

- `tests/test_parallel_test_runner.py::TestHypothesisStatsRecorder` — every
  statistics mapping under test is produced by **real Hypothesis** through the
  real collector seam (Rule C): a 4-world property pins
  `STRATEGY_SPACE_EXHAUSTED` against the live engine, an `assume` property pins
  invalid counting, a planted failing property pins `interesting` and feeds the
  composed carve-out pin, and an inner-`@given` pin proves the enclosing test
  records nothing. The status vocabulary is pinned against the live
  `hypothesis.internal.conjecture.data.Status` enum. Plus an end-to-end pin
  driving the real `--_run-target` child and decoding the real
  `ChildTargetResult` wire.
- `tests/test_fuzz_burst.py::TestBurstDepthReport` — shard aggregation (8
  shards → one row, judged once), single-shard wording, spent-budget and
  partial-exhaustion carve-outs, discard rate, and ranking + truncation for
  BOTH sections. `TestFuzzRunnerProcess` adds the real-runner SHALLOW
  disclosure and the self-verifying property-count test.
- `tests/test_fuzz_runner_generated.py::TestGeneratedBurstDepthReport` — the
  generated half: aggregation conserves every shard's budget and counts, a
  shallow verdict never overclaims, and the report names exactly the shallow
  and the discarding properties in the right order with the right truncation.
  `TestDepthCheckersTripOnViolations` gives every checker a known-bad self-test
  plus must-still-work guards.

## Gates (re-run on the pushed tree, separately, exit status echoed)

- `nix-shell --run "pyright --threads 4"` (whole repo) -> `exit=0`, 0 errors.
- `nix-shell --run "bash scripts/run_tests.sh"` -> `exit=0`, 7435 tests OK.
- `tests/_typing_ratchet_baseline.py` unchanged: the ratchet counts `Any` /
  `cast` / `# type: ignore` / **bare** `# pyright: ignore`, and the one new
  escape hatch is the sanctioned scoped
  `# pyright: ignore[reportArgumentType]` form, which
  `_BARE_PYRIGHT_IGNORE_RE`'s negative lookahead deliberately excludes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
