### PR TITLE
Fix automatic Wrong Matches triage after automation rejection

### DIFF
--- a/scripts/importer.py
+++ b/scripts/importer.py
@@ -1697,6 +1697,12 @@ def process_claimed_job(
                 reason=f"{type(exc).__name__}: {exc}",
                 result=result,
             )
+        _cleanup_committed_wrong_match_rejection(
+            db,
+            job,
+            terminal.download_log_id,
+            outcome,
+        )
         return terminal.job
     if outcome.success:
         if outcome.terminal_outcome is not None:

--- a/tests/test_import_dispatch.py
+++ b/tests/test_import_dispatch.py
@@ -61,6 +61,7 @@ from tests.helpers import (
     RecordingQualityGate,
     claim_next_import_job,
     claim_next_import_preview_job,
+    finalize_claimed_dispatch,
     hermetic_beets_config_defaults,
     make_album_quality_evidence,
     make_ctx_with_fake_db,
@@ -1310,6 +1311,105 @@ class TestAudioCorruptPostCommitQuarantine(unittest.TestCase):
             )
             self.assertNotIn("wrong_match_triage", terminal_audit)
             self.assertEqual(db.request(835)["status"], "unsearchable")
+
+
+class TestAutomationWrongMatchPostCommitTriage(unittest.TestCase):
+    def test_high_distance_rejection_triages_after_owner_terminal_commit(
+        self,
+    ) -> None:
+        from lib.dispatch import (
+            DispatchOutcome,
+            _record_rejection_and_maybe_requeue,
+        )
+        from lib.terminal_outcomes import PendingImportTerminalOutcome
+
+        with tempfile.TemporaryDirectory() as root:
+            processing_albums = os.path.join(root, "processing", "albums")
+            canonical_path = os.path.join(
+                processing_albums,
+                "Stone Sour - Come What(ever) May",
+            )
+            db = FakePipelineDB()
+            db.seed_request(make_request_row(
+                id=42,
+                status="wanted",
+                mb_release_id="stone-sour-release",
+            ))
+            claimed, _candidate, _execution_lease = _claim_dispatch_job(
+                db,
+                path=canonical_path,
+                release_id="stone-sour-release",
+            )
+
+            wrong_matches = os.path.join(processing_albums, "wrong_matches")
+            os.makedirs(wrong_matches)
+            failed_path = os.path.join(
+                wrong_matches,
+                "Stone Sour - Come What(ever) May",
+            )
+            os.rename(canonical_path, failed_path)
+
+            validation = ValidationResult(
+                valid=False,
+                distance=0.1697,
+                scenario="high_distance",
+                detail="distance=0.1697",
+                failed_path=failed_path,
+                soulseek_username="Strudel",
+            )
+            pending = _record_rejection_and_maybe_requeue(
+                db,  # pyright: ignore[reportArgumentType]
+                42,
+                DownloadInfo(filetype="mp3", username="Strudel"),
+                detail=validation.detail,
+                error=None,
+                validation_result=validation.to_json(),
+                requeue=True,
+                import_job_id=claimed.id,
+            )
+            self.assertIsInstance(pending, PendingImportTerminalOutcome)
+            assert isinstance(pending, PendingImportTerminalOutcome)
+            outcome = DispatchOutcome(
+                success=False,
+                message="Rejected: high_distance - distance=0.1697",
+                terminal_outcome=pending,
+                post_commit_wrong_match_scenario="high_distance",
+            )
+            observed: list[tuple[int, int | None, str, str]] = []
+
+            def cleanup_after_commit(
+                db_arg,
+                download_log_id: int,
+                *,
+                ignore_import_job_id: int | None,
+            ) -> None:
+                request = db_arg.request(42)
+                terminal_job = db_arg.get_import_job(claimed.id)
+                assert terminal_job is not None
+                observed.append((
+                    download_log_id,
+                    ignore_import_job_id,
+                    str(request["status"]),
+                    terminal_job.status,
+                ))
+
+            with patch(
+                "lib.wrong_match_cleanup_service.cleanup_wrong_match",
+                side_effect=cleanup_after_commit,
+            ):
+                terminal_job = finalize_claimed_dispatch(db, claimed, outcome)
+
+            assert terminal_job is not None
+            terminal_log = db.download_logs[-1]
+            self.assertEqual(
+                observed,
+                [(terminal_log.id, claimed.id, "wanted", "failed")],
+            )
+            self.assertEqual(
+                terminal_log.candidate_evidence_id,
+                claimed.candidate_evidence_id,
+            )
+            self.assertTrue(os.path.isdir(failed_path))
 
 
 class TestRecordRejectionAndRequeueSeam(unittest.TestCase):

