### PR TITLE
Replace empty mock ratchets with a direct audit

### DIFF
--- a/.claude/memory/project_430_fakedb_migration_done.md
+++ b/.claude/memory/project_430_fakedb_migration_done.md
@@ -7,10 +7,11 @@ metadata:
   originSessionId: 67e95325-7ad6-4fe8-932e-a5ab7533f2ae
 ---
 
-Issue #430 closed 2026-06-12: all `tests/web` contract tests migrated from the MagicMock harness to per-test bare `FakePipelineDB` (`_FakeDbWebServerCase`, `DB_FACTORY` hook for typed failure-injecting subclasses). `WEB_HARNESS_MOCK_BASELINE` in `tests/_mock_audit_scanner.py` is permanently empty — it bans `mock_db` references in tests/web and `_pipeline_db_test_harness` anywhere.
+Issue #430 closed 2026-06-12: all `tests/web` contract tests migrated from the MagicMock harness to per-test bare `FakePipelineDB` (`_FakeDbWebServerCase`, `DB_FACTORY` hook for typed failure-injecting subclasses). The direct zero-tolerance rule in `tests/test_mock_audit.py` bans `mock_db` references in tests/web and `_pipeline_db_test_harness` anywhere.
 
 **Why:** patterns that compounded and are worth reusing on future multi-PR refactors:
 - Exact-match ratchet baseline (growth fails AND un-shrunk baseline fails) made the migration self-enforcing across 5 PRs.
+- Once the baseline reached zero, issue #895 retired its migration accounting and folded the same forbidden names into the main direct mock audit.
 - `TestDashboardFakeParity` (real-PG vs fake shape comparison on identical seeds) converts fake-mirror drift from review archaeology into mechanical failures — the adversarial reviewer found 6 birth-drift divergences in my hand-written mirror; the parity gate would have caught them all.
 - Adversarial same-engine pre-review caught structural gameability (ratchet evasion via aliasing, partial-wipe pins); Codex partner rounds caught production-SQL semantics drift (dense vs sparse series, errors-bucket FILTER, cycle-row ordering). Run both; they find disjoint things.
 

--- a/.claude/memory/project_445_beets_mock_migration_done.md
+++ b/.claude/memory/project_445_beets_mock_migration_done.md
@@ -9,7 +9,7 @@ metadata:
 
 Issue #445 items 1 and 4 shipped 2026-06-12 (PRs #446, #447, #448, all merged):
 
-- `WEB_BEETS_MOCK_BASELINE` in `tests/_mock_audit_scanner.py` is permanently EMPTY — tests/web has zero beets-collaborator MagicMocks. Migrated fakes are named `self.beets_db` (the ratchet counts `mock_beets*`/`self._beets`/`self.beets`, not `beets_db`).
+- Tests/web has zero beets-collaborator MagicMocks. The direct zero-tolerance rule in `tests/test_mock_audit.py` bans `mock_beets*`/`self._beets`/`self.beets`; migrated fakes are named `self.beets_db`. Issue #895 retired the completed migration's empty baseline without weakening that rule.
 - `FakePipelineDB` enforces UNIQUE(mb_release_id) (seed/add/update paths) and sequence-faithful download_log id minting. `make_request_row` default mbid is id-derived (`test-mbid-{id:04d}`; id=1 keeps the old literal).
 - `FakeBeetsDB` now covers the web-route surface: `get_album_ids_by_mbids`, `get_tracks_by_mb_release_id`, `search_albums`, `get_recent`, `get_album_detail`, `get_min_bitrate`, and `locate` with a typed `queue_locate_results` API (rejects production-impossible ReleaseLocations). `album_exists`/`get_min_bitrate` route through one `_presence` helper (queued locate head → explicit seed → album-ids store → default), mirroring production's single locate seam (issue #121).
 

--- a/docs/generated-testing.md
+++ b/docs/generated-testing.md
@@ -584,9 +584,8 @@ may still patrol nothing; only review and mutant-kill counts show that.
   too, since discovery is by decorator name. A future DRY idiom such as
   `@given(**_COMMON_STRATEGIES)` is therefore a hard build break until the
   audit is extended — deliberate: an unmappable decorator must not pass.
