### PR TITLE
Fix monitored staging across normal production layouts

### DIFF
--- a/lib/staged_album.py
+++ b/lib/staged_album.py
@@ -63,9 +63,6 @@ class StagedAlbum:
         cancellation_token: CancellationToken | None = None,
     ) -> str:
         """Move album contents without inferring lifecycle ownership from path."""
-        if cancellation_token is not None:
-            return self._move_to_cancellable(dest, cancellation_token)
-
         source = os.path.abspath(self.current_path)
         target = os.path.abspath(dest)
         target_preexisted = os.path.isdir(target)
@@ -119,77 +116,6 @@ class StagedAlbum:
             ):
                 _checkpoint(cancellation_token)
                 shutil.rmtree(target, ignore_errors=True)
-            self.current_path = source
-            if rollback_failures:
-                first_source, first_target = rollback_failures[0]
-                raise RuntimeError(
-                    "Failed to roll back staged move cleanly after a staging "
-                    f"error: {first_target} -> {first_source}"
-                ) from exc
-            raise
-
-    def _move_to_cancellable(
-        self,
-        dest: str,
-        cancellation_token: CancellationToken,
-    ) -> str:
-        """Move with atomic same-filesystem mutations and no hidden fallback."""
-        source = os.path.abspath(self.current_path)
-        target = os.path.abspath(dest)
-        target_preexisted = os.path.isdir(target)
-
-        if source == target:
-            self.current_path = target
-            return self.current_path
-
-        moved_entries: list[tuple[str, str]] = []
-        try:
-            _checkpoint(cancellation_token)
-            if not target_preexisted:
-                # A missing parent is a configuration/recovery error. Avoid
-                # os.makedirs: it can perform several uncheckpointed writes.
-                os.mkdir(target)
-            for entry in sorted(os.listdir(source)):
-                source_entry = os.path.join(source, entry)
-                target_entry = os.path.join(target, entry)
-                _checkpoint(cancellation_token)
-                # Never inherit shutil.move's cross-filesystem recursive
-                # copy/delete fallback while processor ownership is monitored.
-                os.rename(source_entry, target_entry)
-                moved_entries.append((source_entry, target_entry))
-            self.current_path = target
-            _checkpoint(cancellation_token)
-            os.rmdir(source)
-            return self.current_path
-        except ExecutionCancelled:
-            # Completed atomic renames are durable recovery evidence. A stale
-            # worker must not roll them back or remove either partial tree.
-            raise
-        except Exception as exc:
-            rollback_failures: list[tuple[str, str]] = []
-            _checkpoint(cancellation_token)
-            for source_entry, target_entry in reversed(moved_entries):
-                if os.path.exists(target_entry):
-                    try:
-                        _checkpoint(cancellation_token)
-                        os.rename(target_entry, source_entry)
-                    except ExecutionCancelled:
-                        raise
-                    except Exception:
-                        rollback_failures.append((source_entry, target_entry))
-                        logger.exception(
-                            "Failed to roll back staged move %s -> %s",
-                            target_entry,
-                            source_entry,
-                        )
-            if (
-                not moved_entries
-                and not target_preexisted
-                and os.path.isdir(target)
-                and not os.listdir(target)
-            ):
-                _checkpoint(cancellation_token)
-                os.rmdir(target)
             self.current_path = source
             if rollback_failures:
                 first_source, first_target = rollback_failures[0]

--- a/tests/test_processing_cancellation.py
+++ b/tests/test_processing_cancellation.py
@@ -478,7 +478,32 @@ class TestStagedAlbumCancellation(unittest.TestCase):
                 b"audio",
             )
 
