### PR TITLE
Fix #942 recovery cleanup and compatibility gaps

### DIFF
--- a/docs/webui-primer.md
+++ b/docs/webui-primer.md
@@ -102,8 +102,7 @@ operation.
 | `/api/import-jobs` | GET | List recent import queue jobs |
 | `/api/import-jobs/timeline` | GET | List active queued/running/recovery-required import jobs in importer order, with server-classified display fields |
 | `/api/import-jobs/<id>` | GET | Poll a single import queue job |
-| `/api/import-jobs/<id>/recovery` | GET | Inspect exact automation recovery evidence, liveness, cleanup progress, and opaque revision |
-| `/api/import-jobs/<id>/recovery` | POST | Revision-bound explicit close (`wanted|imported`) or fresh retry of an ambiguous automation owner |
+| `/api/import-jobs/<id>/recovery` | GET | Inspect read-only exact-owner recovery evidence, liveness, and cleanup progress for any import job; historical `recovery_required` rows remain readable |
 | `/api/library/artist?name=...` | GET | Albums by artist from beets library (MB vs Discogs source) |
 | `/api/discogs/search?q=...` | GET | Search Discogs mirror (artist or release mode via `type=` param) |
 | `/api/discogs/artist/<id>` | GET | Artist's normalized catalogue identities, including exact masterless releases (via mirror `/masters/all` + `/appearances`) |