-- `PROPERTY_INPUT_ALLOWLIST` is **empty and armed**, the same ratchet shape as
-  `WEB_HARNESS_MOCK_BASELINE` in `tests/_mock_audit_scanner.py`. The one
-  property that used to flag — the planted-bad-decider self-test in
+- `PROPERTY_INPUT_ALLOWLIST` is **empty and armed**. The one property that
+  used to flag — the planted-bad-decider self-test in
   `tests/test_quality_generated.py` — now passes its world to a decider that
   ignores it, which models "a decider that ignores its world" more faithfully
   than discarding the world did. A stale entry that no longer flags also fails

--- a/tests/_mock_audit_scanner.py
+++ b/tests/_mock_audit_scanner.py
@@ -1,10 +1,8 @@
 """Shared scanner for the stateful-MagicMock audit.
 
-Isolated so test_mock_audit.py and the baseline-rebuild helper share one
-source of truth for the heuristic. See CLAUDE.md § "Mocks: leaf-seam only"
-and issue #290.
+See CLAUDE.md § "Mocks: leaf-seam only" and issue #290.
 
-The heuristic flags two anti-patterns:
+The heuristic flags three anti-patterns:
 
 1. **Stateful-collaborator MagicMock by variable name.** Lines that
    assign ``MagicMock(...)`` to a variable whose name implies a stateful
@@ -19,6 +17,11 @@ The heuristic flags two anti-patterns:
    the outermost edge — subprocess, urllib/requests, os.path, time.sleep,
    third-party libs we don't own (``music_tag``, ``redis``), and a small
    set of one-way notifier helpers in ``lib.util``.
+
+3. **Retired web MagicMock harness names.** ``tests/web`` must use
+   ``FakePipelineDB`` and ``FakeBeetsDB`` state, never the old ``mock_db`` /
+   beets-mock names. The deleted ``_pipeline_db_test_harness`` constructor is
+   forbidden throughout the scanned test tree.
 
 Patch calls split across physical lines are parsed through the AST. Existing
 multiline debt is held to an exact target-count baseline; new occurrences fail
@@ -70,8 +73,17 @@ _PATCH_OBJECT_RE = re.compile(
     r'\bpatch\.object\s*\(\s*([A-Za-z_][A-Za-z0-9_.]*)\s*,\s*["\']([^"\']+)["\']'
 )
 
+# Direct zero-tolerance names left behind by the completed #430 and #445
+# migrations. These remain deliberately lexical: the names themselves encode
+# the retired test shapes, while current fakes use ``self.db`` /
+# ``self.beets_db``.
+_WEB_HARNESS_MOCK_DB_RE = re.compile(r"\bmock_db\b")
+_HARNESS_CTOR_RE = re.compile(r"\b_pipeline_db_test_harness\b")
+_WEB_BEETS_MOCK_RE = re.compile(
+    r"\bmock_beets\w*|self\._beets\b|self\.beets\b")
+
 # Module aliases the audit knows how to resolve to canonical paths.
-# Keep narrow — false positives become baseline noise. Detected by
+# Keep narrow — false positives become audit noise. Detected by
 # scanning each file's import statements before classification.
 _ALIAS_TO_CANONICAL = {
     "cratedigger": "cratedigger",
@@ -521,45 +533,59 @@ def scan_multiline_patch_targets() -> dict[str, int]:
     return dict(counts)
 
 
-def scan_file(path: str) -> dict[str, int]:
-    """Return ``{finding_key: count}`` for one test file.
-
-    Finding keys are stable (no line numbers) so the baseline survives
-    line shifts from refactors.
-    """
+def scan_source(source: str, *, web_file: bool) -> dict[str, int]:
+    """Return grouped mock-audit findings for one source string."""
     counts: dict[str, int] = defaultdict(int)
-    with open(path, encoding="utf-8") as f:
-        for line in f:
-            if _STATEFUL_ASSIGN_RE.match(line):
-                # Group findings by the assigned name so the baseline is
-                # informative when shrinking.
-                m = _STATEFUL_ASSIGN_RE.match(line)
-                assert m is not None
-                counts[f"stateful_mock_assign:{m.group(1)}"] += 1
-            for pm in _PATCH_RE.finditer(line):
-                target = pm.group(1)
-                if not _is_repo_target(target):
-                    continue
-                if _is_leaf_seam(target):
-                    continue
-                counts[f"patch:{target}"] += 1
-            # patch.object(MODULE_REF, "name", ...) form — the first arg
-            # is an identifier (typically a module alias from imports);
-            # we resolve it against _ALIAS_TO_CANONICAL to recover the
-            # canonical patch target ``<canonical>.<name>``. Unknown
-            # aliases are reported verbatim so they show up in the
-            # baseline and either land on the allowlist or get migrated.
-            for pom in _PATCH_OBJECT_RE.finditer(line):
-                module_ref = pom.group(1)
-                attr_name = pom.group(2)
-                canonical = _ALIAS_TO_CANONICAL.get(module_ref, module_ref)
-                target = f"{canonical}.{attr_name}"
-                if not _is_repo_target(target):
-                    continue
-                if _is_leaf_seam(target):
-                    continue
-                counts[f"patch:{target}"] += 1
+    for line in source.splitlines():
+        if _STATEFUL_ASSIGN_RE.match(line):
+            # Group findings by assigned name so the failure identifies
+            # the stateful collaborator shape.
+            m = _STATEFUL_ASSIGN_RE.match(line)
+            assert m is not None
+            counts[f"stateful_mock_assign:{m.group(1)}"] += 1
+        for pm in _PATCH_RE.finditer(line):
+            target = pm.group(1)
+            if not _is_repo_target(target):
+                continue
+            if _is_leaf_seam(target):
+                continue
+            counts[f"patch:{target}"] += 1
+        # patch.object(MODULE_REF, "name", ...) form — the first arg
+        # is an identifier (typically a module alias from imports);
+        # we resolve it against _ALIAS_TO_CANONICAL to recover the
+        # canonical patch target ``<canonical>.<name>``. Unknown
+        # aliases are reported verbatim so they can be migrated or
+        # deliberately allowlisted.
+        for pom in _PATCH_OBJECT_RE.finditer(line):
+            module_ref = pom.group(1)
+            attr_name = pom.group(2)
+            canonical = _ALIAS_TO_CANONICAL.get(module_ref, module_ref)
+            target = f"{canonical}.{attr_name}"
+            if not _is_repo_target(target):
+                continue
+            if _is_leaf_seam(target):
+                continue
+            counts[f"patch:{target}"] += 1
+
+    harness_count = len(_HARNESS_CTOR_RE.findall(source))
+    if harness_count:
+        counts["retired_pipeline_db_harness"] = harness_count
+    if web_file:
+        db_count = len(_WEB_HARNESS_MOCK_DB_RE.findall(source))
+        if db_count:
+            counts["web_mock_db"] = db_count
+        beets_count = len(_WEB_BEETS_MOCK_RE.findall(source))
+        if beets_count:
+            counts["web_beets_mock"] = beets_count
     return dict(counts)
+
+
+def scan_file(path: str) -> dict[str, int]:
+    """Return grouped mock-audit findings for one test file."""
+    with open(path, encoding="utf-8") as source_file:
+        source = source_file.read()
+    rel = os.path.relpath(path, TESTS_DIR)
+    return scan_source(source, web_file=rel.startswith("web" + os.sep))
 
 
 def iter_scan_paths():
@@ -594,122 +620,3 @@ def scan_tree() -> dict[str, dict[str, int]]:
         if counts:
             result[rel] = counts
     return result
-
-
-# === Web-harness MagicMock ratchet (#430) ===
-#
-# The tests/web contract harness historically injected a MagicMock
-# pipeline DB (now ``MagicMock(wraps=FakePipelineDB)``), so contract
-# tests pass whenever the mock's shape matches the assertion's shape —
-# production query semantics never enter the loop. Issue #430 migrates
-# the harness and every per-route test to a bare ``FakePipelineDB``,
-# route-module by route-module.
-#
-# This ratchet counts MagicMock-harness usage OCCURRENCES: every
-# ``mock_db`` reference in a ``tests/web`` file (dotted, aliased,
-# passed bare — aliasing the mock away is the evasion the occurrence
-# count exists to close) plus every ``_pipeline_db_test_harness``
-# reference in ANY scanned test file. The audit test requires the live
-# counts to match this baseline EXACTLY — and the baseline is now
-# permanently empty: contract tests seed FakePipelineDB state, never
-# configure mock returns.
-
-_WEB_HARNESS_MOCK_DB_RE = re.compile(r"\bmock_db\b")
-_HARNESS_CTOR_RE = re.compile(r"\b_pipeline_db_test_harness\b")
-
-# EMPTY — the #430 migration is complete (PRs #440-#443 + the final
-# harness deletion). The ratchet stays armed at zero: any reintroduced
-# ``mock_db`` reference in tests/web, or ``_pipeline_db_test_harness``
-# reference anywhere, fails the audit immediately.
-WEB_HARNESS_MOCK_BASELINE: dict[str, int] = {}
-
-
-def count_harness_overrides(text: str, *, web_file: bool) -> int:
-    """Count MagicMock-harness usage occurrences in one file's text.
-
-    ``mock_db`` references only count inside ``tests/web`` files (the
-    name has no meaning elsewhere); ``_pipeline_db_test_harness``
-    references count everywhere the scanner walks.
-    """
-    n = len(_HARNESS_CTOR_RE.findall(text))
-    if web_file:
-        n += len(_WEB_HARNESS_MOCK_DB_RE.findall(text))
-    return n
-
-
-def scan_web_harness_overrides() -> dict[str, int]:
-    """Count MagicMock-harness usage occurrences per test file."""
-    counts: dict[str, int] = {}
-    web_prefix = "web" + os.sep
-    for rel, path in iter_scan_paths():
-        with open(path, encoding="utf-8") as f:
-            n = count_harness_overrides(
-                f.read(), web_file=rel.startswith(web_prefix))
-        if n:
-            counts[rel] = n
-    return counts
-
-
-# === Web beets-MagicMock ratchet (#445 item 1) ===
-#
-# The #430 migration covered the pipeline DB; the browse / library /
-# pipeline contract tests historically configured MagicMock shapes for
-# the OTHER stateful collaborator — ``BeetsDB``. Those mocks evaded the
-# stateful-assign heuristic purely by variable naming: ``mock_beets``,
-# ``self._beets`` and ``self.beets`` don't match ``STATEFUL_VAR_NAMES``
-# (same evasion class the r1 ratchet review caught for ``mock_db``).
-#
-# This ratchet counts OCCURRENCES of the beets-mock variable names in
-# ``tests/web`` files: ``mock_beets`` (plus suffixed forms like
-# ``mock_beets_cls``), ``self._beets`` and ``self.beets``. It does NOT
-# count the production attribute ``web.server._beets`` itself —
-# migrated tests still inject a fake via ``srv._beets = fake`` (the
-# same constructor-replacement seam as ``web.server.db``), and
-# ``test_routes_browse``'s real-SQLite class fixture (``cls._beets =
-# BeetsDB(...)``) is legitimate. The audit test requires the live
-# counts to match this baseline EXACTLY — growth fails, and an
-# un-shrunk baseline after a migration also fails, so every migration
-# PR is forced to record its own progress. The replacement is
-# ``FakeBeetsDB`` from ``tests/fakes.py`` (extend it + add a self-test
-# in ``tests/test_fakes.py::TestFakeBeetsDB`` when a route exercises a
-# method it lacks).
-#
-# Known limits (adversarial review of the landing PR):
-# - Name the migrated attribute ``self.beets_db`` (uncounted), NOT
-#   ``self._beets = FakeBeetsDB()`` — the regex counts the name, not
-#   the type, so reusing the mock's name would keep the file's count
-#   inflated and make the failure message lie.
-# - ``cls``-level shapes are uncounted because browse's real-SQLite
-#   fixture legitimately uses ``cls._beets``. Do NOT introduce
-#   ``cls._beets = MagicMock()`` — the general stateful-assign audit
-#   misses it too; it is a review tripwire, not a sanctioned gap.
-# - Shrinking this baseline is only legitimate when the mocks were
-#   replaced with ``FakeBeetsDB`` seeding — aliasing
-#   (``b = self._beets``) also shrinks the count and is an evasion.
-
-_WEB_BEETS_MOCK_RE = re.compile(
-    r"\bmock_beets\w*|self\._beets\b|self\.beets\b")
-
-# EMPTY — the #445 item 1 migration is complete (ratchet + four
-# migration batches). The ratchet stays armed at zero: any reintroduced
-# beets-mock variable name in tests/web fails the audit immediately.
-WEB_BEETS_MOCK_BASELINE: dict[str, int] = {}
-
-
-def count_beets_mock_overrides(text: str) -> int:
-    """Count beets-MagicMock variable-name occurrences in one file's text."""
-    return len(_WEB_BEETS_MOCK_RE.findall(text))
-
-
-def scan_web_beets_overrides() -> dict[str, int]:
-    """Count beets-MagicMock occurrences per ``tests/web`` test file."""
-    counts: dict[str, int] = {}
-    web_prefix = "web" + os.sep
-    for rel, path in iter_scan_paths():
-        if not rel.startswith(web_prefix):
-            continue
-        with open(path, encoding="utf-8") as f:
-            n = count_beets_mock_overrides(f.read())
-        if n:
-            counts[rel] = n
-    return counts

