### PR TITLE
Surface possible filesystem errors before import enqueue

### DIFF
--- a/lib/download.py
+++ b/lib/download.py
@@ -789,10 +789,11 @@ def materialize_failure_action(
 ) -> str:
     """Decide what the poller does with a non-``Materialized`` outcome.
 
-    - ``"leave"`` — ``MaterializeGuarded`` marks paths needing manual
-      recovery; NEVER auto-reset those, regardless of age. (Also the
-      no-op answer if ``materialized`` is actually ``Materialized`` —
-      callers only invoke this after already excluding that case.)
+    - ``"leave"`` — ``MaterializeGuarded`` means this caller must not apply
+      a generic reset: either manual recovery owns the path or a successful
+      abandonment already reset and audited it. (Also the no-op answer if
+      ``materialized`` is actually ``Materialized`` — callers only invoke
+      this after already excluding that case.)
     - ``"retry"`` — ``MaterializeFailed`` within the grace window retries
       next cycle (covers the benign completion-vs-event-write race,
       which resolves on the next ingest).
@@ -996,15 +997,6 @@ def _processing_path_ready_for_importer(
         return False
 
     assert isinstance(result, MaterializeFailed)
-    # This gate writes no ``download_log`` row (deliberately — it fails
-    # closed BEFORE any import attempt exists to audit), so the journal is
-    # the only place the cause can land. Name it (issue #868).
-    logger.warning(
-        "PRE-ENQUEUE GATE RESET: request_id=%s reason=%s current_path=%s",
-        request_id,
-        result.reason,
-        state.current_path,
-    )
     transitions.require_transition_applied(transitions.finalize_request(
         db,
         request_id,
@@ -1013,6 +1005,20 @@ def _processing_path_ready_for_importer(
             attempt_type="download",
         ),
     ))
+    db.log_download(
+        request_id=request_id,
+        soulseek_username=None,
+        filetype=state.filetype,
+        outcome="failed",
+        beets_detail=result.reason,
+        error_message=result.reason,
+    )
+    logger.warning(
+        "PRE-ENQUEUE GATE RESET: request_id=%s reason=%s current_path=%s",
+        request_id,
+        result.reason,
+        state.current_path,
+    )
     return False
 
 

--- a/lib/download_materialization.py
+++ b/lib/download_materialization.py
@@ -329,12 +329,13 @@ class MaterializeFailed:
 
 @dataclass(frozen=True)
 class MaterializeGuarded:
-    """Ownership/resume ambiguity: leave the row untouched (an active
-    release lock, unverifiable subprocess-start evidence, a post-move
-    resume block). Historical bare ``None``.
+    """The caller must stop without applying a generic materialize reset.
 
-    ``detail`` is diagnostic only — consumers must branch on the type
-    tag, never on this string.
+    This covers ownership/resume ambiguity (an active release lock,
+    unverifiable subprocess-start evidence, a post-move resume block) and
+    a successful abandonment whose reset and audit already committed.
+    Historical bare ``None``. ``detail`` is diagnostic only — consumers
+    must branch on the type tag, never on this string.
     """
 
     detail: str
@@ -809,10 +810,8 @@ def _evaluate_staged_path_readiness(
                 ),
             )
             if handled:
