### PR TITLE
Fix processing owner path continuity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,11 +137,13 @@ docs/             — subsystem docs; docs/solutions/ = compounding lessons (gre
 Web UI / CLI → PostgreSQL (wanted → downloading → processing → imported; wanted ↔ unsearchable)
    Phase 1: poll_active_downloads()   Phase 2: get_wanted() → search + enqueue
    completed download → validate vs exact release ID (dist ≤ 0.15)
-   source=request    → stage /Incoming/auto-import  → import_one.py (spectral → convert → quality gate) → /Beets
+   source=request    → keep exact processing owner path → import_one.py (spectral → convert → quality gate) → /Beets
    source=redownload → stage /Incoming/post-validation (manual review only, never auto-imported)
 ```
 
-**Don't assume a path under `/Incoming` is a redownload** — request imports can be mid-move or mid-import there too. Schema fields, JSONB audit blobs, and the force-import flow: `docs/pipeline-db-schema.md`.
+**Don't assume a path under `/Incoming` is a redownload** — YouTube rescues
+still enter through `/Incoming/auto-import`. Schema fields, JSONB audit blobs,
+and the force-import flow: `docs/pipeline-db-schema.md`.
 
 ## CLI ⇄ API surface symmetry
 

--- a/docs/beets-primer.md
+++ b/docs/beets-primer.md
@@ -155,7 +155,7 @@ fetchart:
 | `/mnt/virtio/cratedigger/beets-db/beets-library.db` | SQLite database — the DB source of truth |
 | `/mnt/virtio/cratedigger/beets-db/beets-import.log` | Import log |
 | `/mnt/virtio/Music/AI` | Staging area — raw copies from `/Me`, pre-import |
-| `/mnt/virtio/Music/Incoming` | Processing staging root — `/Incoming/auto-import` for request auto-imports, `/Incoming/post-validation` for redownload/manual-review staging |
+| `/mnt/virtio/Music/Incoming` | Auxiliary import staging — `/Incoming/auto-import` for YouTube rescues, `/Incoming/post-validation` for redownload/manual-review staging; Soulseek request imports stay at their exact processing-owner path |
 | `/mnt/virtio/Music/Re-download` | Re-download queue — each album has a README.md explaining why |
 
 ### File Organization

--- a/docs/multi-disc-current-behaviour.md
+++ b/docs/multi-disc-current-behaviour.md
@@ -183,7 +183,7 @@ For the multi-disc flow the key facts are:
 
 `lib/staged_album.py::staged_filename` (lines 29-34) prepends `Disk N - `
 to the filename when `disk_count > 1`. So a multi-disc download lands
-in a single staging directory under `/Incoming/auto-import/` with
+in one exact processing-owner directory with
 filenames like `Disk 1 - 01 - Pi.flac`, `Disk 1 - 02 - Bertie.flac`,
 …, `Disk 2 - 01 - Prelude.flac`, …. This is the auto-import flatten
 that the `preimport_nested` gate (`lib/quality/gates.py`) is
@@ -191,7 +191,7 @@ expected to find pre-flattened. Force-import accepts an existing rejected
 folder and trips the shared `nested_layout` gate if it contains raw
 subfolders.
 
-The beets harness sees a flat staging dir with disk-numbered prefixes
+The beets harness sees that flat owned dir with disk-numbered prefixes
 and does its match against the full multi-disc release on MB. Beets'
 tagging then writes the files into the library with the configured
 per-disc path template.

--- a/docs/nixos-module.md
+++ b/docs/nixos-module.md
@@ -33,7 +33,7 @@ The flake export is a wrapper that pins the module's package set to **cratedigge
 | `musicbrainz.apiBase` | `https://musicbrainz.org` | ONE MB origin for web/mb.py (via config.ini, read at `cratedigger-web` startup), pipeline-cli lookups, and the rendered beets musicbrainz block (KTD6). Public default is functional but ~1 req/s. |
 | `discogs.apiBase` | `null` | Discogs mirror origin. Mirror-REQUIRED: unset ⇒ Discogs browse off with a 503 mirror-required message (public api.discogs.com does not serve this API shape). |
 | `stateDir` | `/var/lib/cratedigger` | Runtime state (config.ini, lock file). |
-| `processingDir` | `${stateDir}/processing` | Private `0700` Cratedigger-owned root: canonical albums live in `albums/`, bounded preview scratch in `preview/`. Must be absolute and disjoint from slskd's download tree. |
+| `processingDir` | `${stateDir}/processing` | Private `0700` Cratedigger-owned root: canonical albums and their same-filesystem failure quarantine live in `albums/`, bounded preview scratch in `preview/`. Must be absolute and disjoint from slskd's download tree. |
 | `slskd.apiKeyFile` | (required) | Path to a file containing the raw slskd API key (one line). |
 | `slskd.downloadDir` | (required) | Where slskd downloads land. |
 | `slskd.hostUrl` | `http://localhost:5030` | slskd HTTP base URL. |
@@ -341,9 +341,10 @@ services (Jellyfin, Plex) need to read AND write inside the same library tree.
 ### Private processing boundary
 
 `processingDir` is deliberately separate from `slskd.downloadDir`: slskd is a
-source authority, not a safe destination. The module creates the root and its
-`albums/` and `preview/` children as `0700` for the Cratedigger identity;
-tmpfiles may age-clean only `preview/` children. Put a large processing root
+source authority, not a safe destination. The module creates the root,
+`albums/`, `albums/failed_imports/`, and `preview/` as `0700` for the
+Cratedigger identity; tmpfiles may age-clean only `preview/` children. Put a
+large processing root
 directly beneath a root-owned, non-group-writable parent. Do not run slskd as
 the Cratedigger user and do not put processing beneath a parent writable by
 slskd. The module rejects relative and lexically overlapping paths, while the

--- a/docs/pipeline-db-schema.md
+++ b/docs/pipeline-db-schema.md
@@ -261,16 +261,19 @@ Audio-integrity failures split at the evidence boundary:
 - Stable readable bytes that the strict audio-only FFmpeg policy cannot fully
   decode become `audio_corrupt` content evidence. The importer remains the
   only decision owner: it rejects through
-  `full_pipeline_decision_from_evidence`, deny-lists the source peer, commits
-  the terminal row, and only then moves the retained source under the
-  configured `<beets_staging_dir>/failed_imports/bad_files/`.
-  The complete source directory moves by one atomic rename; a cross-filesystem
-  or other rename failure leaves the original directory untouched. Once this
-  archival move is planned, neither force-source cleanup nor the independent
-  Wrong Matches convergence reducer receives either retained path.
-  `validation_result.post_commit_quarantine` records the exact source,
-  destination, move result, and any bounded error; `failed_path` points at the
-  surviving copy.
+  `full_pipeline_decision_from_evidence`, deny-lists the source peer, and
+  archives the retained source as part of terminal convergence. Exact-owner request
+  imports move under
+  `<processing_dir>/albums/failed_imports/bad_files/` while ownership is still
+  attached; keeping source and destination beneath the same private root makes
+  the journaled archival transfer one atomic rename regardless of where
+  Incoming is mounted. The cleanup receipt is consumed by the terminal
+  transaction. Sources outside private processing, such as YouTube imports,
+  retain their configured
+  `<beets_staging_dir>/failed_imports/bad_files/` quarantine; private
+  force-import action copies use the processing-local path. Once an archival
+  move is planned, neither force-source cleanup nor the independent Wrong
+  Matches convergence reducer receives either retained path.
 - Permissions, changed/vanished paths, unavailable/interrupted FFmpeg, and
   persistence failures are `measurement_failed`. Their typed report lives in
   the preview/job validation payload, they never write a denylist, and the

--- a/docs/quality-verification.md
+++ b/docs/quality-verification.md
@@ -58,10 +58,13 @@ measurement itself failed and cannot blame the peer.
 Preview persists completed content facts in
 `album_quality_evidence.audio_validation`, then the importer alone decides via
 `full_pipeline_decision_from_evidence`. Corrupt audio follows the standard
-denylist plus post-terminal `failed_imports/bad_files` quarantine path and
-resumes searching. Quarantine atomically renames the complete source directory
-and fails closed with the original untouched when that rename is unavailable.
-The quarantine plan excludes both post-import Wrong Matches deletion passes.
+denylist plus `failed_imports/bad_files` quarantine path and resumes searching.
+Request-owned processing keeps that quarantine beneath the same private
+processing root, so the exact-owner cleanup journal can atomically rename the
+complete source directory before terminal acknowledgement even when Incoming
+is another filesystem. Other importer lanes retain their configured staging
+quarantine. The quarantine plan excludes both post-import Wrong Matches
+deletion passes.
 A `measurement_failed` attempt writes no denylist and its
 retained source path is protected from the disk reaper. Diagnostics are capped
 at 16 files and 2 KiB per normalized stderr excerpt; success carries no

--- a/lib/dispatch/core.py
+++ b/lib/dispatch/core.py
@@ -68,7 +68,11 @@ from lib.import_execution import (
     checkpoint_automation_owner,
     read_process_start_ticks,
 )
-from lib.processing_paths import normalize_source_dirs
+from lib.processing_paths import (
+    normalize_source_dirs,
+    path_is_within_root,
+    processing_albums_dir,
+)
 from lib.quality import (
     AlbumQualityEvidenceDecisionFacts,
     DownloadInfo,
@@ -96,6 +100,23 @@ if TYPE_CHECKING:
     from lib.quality import SpectralDetail
 
 logger = logging.getLogger("cratedigger")
+
+
+def _processing_quarantine_root(
+    source_path: str,
+    cfg: CratediggerConfig,
+) -> str:
+    """Keep exact-owner quarantine on the canonical source filesystem.
+
+    Sources outside private processing retain their configured Incoming
+    quarantine. Any Cratedigger-owned source beneath ``processing/albums``
+    instead quarantines beneath that same private root, so cleanup remains one
+    journaled atomic rename regardless of where the operator mounts Incoming.
+    """
+    albums_root = processing_albums_dir(cfg.processing_dir)
+    if path_is_within_root(source_path, albums_root):
+        return albums_root
+    return cfg.beets_staging_dir
 
 
 @dataclass(frozen=True)
@@ -189,8 +210,8 @@ def _describe_rejection(
         detail = _guard_failure_detail(import_result)
         duplicate_guard_path = path
         duplicate_guard_staging_dir = (
-            cfg.beets_staging_dir
-            if cfg is not None and cfg.beets_staging_dir
+            _processing_quarantine_root(path, cfg)
+            if cfg is not None
             else os.path.dirname(os.path.abspath(path))
         )
         guard = import_result.postflight.duplicate_remove_guard
@@ -972,7 +993,10 @@ def dispatch_import_core(
                         quality_ranks=(
                             cfg.quality_ranks if cfg is not None else None
                         ),
-                        audio_quarantine_root=beets_cfg.beets_staging_dir,
+                        audio_quarantine_root=_processing_quarantine_root(
+                            path,
+                            beets_cfg,
+                        ),
                         preserve_corrupt_source=force,
                     )
                 quality_evidence_action_file = _write_quality_evidence_action_file(
@@ -1018,8 +1042,9 @@ def dispatch_import_core(
             # material (typically failed_imports/…). Tell the harness to keep
             # lossless originals intact until the quality decision — on
             # downgrade/transcode_downgrade verdicts we exit before deletion so
-            # the user's FLACs survive (#111). Auto-import stages to disposable
-            # /Incoming and does not need the flag.
+            # the user's FLACs survive (#111). An automatic request import runs
+            # from its disposable, exact-owner processing path and does not
+            # need the flag.
             quality_rank_config_json = (
                 cfg.quality_ranks.to_json() if cfg is not None else None
             )
@@ -1390,7 +1415,7 @@ def dispatch_import_core(
                     # directory is now empty), which keeps the wrong-matches
                     # tab honest and prevents duplicate re-imports of an
                     # already-imported album. Auto-import scenarios always
-                    # clean — their staging dir under ``/Incoming`` is
+                    # clean — their exact-owner processing source is
                     # disposable by design.
                     post_commit_staged_path = path
         except ExecutionCancelled:

--- a/lib/dispatch/helpers.py
+++ b/lib/dispatch/helpers.py
@@ -28,7 +28,7 @@ def _should_cleanup_path(scenario: str, action: DispatchAction) -> bool:
     Issue #89 rules:
 
     * Auto-import (scenario not in ``FORCE_IMPORT_SCENARIOS``) always
-      cleans its disposable ``/Incoming`` staging dir.
+      cleans its disposable processing-owner source.
     * Force-import paths pass the user's ``wrong_matches/…`` folder (or a
       legacy ``failed_imports/…`` folder) — cleanup is only safe on a
       successful import

--- a/lib/dispatch/types.py
+++ b/lib/dispatch/types.py
@@ -72,7 +72,7 @@ DISPATCH_CODE_IMPORT_MANIFEST_REJECTED = "import_manifest_rejected"
 # can never delete the user's only copy of the source. Auto-import dispatches
 # under ``bv_result.scenario``, which on that path is always ``strong_match``
 # (``lib/beets.py`` sets ``valid`` and that name in one statement) and never
-# appears here — its staging dir under ``/Incoming`` is always safe to remove
+# appears here — its exact-owner processing source is always safe to remove
 # (see issue #89).
 FORCE_IMPORT_SCENARIOS: frozenset[str] = frozenset({"force_import"})
 

--- a/lib/download_validation.py
+++ b/lib/download_validation.py
@@ -258,10 +258,10 @@ def _handle_valid_result(
     execution_lease: ExecutionLeaseSnapshot | None = None,
     owner_session_identity: OwnerSessionIdentity | None = None,
 ) -> DispatchOutcome | None:
-    """Stage a valid exact-release result and dispatch request imports.
+    """Dispatch a valid exact-release result from its authoritative path.
 
-    The release advisory lock is acquired before the staged move. Redownloads
-    only stage for manual review and mark the request done.
+    Request imports remain at their durable processing-owner path. Redownloads
+    move to manual-review staging and mark the request done.
     """
     from contextlib import nullcontext
 
@@ -325,7 +325,7 @@ def _handle_valid_result(
                 f"AUTO-IMPORT DEFERRED: {album_data.artist} - "
                 f"{album_data.title} — release lock held by another "
                 f"process (mbid={album_data.mb_release_id}); skipping "
-                "staged move and dispatch. Files stay at "
+                "dispatch. Files stay at "
                 f"{staged_album.current_path} so the next cycle can "
                 "idempotently resume from process_completed_album."
             )
@@ -345,22 +345,31 @@ def _handle_valid_result(
                 deferred=True,
             )
 
-        _checkpoint(cancellation_token)
-        dest = staged_album.move_to(
-            stage_to_ai_path(
-                artist=album_data.artist,
-                title=album_data.title,
-                staging_dir=ctx.cfg.beets_staging_dir,
-                request_id=request_id,
-                auto_import=will_auto_import,
-            ),
-            cancellation_token=cancellation_token,
-        )
+        if will_auto_import:
+            # The processing handoff persisted this exact path as immutable
+            # owner provenance. Beets launch, journaled cleanup, and terminal
+            # acknowledgement all fence on the same value, so relocating the
+            # folder here would split live filesystem state from its durable
+            # authority.
+            dest = staged_album.current_path
+        else:
+            _checkpoint(cancellation_token)
+            dest = staged_album.move_to(
+                stage_to_ai_path(
+                    artist=album_data.artist,
+                    title=album_data.title,
+                    staging_dir=ctx.cfg.beets_staging_dir,
+                    request_id=request_id,
+                    auto_import=False,
+                ),
+                cancellation_token=cancellation_token,
+            )
         _checkpoint(cancellation_token)
         album_data.import_folder = dest
         log_validation_result(album_data, bv_result, ctx.cfg, dest_path=dest)
         logger.info(
-            f"STAGED: {album_data.artist} - {album_data.title} "
+            f"{'PROCESSING SOURCE' if will_auto_import else 'STAGED'}: "
+            f"{album_data.artist} - {album_data.title} "
             f"(scenario={bv_result.scenario}, "
             f"distance={bv_result.distance:.4f}) → {dest}"
         )

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -2323,6 +2323,7 @@ in {
         "d ${cfg.stateDir} 0755 ${cfg.user} ${cfg.group} -"
         "d ${cfg.processingDir} 0700 ${cfg.user} ${cfg.group} -"
         "d ${cfg.processingDir}/albums 0700 ${cfg.user} ${cfg.group} -"
+        "d ${cfg.processingDir}/albums/failed_imports 0700 ${cfg.user} ${cfg.group} -"
         "d ${cfg.processingDir}/preview 0700 ${cfg.user} ${cfg.group} -"
         # Only ephemeral preview children are age-cleaned.  Canonical albums
         # are durable in-flight state and are never a tmpfiles cleanup target.

--- a/nix/tests/module-vm.nix
+++ b/nix/tests/module-vm.nix
@@ -1232,6 +1232,7 @@ pkgs.testers.nixosTest {
     machine.succeed("test $(id -u cratedigger) -ne 0")
     machine.succeed("test \"$(stat -c %U:%G:%a /var/lib/cratedigger/processing)\" = cratedigger:beets-library:700")
     machine.succeed("test \"$(stat -c %U:%G:%a /var/lib/cratedigger/processing/albums)\" = cratedigger:beets-library:700")
+    machine.succeed("test \"$(stat -c %U:%G:%a /var/lib/cratedigger/processing/albums/failed_imports)\" = cratedigger:beets-library:700")
     machine.succeed("test \"$(stat -c %U:%G:%a /var/lib/cratedigger/processing/preview)\" = cratedigger:beets-library:700")
     machine.succeed("runuser -u cratedigger -- mkdir /var/lib/cratedigger/processing/preview/vm-nonroot-snapshot")
     machine.fail("runuser -u unrelated-user -- test -r /var/lib/cratedigger/processing/preview")

--- a/tests/test_dispatch_core.py
+++ b/tests/test_dispatch_core.py
@@ -182,6 +182,7 @@ class TestDispatchCoreOrchestration(unittest.TestCase):
                   candidate_kwargs: dict[str, object] | None = None,
                   beets_staging_dir: str | None = None,
                   slskd_download_dir: str | None = None,
+                  processing_dir: str | None = None,
                   path_parent: str | None = None,
                   post_dispatch_fn: Callable[
                       [DispatchOutcome, FakePipelineDB, str], None,
@@ -201,6 +202,7 @@ class TestDispatchCoreOrchestration(unittest.TestCase):
             verified_lossless_target=verified_lossless_target,
             beets_staging_dir=beets_staging_dir or "/staging",
             slskd_download_dir=slskd_download_dir or "/slskd",
+            processing_dir=processing_dir or "./processing",
         )
         dl_info = DownloadInfo(username=source_username)
 
@@ -406,6 +408,54 @@ class TestDispatchCoreOrchestration(unittest.TestCase):
                 dispatched["db"].download_logs[-1].validation_result or "{}",
             )
             self.assertEqual(audit["processing_cleanup"], receipt)
+
+    def test_audio_corrupt_processing_owner_quarantines_on_its_own_root(self):
+        with tempfile.TemporaryDirectory() as root:
+            processing = os.path.join(root, "private-processing")
+            albums = os.path.join(processing, "albums")
+            incoming = os.path.join(root, "Incoming")
+            os.makedirs(os.path.join(albums, "failed_imports"))
+            os.makedirs(incoming)
+            observed: dict[str, object] = {}
+
+            def post_dispatch(
+                result: DispatchOutcome,
+                db: FakePipelineDB,
+                source: str,
+            ) -> None:
+                del result, db
+                with open(os.path.join(source, "01.flac"), "wb") as handle:
+                    handle.write(b"bad")
+                observed["source"] = source
+
+            dispatched = self._dispatch(
+                candidate_kwargs={"audio_corrupt": True},
+                path_parent=albums,
+                processing_dir=processing,
+                beets_staging_dir=incoming,
+                post_dispatch_fn=post_dispatch,
+            )
+
+            source = observed["source"]
+            assert isinstance(source, str)
+            completed_job = dispatched["db"].get_import_job(1)
+            assert completed_job is not None
+            receipt = (completed_job.result or {})["processing_cleanup"]
+            assert isinstance(receipt, dict)
+            target = receipt["selected_destination_path"]
+            assert isinstance(target, str)
+            self.assertTrue(target.startswith(os.path.join(
+                albums,
+                "failed_imports",
+                "bad_files",
+            )))
+            self.assertFalse(target.startswith(incoming))
+            self.assertFalse(os.path.exists(source))
+            self.assertTrue(os.path.exists(os.path.join(target, "01.flac")))
+            self.assertEqual(
+                os.stat(albums).st_dev,
+                os.stat(target).st_dev,
+            )
 
     def test_successful_import_creates_one_log_row(self):
         r = self._dispatch()

--- a/tests/test_dispatch_outcomes_generated.py
+++ b/tests/test_dispatch_outcomes_generated.py
@@ -298,13 +298,21 @@ def _run_dispatch(
             was_converted=world.was_converted,
         )
 
+    dl_info = DownloadInfo(username=world.source_username)
+
+    root = tempfile.mkdtemp()
+    processing_dir = os.path.join(root, "processing")
+    processing_albums = os.path.join(processing_dir, "albums")
+    incoming = os.path.join(root, "Incoming")
+    os.makedirs(os.path.join(processing_albums, "failed_imports"))
+    os.makedirs(incoming)
+    tmpdir = tempfile.mkdtemp(dir=processing_albums)
     cfg = CratediggerConfig(
         beets_harness_path=_HARNESS,
         pipeline_db_enabled=True,
+        processing_dir=processing_dir,
+        beets_staging_dir=incoming,
     )
-    dl_info = DownloadInfo(username=world.source_username)
-
-    tmpdir = tempfile.mkdtemp()
     try:
         del queued  # retained argument for existing generated call sites
         db = FakePipelineDB()
@@ -454,7 +462,7 @@ def _run_dispatch(
         else:
             finalize_claimed_dispatch(db, claimed, result)
     finally:
-        shutil.rmtree(tmpdir, ignore_errors=True)
+        shutil.rmtree(root, ignore_errors=True)
     return {"db": db, "result": result}
 
 

--- a/tests/test_dispatch_quarantine_root_generated.py
+++ b/tests/test_dispatch_quarantine_root_generated.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+import tempfile
 import unittest
 
 from hypothesis import assume, given
@@ -11,10 +13,17 @@ import tests._hypothesis_profiles  # noqa: F401  (loads the active profile)
 from tests.test_dispatch_core import TestDispatchCoreOrchestration
 
 
-def assert_quarantine_root_selection(*, observed: str | None, staging: str, slskd: str) -> None:
-    """Independent oracle: corrupt automation quarantine belongs on staging."""
-    if observed != staging or observed == slskd:
-        raise AssertionError("corrupt automation quarantine selected slskd instead of staging")
+def assert_quarantine_root_selection(
+    *,
+    observed: str | None,
+    processing_albums: str,
+    staging: str,
+) -> None:
+    """Independent oracle: owned quarantine stays on its processing root."""
+    if observed != processing_albums or observed == staging:
+        raise AssertionError(
+            "owned quarantine escaped its canonical processing root"
+        )
 
 
 class TestDispatchQuarantineRootGenerated(unittest.TestCase):
@@ -22,32 +31,38 @@ class TestDispatchQuarantineRootGenerated(unittest.TestCase):
         staging_name=st.from_regex(r"[a-z]{1,8}", fullmatch=True),
         slskd_name=st.from_regex(r"[a-z]{1,8}", fullmatch=True),
     )
-    def test_real_dispatch_uses_staging_for_distinct_configured_roots(
+    def test_real_dispatch_uses_processing_for_distinct_configured_roots(
         self, staging_name: str, slskd_name: str,
     ) -> None:
-        # Identical roots are discarded, not asserted: the oracle's claim is
-        # "staging was chosen INSTEAD OF slskd", which is unanswerable when
-        # they are the same directory. A bare ``return`` spent the example as
-        # a PASS; ``assume`` marks it invalid so Hypothesis refills the budget
-        # with worlds that actually reach dispatch (#882).
+        # Identical external roots are discarded so the world still proves
+        # Incoming and slskd placement are irrelevant to owner-local cleanup.
         assume(staging_name != slskd_name)
-        staging = f"/configured/{staging_name}"
-        slskd = f"/configured/{slskd_name}"
-        world = TestDispatchCoreOrchestration()._dispatch(
-            candidate_kwargs={"audio_corrupt": True},
-            beets_staging_dir=staging,
-            slskd_download_dir=slskd,
-            finalize=False,
-        )
-        cleanup = world["result"].post_commit_cleanup
-        assert cleanup is not None
-        assert_quarantine_root_selection(
-            observed=cleanup.audio_quarantine_root, staging=staging, slskd=slskd,
-        )
-
-    def test_oracle_rejects_slskd_root(self) -> None:
-        with self.assertRaisesRegex(AssertionError, "slskd"):
+        with tempfile.TemporaryDirectory() as root:
+            processing = os.path.join(root, "processing")
+            processing_albums = os.path.join(processing, "albums")
+            staging = os.path.join(root, staging_name)
+            slskd = os.path.join(root, slskd_name)
+            os.makedirs(processing_albums)
+            world = TestDispatchCoreOrchestration()._dispatch(
+                candidate_kwargs={"audio_corrupt": True},
+                beets_staging_dir=staging,
+                slskd_download_dir=slskd,
+                processing_dir=processing,
+                path_parent=processing_albums,
+                finalize=False,
+            )
+            cleanup = world["result"].post_commit_cleanup
+            assert cleanup is not None
             assert_quarantine_root_selection(
-                observed="/configured/slskd", staging="/configured/staging",
-                slskd="/configured/slskd",
+                observed=cleanup.audio_quarantine_root,
+                processing_albums=processing_albums,
+                staging=staging,
+            )
+
+    def test_oracle_rejects_external_staging_root(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "escaped"):
+            assert_quarantine_root_selection(
+                observed="/configured/staging",
+                processing_albums="/private/processing/albums",
+                staging="/configured/staging",
             )

--- a/tests/test_import_dispatch.py
+++ b/tests/test_import_dispatch.py
@@ -2570,9 +2570,13 @@ class TestDispatchImport(unittest.TestCase):
         from lib.dispatch import dispatch_import_core
         from lib.quality import SpectralAnalysisDetail, SpectralDetail
 
-        staging_root = tempfile.mkdtemp()
-        source = os.path.join(staging_root, "auto-import", "Artist", "Album")
+        root = tempfile.mkdtemp()
+        processing_dir = os.path.join(root, "processing")
+        processing_albums = os.path.join(processing_dir, "albums")
+        staging_root = os.path.join(root, "Incoming")
+        source = os.path.join(processing_albums, "Artist - Album")
         os.makedirs(source)
+        os.makedirs(staging_root)
         with open(os.path.join(source, "track.mp3"), "w", encoding="utf-8") as f:
             f.write("x")
 
@@ -2629,6 +2633,7 @@ class TestDispatchImport(unittest.TestCase):
         cfg = CratediggerConfig(
             beets_harness_path=_HARNESS,
             beets_staging_dir=staging_root,
+            processing_dir=processing_dir,
             pipeline_db_enabled=True,
         )
         try:
@@ -2666,7 +2671,7 @@ class TestDispatchImport(unittest.TestCase):
 
                 finalize_claimed_dispatch(db, claimed, outcome)
         finally:
-            shutil.rmtree(staging_root, ignore_errors=True)
+            shutil.rmtree(root, ignore_errors=True)
 
         self.assertEqual(db.download_logs[0].outcome, "rejected")
         self.assertEqual(db.download_logs[0].beets_scenario,
@@ -2691,8 +2696,10 @@ class TestDispatchImport(unittest.TestCase):
         quarantine = completed_job.result["processing_cleanup"]
         self.assertIsNotNone(quarantine["destination_path"])
         assert quarantine["destination_path"] is not None
-        self.assertIn("duplicate-remove-guard",
-                      quarantine["destination_path"])
+        self.assertTrue(quarantine["destination_path"].startswith(
+            os.path.join(processing_albums, "duplicate-remove-guard"),
+        ))
+        self.assertFalse(quarantine["destination_path"].startswith(staging_root))
         self.assertFalse(os.path.exists(source))
 
     def _assert_world_failure_self_heal(

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -3386,28 +3386,10 @@ class TestHandleValidResultReleaseLock(unittest.TestCase):
         namespaces_used = {ns for ns, _key in db.advisory_lock_calls}
         self.assertNotIn(ADVISORY_LOCK_NAMESPACE_RELEASE, namespaces_used)
 
-    def test_auto_staging_does_not_rewrite_request_lifecycle_path(self):
+    def test_processing_owner_imports_from_its_canonical_path(self):
         from lib import download_validation as validation_mod
-        from lib.pipeline_db import (
-            ADVISORY_LOCK_NAMESPACE_RELEASE,
-            release_id_to_lock_key,
-        )
         from lib.quality import ValidationResult
         from tests.fakes import RecordingDispatchCore
-
-        db = FakePipelineDB()
-        db.seed_request(make_request_row(
-            id=42,
-            mb_release_id=self.MBID,
-            status="downloading",
-            active_download_state={
-                "filetype": "mp3",
-                "enqueued_at": "2026-04-03T12:00:00+00:00",
-                "files": [],
-                "current_path": None,
-            },
-        ))
-
         from tests.helpers import make_ctx_with_fake_db
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -3417,11 +3399,25 @@ class TestHandleValidResultReleaseLock(unittest.TestCase):
             with open(track_path, "w") as fp:
                 fp.write("fake audio")
 
+            db = FakePipelineDB()
+            db.seed_request(make_request_row(
+                id=42,
+                mb_release_id=self.MBID,
+                status="processing",
+                active_automation_import_job_id=99,
+                active_download_state={
+                    "filetype": "mp3",
+                    "enqueued_at": "2026-04-03T12:00:00+00:00",
+                    "files": [],
+                    "current_path": processing_dir,
+                },
+            ))
             cfg = CratediggerConfig(
                 beets_harness_path=_HARNESS,
                 pipeline_db_enabled=True,
                 beets_distance_threshold=0.15,
                 beets_staging_dir=os.path.join(tmpdir, "beets-staging"),
+                beets_tracking_file=os.path.join(tmpdir, "tracking.log"),
             )
             ctx = make_ctx_with_fake_db(db, cfg=cfg)
             entry = GrabListEntry(
@@ -3445,53 +3441,9 @@ class TestHandleValidResultReleaseLock(unittest.TestCase):
                 distance=0.05,
                 scenario="strong_match",
             )
-            move_saw_release_lock = False
-
-            original_advisory_lock = db.advisory_lock
-
-            @contextmanager
-            def tracking_advisory_lock(namespace: int, key: int):
-                nonlocal move_saw_release_lock
-                with original_advisory_lock(namespace, key) as acquired:
-                    if (
-                        acquired
-                        and namespace == ADVISORY_LOCK_NAMESPACE_RELEASE
-                        and key == release_id_to_lock_key(self.MBID)
-                    ):
-                        move_saw_release_lock = True
-                        try:
-                            yield acquired
-                        finally:
-                            move_saw_release_lock = False
-                    else:
-                        yield acquired
-
-            original_move_to = StagedAlbum.move_to
-
-            def checked_move_to(
-                album,
-                dest,
-                *,
-                cancellation_token=None,
-            ):
-                self.assertTrue(move_saw_release_lock)
-                return original_move_to(
-                    album,
-                    dest,
-                    cancellation_token=cancellation_token,
-                )
 
             dispatch = RecordingDispatchCore()
-            with patch.object(
-                db,
-                "advisory_lock",
-                side_effect=tracking_advisory_lock,
-            ), patch.object(
-                StagedAlbum,
-                "move_to",
-                autospec=True,
-                side_effect=checked_move_to,
-            ):
+            with patch.object(StagedAlbum, "move_to") as move_to:
                 outcome = validation_mod._handle_valid_result(
                     entry,
                     bv_result,
@@ -3502,21 +3454,16 @@ class TestHandleValidResultReleaseLock(unittest.TestCase):
 
             assert outcome is not None
             self.assertTrue(outcome.success)
-            staged_path = os.path.join(
-                cfg.beets_staging_dir,
-                "auto-import",
-                "Test Artist",
-                "Test Album [request-42]",
-            )
-            self.assertEqual(staged_album.current_path, staged_path)
-            self.assertTrue(os.path.exists(os.path.join(staged_path, "01 - Track.mp3")))
-            self.assertFalse(os.path.exists(processing_dir))
-            self.assertFalse(move_saw_release_lock)
-            self.assertIsNone(
+            move_to.assert_not_called()
+            self.assertEqual(staged_album.current_path, processing_dir)
+            self.assertTrue(os.path.exists(track_path))
+            self.assertFalse(os.path.exists(cfg.beets_staging_dir))
+            self.assertEqual(
                 db.request(42)["active_download_state"]["current_path"],
+                processing_dir,
             )
             self.assertEqual(len(dispatch.calls), 1)
-            self.assertEqual(dispatch.calls[0].path, staged_path)
+            self.assertEqual(dispatch.calls[0].path, processing_dir)
 
     def test_auto_path_not_blocked_when_processing_dir_is_under_staging_root(self):
         """The duplicate-import guard must not quarantine the source processing dir."""

--- a/tests/test_processing_path_continuity_generated.py
+++ b/tests/test_processing_path_continuity_generated.py
@@ -1,0 +1,254 @@
+"""Generated patrol for processing-owner filesystem path continuity."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from collections.abc import Callable
+
+from hypothesis import example, given
+from hypothesis import strategies as st
+
+import tests._hypothesis_profiles  # noqa: F401
+from lib import download_validation
+from lib.config import CratediggerConfig
+from lib.context import CratediggerContext
+from lib.dispatch import DispatchCoreFn, DispatchOutcome
+from lib.dispatch import core as dispatch_core
+from lib.grab_list import GrabListEntry
+from lib.processing_paths import stage_to_ai_path
+from lib.quality import ValidationResult
+from lib.staged_album import StagedAlbum
+from tests.fakes import FakePipelineDB, RecordingDispatchCore
+from tests.helpers import make_ctx_with_fake_db, make_request_row
+
+HandleFn = Callable[..., DispatchOutcome | None]
+CleanupRootFn = Callable[[str, CratediggerConfig], str]
+_MBID = "11111111-2222-3333-4444-555555555555"
+
+
+def _known_bad_relocate_before_dispatch(
+    album_data: GrabListEntry,
+    bv_result: ValidationResult,
+    staged_album: StagedAlbum,
+    ctx: CratediggerContext,
+    *,
+    dispatch_fn: DispatchCoreFn | None = None,
+) -> DispatchOutcome | None:
+    """Mutant: splits the live folder from its durable owner path."""
+    dest = stage_to_ai_path(
+        artist=album_data.artist,
+        title=album_data.title,
+        staging_dir=ctx.cfg.beets_staging_dir,
+        request_id=album_data.db_request_id,
+        auto_import=True,
+    )
+    staged_album.move_to(dest)
+    return download_validation._handle_valid_result(
+        album_data,
+        bv_result,
+        staged_album,
+        ctx,
+        dispatch_fn=dispatch_fn,
+    )
+
+
+def assert_processing_owner_keeps_one_path(
+    *,
+    file_count: int,
+    processing_depth: int,
+    staging_depth: int,
+    handle_fn: HandleFn,
+) -> None:
+    """The imported folder, durable owner path, and cleanup path stay equal."""
+    with tempfile.TemporaryDirectory() as raw:
+        processing_path = os.path.join(
+            raw,
+            "processing",
+            *(f"level-{index}" for index in range(processing_depth)),
+            "album",
+        )
+        staging_root = os.path.join(
+            raw,
+            "incoming",
+            *(f"level-{index}" for index in range(staging_depth)),
+        )
+        os.makedirs(processing_path)
+        expected_files = {f"{index:02d}.flac" for index in range(file_count)}
+        for name in expected_files:
+            with open(os.path.join(processing_path, name), "wb") as handle:
+                handle.write(name.encode())
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42,
+            mb_release_id=_MBID,
+            status="processing",
+            active_automation_import_job_id=99,
+            active_download_state={
+                "filetype": "flac",
+                "enqueued_at": "2026-07-30T12:00:00+00:00",
+                "files": [],
+                "current_path": processing_path,
+            },
+        ))
+        ctx = make_ctx_with_fake_db(
+            db,
+            cfg=CratediggerConfig(
+                beets_harness_path="/harness",
+                pipeline_db_enabled=True,
+                beets_distance_threshold=0.15,
+                processing_dir=os.path.join(raw, "processing"),
+                beets_staging_dir=staging_root,
+                beets_tracking_file=os.path.join(raw, "tracking.log"),
+            ),
+        )
+        album_data = GrabListEntry(
+            album_id=42,
+            artist="Generated Artist",
+            title="Generated Album",
+            year="2026",
+            files=[],
+            filetype="flac",
+            mb_release_id=_MBID,
+            db_source="request",
+            db_request_id=42,
+            import_folder=processing_path,
+        )
+        staged_album = StagedAlbum.from_entry(
+            album_data,
+            default_path=processing_path,
+        )
+        dispatch = RecordingDispatchCore()
+
+        outcome = handle_fn(
+            album_data,
+            ValidationResult(
+                valid=True,
+                distance=0.05,
+                scenario="strong_match",
+            ),
+            staged_album,
+            ctx,
+            dispatch_fn=dispatch,
+        )
+
+        if outcome is None or not outcome.success:
+            raise AssertionError("processing owner did not reach import dispatch")
+        durable_path = db.request(42)["active_download_state"]["current_path"]
+        dispatched_paths = [call.path for call in dispatch.calls]
+        if durable_path != processing_path:
+            raise AssertionError("processing mutated its immutable path provenance")
+        if staged_album.current_path != processing_path:
+            raise AssertionError("live folder diverged from its durable owner path")
+        if dispatched_paths != [processing_path]:
+            raise AssertionError("Beets was dispatched against a relocated path")
+        if not os.path.isdir(processing_path):
+            raise AssertionError("canonical processing folder was relocated")
+        if set(os.listdir(processing_path)) != expected_files:
+            raise AssertionError("canonical processing manifest changed")
+
+
+def _known_bad_external_cleanup_root(
+    _source_path: str,
+    cfg: CratediggerConfig,
+) -> str:
+    """Mutant: sends owned cleanup back across a configured mount boundary."""
+    return cfg.beets_staging_dir
+
+
+def assert_processing_quarantine_stays_on_owner_filesystem(
+    *,
+    processing_depth: int,
+    staging_depth: int,
+    root_fn: CleanupRootFn,
+) -> None:
+    """Owned quarantine is rooted beside canonical albums, not in Incoming."""
+    with tempfile.TemporaryDirectory() as raw:
+        processing_root = os.path.join(
+            raw,
+            "private",
+            *(f"level-{index}" for index in range(processing_depth)),
+        )
+        albums_root = os.path.join(processing_root, "albums")
+        source_path = os.path.join(albums_root, "candidate")
+        staging_root = os.path.join(
+            raw,
+            "incoming",
+            *(f"level-{index}" for index in range(staging_depth)),
+        )
+        os.makedirs(source_path)
+        os.makedirs(staging_root)
+        cfg = CratediggerConfig(
+            processing_dir=processing_root,
+            beets_staging_dir=staging_root,
+        )
+
+        selected = root_fn(source_path, cfg)
+        if selected != albums_root:
+            raise AssertionError(
+                "processing quarantine crossed out of its owner filesystem"
+            )
+
+
+class TestProcessingPathContinuityGenerated(unittest.TestCase):
+    @given(
+        file_count=st.integers(min_value=1, max_value=5),
+        processing_depth=st.integers(min_value=0, max_value=3),
+        staging_depth=st.integers(min_value=0, max_value=3),
+    )
+    @example(file_count=1, processing_depth=0, staging_depth=3)
+    def test_processing_owner_keeps_one_path_in_every_layout(
+        self,
+        *,
+        file_count: int,
+        processing_depth: int,
+        staging_depth: int,
+    ) -> None:
+        assert_processing_owner_keeps_one_path(
+            file_count=file_count,
+            processing_depth=processing_depth,
+            staging_depth=staging_depth,
+            handle_fn=download_validation._handle_valid_result,
+        )
+
+    def test_checker_rejects_relocation_known_bad_mutant(self) -> None:
+        with self.assertRaisesRegex(
+            AssertionError,
+            "live folder diverged",
+        ):
+            assert_processing_owner_keeps_one_path(
+                file_count=1,
+                processing_depth=1,
+                staging_depth=2,
+                handle_fn=_known_bad_relocate_before_dispatch,
+            )
+
+    @given(
+        processing_depth=st.integers(min_value=0, max_value=3),
+        staging_depth=st.integers(min_value=0, max_value=3),
+    )
+    @example(processing_depth=3, staging_depth=0)
+    def test_owned_quarantine_ignores_every_external_staging_layout(
+        self,
+        *,
+        processing_depth: int,
+        staging_depth: int,
+    ) -> None:
+        assert_processing_quarantine_stays_on_owner_filesystem(
+            processing_depth=processing_depth,
+            staging_depth=staging_depth,
+            root_fn=dispatch_core._processing_quarantine_root,
+        )
+
+    def test_checker_rejects_external_quarantine_known_bad_mutant(self) -> None:
+        with self.assertRaisesRegex(
+            AssertionError,
+            "crossed out",
+        ):
+            assert_processing_quarantine_stays_on_owner_filesystem(
+                processing_depth=1,
+                staging_depth=2,
+                root_fn=_known_bad_external_cleanup_root,
+            )


### PR DESCRIPTION
## Summary

- keep request automation imports on the exact canonical processing-owner path through Beets and terminal cleanup
- keep quarantine for private processing sources on the same filesystem, independent of the configured Incoming mount
- add deterministic and generated lifecycle/path patrols plus the private quarantine tmpfiles contract
- update operator documentation for the new path invariant

## Why

The lifecycle ownership change made the database path immutable but still relocated the live directory to Incoming before dispatch. That created two path truths and made cleanup depend on arbitrary cross-filesystem topology. The invariant is now one path: durable owner path = live source = Beets input = cleanup source.

## Validation

- fresh report-only review: no actionable production correctness findings
- fuzz-profile generated patrol: 37 tests passed
- full development suite: all 6 phases passed
- clean-HEAD final Pyright receipt: pass
- clean-HEAD final full-suite receipt: pass
- module VM: current main and this branch both reach the same pre-existing deploy-hold controlled-start failure; the new tmpfiles path also has an explicit VM ownership/mode assertion