--- a/tests/test_mock_audit.py
+++ b/tests/test_mock_audit.py
@@ -26,16 +26,11 @@ sys.path.insert(0, os.path.normpath(os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "..")))
 from tests._mock_audit_scanner import (
     MULTILINE_PATCH_BASELINE,
-    WEB_BEETS_MOCK_BASELINE,
-    WEB_HARNESS_MOCK_BASELINE,
-    count_beets_mock_overrides,
-    count_harness_overrides,
     find_multiline_patch_targets,
     iter_scan_paths,
     scan_multiline_patch_targets,
+    scan_source,
     scan_tree,
-    scan_web_beets_overrides,
-    scan_web_harness_overrides,
 )
 
 
@@ -63,6 +58,51 @@ class TestStatefulMockAudit(unittest.TestCase):
             "or real-input call.\n\n"
             + "\n".join(lines)
         )
+
+    def test_direct_web_mock_rules_catch_known_bad_shapes(self) -> None:
+        cases = [
+            ("dotted pipeline mock", "self.mock_db.get_log()", True,
+             {"web_mock_db": 1}),
+            ("aliased pipeline mock", "m = self.mock_db", True,
+             {"web_mock_db": 1}),
+            ("reflected pipeline mock", "getattr(self.mock_db, name)", True,
+             {"web_mock_db": 1}),
+            ("passed pipeline mock", "helper(self.mock_db, x)", True,
+             {"web_mock_db": 1}),
+            ("two pipeline mocks",
+             "mock_db.a.return_value = 1; mock_db.b.side_effect = e", True,
+             {"web_mock_db": 2}),
+            ("pipeline substring", "my_mock_database = 1", True, {}),
+            ("pipeline mock outside web", "self.mock_db.get_log()", False, {}),
+            ("retired harness inside web", "_pipeline_db_test_harness()",
+             True, {"retired_pipeline_db_harness": 1}),
+            ("retired harness outside web", "_pipeline_db_test_harness()",
+             False, {"retired_pipeline_db_harness": 1}),
+            ("dotted beets mock",
+             "self._beets.album_exists.return_value = True", True,
+             {"web_beets_mock": 1}),
+            ("bare beets mock", "mock_beets = MagicMock()", True,
+             {"web_beets_mock": 1}),
+            ("suffixed beets mock", "mock_beets_cls: MagicMock", True,
+             {"web_beets_mock": 1}),
+            ("library beets mock", "self.beets.get_recent.return_value", True,
+             {"web_beets_mock": 1}),
+            ("injected beets mock", "srv._beets = self.beets", True,
+             {"web_beets_mock": 1}),
+            ("two beets mocks", "self._beets = mock_beets", True,
+             {"web_beets_mock": 2}),
+            ("beets mock outside web", "self._beets = mock_beets", False, {}),
+            ("production beets attribute", "self._orig_beets = srv._beets",
+             True, {}),
+            ("real BeetsDB fixture", "cls._beets = BeetsDB(path)", True, {}),
+            ("fake beets name", "self.beets_db = FakeBeetsDB()", True, {}),
+        ]
+        for desc, source, web_file, expected in cases:
+            with self.subTest(desc=desc):
+                self.assertEqual(
+                    scan_source(source, web_file=web_file),
+                    expected,
+                )
 
     def test_multiline_patch_scanner_catches_known_bad_shape(self) -> None:
         source = '''
@@ -195,133 +235,6 @@ class TestSysPathAudit(unittest.TestCase):
             "#95 dual-load class). Only the repo root may be inserted; "
             "tests/ dirs may only be appended:\n" + "\n".join(offenders),
         )
-
-
-class TestWebHarnessMockRatchet(unittest.TestCase):
-    """Ratchet for the #430 MagicMock → FakePipelineDB harness migration.
-
-    Per-file counts of remaining MagicMock-harness usage in ``tests/web``
-    must match ``WEB_HARNESS_MOCK_BASELINE`` exactly: growth means a new
-    test leaned on mock shapes instead of FakePipelineDB state; shrink
-    means a migration landed and the baseline entry must drop with it.
-    """
-
-    def test_counter_pins_evasion_shapes(self) -> None:
-        """Document exactly what the ratchet counts — occurrences, not
-        lines, including alias/bare-reference shapes that a dotted-only
-        regex would miss (the r1 adversarial-review evasion vectors)."""
-        cases = [
-            ("dotted config", "self.mock_db.get_log.return_value = []", 1),
-            ("alias assignment", "m = self.mock_db", 1),
-            ("getattr reflection", "getattr(self.mock_db, name)", 1),
-            ("bare positional arg", "helper(self.mock_db, x)", 1),
-            ("two occurrences one line",
-             "mock_db.a.return_value = 1; mock_db.b.side_effect = e", 2),
-            ("substring does not count", "my_mock_database = 1", 0),
-            ("harness ctor", "db = _pipeline_db_test_harness()", 1),
-        ]
-        for desc, line, expected in cases:
-            with self.subTest(desc=desc):
-                self.assertEqual(
-                    count_harness_overrides(line, web_file=True), expected)
-        # mock_db is only meaningful inside tests/web; the transitional
-        # wrapped-MagicMock constructor is counted EVERYWHERE so it
-        # cannot leak outside tests/web unseen.
-        self.assertEqual(count_harness_overrides(
-            "self.mock_db.get_log()", web_file=False), 0)
-        self.assertEqual(count_harness_overrides(
-            "db = _pipeline_db_test_harness()", web_file=False), 1)
-
-    def test_counts_match_baseline_exactly(self) -> None:
-        current = scan_web_harness_overrides()
-        problems: list[str] = []
-        for rel in sorted(set(current) | set(WEB_HARNESS_MOCK_BASELINE)):
-            cur = current.get(rel, 0)
-            base = WEB_HARNESS_MOCK_BASELINE.get(rel, 0)
-            if cur > base:
-                problems.append(
-                    f"  - {rel}: {base} → {cur} MagicMock-harness occurrences. "
-                    "New tests must seed FakePipelineDB state (see "
-                    "tests/fakes.py), not configure mock_db returns."
-                )
-            elif cur < base:
-                problems.append(
-                    f"  - {rel}: {base} → {cur} MagicMock-harness occurrences. "
-                    "Migration progress — shrink WEB_HARNESS_MOCK_BASELINE "
-                    "in tests/_mock_audit_scanner.py to match"
-                    + (" (delete the entry)." if cur == 0 else ".")
-                )
-        if problems:
-            self.fail(
-                "Web-harness MagicMock ratchet (#430) out of sync with "
-                "WEB_HARNESS_MOCK_BASELINE:\n" + "\n".join(problems)
-            )
-
-
-class TestWebBeetsMockRatchet(unittest.TestCase):
-    """Ratchet for the #445 beets-MagicMock → FakeBeetsDB migration.
-
-    Per-file counts of remaining beets-mock variable-name occurrences in
-    ``tests/web`` must match ``WEB_BEETS_MOCK_BASELINE`` exactly: growth
-    means a new test configured beets mock shapes instead of seeding
-    ``FakeBeetsDB`` state; shrink means a migration landed and the
-    baseline entry must drop with it.
-    """
-
-    def test_counter_pins_evasion_shapes(self) -> None:
-        """Document exactly what the ratchet counts — occurrences of the
-        beets-mock variable names, including alias / suffixed / dotted
-        shapes, while leaving the production ``web.server._beets``
-        attribute and real-BeetsDB class fixtures uncounted."""
-        cases = [
-            ("dotted config",
-             "self._beets.album_exists.return_value = True", 1),
-            ("bare assignment", "mock_beets = MagicMock()", 1),
-            ("suffixed patch arg", "mock_beets_cls: MagicMock,", 1),
-            ("alias assignment", "b = self._beets", 1),
-            ("library dotted form", "self.beets.get_recent.return_value", 1),
-            ("injection counts the mock side only",
-             "srv._beets = self.beets", 1),
-            ("two occurrences one line",
-             "srv._beets = self._beets; m = mock_beets", 2),
-            ("production attr alone does not count",
-             "self._orig_beets = srv._beets", 0),
-            ("real-BeetsDB class fixture does not count",
-             "cls._beets = BeetsDB(cls._db_path)", 0),
-            ("beets_db var name does not count (general audit owns it)",
-             "self.beets_db = FakeBeetsDB()", 0),
-        ]
-        for desc, line, expected in cases:
-            with self.subTest(desc=desc):
-                self.assertEqual(count_beets_mock_overrides(line), expected)
-
-    def test_counts_match_baseline_exactly(self) -> None:
-        current = scan_web_beets_overrides()
-        problems: list[str] = []
-        for rel in sorted(set(current) | set(WEB_BEETS_MOCK_BASELINE)):
-            cur = current.get(rel, 0)
-            base = WEB_BEETS_MOCK_BASELINE.get(rel, 0)
-            if cur > base:
-                problems.append(
-                    f"  - {rel}: {base} → {cur} beets-mock occurrences. "
-                    "New tests must seed FakeBeetsDB state (see "
-                    "tests/fakes.py), not configure beets mock returns."
-                )
-            elif cur < base:
-                problems.append(
-                    f"  - {rel}: {base} → {cur} beets-mock occurrences. "
-                    "Migration progress — shrink WEB_BEETS_MOCK_BASELINE "
-                    "in tests/_mock_audit_scanner.py to match"
-                    + (" (delete the entry)." if cur == 0 else ".")
-                    + " Only shrink if the mocks were replaced with "
-                    "FakeBeetsDB seeding — aliasing the mock away is "
-                    "an evasion, not progress."
-                )
-        if problems:
-            self.fail(
-                "Web beets-MagicMock ratchet (#445) out of sync with "
-                "WEB_BEETS_MOCK_BASELINE:\n" + "\n".join(problems)
-            )
 
 
 if __name__ == "__main__":

--- a/tests/test_property_input_audit.py
+++ b/tests/test_property_input_audit.py
@@ -156,9 +156,8 @@ _UNALIASABLE_IMPORTS = PROPERTY_DECORATORS | {"invariant"}
 
 _IMPLICIT_FIRST_PARAMETERS = frozenset({"self", "cls"})
 
-# EMPTY, and armed — the same ratchet shape as
-# ``WEB_HARNESS_MOCK_BASELINE`` in ``tests/_mock_audit_scanner.py``. The one
-# property that used to flag (the planted-bad-decider self-test in
+# EMPTY, and armed. The one property that used to flag (the
+# planted-bad-decider self-test in
 # ``tests/test_quality_generated.py``) now passes its world to a decider that
 # ignores it, which models the planted defect more faithfully than discarding
 # the world did. If an entry ever becomes necessary, key it


### PR DESCRIPTION
## Summary

- fold the completed #430/#445 web-mock migration rules into the main zero-tolerance `scan_source()` audit
- delete both permanently empty baseline dictionaries, their dedicated tree scans, migration accounting, and separate ratchet test classes
- preserve the same positive and negative detector cases through the exact source checker used by `scan_tree()`
- update generated-testing docs and project memory references without changing the separate property-input allowlist

This removes 181 net lines while retaining the same forbidden-code boundary.

## Equivalence map

| Retired ratchet rule | Direct finding now emitted by the main audit |
|---|---|
| `mock_db` in `tests/web` | `web_mock_db` |
| `_pipeline_db_test_harness` anywhere in the scanned test tree | `retired_pipeline_db_harness` |
| `mock_beets*`, `self._beets`, or `self.beets` in `tests/web` | `web_beets_mock` |

Known-bad pins retain dotted, aliased, reflected, passed-as-argument, suffixed, and multiple-occurrence shapes. Negative pins retain the old scope boundaries and legitimate `srv._beets`, real `BeetsDB`, and `FakeBeetsDB` names.

## Validation

- `python3 -m unittest tests.test_mock_audit tests.test_property_input_audit tests.test_docs_audit -v` — 71 passed
- focused Ruff — passed
- `pyright --threads 4` — 0 errors
- `bash scripts/run_tests.sh` — 7,699 Python tests passed; all JavaScript, production-strict Pyright, Ruff, and Vulture gates passed

Refs #895