### PR TITLE
Make ID/URL paste discoverable and harden reference parsing

### DIFF
--- a/docs/webui-primer.md
+++ b/docs/webui-primer.md
@@ -116,7 +116,9 @@ operation.
   row, the selected source authors the exact expansion/action identity; the UI
   never substitutes the counterpart pressing or copies its ownership/request
   state onto the selected identity. The hint line states this action contract.
-- **Search** — debounced text search, returns artists (or releases in album mode)
+- **Search** — debounced text search returns artists (or releases in album
+  mode); the explicit **ID/URL** mode accepts canonical MusicBrainz and Discogs
+  release, release-group, and master URLs as well as bare release identifiers.
 - **Unified artist page (#575 PR4)** — one scrolling page (the old
   Discography / Analysis / Library / Compare sub-tabs are gone) with the simple
   top-level model: **In library / In flight / Missing / Other releases**.

--- a/tests/test_browse_reference_generated.py
+++ b/tests/test_browse_reference_generated.py
@@ -1,0 +1,143 @@
+"""Generated hostile-input contracts for the real browser reference parser."""
+
+from __future__ import annotations
+
+import json
+import string
+import subprocess
+import unittest
+from dataclasses import dataclass
+from pathlib import Path
+
+from hypothesis import example, given
+from hypothesis import strategies as st
+
+import tests._hypothesis_profiles  # noqa: F401
+
+ROOT = Path(__file__).resolve().parents[1]
+MB_RELEASE_ID = "c1f6a2c9-bcba-4e69-96f5-233c85b2830a"
+
+
+@dataclass(frozen=True)
+class ReferenceWorld:
+    pasted: str
+    expected: dict[str, str] | None
+
+
+def _parse_with_real_javascript(pasted: str) -> object:
+    script = """
+import { parsePastedId } from './web/js/util.js';
+let input = '';
+for await (const chunk of process.stdin) input += chunk;
+process.stdout.write(JSON.stringify(parsePastedId(JSON.parse(input))));
+"""
+    result = subprocess.run(
+        ["node", "--input-type=module", "--eval", script],
+        cwd=ROOT,
+        input=json.dumps(pasted),
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+@st.composite
+def canonical_reference_worlds(draw: st.DrawFn) -> ReferenceWorld:
+    family = draw(st.sampled_from(("mb", "discogs")))
+    as_url = draw(st.booleans())
+    if family == "mb":
+        release_id = str(draw(st.uuids()))
+        if not as_url:
+            return ReferenceWorld(
+                pasted=release_id.upper() if draw(st.booleans()) else release_id,
+                expected={"family": "mb", "kind": "unknown", "id": release_id},
+            )
+        kind = draw(st.sampled_from(("release", "release-group")))
+        host = "musicbrainz.org"
+        path = f"/{kind}/{release_id}"
+    else:
+        release_id = str(draw(st.integers(min_value=1, max_value=999_999_999_999)))
+        if not as_url:
+            return ReferenceWorld(
+                pasted=release_id,
+                expected={
+                    "family": "discogs", "kind": "unknown", "id": release_id,
+                },
+            )
+        kind = draw(st.sampled_from(("release", "master")))
+        host = draw(st.sampled_from(("discogs.com", "www.discogs.com")))
+        slug = draw(
+            st.text(
+                alphabet=string.ascii_letters + string.digits + "-",
+                min_size=0,
+                max_size=30,
+            )
+        )
+        path = f"/{kind}/{release_id}" + (f"-{slug}" if slug else "")
+
+    scheme = draw(st.sampled_from(("https://", "http://", "")))
+    suffix = draw(st.sampled_from(("", "/", "?utm_source=mobile", "#images")))
+    return ReferenceWorld(
+        pasted=f"{scheme}{host}{path}{suffix}",
+        expected={"family": family, "kind": kind, "id": release_id},
+    )
+
+
+@st.composite
+def hostile_reference_worlds(draw: st.DrawFn) -> ReferenceWorld:
+    family = draw(st.sampled_from(("mb", "discogs")))
+    if family == "mb":
+        host = "musicbrainz.org"
+        path = f"/release/{draw(st.uuids())}"
+    else:
+        host = draw(st.sampled_from(("discogs.com", "www.discogs.com")))
+        release_id = draw(st.integers(min_value=1, max_value=999_999_999_999))
+        path = f"/release/{release_id}"
+
+    variant = draw(st.sampled_from((
+        "attacker_path",
+        "scheme",
+        "host_suffix",
+        "userinfo",
+        "port",
+        "extra_path",
+        "control",
+        "oversized",
+    )))
+    if variant == "attacker_path":
+        pasted = f"https://evil.example/{host}{path}"
+    elif variant == "scheme":
+        pasted = f"{draw(st.sampled_from(('javascript', 'ftp', 'file')))}://{host}{path}"
+    elif variant == "host_suffix":
+        pasted = f"https://{host}.evil.example{path}"
+    elif variant == "userinfo":
+        pasted = f"https://:x@{host}{path}"
+    elif variant == "port":
+        pasted = f"https://{host}:444{path}"
+    elif variant == "extra_path":
+        pasted = f"https://{host}{path}/extra"
+    elif variant == "control":
+        pasted = f"https://{host}\n{path}"
+    else:
+        pasted = f"https://{host}{path}?{'x' * 2048}"
+    return ReferenceWorld(pasted=pasted, expected=None)
+
+
+class TestBrowseReferenceParserGenerated(unittest.TestCase):
+    @given(st.one_of(canonical_reference_worlds(), hostile_reference_worlds()))
+    @example(ReferenceWorld(
+        pasted=(
+            "https://evil.example/musicbrainz.org/release/"
+            + MB_RELEASE_ID
+        ),
+        expected=None,
+    ))
+    def test_only_exact_canonical_references_produce_normalized_ids(
+        self, world: ReferenceWorld,
+    ) -> None:
+        self.assertEqual(_parse_with_real_javascript(world.pasted), world.expected)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_browse_route_generated.py
+++ b/tests/test_browse_route_generated.py
@@ -4,12 +4,13 @@ from __future__ import annotations
 
 import email.message
 import json
+import string
 import unittest
 import uuid
 from unittest.mock import MagicMock, patch
 from urllib.error import HTTPError, URLError
 
-from hypothesis import given
+from hypothesis import example, given
 from hypothesis import strategies as st
 
 import tests._hypothesis_profiles  # noqa: F401 - registers active profile
@@ -195,6 +196,7 @@ class TestBrowseResolverMusicBrainzIdGenerated(unittest.TestCase):
             assert_mb_resolver_adapter_boundary(handler, adapter, accepted=False)
 
     @given(raw_id=st.text(alphabet="/?&#%=", min_size=1, max_size=80))
+    @example(raw_id="x" * 2049)
     def test_invalid_mb_identifier_never_reaches_the_adapter(self, raw_id: str) -> None:
         handler = _RecordingHandler()
         with patch("web.server.mb_api") as mock_mb:
@@ -236,6 +238,73 @@ class TestBrowseResolverMusicBrainzIdGenerated(unittest.TestCase):
                     "id": [noncanonical], "source": ["mb"], "kind": ["release"],
                 })
             assert_mb_resolver_adapter_boundary(handler, mock_mb, accepted=False)