--- a/lib/pipeline_db/import_jobs.py
+++ b/lib/pipeline_db/import_jobs.py
@@ -698,6 +698,20 @@ class _ImportJobsMixin(
         """)
         return [ImportJob.from_row(dict(row)) for row in cur.fetchall()]
 
+    def list_terminal_force_action_cleanup_jobs(self) -> list[ImportJob]:
+        """Return terminal force jobs whose private copies need convergence."""
+        cur = self._execute("""
+            SELECT *
+            FROM import_jobs
+            WHERE job_type = 'force_import'
+              AND status IN ('completed', 'failed')
+              AND NULLIF(preview_result->>'action_path', '') IS NOT NULL
+              AND result #>> '{force_action_cleanup,removed}'
+                  IS DISTINCT FROM 'true'
+            ORDER BY created_at ASC, id ASC
+        """)
+        return [ImportJob.from_row(dict(row)) for row in cur.fetchall()]
+
 
     def peek_import_job_candidates(
         self,

--- a/scripts/importer.py
+++ b/scripts/importer.py
@@ -172,6 +172,34 @@ class _AutomationRecoveryDB(Protocol):
     ) -> ImportJob | None: ...
 
 
+class _ForceActionCleanupDB(Protocol):
+    """Persistence surface for durable force-action cleanup receipts."""
+
+    def list_terminal_force_action_cleanup_jobs(self) -> list[ImportJob]: ...
+
+    def merge_import_job_result(
+        self,
+        job_id: int,
+        patch: dict[str, object],
+    ) -> ImportJob | None: ...
+
+
+class _StartupRecoveryDB(
+    _AutomationRecoveryDB,
+    _ForceActionCleanupDB,
+    Protocol,
+):
+    """Complete persistence surface used by the one-shot startup sweep."""
+
+    def recover_running_import_jobs(
+        self,
+        *,
+        requeue_message: str,
+        recovery_message: str,
+        limit: int = 50,
+    ) -> list[ImportJob]: ...
+
+
 def _run_post_commit_cleanup(
     db: _PostCommitCleanupDB,
     outcome: DispatchOutcome,
@@ -461,7 +489,7 @@ def _cleanup_terminal_force_action(job: ImportJob) -> dict[str, object] | None:
 
 
 def _record_terminal_force_action_cleanup(
-    db: PipelineDB,
+    db: _ForceActionCleanupDB,
     job: ImportJob,
     terminal_job: ImportJob | None,
 ) -> ImportJob | None:
@@ -1962,7 +1990,7 @@ def recover_abandoned_automation_owners(
 
 
 def recover_abandoned_running_jobs(
-    db: PipelineDB,
+    db: _StartupRecoveryDB,
     *,
     liveness_probe: ExecutionLivenessProbe | None = None,
 ) -> list[ImportJob]:

--- a/scripts/importer.py
+++ b/scripts/importer.py
@@ -1984,6 +1984,11 @@ def recover_abandoned_running_jobs(
         recovered.extend(batch)
         if len(batch) < batch_size:
             break
+    # The terminal job is the durable retry edge across a process kill or a
+    # transient cleanup failure. Successful exact-path cleanup is recorded in
+    # the job result; every missing/failed marker is retried on this startup.
+    for job in db.list_terminal_force_action_cleanup_jobs():
+        _record_terminal_force_action_cleanup(db, job, job)
     recovered.extend(recover_abandoned_automation_owners(
         db,
         liveness_probe=liveness_probe,

--- a/tests/_tests_typing_ratchet_baseline.py
+++ b/tests/_tests_typing_ratchet_baseline.py
@@ -67,7 +67,7 @@ TESTS_TYPING_RATCHET_BASELINE: dict[str, dict[str, int]] = {
     "tests/test_import_operation_fence.py": {"any": 10, "cast": 7},
     "tests/test_import_operation_fence_generated.py": {"type_ignore": 1},
     "tests/test_import_preview.py": {"any": 8, "cast": 3},
-    "tests/test_import_queue.py": {"any": 77, "cast": 43},
+    "tests/test_import_queue.py": {"any": 76, "cast": 42},
     "tests/test_import_result.py": {"type_ignore": 4},
     "tests/test_integration.py": {"type_ignore": 1},
     "tests/test_integration_slices.py": {"any": 39, "cast": 21, "type_ignore": 33},

--- a/tests/fakes/pipeline_db.py
+++ b/tests/fakes/pipeline_db.py
@@ -1503,7 +1503,7 @@ class FakePipelineDB:
         return [ImportJob.from_row(copy.deepcopy(row)) for row in rows]
 
     def list_terminal_force_action_cleanup_jobs(self) -> list[ImportJob]:
-        rows: list[dict[str, Any]] = []
+        rows = []
         for row in self._import_jobs:
             if (
                 row.get("job_type") != IMPORT_JOB_FORCE

--- a/tests/fakes/pipeline_db.py
+++ b/tests/fakes/pipeline_db.py
@@ -1502,6 +1502,38 @@ class FakePipelineDB:
         ))
         return [ImportJob.from_row(copy.deepcopy(row)) for row in rows]
 
+    def list_terminal_force_action_cleanup_jobs(self) -> list[ImportJob]:
+        rows: list[dict[str, Any]] = []
+        for row in self._import_jobs:
+            if (
+                row.get("job_type") != IMPORT_JOB_FORCE
+                or row.get("status") not in ("completed", "failed")
+            ):
+                continue
+            preview = row.get("preview_result")
+            action_path = (
+                preview.get("action_path")
+                if isinstance(preview, dict) else None
+            )
+            if not isinstance(action_path, str) or not action_path:
+                continue
+            result = row.get("result")
+            cleanup = (
+                result.get("force_action_cleanup")
+                if isinstance(result, dict) else None
+            )
+            removed = (
+                cleanup.get("removed")
+                if isinstance(cleanup, dict) else None
+            )
+            if removed is not True:
+                rows.append(row)
+        rows.sort(key=lambda row: (
+            _as_datetime(row.get("created_at")),
+            int(row["id"]),
+        ))
+        return [ImportJob.from_row(copy.deepcopy(row)) for row in rows]
+
     def _import_job_candidate_rows(
         self,
         *,

--- a/tests/read_projection_registry.py
+++ b/tests/read_projection_registry.py
@@ -603,6 +603,8 @@ ALLOWLIST: dict[str, str] = {
         "list[ImportJob] — typed dataclass rows, no dict projection",
     "list_import_job_timeline":
         "list[ImportJob] — typed dataclass rows, no dict projection",
+    "list_terminal_force_action_cleanup_jobs":
+        "list[ImportJob] — typed terminal cleanup rows, no dict projection",
     "list_automation_import_jobs_for_startup_recovery":
         "list[ImportJob] — exact processing-owner typed dataclass rows, "
         "no dict projection",

--- a/tests/test_automation_startup_recovery.py
+++ b/tests/test_automation_startup_recovery.py
@@ -358,6 +358,41 @@ class _StartupRecoveryContract:
             recovery_message="importer restarted mid-import",
         )
 
+    def _mark_historical_recovery_required(self, job_id: int) -> None:
+        """Plant the exact pre-#942 parked owner shape for compatibility."""
+        lease_fields = (
+            "execution_invocation_id",
+            "execution_host_boot_id",
+            "execution_systemd_unit",
+            "execution_worker_pid",
+            "execution_worker_start_ticks",
+            "execution_beets_pid",
+            "execution_beets_start_ticks",
+        )
+        if isinstance(self.db, FakePipelineDB):
+            row = next(
+                item for item in self.db._import_jobs
+                if item["id"] == job_id
+            )
+            row["status"] = "recovery_required"
+            row["worker_id"] = None
+            row["heartbeat_at"] = None
+            for field in lease_fields:
+                row[field] = None
+            return
+        assignments = ", ".join(f"{field} = NULL" for field in lease_fields)
+        self.db._execute(
+            f"""
+            UPDATE import_jobs
+            SET status = 'recovery_required',
+                worker_id = NULL,
+                heartbeat_at = NULL,
+                {assignments}
+            WHERE id = %s
+            """,
+            (job_id,),
+        )
+
     # --- assertions -----------------------------------------------------
 
     def _assert_returned_to_search_pool(self, job_id: int) -> None:
@@ -456,6 +491,23 @@ class _StartupRecoveryContract:
             os.path.exists(path),
             "recovery abandoned the journaled cleanup instead of resuming it",
         )