--- a/tests/test_wrong_match_post_commit_generated.py
+++ b/tests/test_wrong_match_post_commit_generated.py
@@ -1,0 +1,228 @@
+"""Generated patrol for automation Wrong Matches post-commit triage."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from hypothesis import example, given
+from hypothesis import strategies as st
+
+import tests._hypothesis_profiles  # noqa: F401
+from lib.dispatch import (
+    DispatchOutcome,
+    _record_rejection_and_maybe_requeue,
+)
+from lib.import_execution import ExecutionLeaseSnapshot, ProcessIdentity
+from lib.quality import ActiveDownloadState, DownloadInfo, ValidationResult
+from lib.quality_evidence import snapshot_audio_files
+from lib.terminal_outcomes import PendingImportTerminalOutcome
+from lib.wrong_match_policy import WRONG_MATCH_EXCLUDED_REJECTION_SCENARIOS
+from tests.fakes import FakePipelineDB
+from tests.helpers import (
+    claim_next_import_job,
+    claim_next_import_preview_job,
+    finalize_claimed_dispatch,
+    handoff_automation_owner,
+    make_album_quality_evidence,
+    make_request_row,
+)
+
+_REQUEST_ID = 42
+_RELEASE_ID = "generated-wrong-match-release"
+_CANDIDATE_SCENARIOS = (
+    "high_distance",
+    "strong_mismatch",
+    "downgrade",
+    "transcode_downgrade",
+)
+_SCENARIOS = tuple(sorted(
+    {*_CANDIDATE_SCENARIOS, *WRONG_MATCH_EXCLUDED_REJECTION_SCENARIOS},
+))
+
+
+def assert_wrong_match_cleanup_reaches_post_commit(
+    *,
+    scenario: str,
+    cleanup_calls: list[tuple[str, str]],
+) -> None:
+    """Candidate rejects clean once, after request and job are terminal."""
+    expected_calls = (
+        [("wanted", "failed")]
+        if scenario not in WRONG_MATCH_EXCLUDED_REJECTION_SCENARIOS
+        else []
+    )
+    if cleanup_calls != expected_calls:
+        raise AssertionError(
+            "automation rejection bypassed post-commit Wrong Matches triage: "
+            f"scenario={scenario!r} calls={cleanup_calls!r}"
+        )
+
+
+def _execution_lease(lane: str) -> ExecutionLeaseSnapshot:
+    return ExecutionLeaseSnapshot(
+        host_boot_id="generated-wrong-match-boot",
+        invocation_id=f"generated-wrong-match-{lane}",
+        systemd_unit=f"cratedigger-{lane}.service",
+        worker=ProcessIdentity(
+            pid=1001 if lane == "preview" else 1002,
+            start_ticks=2001 if lane == "preview" else 2002,
+        ),
+    )
+
+
+def _run_automation_rejection(
+    *,
+    scenario: str,
+    file_count: int,
+) -> list[tuple[str, str]]:
+    with tempfile.TemporaryDirectory() as root:
+        processing_albums = os.path.join(root, "processing", "albums")
+        canonical_path = os.path.join(processing_albums, "candidate")
+        os.makedirs(canonical_path)
+        for index in range(file_count):
+            with open(
+                os.path.join(canonical_path, f"{index:02d}.mp3"),
+                "wb",
+            ) as handle:
+                handle.write(f"track-{index}".encode())
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=_REQUEST_ID,
+            status="wanted",
+            mb_release_id=_RELEASE_ID,
+        ))
+        owner = handoff_automation_owner(
+            db,
+            _REQUEST_ID,
+            state=ActiveDownloadState(
+                filetype="mp3",
+                enqueued_at="2026-07-30T13:13:58+00:00",
+                files=[],
+                current_path=canonical_path,
+            ).to_json(),
+            canonical_path=canonical_path,
+        )
+        preview_lease = _execution_lease("preview")
+        preview_job = claim_next_import_preview_job(
+            db,
+            worker_id="generated-preview",
+            execution_lease=preview_lease,
+        )
+        assert preview_job is not None and preview_job.id == owner.id
+
+        evidence = make_album_quality_evidence(
+            mb_release_id=_RELEASE_ID,
+            source_path=canonical_path,
+            files=snapshot_audio_files(canonical_path),
+        )
+        db.upsert_album_quality_evidence(evidence)
+        persisted = db.find_album_quality_evidence(
+            mb_release_id=_RELEASE_ID,
+            snapshot_fingerprint=evidence.snapshot_fingerprint,
+        )
+        assert persisted is not None and persisted.id is not None
+        assert db.set_import_job_candidate_evidence(
+            owner.id,
+            persisted.id,
+            expected_execution_lease=preview_lease,
+        )
+        assert db.mark_import_job_preview_importable(
+            owner.id,
+            preview_result={"ready": True},
+            expected_execution_lease=preview_lease,
+        ) is not None
+
+        import_lease = _execution_lease("import")
+        claimed = claim_next_import_job(
+            db,
+            worker_id="generated-import",
+            execution_lease=import_lease,
+        )
+        assert claimed is not None and claimed.id == owner.id
+
+        wrong_matches = os.path.join(processing_albums, "wrong_matches")
+        os.makedirs(wrong_matches)
+        failed_path = os.path.join(wrong_matches, "candidate")
+        os.rename(canonical_path, failed_path)
+
+        validation = ValidationResult(
+            valid=False,
+            distance=0.1697,
+            scenario=scenario,
+            detail=f"generated {scenario}",
+            failed_path=failed_path,
+        )
+        pending = _record_rejection_and_maybe_requeue(
+            db,  # pyright: ignore[reportArgumentType]
+            _REQUEST_ID,
+            DownloadInfo(filetype="mp3", username="generated-peer"),
+            detail=validation.detail,
+            error=None,
+            validation_result=validation.to_json(),
+            requeue=True,
+            import_job_id=claimed.id,
+        )
+        assert isinstance(pending, PendingImportTerminalOutcome)
+        outcome = DispatchOutcome(
+            success=False,
+            message=f"Rejected: {scenario}",
+            terminal_outcome=pending,
+            post_commit_wrong_match_scenario=scenario,
+        )
+        calls: list[tuple[str, str]] = []
+
+        def observe_cleanup(
+            db_arg,
+            _download_log_id: int,
+            *,
+            ignore_import_job_id: int | None,
+        ) -> None:
+            assert ignore_import_job_id == claimed.id
+            terminal_job = db_arg.get_import_job(claimed.id)
+            assert terminal_job is not None
+            calls.append((
+                str(db_arg.request(_REQUEST_ID)["status"]),
+                terminal_job.status,
+            ))
+
+        with patch(
+            "lib.wrong_match_cleanup_service.cleanup_wrong_match",
+            side_effect=observe_cleanup,
+        ):
+            finalize_claimed_dispatch(db, claimed, outcome)
+        return calls
+
+
+class TestWrongMatchPostCommitGenerated(unittest.TestCase):
+    @given(
+        scenario=st.sampled_from(_SCENARIOS),
+        file_count=st.integers(min_value=1, max_value=4),
+    )
+    @example(scenario="high_distance", file_count=14)
+    def test_every_automation_rejection_reaches_eligible_post_commit_triage(
+        self,
+        *,
+        scenario: str,
+        file_count: int,
+    ) -> None:
+        assert_wrong_match_cleanup_reaches_post_commit(
+            scenario=scenario,
+            cleanup_calls=_run_automation_rejection(
+                scenario=scenario,
+                file_count=file_count,
+            ),
+        )
+
+    def test_checker_rejects_known_bad_automation_early_return(self) -> None:
+        with self.assertRaisesRegex(
+            AssertionError,
+            "bypassed post-commit",
+        ):
+            assert_wrong_match_cleanup_reaches_post_commit(
+                scenario="high_distance",
+                cleanup_calls=[],
+            )


### PR DESCRIPTION
## Summary

- restore the established post-commit Wrong Matches cleanup continuation in the exact processing-owner terminal path
- preserve atomic owner cleanup and terminal persistence before any destructive triage work
- add a Stone Sour regression pin plus generated eligible/excluded-scenario coverage and a known-bad early-return self-test

## Root cause

The exact processing-owner path added by #951 committed the automation terminal bundle and returned immediately. That bypassed `_cleanup_committed_wrong_match_rejection`, so eligible rejected sources remained visible in Wrong Matches without a triage receipt.

## Validation

- focused importer, post-rejection triage, and generated tests: 110 passed
- full development gate: 6 phases passed
- fresh independent diff review: no findings
- receipt-backed whole-tree Pyright: pass
- receipt-backed complete suite: pass