+
+
+_INVALID_DISCOGS_IDS = st.one_of(
+    st.just("0"),
+    st.integers(min_value=1, max_value=99_999_999_999).map(
+        lambda value: f"0{value}"
+    ),
+    st.integers(min_value=1_000_000_000_000, max_value=10**20).map(str),
+    st.tuples(
+        st.text(alphabet=string.digits, min_size=0, max_size=11),
+        st.sampled_from(tuple(string.ascii_letters + ".+-_/")),
+    ).map(lambda parts: "".join(parts)),
+    st.text(alphabet="١٢٣٤٥٦７８９", min_size=1, max_size=12),
+)
+
+
+class TestBrowseResolverInputBoundaryGenerated(unittest.TestCase):
+    @given(raw_id=_INVALID_DISCOGS_IDS)
+    def test_noncanonical_discogs_id_never_reaches_the_adapter(
+        self, raw_id: str,
+    ) -> None:
+        handler = _RecordingHandler()
+        with patch("web.routes.browse.discogs_api") as mock_dg:
+            get_browse_resolve(handler, {
+                "id": [raw_id], "source": ["discogs"], "kind": ["release"],
+            })
+
+        self.assertEqual(handler.status, 400)
+        self.assertEqual(
+            handler.data,
+            {"error": "Invalid Discogs ID (must be 1-12 canonical digits)"},
+        )
+        self.assertEqual(mock_dg.require_mirror_configured.call_count, 0)
+        self.assertEqual(mock_dg.get_release.call_count, 0)
+        self.assertEqual(mock_dg.get_master_releases.call_count, 0)
+
+    @given(value=st.uuids())
+    def test_musicbrainz_master_kind_never_reaches_the_adapter(
+        self, value: uuid.UUID,
+    ) -> None:
+        handler = _RecordingHandler()
+        with patch("web.server.mb_api") as mock_mb:
+            get_browse_resolve(handler, {
+                "id": [str(value)], "source": ["mb"], "kind": ["master"],
+            })
+
+        self.assertEqual(handler.status, 400)
+        self.assertEqual(mock_mb.get_release.call_count, 0)
+        self.assertEqual(mock_mb.get_release_group.call_count, 0)
+
+    @given(
+        raw_id=st.integers(min_value=1, max_value=999_999_999_999).map(str),
+    )
+    def test_discogs_release_group_kind_never_reaches_the_adapter(
+        self, raw_id: str,
+    ) -> None:
+        handler = _RecordingHandler()
+        with patch("web.routes.browse.discogs_api") as mock_dg:
+            get_browse_resolve(handler, {
+                "id": [raw_id], "source": ["discogs"],
+                "kind": ["release-group"],
+            })
+
+        self.assertEqual(handler.status, 400)
+        self.assertEqual(mock_dg.require_mirror_configured.call_count, 0)
+        self.assertEqual(mock_dg.get_release.call_count, 0)
+        self.assertEqual(mock_dg.get_master_releases.call_count, 0)
 
 
 def assert_discogs_target_identity(

--- a/tests/test_js_util.mjs
+++ b/tests/test_js_util.mjs
@@ -711,6 +711,11 @@ assertParse(
   { family: 'discogs', kind: 'release', id: '32457180' },
   'Discogs URL with querystring',
 );
+assertParse(
+  'https://www.discogs.com/release/32457180-Various-Rock-Christmas?utm_source=mobile#images',
+  { family: 'discogs', kind: 'release', id: '32457180' },
+  'phone-copied Discogs URL with slug, tracking query, and fragment',
+);
 
 // Whitespace handling
 assertParse(
@@ -742,6 +747,76 @@ assertParse(
   '32-char UUID without dashes rejected',
 );
 assertParse('1234567890123', null, '13-digit numeric rejected (out of range)');
+assertParse('0', null, 'zero is not a Discogs release identity');
+assertParse('000123', null, 'leading-zero Discogs identity rejected');
+assertParse(
+  'https://www.discogs.com/release/000123-Slug',
+  null,
+  'leading-zero Discogs URL identity rejected',
+);
+
+// Hostile URL boundaries: a trusted hostname must be the exact parsed origin,
+// never a path fragment, credential, suffix, or non-HTTP scheme.
+assertParse(
+  'https://evil.example/musicbrainz.org/release/c1f6a2c9-bcba-4e69-96f5-233c85b2830a',
+  null,
+  'MusicBrainz hostname embedded in an attacker path rejected',
+);
+assertParse(
+  'https://evil.example/discogs.com/release/32457180',
+  null,
+  'Discogs hostname embedded in an attacker path rejected',
+);
+assertParse(
+  'javascript://musicbrainz.org/release/c1f6a2c9-bcba-4e69-96f5-233c85b2830a',
+  null,
+  'javascript scheme rejected',
+);
+assertParse(
+  'ftp://www.discogs.com/release/32457180',
+  null,
+  'non-HTTP URL scheme rejected',
+);
+assertParse(
+  'https://musicbrainz.org.evil.example/release/c1f6a2c9-bcba-4e69-96f5-233c85b2830a',
+  null,
+  'trusted-host suffix rejected',
+);
+assertParse(
+  'https://musicbrainz.org@evil.example/release/c1f6a2c9-bcba-4e69-96f5-233c85b2830a',
+  null,
+  'trusted hostname in URL credentials rejected',
+);
+assertParse(
+  'https://:x@musicbrainz.org/release/c1f6a2c9-bcba-4e69-96f5-233c85b2830a',
+  null,
+  'userinfo rejected even when the parsed host is trusted',
+);
+assertParse(
+  'https://musicbrainz.org:444/release/c1f6a2c9-bcba-4e69-96f5-233c85b2830a',
+  null,
+  'non-canonical port rejected',
+);
+assertParse(
+  'https://musicbrainz.org/release/c1f6a2c9-bcba-4e69-96f5-233c85b2830a/extra',
+  null,
+  'extra MusicBrainz path components rejected',
+);
+assertParse(
+  'https://www.discogs.com/release/32457180/extra',
+  null,
+  'extra Discogs path components rejected',
+);
+assertParse(
+  'https://musicbrainz.org/release/------------------------------------',
+  null,
+  'malformed 36-character UUID rejected before the resolver',
+);
+assertParse(
+  `https://musicbrainz.org/release/c1f6a2c9-bcba-4e69-96f5-233c85b2830a?${'x'.repeat(2048)}`,
+  null,
+  'oversized pasted input rejected before URL parsing',
+);
 
 // Non-canonical hosts (deferred per Scope Boundaries)
 assertParse(

--- a/tests/web/test_routes_browse.py
+++ b/tests/web/test_routes_browse.py
@@ -1488,6 +1488,31 @@ class TestSearchByIdResolveContract(_FakeDbWebServerCase):
         # artists[0].id == 194 → VA
         self.assertTrue(data["is_va"])
 
+    def test_invalid_discogs_id_is_rejected_before_mirror_lookup(self):
+        for raw_id in (
+            "0",
+            "000123",
+            "1234567890123",
+            "-1",
+            "12.3",
+            "%D9%A1%D9%A2%D9%A3",
+        ):
+            with self.subTest(raw_id=raw_id), patch(
+                "web.routes.browse.discogs_api"
+            ) as mock_dg:
+                status, data = self._get(
+                    f"/api/browse/resolve?source=discogs&id={raw_id}&kind=release"
+                )
+
+            self.assertEqual(status, 400)
+            self.assertEqual(
+                data,
+                {"error": "Invalid Discogs ID (must be 1-12 canonical digits)"},
+            )
+            self.assertEqual(mock_dg.require_mirror_configured.call_count, 0)
+            self.assertEqual(mock_dg.get_release.call_count, 0)
+            self.assertEqual(mock_dg.get_master_releases.call_count, 0)
+
     def test_discogs_master_resolved(self):
         """Discogs master ID → group shape, no leaf."""
         with patch("web.routes.browse.discogs_api") as mock_dg:
@@ -1650,9 +1675,52 @@ class TestSearchByIdResolveContract(_FakeDbWebServerCase):
         self.assertEqual(status, 400)
 
     def test_invalid_kind(self):
-        status, _data = self._get(
-            f"/api/browse/resolve?source=mb&id={self.MB_RELEASE_ID}&kind=garbage")
+        raw_kind = "%3Cscript%3Eprivate-input%3C%2Fscript%3E"
+        status, data = self._get(
+            f"/api/browse/resolve?source=mb&id={self.MB_RELEASE_ID}&kind={raw_kind}")
         self.assertEqual(status, 400)
+        self.assertEqual(data, {"error": "Invalid kind for source"})
+        self.assertNotIn("private-input", str(data))
+
+    def test_source_incompatible_kind_is_rejected_before_lookup(self):
+        cases = (
+            ("mb", self.MB_RELEASE_ID, "master"),
+            ("discogs", "32457180", "release-group"),
+        )
+        for source, raw_id, kind in cases:
+            with self.subTest(source=source, kind=kind), \
+                    patch("web.server.mb_api") as mock_mb, \
+                    patch("web.routes.browse.discogs_api") as mock_dg:
+                status, data = self._get(
+                    f"/api/browse/resolve?source={source}&id={raw_id}&kind={kind}"
+                )
+
+            self.assertEqual(status, 400)
+            self.assertEqual(
+                data,
+                {"error": "Invalid kind for source"},
+            )
+            self.assertEqual(mock_mb.get_release.call_count, 0)
+            self.assertEqual(mock_mb.get_release_group.call_count, 0)
+            self.assertEqual(mock_dg.require_mirror_configured.call_count, 0)
+            self.assertEqual(mock_dg.get_release.call_count, 0)
+            self.assertEqual(mock_dg.get_master_releases.call_count, 0)
+
+    def test_resolver_transport_failure_does_not_leak_adapter_detail(self):
+        raw_reason = "private mirror address and TLS failure"
+        uncached_id = "22222222-2222-2222-2222-222222222222"
+        with patch("web.server.mb_api") as mock_mb:
+            mock_mb.get_release.side_effect = URLError(raw_reason)
+            status, data = self._get(
+                f"/api/browse/resolve?source=mb&id={uncached_id}&kind=release"
+            )
+
+        self.assertEqual(status, 502)
+        self.assertEqual(data, {
+            "error": "Resolver upstream unavailable, retry",
+            "retryable": True,
+        })
+        self.assertNotIn(raw_reason, str(data))
 
 
 class TestLibraryArtistContract(unittest.TestCase):

--- a/tests/web/test_server_endpoints.py
+++ b/tests/web/test_server_endpoints.py
@@ -303,6 +303,14 @@ class TestServerEndpoints(_FakeDbWebServerCase):
             self.assertEqual(resp.status, 200)
             self.assertIn("text/html", resp.headers.get("Content-Type", ""))
 
+    def test_index_names_the_existing_id_and_url_search_mode(self):
+        body = self._current_index_bytes()
+
+        self.assertIn(
+            b'id="search-type-id" onclick="setSearchType(\'id\')">ID/URL</button>',
+            body,
+        )
+
     def _current_index_bytes(self) -> bytes:
         request = Request(
             f"{self.base}/",

--- a/web/index.html
+++ b/web/index.html
@@ -591,7 +591,7 @@
       <button class="p-btn active-status" id="search-type-artist" onclick="setSearchType('artist')">Artist</button>
       <button class="p-btn" id="search-type-release" onclick="setSearchType('release')">Album</button>
       <button class="p-btn" id="search-type-label" onclick="setSearchType('label')">Label</button>
-      <button class="p-btn" id="search-type-id" onclick="setSearchType('id')">ID</button>
+      <button class="p-btn" id="search-type-id" onclick="setSearchType('id')">ID/URL</button>
     </div>
     <div class="browse-source-toggle">
       <span class="source-label">Source</span>

--- a/web/js/util.js
+++ b/web/js/util.js
@@ -378,38 +378,66 @@ export function consoleEmphasis(row) {
 export function parsePastedId(text) {
   if (typeof text !== 'string') return null;
   const trimmed = text.trim();
-  if (!trimmed) return null;
-
-  // Canonical URL forms — the URL path tells us the type, so the resolver
-  // doesn't need to probe both endpoints. release-group must be checked
-  // before release because the prefix matters.
-  const mbRgRe = /(?:^|\/)musicbrainz\.org\/release-group\/([0-9a-f-]{36})(?:[/?#]|$)/i;
-  const mbReleaseRe = /(?:^|\/)musicbrainz\.org\/release\/([0-9a-f-]{36})(?:[/?#]|$)/i;
-  const discogsMasterRe = /(?:^|\/)(?:www\.)?discogs\.com\/master\/(\d{1,12})(?:[-/?#]|$)/i;
-  const discogsReleaseRe = /(?:^|\/)(?:www\.)?discogs\.com\/release\/(\d{1,12})(?:[-/?#]|$)/i;
-
-  let m;
-  if ((m = trimmed.match(mbRgRe))) {
-    return { family: 'mb', kind: 'release-group', id: m[1].toLowerCase() };
-  }
-  if ((m = trimmed.match(mbReleaseRe))) {
-    return { family: 'mb', kind: 'release', id: m[1].toLowerCase() };
-  }
-  if ((m = trimmed.match(discogsMasterRe))) {
-    return { family: 'discogs', kind: 'master', id: m[1] };
-  }
-  if ((m = trimmed.match(discogsReleaseRe))) {
-    return { family: 'discogs', kind: 'release', id: m[1] };
+  // Keep parsing work bounded and reject controls that WHATWG URL parsing
+  // would otherwise silently strip. The pasted string is hostile input: its
+  // hostname is evidence only after URL has parsed the complete authority.
+  if (!trimmed || trimmed.length > 2048 || /[\u0000-\u001f\u007f]/.test(trimmed)) {
+    return null;
   }
 
   // Bare IDs — kind unknown, resolver disambiguates server-side.
   const bareUuidRe = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-  const bareDigitsRe = /^\d{1,12}$/;
+  const bareDigitsRe = /^[1-9][0-9]{0,11}$/;
   if (bareUuidRe.test(trimmed)) {
     return { family: 'mb', kind: 'unknown', id: trimmed.toLowerCase() };
   }
   if (bareDigitsRe.test(trimmed)) {
     return { family: 'discogs', kind: 'unknown', id: trimmed };
+  }
+
+  // Preserve the documented scheme-less canonical forms without allowing an
+  // arbitrary prefix to hide the actual authority.
+  const schemeLessCanonical = /^(?:musicbrainz\.org|(?:www\.)?discogs\.com)\//i;
+  const candidate = schemeLessCanonical.test(trimmed)
+    ? `https://${trimmed}`
+    : trimmed;
+  let url;
+  try {
+    url = new URL(candidate);
+  } catch (_e) {
+    return null;
+  }
+  // For credential-bearing URLs, href has userinfo between "//" and the host
+  // while origin does not. Requiring the normalized href to begin at its own
+  // origin rejects that authority confusion without inspecting secret values.
+  const hasCredentialFreeAuthority = url.href.startsWith(`${url.origin}/`);
+  if ((url.protocol !== 'https:' && url.protocol !== 'http:')
+      || !hasCredentialFreeAuthority || url.port) {
+    return null;
+  }
+
+  const host = url.hostname.toLowerCase();
+  if (host === 'musicbrainz.org') {
+    const match = url.pathname.match(
+      /^\/(release|release-group)\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\/?$/i,
+    );
+    if (!match) return null;
+    return {
+      family: 'mb',
+      kind: /** @type {'release'|'release-group'} */ (match[1].toLowerCase()),
+      id: match[2].toLowerCase(),
+    };
+  }
+  if (host === 'discogs.com' || host === 'www.discogs.com') {
+    const match = url.pathname.match(
+      /^\/(release|master)\/([1-9][0-9]{0,11})(?:-[^/]+)?\/?$/i,
+    );
+    if (!match) return null;
+    return {
+      family: 'discogs',
+      kind: /** @type {'release'|'master'} */ (match[1].toLowerCase()),
+      id: match[2],
+    };
   }
   return null;
 }

--- a/web/routes/browse.py
+++ b/web/routes/browse.py
@@ -121,7 +121,7 @@ ArtistPipelineKey = tuple[str, str, str]
 def _is_canonical_mbid(value: str) -> bool:
     """Whether a resolver-supplied MusicBrainz ID has canonical UUID form."""
     try:
-        return str(uuid.UUID(value)) == value
+        return len(value) == 36 and str(uuid.UUID(value)) == value
     except ValueError:
         return False
 
@@ -844,7 +844,20 @@ def get_artist_compare(h: RouteHandler, params: dict[str, list[str]]) -> None:
 
 # ── Search-by-ID resolver ────────────────────────────────────────────
 
-_RESOLVE_VALID_KINDS = {"release", "release-group", "master", "unknown"}
+_RESOLVE_VALID_KINDS_BY_SOURCE = {
+    "mb": frozenset(("release", "release-group", "unknown")),
+    "discogs": frozenset(("release", "master", "unknown")),
+}
+
+
+def _is_canonical_discogs_id(value: str) -> bool:
+    """Whether a resolver-supplied Discogs ID has one canonical spelling."""
+    return (
+        value.isascii()
+        and value.isdigit()
+        and 1 <= len(value) <= 12
+        and value[0] != "0"
+    )
 
 
 def _resolve_mb(raw_id: str, kind: str) -> dict[str, object]:
@@ -954,19 +967,21 @@ def get_browse_resolve(h: RouteHandler, params: dict[str, list[str]]) -> None:
     if not raw_id:
         h._error("Missing 'id' parameter")
         return
-    if source not in ("mb", "discogs"):
+    valid_kinds = _RESOLVE_VALID_KINDS_BY_SOURCE.get(source)
+    if valid_kinds is None:
         h._error("Missing or invalid 'source' (must be 'mb' or 'discogs')")
         return
-    if kind not in _RESOLVE_VALID_KINDS:
-        h._error(f"Invalid 'kind' (must be one of {sorted(_RESOLVE_VALID_KINDS)})")
+    if kind not in valid_kinds:
+        h._error("Invalid kind for source")
         return
     if source == "mb" and not _is_canonical_mbid(raw_id):
         h._error("Invalid MusicBrainz ID (must be a canonical UUID)")
         return
-    # Discogs IDs must be all-digit. Frontend parsePastedId already enforces
-    # this, but defense-in-depth so the resolver never hits int() on garbage.
-    if source == "discogs" and not raw_id.isdigit():
-        h._error("Invalid Discogs ID (must be numeric)")
+    # The browser parser is convenience, never authority. Require a positive,
+    # bounded canonical ASCII spelling before the cache or mirror boundary so
+    # zero/leading-zero aliases and arbitrary-size integers cannot fan out.
+    if source == "discogs" and not _is_canonical_discogs_id(raw_id):
+        h._error("Invalid Discogs ID (must be 1-12 canonical digits)")
         return
     if source == "discogs":
         discogs_api.require_mirror_configured()
@@ -988,8 +1003,11 @@ def get_browse_resolve(h: RouteHandler, params: dict[str, list[str]]) -> None:
         else:
             h._error(f"upstream_error: HTTP {e.code}", 502)
         return
-    except urllib.error.URLError as e:
-        h._error(f"upstream_unreachable: {e}", 502)
+    except urllib.error.URLError:
+        h._json({
+            "error": "Resolver upstream unavailable, retry",
+            "retryable": True,
+        }, 502)
         return
 
     h._json(result)


### PR DESCRIPTION
## Summary

- rename the existing explicit `ID` search mode to `ID/URL`, making the already-supported paste flow discoverable on phones
- replace substring matching with bounded WHATWG URL parsing, exact trusted hosts, canonical identity paths, and strict bare-ID forms
- independently enforce source/kind compatibility and bounded canonical IDs at the resolver route before cache or upstream adapters
- return a stable retryable resolver error without leaking transport details

## Security boundary

The pasted URL is never fetched, navigated to, or reflected. The browser extracts only a normalized MusicBrainz or Discogs identity, then calls the fixed same-origin resolver route. Generated and deterministic tests reject trusted hostnames hidden in attacker paths, suffix hosts, userinfo, non-HTTP schemes, extra path segments, control characters, oversized input, Unicode/aliased numeric IDs, and cross-source kind hints.

The tests were qualified RED against the previous parser: attacker paths such as `https://evil.example/musicbrainz.org/release/<uuid>` were accepted before this change and are now rejected.

## Verification

- final receipt-backed whole-tree Pyright: 0 errors
- final receipt-backed complete suite: 6 phases passed; Python 245.6s, 0 failures
- JavaScript utility suite: 504 passed
- fresh independent hostile-input review: no remaining findings after one test-collection fix
- 390x844 live-db browser proof: `ID/URL` fits the phone layout, a real Discogs mobile URL resolves, and a hostile lookalike shows local validation with no resolver request

Refs #963