+        self._assert_returned_to_search_pool(owner.id)
+
+    def test_historical_recovery_required_owner_converges_automatically(
+        self,
+    ) -> None:
+        """A pre-#942 parked owner remains readable but never stays parked."""
+        from scripts.importer import recover_abandoned_automation_owners
+
+        path = self._album_dir("historical", "01 - Historical.mp3")
+        owner, _lease = self._preview_owner(path)
+        self._journal(owner.id, path)
+        self._mark_historical_recovery_required(owner.id)
+
+        recovered = recover_abandoned_automation_owners(self.db)
+
+        self._case().assertEqual([item.id for item in recovered], [owner.id])
+        self._case().assertFalse(os.path.exists(path))
         self._assert_returned_to_search_pool(owner.id)
 
     def test_persistent_cleanup_refusal_preserves_remaining_tree_and_closes(

--- a/tests/test_automation_startup_recovery_generated.py
+++ b/tests/test_automation_startup_recovery_generated.py
@@ -438,7 +438,7 @@ class TestAutomationStartupRecoveryGenerated(unittest.TestCase):
             )
         else:
             recovered = importer.recover_abandoned_running_jobs(
-                world.db,  # pyright: ignore[reportArgumentType]
+                world.db,
                 liveness_probe=_DeadProbe(),
             )
 

--- a/tests/test_import_operation_fence.py
+++ b/tests/test_import_operation_fence.py
@@ -811,6 +811,97 @@ class TestImportOperationFence(unittest.TestCase):
 
 @requires_postgres
 class TestImportOperationFencePostgres(unittest.TestCase):
+    def test_startup_recovery_removes_launched_force_action_copy(self) -> None:
+        from lib.config import CratediggerConfig
+        from lib.import_preview import force_action_copy_path
+        from scripts import importer
+
+        db = make_db()
+        self.addCleanup(db.close)
+        with tempfile.TemporaryDirectory() as root:
+            downloads = os.path.join(root, "downloads")
+            processing = os.path.join(root, "processing")
+            os.mkdir(downloads, 0o700)
+            os.mkdir(processing, 0o700)
+            os.mkdir(os.path.join(processing, "albums"), 0o700)
+            os.mkdir(os.path.join(processing, "preview"), 0o700)
+            cfg = CratediggerConfig(
+                slskd_download_dir=downloads,
+                processing_dir=processing,
+                audio_check_mode="off",
+            )
+            request_id = db.add_request(
+                artist_name="Fence",
+                album_title="Startup force cleanup",
+                source="request",
+                mb_release_id="release-pg-startup-force",
+                status="wanted",
+            )
+            job = db.enqueue_import_job(
+                IMPORT_JOB_FORCE,
+                request_id=request_id,
+                dedupe_key="force:postgres-startup-cleanup",
+                payload={
+                    "download_log_id": 1,
+                    "failed_path": "/failed-imports/startup-force",
+                },
+            )
+            action_path = force_action_copy_path(cfg, job.id)
+            os.mkdir(action_path, 0o700)
+            with open(os.path.join(action_path, "01.mp3"), "wb") as handle:
+                handle.write(b"private action copy")
+            evidence = make_album_quality_evidence(
+                mb_release_id="release-pg-startup-force",
+                source_path=action_path,
+                files=snapshot_audio_files(action_path),
+            )
+            db.upsert_album_quality_evidence(evidence)
+            persisted = db.find_album_quality_evidence(
+                mb_release_id=evidence.mb_release_id,
+                snapshot_fingerprint=evidence.snapshot_fingerprint,
+            )
+            assert persisted is not None and persisted.id is not None
+            self.assertTrue(db.set_import_job_candidate_evidence(
+                job.id,
+                persisted.id,
+            ))
+            self.assertIsNotNone(db.mark_import_job_preview_importable(
+                job.id,
+                preview_result={
+                    "verdict": "evidence_ready",
+                    "action_path": action_path,
+                },
+            ))
+            claimed = claim_next_import_job(db, worker_id="postgres-worker")
+            assert claimed is not None
+            self.assertIsNotNone(db.authorize_import_job_launch(
+                claimed.id,
+                request_id=request_id,
+                release_id="release-pg-startup-force",
+                source_path="/failed-imports/startup-force",
+            ))
+            terminalized = db.recover_running_import_jobs(
+                requeue_message="safe retry",
+                recovery_message="startup ambiguity",
+            )
+            self.assertEqual([item.id for item in terminalized], [job.id])
+            self.assertEqual(terminalized[0].status, "failed")
+            self.assertTrue(os.path.exists(action_path))
+
+            with patch("lib.config.read_runtime_config", return_value=cfg):
+                recovered = importer.recover_abandoned_running_jobs(
+                    cast(Any, db),
+                )
+
+            self.assertEqual(recovered, [])
+            self.assertFalse(os.path.exists(action_path))
+            stored = db.get_import_job(job.id)
+            assert stored is not None and stored.result is not None
+            cleanup = stored.result["force_action_cleanup"]
+            assert isinstance(cleanup, dict)
+            self.assertEqual(cleanup["action_path"], action_path)
+            self.assertTrue(cleanup["removed"])
+
     def test_relocated_evidence_path_does_not_override_job_authority(self) -> None:
         db = make_db()
         self.addCleanup(db.close)

