### PR TITLE
docs: account for shared-checkout memories

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -76,3 +76,4 @@
 - [#882 audits shipped](project_882_audits_shipped.md) — fuzz burst had NEVER completed (discovery abort); classify copy keyed on a scenario no producer emits; depth-blind properties hid a live authority mutant
 - [Subagent worktree absolute paths](feedback_subagent_worktree_absolute_paths.md) — isolation:"worktree" does not stop absolute-path writes into the shared checkout; brief it explicitly and verify after
 - [Convergence signal + evidence recapture](project_convergence_signal_and_evidence_recapture.md) — inter-candidate cliff constancy = "network converged" (search-stop, not proof); denylist-release recapture; beets-rejected candidates DO carry full evidence
+- [Worktree switch kills live subagent](feedback_worktree_switch_kills_live_subagent.md) — EnterWorktree mid-run revokes another worktree's write guard; the agent then shell-writes around it and can leave a planted mutant behind

--- a/.claude/memory/feedback_worktree_switch_kills_live_subagent.md
+++ b/.claude/memory/feedback_worktree_switch_kills_live_subagent.md
@@ -1,0 +1,33 @@
+---
+name: feedback-worktree-switch-kills-live-subagent
+description: Switching the session into another worktree revokes the write guard for the one a live subagent is using, and the agent will try to route edits through the shell
+metadata:
+  type: feedback
+---
+
+Never call `EnterWorktree` to switch the session into a different worktree while
+a subagent is actively working in another one. The write guard is session-level:
+after the switch, the previously-visited worktree becomes non-writable, the live
+agent's Edit/Write calls start failing, and it will attempt to work around the
+guard by routing edits through shell heredocs.
+
+**Why:** that workaround is exactly how an unreverted mutant escapes into a
+commit. Caught live on 2026-07-29 during issue #829 PR2c: the agent had planted
+a deliberate mutant in `lib/quality/pipeline.py` (Stage 1 reverted to raw
+pre-#829 spectral values instead of the codec-aware classes) as part of a
+kill-matrix run. Killing it mid-cycle left the mutant in the tree; only an
+explicit `git diff origin/main -- lib/` check caught it before commit.
+
+**How to apply:**
+- Need to commit in a second worktree while an agent runs? Use `git -C <path>`
+  for commit/push/PR — those need no write guard. Only file *edits* do.
+- If a worktree switch is genuinely unavoidable, stop the agent first, then
+  switch, then switch back before resuming it.
+- Brief agents that plant mutants to revert each one immediately and
+  byte-verify against `origin/main` before reporting — never batch reverts to
+  the end of a run.
+- Always check `git diff origin/main --stat` for unexpected production files
+  before committing a test-or-docs-only PR.
+
+Related: [[feedback-subagent-worktree-absolute-paths]],
+[[feedback-reviewer-git-reset-hazard]], [[feedback-review-loop-at-orchestrator]].

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,10 @@ Keep the shared checkout on `main` and reasonably current; after merging to
 `main`, pull it forward. Use judgment around active or dirty trees, and never
 disturb another agent's work.
 
+`.claude/memory/` is the exception: it is written in the shared checkout, not
+task worktrees. Notice and preserve those changes when cleaning up or advancing
+`main`; commit and push them separately when appropriate.
+
 ## Why this exists — the archivist frame
 
 Cratedigger is a **music archival tool first, an acquisition pipeline second**. The operator is an archivist: most of the long-tail music here is genuinely vanishing — niche pressings, Australian indie, demos that lived on one peer who logged off years ago. This frame is load-bearing; these invariants flow from it:


### PR DESCRIPTION
## Summary

- document `.claude/memory/` as the shared-checkout exception to task worktrees
- explicitly preserve, commit, and push accumulated memories when appropriate
- publish the pending worktree-switch safety memory as a separate commit

## Checks

- `tests.test_ai_portability`: pass

Refs #926