### PR TITLE
fix(ui): explain equivalent proof upgrades truthfully

### DIFF
--- a/tests/test_web_recents.py
+++ b/tests/test_web_recents.py
@@ -2253,7 +2253,40 @@ class TestClassifyComparisonBasis(unittest.TestCase):
         c = classify_log_entry(entry)
         self.assertEqual(
             c.verdict,
-            "Upgrade: MP3 V0 to MP3 V0, verified lossless")
+            "Proof upgrade: equivalent quality — MP3 vs MP3, "
+            "verified lossless")
+
+    def test_ep1_proof_upgrade_names_opus_have_from_persisted_basis(self):
+        """Live issue #911 world: equivalent Opus replaced only for proof."""
+        basis = self._bypass_basis_dict(
+            {"avg_bitrate_kbps": 141, "format": "opus 128"},
+            {"min_bitrate_kbps": 129, "avg_bitrate_kbps": 141,
+             "format": "opus"},
+        )
+        self.assertEqual(basis["verdict"], "equivalent")
+        self.assertEqual(basis["existing_format"], "opus")
+        entry = _entry(
+            outcome="success",
+            was_converted=True,
+            original_filetype="flac",
+            actual_filetype="opus",
+            actual_min_bitrate=129,
+            existing_min_bitrate=129,
+            spectral_grade="likely_transcode",
+            import_result={
+                "version": 2,
+                "decision": "import",
+                "comparison_basis": basis,
+            },
+        )
+        result = classify_log_entry(entry)
+        self.assertEqual(result.badge, "Upgraded")
+        self.assertEqual(
+            result.verdict,
+            "Proof upgrade: equivalent quality — OPUS 128 vs OPUS, "
+            "from FLAC, verified lossless",
+        )
+        self.assertNotIn("MP3", result.verdict)
 
     def test_schmotime_verified_lossless_upgrade_restores_concise_copy(self):
         entry = _entry(
@@ -2289,7 +2322,8 @@ class TestClassifyComparisonBasis(unittest.TestCase):
         self.assertEqual(result.badge, "Upgraded")
         self.assertEqual(
             result.summary,
-            "Upgrade: MP3 320 to OPUS 127k, from FLAC, verified lossless"
+            "Proof upgrade: equivalent quality — OPUS 128 vs MP3, "
+            "from FLAC, verified lossless"
             " · trelospatrinos",
         )
 

--- a/tests/test_web_recents_generated.py
+++ b/tests/test_web_recents_generated.py
@@ -280,11 +280,26 @@ def assert_only_explicit_source_receives_materialized_output(
         raise AssertionError("unrelated same-release row received inferred output")
 
 
-def assert_verified_lossless_upgrade_copy_is_concise(verdict: str) -> None:
-    if "Equivalent:" in verdict or "both transparent" in verdict:
-        raise AssertionError("internal comparison trace leaked into upgrade copy")
-    if not verdict.startswith("Upgrade: "):
-        raise AssertionError("verified-lossless import lost upgrade grammar")
+def assert_verified_lossless_proof_upgrade_names_basis(
+    verdict: str,
+    basis: QualityComparisonBasis,
+) -> None:
+    if not verdict.startswith("Proof upgrade: equivalent quality — "):
+        raise AssertionError("verified-lossless import lost proof-upgrade grammar")
+    if basis.new_format is None or basis.existing_format is None:
+        raise AssertionError("proof-upgrade basis is missing a format")
+    new_format = basis.new_format.upper()
+    existing_format = basis.existing_format.upper()
+    if f"{new_format} vs {existing_format}" not in verdict:
+        raise AssertionError("proof upgrade lost the persisted format comparison")
+    if (
+        "MP3" in verdict
+        and not any(
+            "MP3" in format_name
+            for format_name in (new_format, existing_format)
+        )
+    ):
+        raise AssertionError("proof upgrade invented MP3 outside the basis")
     if "verified lossless" not in verdict:
         raise AssertionError("verified-lossless reason disappeared")
 
@@ -1020,62 +1035,94 @@ class TestGeneratedRejectVerdictGrammar(unittest.TestCase):
                 expected_format="Opus",
             )
 
-    def test_verified_lossless_copy_checker_rejects_internal_trace(self) -> None:
-        with self.assertRaisesRegex(AssertionError, "internal comparison trace"):
-            assert_verified_lossless_upgrade_copy_is_concise(
-                "Equivalent: OPUS 128 vs MP3 — both transparent — "
-                "imported: verified lossless",
+    def test_verified_lossless_copy_checker_rejects_hardcoded_mp3_legacy_copy(
+        self,
+    ) -> None:
+        basis = msgspec.convert({
+            "verdict": "equivalent",
+            "branch": "label_contract_same_rank",
+            "new_rank": "transparent",
+            "existing_rank": "transparent",
+            "new_metric": "contract",
+            "existing_metric": "avg",
+            "new_value_kbps": 128,
+            "existing_value_kbps": 141,
+            "new_format": "opus 128",
+            "existing_format": "opus",
+            "spectral_clamped": False,
+            "tolerance_kbps": None,
+            "verified_lossless_bypass": True,
+        }, type=QualityComparisonBasis)
+        with self.assertRaisesRegex(AssertionError, "persisted format comparison"):
+            assert_verified_lossless_proof_upgrade_names_basis(
+                "Proof upgrade: equivalent quality — OPUS 128 vs MP3, "
+                "from FLAC, verified lossless",
+                basis,
             )
 
     @given(
-        existing_min=st.integers(min_value=1, max_value=2_000),
-        output_min=st.integers(min_value=1, max_value=2_000),
-        existing_avg=st.integers(min_value=1, max_value=2_000),
-        target=st.sampled_from(("opus 128", "mp3 v0")),
+        target=st.sampled_from((
+            ("opus 128", 141),
+            ("mp3 v0", 250),
+        )),
+        existing=st.sampled_from((
+            ("opus", 141, 129),
+            ("mp3", 250, 230),
+            ("aac", 256, 240),
+        )),
     )
     @example(
-        existing_min=320,
-        output_min=127,
-        existing_avg=320,
-        target="opus 128",
+        target=("opus 128", 141),
+        existing=("opus", 141, 129),
     )
-    def test_verified_lossless_bypass_uses_concise_upgrade_copy(
+    def test_verified_lossless_bypass_uses_persisted_existing_codec(
         self,
-        existing_min: int,
-        output_min: int,
-        existing_avg: int,
-        target: str,
+        target: tuple[str, int],
+        existing: tuple[str, int, int],
     ) -> None:
-        actual_format = "opus" if target == "opus 128" else "mp3"
+        from lib.quality import (
+            AudioQualityMeasurement,
+            QualityRankConfig,
+            import_quality_decision,
+        )
+
+        target_format, target_avg = target
+        existing_format, existing_avg, existing_min = existing
+        decision = import_quality_decision(
+            AudioQualityMeasurement(
+                avg_bitrate_kbps=target_avg,
+                format=target_format,
+            ),
+            AudioQualityMeasurement(
+                min_bitrate_kbps=existing_min,
+                avg_bitrate_kbps=existing_avg,
+                format=existing_format,
+            ),
+            cfg=QualityRankConfig.defaults(),
+            verified_lossless_proof=True,
+        )
+        self.assertEqual(decision.decision, "import")
+        self.assertIsNotNone(decision.basis)
+        assert decision.basis is not None
+        self.assertTrue(decision.basis.verified_lossless_bypass)
+
+        actual_format = "opus" if target_format == "opus 128" else "mp3"
         result = classify_log_entry(_entry(
             outcome="success",
             was_converted=True,
             original_filetype="flac",
             actual_filetype=actual_format,
-            actual_min_bitrate=output_min,
+            actual_min_bitrate=target_avg,
             existing_min_bitrate=existing_min,
             spectral_grade="genuine",
             import_result={
                 "version": 2,
                 "decision": "import",
-                "comparison_basis": {
-                    "verdict": "equivalent",
-                    "branch": "cross_family_same_rank",
-                    "new_rank": "transparent",
-                    "existing_rank": "transparent",
-                    "new_metric": "contract",
-                    "existing_metric": "avg",
-                    "new_value_kbps": 128,
-                    "existing_value_kbps": existing_avg,
-                    "new_format": target,
-                    "existing_format": "mp3",
-                    "spectral_clamped": False,
-                    "tolerance_kbps": None,
-                    "verified_lossless_bypass": True,
-                },
+                "comparison_basis": msgspec.to_builtins(decision.basis),
             },
         ))
-        assert_verified_lossless_upgrade_copy_is_concise(result.verdict)
+        assert_verified_lossless_proof_upgrade_names_basis(
+            result.verdict, decision.basis)
 
     @given(
         source_id=st.integers(min_value=1, max_value=1_000),

--- a/web/classify.py
+++ b/web/classify.py
@@ -1142,17 +1142,10 @@ def _classify(
                 return _classify_search_filetype_override(entry, is_verified_lossless)
             basis = _entry_comparison_basis(entry)
             if basis is not None and basis.verified_lossless_bypass:
-                # The evidence rows already carry the exact comparison. Keep
-                # the collapsed footer on the older concise upgrade grammar;
-                # the basis trace ("Equivalent ... both transparent") is an
-                # internal decision explanation, not a useful success label.
-                verdict = _upgrade_verdict(
-                    entry.existing_min_bitrate,
-                    _downloaded_min_bitrate_kbps(entry),
+                verdict = _proof_upgrade_verdict_from_basis(
+                    basis,
                     entry.was_converted,
                     entry.original_filetype,
-                    True,
-                    actual_filetype=entry.actual_filetype,
                 )
             elif basis is not None:
                 verdict = _upgrade_verdict_from_basis(
@@ -1309,6 +1302,26 @@ def _upgrade_verdict_from_basis(
         parts.append(f"from {original_ft.upper()}")
     if is_verified_lossless and not basis.verified_lossless_bypass:
         parts.append("verified lossless")
+    return ", ".join(parts)
+
+
+def _proof_upgrade_verdict_from_basis(
+    basis: QualityComparisonBasis,
+    was_converted: bool,
+    original_ft: str | None,
+) -> str:
+    """Describe an equivalent-quality replacement made only to gain proof."""
+    new_format = (basis.new_format or "?").upper()
+    existing_format = (basis.existing_format or "?").upper()
+    parts = [
+        (
+            f"Proof upgrade: {basis.verdict} quality — "
+            f"{new_format} vs {existing_format}"
+        ),
+    ]
+    if was_converted and original_ft:
+        parts.append(f"from {original_ft.upper()}")
+    parts.append("verified lossless")
     return ", ".join(parts)
 
 


### PR DESCRIPTION
## Summary

- render verified-lossless bypass imports as proof upgrades from persisted comparison-basis truth
- name the actual candidate and existing formats, fixing EP1's false `MP3` label
- preserve legacy no-basis and ordinary non-bypass rendering unchanged

## Scope

This is the approved UI-only portion of #911. It deliberately makes no quality, spectral, proof-minting, lifecycle, or database change.

The Fall 2007 anti-loop decision invariant belongs in #829 PR2. EP1's v3 proof-gate behavior belongs in #829 PR3, and broader carried-source spectral presentation belongs in #829 PR4.

## Verification

- Sol implementation and independent Sol review/re-review: clean
- focused Recents + generated tests: 179 passed
- fault qualification kills the hardcoded-MP3 renderer mutant
- live Rule D differential: 36,541 rows; 38 changed
  - `verdict`: 38
  - `summary`: 38
  - every other watched field: 0
- all 38 changed rows are successful equivalent comparisons with `verified_lossless_bypass=true`
- live-db screenshot on EP1: exact `OPUS 128 vs OPUS` copy, no clipping/overlap, badge and evidence preserved
- final gate Pyright receipt: pass
- final full-suite receipt: pass — 7,685 tests, no skips