-    def test_cross_filesystem_move_fails_closed_without_recursive_fallback(
+    def test_monitored_move_creates_missing_destination_parents(
+        self,
+    ) -> None:
+        token = CancellationToken()
+        with tempfile.TemporaryDirectory() as raw:
+            source = pathlib.Path(raw, "source")
+            source.mkdir()
+            (source / "01.flac").write_bytes(b"audio")
+            destination = pathlib.Path(
+                raw,
+                "Incoming",
+                "auto-import",
+                "Artist",
+                "Album",
+            )
+
+            result = StagedAlbum(str(source)).move_to(
+                str(destination),
+                cancellation_token=token,
+            )
+
+            self.assertEqual(result, str(destination))
+            self.assertEqual((destination / "01.flac").read_bytes(), b"audio")
+            self.assertFalse(source.exists())
+
+    def test_monitored_move_supports_cross_filesystem_fallback(
         self,
     ) -> None:
         token = CancellationToken()
@@ -491,18 +516,15 @@ class TestStagedAlbumCancellation(unittest.TestCase):
             with patch(
                 "lib.staged_album.os.rename",
                 side_effect=OSError(errno.EXDEV, "cross-device link"),
-            ), patch(
-                "lib.staged_album.shutil.move",
-                side_effect=AssertionError("recursive fallback ran"),
-            ) as fallback, self.assertRaises(OSError):
-                StagedAlbum(str(source)).move_to(
+            ):
+                result = StagedAlbum(str(source)).move_to(
                     str(destination),
                     cancellation_token=token,
                 )
 
-            fallback.assert_not_called()
-            self.assertEqual((source / "01.flac").read_bytes(), b"audio")
-            self.assertFalse(destination.exists())
+            self.assertEqual(result, str(destination))
+            self.assertEqual((destination / "01.flac").read_bytes(), b"audio")
+            self.assertFalse(source.exists())
 
 
 class TestMonitoredImportOneCancellation(unittest.TestCase):

--- a/tests/test_processing_cancellation_generated.py
+++ b/tests/test_processing_cancellation_generated.py
@@ -1,5 +1,6 @@
 """Generated fail-stop patrol for staged filesystem mutations."""
 
+import errno
 import os
 import shutil
 import tempfile
@@ -101,6 +102,61 @@ def _known_bad_preflight_only_move(
     shutil.rmtree(staged.current_path)
 
 
+def assert_staged_move_supports_production_layout(
+    *,
+    file_count: int,
+    missing_parent_depth: int,
+    cross_filesystem: bool,
+    move_fn: MoveFn,
+) -> None:
+    """A monitored move keeps the ordinary staging filesystem contract."""
+    with tempfile.TemporaryDirectory() as raw:
+        source = os.path.join(raw, "source")
+        destination = os.path.join(
+            raw,
+            *(f"missing-{index}" for index in range(missing_parent_depth)),
+            "album",
+        )
+        os.mkdir(source)
+        expected = {f"{index:02d}.flac" for index in range(file_count)}
+        for name in expected:
+            with open(os.path.join(source, name), "wb") as handle:
+                handle.write(name.encode())
+
+        token = CancellationToken()
+        if cross_filesystem:
+            with patch(
+                "lib.staged_album.os.rename",
+                side_effect=OSError(errno.EXDEV, "cross-device link"),
+            ):
+                move_fn(StagedAlbum(source), destination, token)
+        else:
+            move_fn(StagedAlbum(source), destination, token)
+
+        if set(os.listdir(destination)) != expected:
+            raise AssertionError("staged move did not preserve every source entry")
+        if os.path.exists(source):
+            raise AssertionError("staged move did not consume its source directory")
+
+
+def _known_bad_rename_only_move(
+    staged: StagedAlbum,
+    destination: str,
+    token: CancellationToken,
+) -> None:
+    """Mutant: requires existing parents and one filesystem."""
+    token.raise_if_cancelled()
+    os.mkdir(destination)
+    for name in os.listdir(staged.current_path):
+        token.raise_if_cancelled()
+        os.rename(
+            os.path.join(staged.current_path, name),
+            os.path.join(destination, name),
+        )
+    token.raise_if_cancelled()
+    os.rmdir(staged.current_path)
+
+
 def assert_recursive_cleanup_is_fail_stop(
     remove_fn: Callable[[int, str, CancellationToken], None],
 ) -> None:
@@ -162,6 +218,27 @@ class TestStagedMoveCancellationGenerated(unittest.TestCase):
             move_fn=_production_move,
         )
 
+    @given(
+        file_count=st.integers(min_value=1, max_value=6),
+        missing_parent_depth=st.integers(min_value=0, max_value=3),
+        cross_filesystem=st.booleans(),
+    )
+    @example(file_count=1, missing_parent_depth=3, cross_filesystem=False)
+    @example(file_count=1, missing_parent_depth=0, cross_filesystem=True)
+    def test_every_production_staging_layout_is_supported(
+        self,
+        *,
+        file_count: int,
+        missing_parent_depth: int,
+        cross_filesystem: bool,
+    ) -> None:
+        assert_staged_move_supports_production_layout(
+            file_count=file_count,
+            missing_parent_depth=missing_parent_depth,
+            cross_filesystem=cross_filesystem,
+            move_fn=_production_move,
+        )
+
     def test_checker_rejects_preflight_only_known_bad_mutant(self) -> None:
         with self.assertRaisesRegex(
             AssertionError,
@@ -171,6 +248,15 @@ class TestStagedMoveCancellationGenerated(unittest.TestCase):
                 file_count=3,
                 cancel_at=2,
                 move_fn=_known_bad_preflight_only_move,
+            )
+
+    def test_layout_checker_rejects_rename_only_known_bad_mutant(self) -> None:
+        with self.assertRaises(OSError):
+            assert_staged_move_supports_production_layout(
+                file_count=1,
+                missing_parent_depth=0,
+                cross_filesystem=True,
+                move_fn=_known_bad_rename_only_move,
             )
 
     def test_recursive_cleanup_checks_every_child_mutation(self) -> None:


### PR DESCRIPTION
## Summary

- remove the duplicate rename-only staging implementation added by PR #933
- use the established `os.makedirs` + `shutil.move` path for monitored imports, retaining cancellation checkpoints and rollback
- patrol both normal missing artist parents and cross-filesystem `EXDEV` fallback with deterministic and generated tests

## Production regression

The three live failures at 19:05–19:22 all passed exact-release Beets validation, then failed in `StagedAlbum._move_to_cancellable`:

- Iron & Wine and Wavves: `os.mkdir` rejected the normal missing artist parent
- The Mountain Goats: `os.rename` rejected the normal processing → Incoming mount boundary with `EXDEV`

The requests self-healed to `wanted`; this restores the staging behavior they require.

## Validation

- focused validation/staging/cancellation slice: 156 tests passed
- final-gate Pyright receipt: pass
- final-gate aggregate suite receipt: pass