--- a/tests/test_import_operation_fence.py
+++ b/tests/test_import_operation_fence.py
@@ -889,9 +889,7 @@ class TestImportOperationFencePostgres(unittest.TestCase):
             self.assertTrue(os.path.exists(action_path))
 
             with patch("lib.config.read_runtime_config", return_value=cfg):
-                recovered = importer.recover_abandoned_running_jobs(
-                    cast(Any, db),
-                )
+                recovered = importer.recover_abandoned_running_jobs(db)
 
             self.assertEqual(recovered, [])
             self.assertFalse(os.path.exists(action_path))

--- a/tests/test_import_operation_fence_generated.py
+++ b/tests/test_import_operation_fence_generated.py
@@ -649,9 +649,7 @@ class TestGeneratedImportOperationFence(unittest.TestCase):
             "lib.config.read_runtime_config",
             return_value=cfg,
         ):
-            importer.recover_abandoned_running_jobs(
-                db,  # type: ignore[arg-type]
-            )
+            importer.recover_abandoned_running_jobs(db)
 
         final = db.get_import_job(job.id)
         assert final is not None

--- a/tests/test_import_operation_fence_generated.py
+++ b/tests/test_import_operation_fence_generated.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import tempfile
 import unittest
 from dataclasses import dataclass
 from unittest.mock import patch
@@ -25,6 +26,7 @@ from lib.import_queue import (
     youtube_import_payload,
 )
 from lib.quality import DownloadInfo
+from lib.quality_evidence import snapshot_audio_files
 from scripts.importer import (
     _WORLD_FAILURE_AUDIT_PREFIX,
     _execution_lease_from_job,
@@ -167,6 +169,34 @@ def assert_operation_fence(
             f"{job_type} ambiguous operation changed request status to "
             f"{row['status']!r}; force/YouTube own no request lifecycle to "
             "self-heal"
+        )
+
+
+def assert_startup_force_action_lifecycle(
+    *,
+    launched: bool,
+    final_status: str,
+    action_path: str,
+) -> None:
+    """Terminal recovery removes its copy; retry recovery retains it."""
+    action_exists = os.path.exists(action_path)
+    if launched:
+        if final_status != "failed":
+            raise AssertionError(
+                f"launched force recovery ended {final_status!r}, want 'failed'"
+            )
+        if action_exists:
+            raise AssertionError(
+                "terminal force recovery leaked its private action copy"
+            )
+        return
+    if final_status != "queued":
+        raise AssertionError(
+            f"unlaunched force recovery ended {final_status!r}, want 'queued'"
+        )
+    if not action_exists:
+        raise AssertionError(
+            "retryable force recovery deleted the action copy it still needs"
         )
 
 
@@ -503,6 +533,134 @@ class TestGeneratedImportOperationFence(unittest.TestCase):
                 )
                 self.assertFalse(replay_claimed)
 
