### PR TITLE
test(generated): model terminal harness transcripts

### DIFF
--- a/tests/test_beets_harness_session.py
+++ b/tests/test_beets_harness_session.py
@@ -406,6 +406,23 @@ class TestSessionsThatOfferedNothing(unittest.TestCase):
         self.assertEqual(session.message_types, ["session_end"])
         assert_every_invariant(result)
 
+    def test_session_end_makes_later_malformed_output_unobservable(self):
+        suffixes = (
+            ("non-object JSON", "[1, 2, 3]"),
+            ("undecodable choose_match", UNDECODABLE_CHOOSE_MATCH_LINE),
+        )
+        for name, suffix in suffixes:
+            with self.subTest(name=name):
+                result = run_fake_harness([SESSION_END_LINE, suffix])
+
+                self.assertEqual(result.scenario, NO_CHOOSE_MATCH_SCENARIO)
+                self.assertIsNone(result.error)
+                session = result.harness_session
+                assert session is not None
+                self.assertEqual(session.message_types, ["session_end"])
+                self.assertTrue(session.session_end_seen)
+                assert_every_invariant(result)
+
     def test_a_quiet_harness_that_said_nothing_at_all_is_named(self):
         result = run_fake_harness([])
 

--- a/tests/test_beets_harness_session_generated.py
+++ b/tests/test_beets_harness_session_generated.py
@@ -130,6 +130,16 @@ def render_transcript(kinds: list[str]) -> list[str]:
     return [LINE_KINDS[kind] for kind in kinds]
 
 
+def controller_consumed_prefix(kinds: list[str]) -> list[str]:
+    """Kinds the controller can observe before its first terminal event."""
+    consumed: list[str] = []
+    for kind in kinds:
+        consumed.append(kind)
+        if kind in ("session_end", "non_object_json"):
+            break
+    return consumed
+
+
 def emitted_message_types(kinds: list[str]) -> set[str]:
     """Every ``type`` this transcript could possibly put on the wire."""
     return {
@@ -295,6 +305,9 @@ class TestNoHarnessTranscriptEverRejectsSilently(unittest.TestCase):
     @example(
         kinds=["undecodable_choose_match", "session_end"], stderr_text="")
     @example(kinds=["non_object_json", "valid_choose_match"], stderr_text="")
+    @example(kinds=["session_end", "non_object_json"], stderr_text="")
+    @example(
+        kinds=["session_end", "undecodable_choose_match"], stderr_text="")
     @example(kinds=["non_string_type", "session_end"], stderr_text="")
     @example(kinds=["garbage", "blank", "typeless_object"], stderr_text="")
     @given(kinds=TRANSCRIPTS, stderr_text=STDERR_TEXTS)
@@ -305,14 +318,16 @@ class TestNoHarnessTranscriptEverRejectsSilently(unittest.TestCase):
     ) -> None:
         result = run_fake_harness(
             render_transcript(kinds), stderr_text=stderr_text)
+        consumed = controller_consumed_prefix(kinds)
 
         assert_scenario_is_always_named(result)
         assert_the_name_matches_the_error_state(result)
-        assert_an_erroring_transcript_is_never_called_matchless(result, kinds)
+        assert_an_erroring_transcript_is_never_called_matchless(
+            result, consumed)
         assert_evidence_accompanies_the_name(result)
         assert_evidence_claims_no_cause(result)
-        assert_no_match_named_exactly_when_none_was_offered(result, kinds)
-        assert_recorded_types_came_from_the_wire(result, kinds)
+        assert_no_match_named_exactly_when_none_was_offered(result, consumed)
+        assert_recorded_types_came_from_the_wire(result, consumed)
         assert_stderr_tail_is_a_real_tail(result, stderr_text)
         assert_stays_a_wrong_match_candidate(result.scenario)
         assert_result_round_trips(result)
@@ -448,6 +463,27 @@ class TestADecodableMatchStillDecides(unittest.TestCase):
 
 class TestCheckersTripOnViolations(unittest.TestCase):
     """Known-bad self-tests for the checkers this module owns."""
+
+    def test_consumed_prefix_stops_only_at_controller_terminal_kinds(
+        self,
+    ) -> None:
+        cases = (
+            (
+                ["session_end", "non_object_json"],
+                ["session_end"],
+            ),
+            (
+                ["non_object_json", "session_end"],
+                ["non_object_json"],
+            ),
+            (
+                ["undecodable_choose_match", "session_end", "garbage"],
+                ["undecodable_choose_match", "session_end"],
+            ),
+        )
+        for kinds, expected in cases:
+            with self.subTest(kinds=kinds):
+                self.assertEqual(controller_consumed_prefix(kinds), expected)
 
     def test_the_oracle_rejects_a_silent_run(self) -> None:
         with self.assertRaises(AssertionError):


### PR DESCRIPTION
## Summary

- model only the stdout prefix beets_validate can consume before session_end or a fatal non-object JSON frame
- keep arbitrary post-terminal suffixes in the generated world while preventing unreachable bytes from being treated as observed errors
- pin both shrunk counterexamples through the real fake-harness subprocess

This is a test-model correction discovered by the complete deep burst after issue #893. Production and protocol behavior are unchanged.

## Evidence

- Initial exact-deployed burst at fcce412d: 2,499 targets; one property failed in all 8 entropy shards, shrinking to session_end followed by malformed output
- Two independent diagnoses: generated oracle defect; session_end is terminal and the real harness emits it last
- Targeted deep replay: 33/33 targets green at the full 20k profile in 380.1s
- Complete reviewed-tree deep burst: all 2,499 targets green across 93 modules and 1,048 tests in 1,041.7s
- Depth report: 320 properties / 22 shallow / 6 discarding
- Independent review: no findings
- Final Pyright gate: pass, 0 errors
- Final full suite: 7,684 tests pass, no skips

Follow-up to #893.