### PR TITLE
Make typing ratchet failures pay down debt

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -98,6 +98,13 @@ delete its generated baseline/regeneration path and retain a direct
 zero-tolerance check; delete the scanner only when a configured tool enforces
 the same syntax.
 
+When either typing ratchet trips, do not stop at making it green. For every
+affected file and finding kind, finish with the committed count at least ten
+below the baseline at the start of the change, or at zero if fewer than ten
+remain, then regenerate the baseline. This is deliberately a convergence rule,
+not another checker: do not add stable-site, diff-aware, or history-aware
+machinery to catch delete-and-add laundering.
+
 ## HTTP request bodies — use `pydantic.BaseModel`
 
 Inbound HTTP bodies use a route-local `pydantic.BaseModel` and the shared


### PR DESCRIPTION
## Summary

- keep the existing exact count typing ratchets
- require every ratchet mismatch to finish ten counts lower, or at zero
- explicitly reject stable-site, diff-aware, and history-aware audit machinery for this case

Closes #947.

## Validation

- `tests.test_docs_audit`: 46 passed
- whole-tree Pyright: clean
- exhaustive suite stopped at operator direction before push; this is a documentation-only rule change