+    def test_startup_recovery_releases_only_terminal_force_actions(self) -> None:
+        """Generated file-count worlds pin startup action-copy ownership."""
+        for launched in (False, True):
+            interrupted_worlds = (False, True) if launched else (False,)
+            for interrupted_after_terminal in interrupted_worlds:
+                for file_count in (0, 1, 3):
+                    with self.subTest(
+                        launched=launched,
+                        interrupted_after_terminal=interrupted_after_terminal,
+                        file_count=file_count,
+                    ), tempfile.TemporaryDirectory() as root:
+                        self._assert_startup_force_action_world(
+                            root=root,
+                            launched=launched,
+                            interrupted_after_terminal=(
+                                interrupted_after_terminal
+                            ),
+                            file_count=file_count,
+                        )
+
+    def _assert_startup_force_action_world(
+        self,
+        *,
+        root: str,
+        launched: bool,
+        interrupted_after_terminal: bool,
+        file_count: int,
+    ) -> None:
+        from lib.import_preview import force_action_copy_path
+        from scripts import importer
+
+        downloads = os.path.join(root, "downloads")
+        processing = os.path.join(root, "processing")
+        os.mkdir(downloads, 0o700)
+        os.mkdir(processing, 0o700)
+        os.mkdir(os.path.join(processing, "albums"), 0o700)
+        os.mkdir(os.path.join(processing, "preview"), 0o700)
+        cfg = CratediggerConfig(
+            slskd_download_dir=downloads,
+            processing_dir=processing,
+            audio_check_mode="off",
+        )
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=_OPERATION_FENCE_REQUEST_ID,
+            mb_release_id="generated-startup-force",
+            status="wanted",
+        ))
+        job = db.enqueue_import_job(
+            IMPORT_JOB_FORCE,
+            request_id=_OPERATION_FENCE_REQUEST_ID,
+            dedupe_key=(
+                "force:generated-startup:"
+                f"{int(launched)}:{int(interrupted_after_terminal)}:"
+                f"{file_count}"
+            ),
+            payload={
+                "download_log_id": 703,
+                "failed_path": "/failed/generated-startup-force",
+            },
+        )
+        action_path = force_action_copy_path(cfg, job.id)
+        os.mkdir(action_path, 0o700)
+        for index in range(file_count):
+            with open(
+                os.path.join(action_path, f"{index:02d}.mp3"),
+                "wb",
+            ) as handle:
+                handle.write(f"audio-{index}".encode())
+        evidence = make_album_quality_evidence(
+            mb_release_id="generated-startup-force",
+            source_path=action_path,
+            files=snapshot_audio_files(action_path),
+        )
+        db.upsert_album_quality_evidence(evidence)
+        persisted = db.find_album_quality_evidence(
+            mb_release_id=evidence.mb_release_id,
+            snapshot_fingerprint=evidence.snapshot_fingerprint,
+        )
+        assert persisted is not None and persisted.id is not None
+        db.set_import_job_candidate_evidence(
+            job.id,
+            persisted.id,
+        )
+        db.mark_import_job_preview_importable(
+            job.id,
+            preview_result={
+                "verdict": "evidence_ready",
+                "action_path": action_path,
+            },
+        )
+        claimed = claim_next_import_job(
+            db,
+            worker_id="generated-old-worker",
+        )
+        assert claimed is not None
+        if launched:
+            assert db.authorize_import_job_launch(
+                claimed.id,
+                request_id=_OPERATION_FENCE_REQUEST_ID,
+                release_id="generated-startup-force",
+                source_path="/failed/generated-startup-force",
+            ) is not None
+        if interrupted_after_terminal:
+            terminalized = db.recover_running_import_jobs(
+                requeue_message="safe retry",
+                recovery_message="startup ambiguity",
+            )
+            assert [item.id for item in terminalized] == [job.id]
+            assert terminalized[0].status == "failed"
+            assert os.path.exists(action_path)
+
+        with patch(
+            "lib.config.read_runtime_config",
+            return_value=cfg,
+        ):
+            importer.recover_abandoned_running_jobs(
+                db,  # type: ignore[arg-type]
+            )
+
+        final = db.get_import_job(job.id)
+        assert final is not None
+        assert_startup_force_action_lifecycle(
+            launched=launched,
+            final_status=final.status,
+            action_path=action_path,
+        )
+
 
 class TestImportOperationFenceChecker(unittest.TestCase):
     def _db(self, **overrides: object) -> FakePipelineDB:
@@ -589,6 +747,18 @@ class TestImportOperationFenceChecker(unittest.TestCase):
                 beets_invocations=[703],
                 replay_claimed=False,
                 db=self._db(status="unsearchable"),
+            )
+
+    def test_checker_rejects_leaked_terminal_force_action_copy(self) -> None:
+        """Known-bad: a terminal force job left its private copy behind."""
+        with tempfile.TemporaryDirectory() as leaked_path, self.assertRaisesRegex(
+            AssertionError,
+            "leaked its private action copy",
+        ):
+            assert_startup_force_action_lifecycle(
+                launched=True,
+                final_status="failed",
+                action_path=leaked_path,
             )
 
 

--- a/tests/test_import_queue.py
+++ b/tests/test_import_queue.py
@@ -1974,7 +1974,7 @@ class TestImporterWorker(unittest.TestCase):
         claimed = claim_next_import_job(db, worker_id="old-worker")
         assert claimed is not None
 
-        recovered = importer.recover_abandoned_running_jobs(cast(Any, db))
+        recovered = importer.recover_abandoned_running_jobs(db)
 
         self.assertEqual([job.id for job in recovered], [claimed.id])
         self.assertEqual(recovered[0].status, "queued")
@@ -2008,7 +2008,7 @@ class TestImporterWorker(unittest.TestCase):
         )
         self.assertTrue(os.path.isdir(action_path))
 
