### PR TITLE
docs: require isolated worktree hygiene

### DIFF
--- a/.claude/skills/orchestrate-issue/SKILL.md
+++ b/.claude/skills/orchestrate-issue/SKILL.md
@@ -22,9 +22,9 @@ evidence. The format does not matter.
 
 Choose the delivery shape that best fits the work: one PR or several,
 sequential or parallel, direct implementation or delegation. Agents,
-worktrees, exact SHAs, detailed ledgers, and extra validation passes are tools
-to use when they reduce a concrete risk or shorten the critical path. They are
-not required ceremony.
+exact SHAs, detailed ledgers, and extra validation passes are tools to use when
+they reduce a concrete risk or shorten the critical path. They are not required
+ceremony.
 
 The orchestrator retains responsibility for scope, architecture, integration,
 merge decisions, deployment, and live proof even when work is delegated.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,6 +12,11 @@ Do not use Compound Engineering (`ce-*`, `compound-engineering:*`, or `lfg`) in
 this repository. Native agent planning, implementation, debugging, and review
 are sufficient.
 
+Work in an isolated git worktree, and clean it up when it is no longer useful.
+Keep the shared checkout on `main` and reasonably current; after merging to
+`main`, pull it forward. Use judgment around active or dirty trees, and never
+disturb another agent's work.
+
 ## Why this exists — the archivist frame
 
 Cratedigger is a **music archival tool first, an acquisition pipeline second**. The operator is an archivist: most of the long-tail music here is genuinely vanishing — niche pressings, Australian indie, demos that lived on one peer who logged off years ago. This frame is load-bearing; these invariants flow from it:


### PR DESCRIPTION
## Summary

- require isolated worktrees and cleanup when they are no longer useful
- keep the shared checkout reasonably current after main merges while preserving active work
- stop describing worktrees as optional orchestration ceremony

## Checks

- `tests.test_ai_portability`: pass
- receipt-backed whole-repository Pyright: pass
- full suite skipped at operator direction for this documentation-only change

Refs #926