-                return _record_materialize_failure(
-                    request_id,
-                    "abandoned_interrupted_auto_import",
-                    f"current_path={staged_album.current_path}",
+                return MaterializeGuarded(
+                    detail="abandoned_interrupted_auto_import",
                 )
             return MaterializeGuarded(
                 detail="abandon_blocked_release_lock_or_probe_unknown")

--- a/lib/failure_presentation.py
+++ b/lib/failure_presentation.py
@@ -847,10 +847,12 @@ _MATERIALIZE_REASON_COPY: Final[dict[str, str]] = {
     ),
     # --- staged-path readiness (literal reasons, same persisted column) ---
     "staged_path_missing": (
-        "The staged download folder disappeared before import; requeued"
+        "The staged download folder could not be accessed before import "
+        "(possible filesystem error); requeued"
     ),
     "staged_path_missing_tracked_files": (
-        "Files were missing from the staged download folder; requeued"
+        "Tracked files in the staged download folder could not be accessed "
+        "before import (possible filesystem error); requeued"
     ),
     "empty_manifest": (
         "The download attempt tracked no files; requeued"

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -3333,9 +3333,8 @@ class TestEvaluateStagedPathReadiness(unittest.TestCase):
 
     def test_abandon_success_resets_via_shared_decision(self):
         """kind=auto-import-staged + subprocess started + abandon commits
-        cleanly: the shared decision reports ``MaterializeFailed`` (the
-        caller's cue to treat this as a completed self-heal, not a
-        guarded manual-recovery case) and the DB row is already reset."""
+        cleanly: the shared decision reports a handled stop, and the DB row
+        is already reset exactly once."""
         from lib.download_materialization import _evaluate_staged_path_readiness
         with tempfile.TemporaryDirectory() as tmpdir:
             entry, staged_album, location, db = self._seed_and_build(
@@ -3348,10 +3347,11 @@ class TestEvaluateStagedPathReadiness(unittest.TestCase):
             result = _evaluate_staged_path_readiness(
                 entry, staged_album, location, db,
             )
-            self.assertIsInstance(result, MaterializeFailed)
-            assert isinstance(result, MaterializeFailed)
-            self.assertEqual(result.reason, "abandoned_interrupted_auto_import")
+            self.assertIsInstance(result, MaterializeGuarded)
+            assert isinstance(result, MaterializeGuarded)
+            self.assertEqual(result.detail, "abandoned_interrupted_auto_import")
             self.assertEqual(db.request(1)["status"], "wanted")
+            self.assertEqual(db.status_history, [(1, "wanted")])
 
 
 def _fail_file(*, last_state=None, last_exception=None):
@@ -3902,6 +3902,39 @@ class TestHarvestTerminalTransferEvidence(unittest.TestCase):
 
 class TestPollActiveDownloads(unittest.TestCase):
     """Test poll_active_downloads() — core polling function."""
+
+    def _assert_pre_enqueue_failure_event(
+        self,
+        db: FakePipelineDB,
+        *,
+        reason: str,
+        filetype: str,
+        expected_verdict: str,
+    ) -> None:
+        from lib.failure_presentation import FailureEvidence, present_failure
+
+        self.assertEqual(db.status_history, [(1, "wanted")])
+        self.assertEqual(len(db.download_logs), 1)
+        row = db.download_logs[0]
+        self.assertEqual(
+            (
+                row.outcome,
+                row.soulseek_username,
+                row.filetype,
+                row.beets_detail,
+                row.error_message,
+            ),
+            ("failed", None, filetype, reason, reason),
+        )
+        presentation = present_failure(FailureEvidence(
+            outcome=row.outcome or "",
+            soulseek_username=row.soulseek_username,
+            error_message=row.error_message,
+            beets_detail=row.beets_detail,
+        ))
+        self.assertEqual(presentation.verdict, expected_verdict)
+        self.assertEqual(db.cooldowns_applied, [])
+        self.assertEqual(db.list_import_jobs(request_id=1), [])
 
     def _make_downloading_row(self, request_id=1, state_dict=None):
         """Build a mock album_requests row with status='downloading'."""
@@ -5697,7 +5730,7 @@ class TestPollActiveDownloads(unittest.TestCase):
         import tempfile
         with tempfile.TemporaryDirectory() as tmpdir:
             row = self._make_downloading_row(state_dict={
-                "filetype": "flac",
+                "filetype": "opus",
                 "enqueued_at": _utc_now_iso(),
                 "processing_started_at": _utc_now_iso(),
                 "current_path": os.path.join(tmpdir, "missing"),
@@ -5711,7 +5744,15 @@ class TestPollActiveDownloads(unittest.TestCase):
             poll_active_downloads(ctx)
 
             self.assertEqual(fake_db.request(1)["status"], "wanted")
-            self.assertIn((1, "wanted"), fake_db.status_history)
+            self._assert_pre_enqueue_failure_event(
+                fake_db,
+                reason="staged_path_missing",
+                filetype="opus",
+                expected_verdict=(
+                    "The staged download folder could not be accessed before "
+                    "import (possible filesystem error); requeued"
+                ),
+            )
 
     def test_poll_missing_canonical_processing_path_queues_importer(self):
         """Missing canonical path can be pre-materialization, not post-move loss."""
@@ -5966,10 +6007,11 @@ class TestPollActiveDownloads(unittest.TestCase):
             cfg = cast(Any, ctx.cfg)
             cfg.beets_staging_dir = staging_root
 
-            poll_active_downloads(ctx)
+            with self.assertLogs("cratedigger", level="WARNING") as logs:
+                poll_active_downloads(ctx)
 
             self.assertEqual(fake_db.request(1)["status"], "wanted")
-            self.assertIn((1, "wanted"), fake_db.status_history)
+            self.assertEqual(fake_db.status_history, [(1, "wanted")])
             self.assertIsNone(fake_db.request(1)["active_download_state"])
             failed_parent = os.path.join(
                 os.path.dirname(resumed_path),
@@ -5992,6 +6034,7 @@ class TestPollActiveDownloads(unittest.TestCase):
             )
             self.assertEqual(fake_db.denylist, [])
             self.assertEqual(fake_db.cooldowns_applied, [])
+            self.assertNotIn("Unhandled exception", "\n".join(logs.output))
 
     def test_poll_subprocess_started_auto_import_waits_for_active_manual_job(self):
         """Any active import job owns the request, not just automation jobs."""
@@ -6250,6 +6293,16 @@ class TestPollActiveDownloads(unittest.TestCase):
                 fake_db.request(1)["status"], "wanted",
                 "Subprocess never launched + missing files = stale "
                 "crash residue; must reset to wanted, not block forever.",
+            )
+            self._assert_pre_enqueue_failure_event(
+                fake_db,
+                reason="staged_path_missing_tracked_files",
+                filetype="flac",
+                expected_verdict=(
+                    "Tracked files in the staged download folder could not be "
+                    "accessed before import (possible filesystem error); "
+                    "requeued"
+                ),
             )
 
     def test_poll_legacy_wedge_row_with_files_present_resumes_via_shared_decision(self):

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -4855,7 +4855,10 @@ class TestPostMoveResumeBlockGuard(unittest.TestCase):
         attempt, preserves leftover files under failed_imports, and
         resets the request for a clean redownload.
         """
-        from lib.download_materialization import MaterializeFailed, _materialize_processing_dir
+        from lib.download_materialization import (
+            MaterializeGuarded,
+            _materialize_processing_dir,
+        )
         from lib.staged_album import StagedAlbum
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -4875,10 +4878,12 @@ class TestPostMoveResumeBlockGuard(unittest.TestCase):
 
         self.assertIsInstance(
             result,
-            MaterializeFailed,
+            MaterializeGuarded,
             "Subprocess-started residue must not retry in place; it should "
             "abandon and let the next search/download cycle own recovery.",
         )
+        assert isinstance(result, MaterializeGuarded)
+        self.assertEqual(result.detail, "abandoned_interrupted_auto_import")
         self.assertEqual(
             ctx.pipeline_db_source._get_db().request(request_id)["status"],
             "wanted",

--- a/tests/test_materialize_evidence_generated.py
+++ b/tests/test_materialize_evidence_generated.py
@@ -11,12 +11,10 @@ Invariants under patrol
 -----------------------
 
 **I1 — a materialize failure never resets a request uncaused.** The
-reason reaches the journal at every failure site, and wherever the reset
-also writes a ``download_log`` row, that row carries the reason. (The
-pre-enqueue gate ``lib.download._processing_path_ready_for_importer``
-deliberately writes no row at all — it fails closed before any import
-attempt exists to audit — so the journal is its only record. Giving that
-path an audit row is a lifecycle change, tracked separately.)
+reason reaches the journal at every failure site, and every reset writes
+a ``download_log`` row carrying that reason. The pre-enqueue gate writes
+its two staged-path failures peer-neutrally because no peer verdict was
+involved.
 
 **I2 — distinguishable outcomes never collapse.** "slskd never stamped a
 location", "the stamp points at nothing", "the name failed containment"
@@ -64,6 +62,7 @@ import socket
 import tempfile
 import unittest
 import unittest.mock
+from collections.abc import Sequence
 from datetime import datetime, timedelta, timezone
 
 import tests._hypothesis_profiles  # noqa: F401  (loads the active profile)
@@ -75,6 +74,7 @@ from lib.config import CratediggerConfig
 from lib.download import (
     PROCESSING_MATERIALIZE_GRACE_S,
     _enqueue_completed_processing,
+    _processing_path_ready_for_importer,
     materialize_failure_action,
 )
 from lib.download_materialization import (
@@ -99,11 +99,13 @@ from lib.download_materialization import (
     MaterializeFailed,
     MaterializeGuarded,
     Materialized,
+    _evaluate_staged_path_readiness,
     _materialize_processing_dir,
-    materialize_authority_reason,
     shared_download_root_reason,
     source_preflight_reason,
 )
+from lib.download_reconstruction import reconstruct_grab_list_entry
+from lib.download_recovery import ProcessingPathLocation
 from lib.fs_authority import (
     CopyDestinationWriteError,
     FilesystemAuthorityError,
@@ -112,12 +114,21 @@ from lib.fs_authority import (
     open_regular_under_held_root,
     open_shared_download_root,
 )
+from lib.failure_presentation import FailureEvidence, present_failure
 from lib.grab_list import DownloadFile
-from lib.processing_paths import canonical_folder_for_row, processing_albums_dir
-from lib.quality import ActiveDownloadState
+from lib.processing_paths import (
+    canonical_folder_for_row,
+    processing_albums_dir,
+    stage_to_ai_path,
+)
+from lib.quality import ActiveDownloadFileState, ActiveDownloadState
 from lib.staged_album import StagedAlbum
 from tests.fakes import FakePipelineDB
-from tests.helpers import make_ctx_with_fake_db, make_grab_list_entry, make_request_row
+from tests.helpers import (
+    make_ctx_with_fake_db,
+    make_grab_list_entry,
+    make_request_row,
+)
 from tests.test_path_authority import assert_publication_invariant
 
 
@@ -234,9 +245,9 @@ def assert_lifecycle_unchanged_by_reason(
     ``failed`` row carrying the reason; an open grace window always
     leaves the row alone with no audit at all — whatever the reason is.
 
-    I1 is scoped to THIS path, which does write a row. The poller's own
-    pre-enqueue gate resets without writing one at all and records its
-    cause in the journal only; that is deliberate and out of scope here.
+    I1 is scoped to THIS grace-window path. The poller's pre-enqueue gate
+    has its own generated property below: its reset writes one peer-neutral
+    failed row carrying the staged-path reason.
     """
     if not grace_expired:
         if status != "downloading":
@@ -263,6 +274,48 @@ def assert_lifecycle_unchanged_by_reason(
             f"expired grace persisted {persisted_details!r}, expected [{reason!r}] "
             "— a reset without a recoverable cause",
         )
+
+
+def check_pre_enqueue_reset_evidence(
+    *,
+    reason: str,
+    filetype: str,
+    event: (
+        tuple[str | None, str | None, str | None, str | None, str | None]
+        | None
+    ),
+    verdict: str | None,
+) -> str | None:
+    """Return why the reset evidence/copy is wrong, or ``None``."""
+    expected_event = ("failed", None, filetype, reason, reason)
+    if event != expected_event:
+        return f"pre-enqueue reset event {event!r}, expected {expected_event!r}"
+    lowered = (verdict or "").casefold()
+    if "possible filesystem error" not in lowered:
+        return f"pre-enqueue copy hid filesystem uncertainty: {verdict!r}"
+    for false_claim in ("missing", "disappeared", "deleted"):
+        if false_claim in lowered:
+            return f"pre-enqueue copy asserted {false_claim!r}: {verdict!r}"
+    if "peer" in lowered:
+        return f"pre-enqueue copy attributed the failure to a peer: {verdict!r}"
+    return None
+
+
+def check_abandonment_handled_once(
+    result: Materialized | MaterializeFailed | MaterializeGuarded,
+    transitions: Sequence[tuple[int, str]],
+    audits: Sequence[tuple[str | None, str | None]],
+) -> str | None:
+    """Return why successful abandonment could fall through, or ``None``."""
+    if not isinstance(result, MaterializeGuarded):
+        return f"successful abandonment returned {result!r}, allowing reset fallthrough"
+    if result.detail != "abandoned_interrupted_auto_import":
+        return f"successful abandonment returned detail {result.detail!r}"
+    if transitions != [(1, "wanted")]:
+        return f"successful abandonment transitioned {transitions!r}"
+    if audits != [("failed", "abandoned_auto_import")]:
+        return f"successful abandonment audited {audits!r}"
+    return None
 
 
 # ============================================================================
@@ -809,6 +862,168 @@ class TestGeneratedMaterializeLifecycle(unittest.TestCase):
         )
 
 
+def _staged_gate_world(
+    parent: str,
+    *,
+    filetype: str,
+    path_state: str,
+    subprocess_started_at: str | None,
+):
+    """Build one persisted staged-path world and reconstruct its entry."""
+    built = _build_world(parent, "healthy", "track")
+    current_path = stage_to_ai_path(
+        artist="Artist",
+        title="Album",
+        staging_dir=built.cfg.beets_staging_dir,
+        request_id=1,
+        auto_import=True,
+    )
+    now = datetime.now(timezone.utc).isoformat()
+    state = ActiveDownloadState(
+        filetype=filetype,
+        enqueued_at=now,
+        files=[
+            ActiveDownloadFileState(
+                username=built.file.username,
+                filename=built.file.filename,
+                file_dir=built.file.file_dir,
+                size=built.file.size,
+                local_path=built.file.local_path,
+            ),
+        ],
+        processing_started_at=now,
+        import_subprocess_started_at=subprocess_started_at,
+        current_path=current_path,
+    )
+    db = FakePipelineDB()
+    db.seed_request(make_request_row(
+        id=1,
+        status="downloading",
+        artist_name="Artist",
+        album_title="Album",
+        year=2020,
+        source="request",
+        active_download_state=state.to_json(),
+    ))
+    entry = reconstruct_grab_list_entry(db.request(1), state)
+    if path_state != "directory_missing":
+        os.makedirs(current_path)
+    if path_state == "present":
+        staged = StagedAlbum.from_entry(entry, default_path=current_path)
+        staged.bind_import_paths(entry.files)
+        for file in entry.files:
+            assert file.import_path is not None
+            with open(file.import_path, "wb") as handle:
+                handle.write(b"audio")
+    ctx = make_ctx_with_fake_db(db, cfg=built.cfg)
+    return built, current_path, entry, state, db, ctx
+
+
+class TestGeneratedPreEnqueueFailureHistory(unittest.TestCase):
+    @given(
+        failure=st.sampled_from(("directory", "tracked_file")),
+        filetype=st.sampled_from(("flac", "mp3 v0", "opus")),
+    )
+    @example(failure="directory", filetype="opus")
+    @example(failure="tracked_file", filetype="flac")
+    @settings(deadline=None, max_examples=6)
+    def test_reset_is_a_single_peer_neutral_visible_event(
+        self,
+        failure: str,
+        filetype: str,
+    ) -> None:
+        """Drive the real readiness classifier, transition, writer and presenter."""
+        with tempfile.TemporaryDirectory() as parent:
+            built, _, entry, state, db, ctx = _staged_gate_world(
+                parent,
+                filetype=filetype,
+                path_state=(
+                    "directory_missing"
+                    if failure == "directory"
+                    else "tracked_file_missing"
+                ),
+                subprocess_started_at=None,
+            )
+            reason = (
+                "staged_path_missing"
+                if failure == "directory"
+                else "staged_path_missing_tracked_files"
+            )
+            try:
+                ready = _processing_path_ready_for_importer(
+                    entry, 1, state, db, ctx,
+                )
+            finally:
+                built.close()
+
+            self.assertFalse(ready)
+            self.assertEqual(db.request(1)["status"], "wanted")
+            self.assertEqual(db.status_history, [(1, "wanted")])
+            self.assertEqual(db.cooldowns_applied, [])
+            self.assertEqual(db.list_import_jobs(request_id=1), [])
+            self.assertEqual(len(db.download_logs), 1)
+            row = db.download_logs[0]
+            presentation = present_failure(FailureEvidence(
+                outcome=row.outcome or "",
+                soulseek_username=row.soulseek_username,
+                error_message=row.error_message,
+                beets_detail=row.beets_detail,
+            ))
+            violation = check_pre_enqueue_reset_evidence(
+                reason=reason,
+                filetype=filetype,
+                event=(
+                    row.outcome,
+                    row.soulseek_username,
+                    row.filetype,
+                    row.beets_detail,
+                    row.error_message,
+                ),
+                verdict=presentation.verdict,
+            )
+            self.assertIsNone(violation, violation)
+
+    @given(
+        path_present=st.booleans(),
+        filetype=st.sampled_from(("flac", "mp3 v0", "opus")),
+    )
+    @example(path_present=True, filetype="flac")
+    @settings(deadline=None, max_examples=6)
+    def test_successful_abandonment_is_a_handled_stop(
+        self,
+        path_present: bool,
+        filetype: str,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as parent:
+            built, current_path, entry, _, db, _ = _staged_gate_world(
+                parent,
+                filetype=filetype,
+                path_state="present" if path_present else "directory_missing",
+                subprocess_started_at="2026-07-27T00:00:00+00:00",
+            )
+            staged = StagedAlbum.from_entry(entry, default_path=current_path)
+            location = ProcessingPathLocation(
+                path=current_path,
+                kind="request_scoped_auto_import_staged",
+            )
+            try:
+                result = _evaluate_staged_path_readiness(
+                    entry, staged, location, db,
+                )
+            finally:
+                built.close()
+
+            violation = check_abandonment_handled_once(
+                result,
+                list(db.status_history),
+                [
+                    (row.outcome, row.beets_scenario)
+                    for row in db.download_logs
+                ],
+            )
+            self.assertIsNone(violation, violation)
+
+
 # ============================================================================
 # Known-bad self-tests — a checker that never trips proves nothing
 # ============================================================================
@@ -892,6 +1107,58 @@ class TestMaterializeEvidenceCheckersTripOnViolations(unittest.TestCase):
                 log_outcomes=[],
                 persisted_details=[],
             )
+
+    def test_pre_enqueue_checker_rejects_missing_persistence_and_false_copy(
+        self,
+    ) -> None:
+        event = (
+            "failed", None, "flac", "staged_path_missing",
+            "staged_path_missing",
+        )
+        good_copy = (
+            "The staged download folder could not be accessed before import "
+            "(possible filesystem error); requeued"
+        )
+        for observed, verdict in (
+            (None, good_copy),
+            (event, "The staged download folder disappeared before import"),
+        ):
+            with self.subTest(event=observed, verdict=verdict):
+                self.assertIsNotNone(check_pre_enqueue_reset_evidence(
+                    reason="staged_path_missing",
+                    filetype="flac",
+                    event=observed,
+                    verdict=verdict,
+                ))
+
+    def test_abandonment_checker_rejects_fallthrough_and_duplicate_reset(
+        self,
+    ) -> None:
+        handled = MaterializeGuarded(
+            detail="abandoned_interrupted_auto_import",
+        )
+        audit = [("failed", "abandoned_auto_import")]
+        for result, transitions, audits in (
+            (
+                MaterializeFailed(
+                    reason="abandoned_interrupted_auto_import",
+                ),
+                [(1, "wanted")],
+                audit,
+            ),
+            (handled, [(1, "wanted"), (1, "wanted")], audit),
+            (handled, [(1, "wanted")], []),
+        ):
+            with self.subTest(
+                result=result,
+                transitions=transitions,
+                audits=audits,
+            ):
+                self.assertIsNotNone(check_abandonment_handled_once(
+                    result,
+                    transitions,
+                    audits,
+                ))
 
     def test_leg_checker_rejects_a_root_refusal_blamed_on_one_file(self) -> None:
         """The exact D1 defect: the share refused, but the reason names a

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -2804,6 +2804,65 @@ class TestDownloadLog(unittest.TestCase):
         self.assertIsNone(history[0]["beets_scenario"])
         self.assertIsNone(history[0]["beets_distance"])
 
+    def test_staged_path_failures_round_trip_to_neutral_history_copy(self):
+        """The real writer/read projections feed the real history presenters."""
+        from lib.failure_presentation import FailureEvidence, present_failure
+        from web.classify import LogEntry, classify_log_entry
+
+        cases = (
+            (
+                "staged_path_missing",
+                "The staged download folder could not be accessed before "
+                "import (possible filesystem error); requeued",
+            ),
+            (
+                "staged_path_missing_tracked_files",
+                "Tracked files in the staged download folder could not be "
+                "accessed before import (possible filesystem error); requeued",
+            ),
+        )
+        for reason, expected in cases:
+            with self.subTest(reason=reason):
+                log_id = self.db.log_download(
+                    request_id=self.req_id,
+                    soulseek_username=None,
+                    filetype="opus",
+                    outcome="failed",
+                    beets_detail=reason,
+                    error_message=reason,
+                )
+
+                history_row = next(
+                    row for row in self.db.get_download_history(self.req_id)
+                    if row["id"] == log_id
+                )
+                self.assertEqual(
+                    (
+                        history_row["outcome"],
+                        history_row["soulseek_username"],
+                        history_row["filetype"],
+                        history_row["beets_detail"],
+                        history_row["error_message"],
+                    ),
+                    ("failed", None, "opus", reason, reason),
+                )
+                evidence = FailureEvidence.from_row(dict(history_row))
+                self.assertEqual(
+                    present_failure(evidence).verdict,
+                    expected,
+                )
+
+                recent_row = next(
+                    row for row in self.db.get_log(limit=10)
+                    if row["id"] == log_id
+                )
+                entry = LogEntry.from_row(dict(recent_row))
+                classified = classify_log_entry(entry)
+                self.assertIsNone(entry.soulseek_username)
+                self.assertEqual(entry.outcome, "failed")
+                self.assertEqual(classified.verdict, expected)
+                self.assertEqual(classified.summary, expected)
+
     def test_log_download_round_trip_preserves_transfer_detail(self):
         """Rule A (test-fidelity.md): migration 043's transfer_detail
         JSONB column must actually preserve what log_download writes —


### PR DESCRIPTION
## Summary

- persist one peer-neutral failed history event when either pre-enqueue staged-path readiness check resets a request
- tell the operator the staged path could not be accessed and label it a possible filesystem error
- stop successful interrupted-import abandonment from falling through to a second generic reset

This deliberately keeps the existing transition and concurrency semantics. It adds no new DB helper, CAS framework, incarnation witness, event-ingest change, or importer refactor.

Refs #887

## Verification

- focused deterministic, generated, known-bad, integration, and real-PostgreSQL writer/read/presentation tests passed
- independent fresh correctness and project-standards reviews converged
- whole-repository Pyright final gate passed on e627bfcb34b828b95b7b019205cf1e74b1137020
- full suite final gate passed on the same commit
- Pyright receipt: /run/user/1000/cratedigger-final-gate.8c3AWjlz
- tests receipt: /run/user/1000/cratedigger-final-gate.EoddsIjM

## Live-corpus render differential

Base and branch renderers were run over all 36,372 live download-history rows. Existing live rows changed: 0. Neither staged-path reason currently exists in the corpus; newly emitted rows will use the new copy.

Changed rows by watched field:

```text
analysis_error 0
bad_extensions 0
badge 0
badge_class 0
beets_detail_label 0
border_color 0
candidate_reference 0
comparison_basis 0
disambiguation_detail 0
disambiguation_failure 0
downloaded_label 0
existing_format 0
existing_spectral_error 0
existing_spectral_grade 0
existing_v0_probe_kind 0
failure_category 0
installed_path 0
materialized_format 0
source_format 0
spectral_error 0
spectral_grade 0
summary 0
target_contract_format 0
transfer_message 0
transfer_message_label 0
v0_probe_kind 0
verdict 0
wrong_match_triage_action 0
wrong_match_triage_detail 0
wrong_match_triage_preview_decision 0
wrong_match_triage_preview_verdict 0
wrong_match_triage_reason 0
wrong_match_triage_stage_chain 0
wrong_match_triage_summary 0
```