-        recovered = importer.recover_abandoned_running_jobs(cast(Any, db))
+        recovered = importer.recover_abandoned_running_jobs(db)
 
         self.assertEqual([item.id for item in recovered], [job.id])
         self.assertEqual(recovered[0].status, "failed")
@@ -2033,7 +2033,7 @@ class TestImporterWorker(unittest.TestCase):
             "lib.config.read_runtime_config",
             side_effect=RuntimeError("temporary config refusal"),
         ):
-            importer.recover_abandoned_running_jobs(cast(Any, db))
+            importer.recover_abandoned_running_jobs(db)
 
         failed_cleanup_job = db.get_import_job(job.id)
         assert failed_cleanup_job is not None
@@ -2044,7 +2044,7 @@ class TestImporterWorker(unittest.TestCase):
         self.assertFalse(cleanup["removed"])
         self.assertTrue(os.path.isdir(action_path))
 
-        importer.recover_abandoned_running_jobs(cast(Any, db))
+        importer.recover_abandoned_running_jobs(db)
 
         converged = db.get_import_job(job.id)
         assert converged is not None
@@ -2069,7 +2069,7 @@ class TestImporterWorker(unittest.TestCase):
             "merge_import_job_result",
             side_effect=RuntimeError("lost cleanup receipt"),
         ):
-            importer.recover_abandoned_running_jobs(cast(Any, db))
+            importer.recover_abandoned_running_jobs(db)
 
         self.assertFalse(os.path.exists(action_path))
         unrecorded = db.get_import_job(job.id)
@@ -2079,7 +2079,7 @@ class TestImporterWorker(unittest.TestCase):
             unrecorded.result or {},
         )
 
-        importer.recover_abandoned_running_jobs(cast(Any, db))
+        importer.recover_abandoned_running_jobs(db)
 
         converged = db.get_import_job(job.id)
         assert converged is not None

--- a/tests/test_import_queue.py
+++ b/tests/test_import_queue.py
@@ -740,6 +740,45 @@ class TestImporterWorker(unittest.TestCase):
         assert job.result is not None
         return job.result
 
+    def _launched_force_action_job(
+        self,
+        db: FakePipelineDB,
+        *,
+        dedupe_key: str,
+    ) -> tuple[ImportJob, str]:
+        from lib.import_preview import force_action_copy_path
+
+        db.seed_request(make_request_row(
+            id=42,
+            mb_release_id="startup-force-release",
+            status="wanted",
+        ))
+        job = db.enqueue_import_job(
+            IMPORT_JOB_FORCE,
+            request_id=42,
+            dedupe_key=dedupe_key,
+            payload={
+                "download_log_id": 1,
+                "failed_path": "/tmp/startup-force-source",
+            },
+        )
+        _seed_candidate_for_import_job(
+            db,
+            job.id,
+            mb_release_id="startup-force-release",
+        )
+        self._mark_importable(db, job)
+        action_path = force_action_copy_path(self._force_cfg, job.id)
+        claimed = claim_next_import_job(db, worker_id="old-worker")
+        assert claimed is not None
+        assert db.authorize_import_job_launch(
+            claimed.id,
+            request_id=42,
+            release_id="startup-force-release",
+            source_path="/tmp/startup-force-source",
+        ) is not None
+        return claimed, action_path
+
     def test_force_stages_queued_before_automation_handoff_have_zero_effect(
         self,
     ) -> None:
@@ -1958,6 +1997,96 @@ class TestImporterWorker(unittest.TestCase):
         assert retried is not None
         self.assertEqual(retried.attempts, 2)
 
+    def test_startup_recovery_removes_launched_force_action_copy(self) -> None:
+        """A terminal crash recovery releases the job's private album copy."""
+        from scripts import importer
+
+        db = FakePipelineDB()
+        job, action_path = self._launched_force_action_job(
+            db,
+            dedupe_key="force_import:startup-terminal-cleanup",
+        )
+        self.assertTrue(os.path.isdir(action_path))
+
+        recovered = importer.recover_abandoned_running_jobs(cast(Any, db))
+
+        self.assertEqual([item.id for item in recovered], [job.id])
+        self.assertEqual(recovered[0].status, "failed")
+        self.assertFalse(os.path.exists(action_path))
+        stored = db.get_import_job(job.id)
+        assert stored is not None
+        cleanup = self._result(stored)["force_action_cleanup"]
+        assert isinstance(cleanup, dict)
+        self.assertEqual(cleanup["action_path"], action_path)
+        self.assertTrue(cleanup["removed"])
+
+    def test_startup_retries_failed_force_action_cleanup(self) -> None:
+        """A transient filesystem refusal remains a durable startup task."""
+        from scripts import importer
+
+        db = FakePipelineDB()
+        job, action_path = self._launched_force_action_job(
+            db,
+            dedupe_key="force_import:startup-cleanup-retry",
+        )
+        with patch(
+            "lib.config.read_runtime_config",
+            side_effect=RuntimeError("temporary config refusal"),
+        ):
+            importer.recover_abandoned_running_jobs(cast(Any, db))
+
+        failed_cleanup_job = db.get_import_job(job.id)
+        assert failed_cleanup_job is not None
+        cleanup = self._result(
+            failed_cleanup_job
+        )["force_action_cleanup"]
+        assert isinstance(cleanup, dict)
+        self.assertFalse(cleanup["removed"])
+        self.assertTrue(os.path.isdir(action_path))
+
+        importer.recover_abandoned_running_jobs(cast(Any, db))
+
+        converged = db.get_import_job(job.id)
+        assert converged is not None
+        cleanup = self._result(converged)["force_action_cleanup"]
+        assert isinstance(cleanup, dict)
+        self.assertTrue(cleanup["removed"])
+        self.assertFalse(os.path.exists(action_path))
+
+    def test_startup_retries_force_cleanup_after_result_merge_failure(
+        self,
+    ) -> None:
+        """A kill-equivalent missing DB receipt re-drives idempotent cleanup."""
+        from scripts import importer
+
+        db = FakePipelineDB()
+        job, action_path = self._launched_force_action_job(
+            db,
+            dedupe_key="force_import:startup-cleanup-merge-retry",
+        )
+        with patch.object(
+            db,
+            "merge_import_job_result",
+            side_effect=RuntimeError("lost cleanup receipt"),
+        ):
+            importer.recover_abandoned_running_jobs(cast(Any, db))
+
+        self.assertFalse(os.path.exists(action_path))
+        unrecorded = db.get_import_job(job.id)
+        assert unrecorded is not None
+        self.assertNotIn(
+            "force_action_cleanup",
+            unrecorded.result or {},
+        )
+
+        importer.recover_abandoned_running_jobs(cast(Any, db))
+
+        converged = db.get_import_job(job.id)
+        assert converged is not None
+        cleanup = self._result(converged)["force_action_cleanup"]
+        assert isinstance(cleanup, dict)
+        self.assertTrue(cleanup["removed"])
+
     def test_importer_does_not_claim_job_waiting_for_preview(self):
         from scripts import importer
 
@@ -2518,6 +2647,11 @@ class TestImporterWorker(unittest.TestCase):
                 return []
 
             def list_automation_import_jobs_for_startup_recovery(
+                self,
+            ) -> list[ImportJob]:
+                return []
+
+            def list_terminal_force_action_cleanup_jobs(
                 self,
             ) -> list[ImportJob]:
                 return []
@@ -8273,9 +8407,9 @@ class TestAutomationWorldFailureNeverParks(unittest.TestCase):
     def test_missing_completion_receipt_reopens_the_search(self) -> None:
         """A launched job with no captured receipt self-heals, not parks.
 
-        The owner authority refuses a ``running`` terminal write without the
-        receipt, so this is the one class that transits ``recovery_required``
-        to close — and it must not REST there.
+        The narrow world-failure terminal shape accepts the missing receipt
+        while retaining the exact owner/lease CAS, so the request returns
+        directly to ``wanted`` without a ``recovery_required`` transit.
         """
         db, canonical, claimed, lease = self._launch(capture_completion=False)
         updated, escaped = self._run(

--- a/tests/test_migrator.py
+++ b/tests/test_migrator.py
@@ -5029,6 +5029,135 @@ class TestProcessingAutomationOwnerMigration(unittest.TestCase):
         finally:
             _drop_database(name)
 
+    def test_067_preserves_historical_recovery_owner_and_cleanup_journal(
+        self,
+    ) -> None:
+        """Dropping operator declarations leaves runtime recovery evidence."""
+        name = "cratedigger_test_processing_owner_067_recovery_history"
+        dsn = _create_fresh_database(name)
+        try:
+            with tempfile.TemporaryDirectory() as migrations_dir:
+                for migration in discover_migrations(DEFAULT_MIGRATIONS_DIR):
+                    if migration.version <= 66:
+                        shutil.copy2(migration.path, migrations_dir)
+                apply_migrations(dsn, migrations_dir)
+
+                conn = psycopg2.connect(dsn)
+                try:
+                    with conn.cursor() as cur:
+                        cur.execute("""
+                            INSERT INTO album_requests (
+                                mb_release_id, artist_name, album_title,
+                                source, status, active_download_state
+                            )
+                            VALUES (
+                                'mig067-recovery-history', 'A', 'B', 'request',
+                                'wanted',
+                                '{"current_path": "/processing/history", '
+                                '"files": []}'::jsonb
+                            )
+                            RETURNING id
+                        """)
+                        request_row = cur.fetchone()
+                        self.assertIsNotNone(request_row)
+                        assert request_row is not None
+                        request_id = int(request_row[0])
+                        cur.execute("""
+                            INSERT INTO import_jobs (
+                                job_type, status, request_id, payload,
+                                preview_status, result, message
+                            )
+                            VALUES (
+                                'automation_import', 'recovery_required', %s,
+                                '{}'::jsonb, 'evidence_ready', '{}'::jsonb,
+                                'historical operator recovery'
+                            )
+                            RETURNING id
+                        """, (request_id,))
+                        job_row = cur.fetchone()
+                        self.assertIsNotNone(job_row)
+                        assert job_row is not None
+                        job_id = int(job_row[0])
+                        cur.execute("""
+                            UPDATE album_requests
+                            SET status = 'processing',
+                                active_automation_import_job_id = %s
+                            WHERE id = %s
+                        """, (job_id, request_id))
+                        cur.execute("""
+                            INSERT INTO processing_cleanup_journal (
+                                job_id, request_id, action, source_path,
+                                source_manifest, source_manifest_hash,
+                                declared_result_status, declared_reason,
+                                evidence_revision
+                            )
+                            VALUES (
+                                %s, %s, 'no_op', '/processing/history',
+                                '[]'::jsonb, 'empty-manifest-sha256',
+                                'wanted', 'historical declared close',
+                                'history-revision'
+                            )
+                        """, (job_id, request_id))
+                    conn.commit()
+                except BaseException:
+                    conn.rollback()
+                    raise
+                finally:
+                    conn.close()
+
+                apply_migrations(dsn, DEFAULT_MIGRATIONS_DIR)
+
+                conn = psycopg2.connect(dsn)
+                conn.autocommit = True
+                try:
+                    with conn.cursor() as cur:
+                        cur.execute("""
+                            SELECT status, active_automation_import_job_id
+                            FROM album_requests WHERE id = %s
+                        """, (request_id,))
+                        self.assertEqual(
+                            cur.fetchone(),
+                            ("processing", job_id),
+                        )
+                        cur.execute("""
+                            SELECT status, request_id, preview_status
+                            FROM import_jobs WHERE id = %s
+                        """, (job_id,))
+                        self.assertEqual(
+                            cur.fetchone(),
+                            ("recovery_required", request_id, "evidence_ready"),
+                        )
+                        cur.execute("""
+                            SELECT action, source_path, source_manifest_hash,
+                                   completed_at
+                            FROM processing_cleanup_journal
+                            WHERE job_id = %s AND request_id = %s
+                        """, (job_id, request_id))
+                        self.assertEqual(
+                            cur.fetchone(),
+                            (
+                                "no_op",
+                                "/processing/history",
+                                "empty-manifest-sha256",
+                                None,
+                            ),
+                        )
+                        cur.execute("""
+                            SELECT column_name
+                            FROM information_schema.columns
+                            WHERE table_name = 'processing_cleanup_journal'
+                              AND column_name IN (
+                                  'declared_result_status',
+                                  'declared_reason',
+                                  'evidence_revision'
+                              )
+                        """)
+                        self.assertEqual(cur.fetchall(), [])
+                finally:
+                    conn.close()
+        finally:
+            _drop_database(name)
+
 
 @requires_postgres
 class TestLosslessLineageSpectralSubjectMigration(unittest.TestCase):


### PR DESCRIPTION
## Summary

Follow-up to #944 after mandatory independent diff review.

- make terminal force-import action-copy cleanup durable and restart-convergent, including filesystem and result-receipt failure retries
- prove historical attached automation `recovery_required` owners still self-heal through startup recovery after migration 067 removes the declaration triple
- prove migration 067 preserves owner/journal state while dropping only the obsolete declaration columns
- correct the retained read-only recovery documentation and remove new typing escape hatches

## Scope boundary

The independent review also surfaced non-automation Recents visibility and historical non-automation `recovery_required` rows. Those are already owned by #940 and are intentionally excluded here; the handoff is recorded at https://github.com/abl030/cratedigger/issues/940#issuecomment-5129555754.

## Independent review

An uninvolved reviewer found the initial crash gap: a process death after terminal DB acknowledgement but before action-copy deletion could leak the private copy permanently. The correction now uses the terminal job row as a durable retry edge. Re-review also caught a typing-ratchet laundering mistake; it was removed and the baseline tightened. Final re-review returned no findings, residual risks, or testing gaps.

## Validation

Reviewed clean HEAD: `560481073b7773de93857526c9aa11d6719d3cf8`

- receipt-backed whole-tree Pyright: pass (`/run/user/1000/cratedigger-final-gate.9tpSwrC3`)
- receipt-backed full suite: pass (`/run/user/1000/cratedigger-final-gate.f2RBYA7C`)
- 6/6 phases passed; 8,364 Python tests across 346 targets
- focused fake, real-PostgreSQL, generated, migration, typing-ratchet, Ruff, Vulture, and docs checks included

Refs #942
