### PR TITLE
test: split local and overnight fuzz depth

### DIFF
--- a/docs/generated-testing.md
+++ b/docs/generated-testing.md
@@ -16,11 +16,11 @@ classifier so only an exact stable or shrinking approved cohort is green.
 `scripts/daily_flake_update.sh` is the single unattended entry point. It
 checks out current `main`, advances `flake.lock` to current nixpkgs unstable,
 and runs whole-repository Pyright, the deterministic suite, `nix flake check`,
-the default lifecycle hammer, the full fuzz burst, and the mirror-harness
-smoke. Independent test stages all run so one notification contains the whole
-day's result. A completely green candidate commits and pushes only
-`flake.lock`; a red candidate pushes nothing. Scheduling, state paths, and
-notification belong to the downstream nixosconfig service.
+the default lifecycle hammer, the 20,000-example fuzz burst, and the
+mirror-harness smoke. Independent test stages all run so one notification
+contains the whole day's result. A completely green candidate commits and
+pushes only `flake.lock`; a red candidate pushes nothing. Scheduling, state
+paths, and notification belong to the downstream nixosconfig service.
 
 ## Bug hunting — the house method
 
@@ -319,12 +319,13 @@ The readable named lifecycle is the durable regression artifact.
 - **`suite`** (default) — deterministic (`derandomize=True`, no example
   database), bounded examples. Runs on every `scripts/run_tests.sh`,
   identical on every machine. This is part of the final local gate.
-- **`fuzz`** — deep randomized burst (20k examples) for local exploration.
-  Fresh entropy per run, local example database (`.hypothesis/`,
+- **`fuzz`** — randomized burst for local exploration, with 500 examples by
+  default. Fresh entropy per run, local example database (`.hypothesis/`,
   gitignored) so found failures replay first on the next burst,
-  `print_blob=True` for exact reproduction.
+  `print_blob=True` for exact reproduction. The unattended overnight gate
+  explicitly sets `CRATEDIGGER_FUZZ_MAX_EXAMPLES=20000`.
 
-Run a deep burst whenever quality policy changes:
+Run a randomized burst whenever quality policy changes:
 
 ```bash
 nix-shell --run "bash scripts/fuzz_burst.sh"                    # all generated modules
@@ -370,19 +371,20 @@ Two independent gates enforce this:
 `scripts/fuzz_burst.sh` discovers the exact unittest IDs and effective
 Hypothesis settings in every generated module. Ordinary deterministic pins run
 once as a batch, and fixed per-test `@settings(max_examples=...)` budgets remain
-single-run. Each property using the default deep profile divides its 20k
+single-run. Each property using the default fuzz profile divides its 500
 generated examples exactly across independent entropy shards. The total budget
-does not grow: on a 30-core host, eight processes each receive 2,500 examples.
-The child runner loads the owning module and selects the exact discovered ID,
-so dynamically named state-machine tests can be sharded without repeating the
-module's other properties or pins. An exact-budget check rejects any schedule
-that omits a test, repeats a pin, changes a property's combined example count,
-or invents an ID.
+does not grow: on a 30-core host, eight processes receive 62 or 63 examples.
+The overnight gate raises the combined budget to 20,000, or 2,500 per shard on
+that host. The child runner loads the owning module and selects the exact
+discovered ID, so dynamically named state-machine tests can be sharded without
+repeating the module's other properties or pins. An exact-budget check rejects
+any schedule that omits a test, repeats a pin, changes a property's combined
+example count, or invents an ID.
 
 The queue uses every host core by default. Set `CRATEDIGGER_FUZZ_JOBS` to cap
 concurrent processes or `CRATEDIGGER_FUZZ_PROPERTY_SHARDS` to override the
 host-scaled entropy fan-out. On doc1's 30-core VM on 2026-07-23, the complete
-71-module, 769-test burst at the unchanged deep budgets completed in 607.8
+71-module, 769-test overnight burst at 20,000 examples completed in 607.8
 seconds. The worst subprocess-heavy generated module completed alone in 142.7
 seconds; its unsharded properties had still not completed after ten minutes.
 
@@ -390,9 +392,9 @@ seconds; its unsharded properties had still not completed after ten minutes.
 
 Issue #888 item 1. A budget is not depth: `@given(authorized=st.booleans(),
 missing=st.booleans())` has four distinct worlds, so Hypothesis exhausts it in
-four examples and stops — whether the budget is 150 or 20,000. A mutant that
-widens a quarantine authority boundary survived 215 tests across seven modules
-for exactly that reason, and nothing in the burst output said so.
+four examples and stops — whether the budget is 150, 500, or 20,000. A mutant
+that widens a quarantine authority boundary survived 215 tests across seven
+modules for exactly that reason, and nothing in the burst output said so.
 
 After the `SLOW` lines, every burst now prints what each property actually
 generated, measured from Hypothesis' own `statistics` collector in the child
@@ -439,12 +441,13 @@ today: no repository property reaches that state, precisely because the
 known-bad self-tests plant their bug in a dropped inner `@given`.
 
 **The ceiling is the per-child budget.** Only a space smaller than the
-`N examples per shard` figure — 150 at the deterministic tier, `budget /
-shards` (2,500 on a 30-core host) at the fuzz tier — can be observed at all.
-A 5,000-world property never exhausts, so it is reported as deep at both
-tiers, and every non-shallow property's worlds are bounded by that per-shard
-budget rather than by its real space. An empty SHALLOW section means "none
-found below the ceiling", never "no shallow properties".
+`N examples per shard` figure — 150 at the deterministic tier, 62 or 63 on a
+30-core host for the default 500-example fuzz burst, and 2,500 for its
+20,000-example overnight counterpart — can be observed at all. A world space
+larger than the applicable ceiling never exhausts, so it is reported as deep,
+and every non-shallow property's worlds are bounded by that per-shard budget
+rather than by its real space. An empty SHALLOW section means "none found
+below the ceiling", never "no shallow properties".
 
 **It cannot see a bare `return`.** A `return` spends the example as a PASS, so
 a vacuously-discarding property reads as a full budget of valid worlds. That
@@ -464,9 +467,9 @@ private per-shell tmpfs. A database named by
 its active database and logs without writing persistent storage. On failure,
 the active database is copied back so the shrunk example replays, and
 `CRATEDIGGER_FUZZ_OUTPUT_DIR` optionally receives the complete logs plus an
-exact target manifest beneath a unique `run.*` directory. The 20k-example
-budget is unchanged. The serial equivalent, when you need one module's live
-output:
+exact target manifest beneath a unique `run.*` directory. The ordinary burst
+uses 500 examples; the daily unattended gate preserves the 20,000-example
+depth. The serial equivalent, when you need one module's live output:
 
 ```bash
 nix-shell --run "CRATEDIGGER_HYPOTHESIS_PROFILE=fuzz \

--- a/scripts/daily_flake_update.sh
+++ b/scripts/daily_flake_update.sh
@@ -15,6 +15,7 @@ world_database="$state_dir/hypothesis/world-model"
 mirror_database="$state_dir/hypothesis/mirror-world"
 fuzz_database="$state_dir/hypothesis/fuzz"
 fuzz_output_dir="$state_dir/fuzz-failures"
+overnight_fuzz_max_examples=20000
 
 mkdir -p \
     "$world_database" \
@@ -83,6 +84,7 @@ run_stage "world-model burst" \
 run_stage "generated fuzz burst" \
     env HYPOTHESIS_STORAGE_DIRECTORY="$fuzz_database" \
         CRATEDIGGER_FUZZ_OUTPUT_DIR="$fuzz_output_dir" \
+        CRATEDIGGER_FUZZ_MAX_EXAMPLES="$overnight_fuzz_max_examples" \
     nix-shell --run "bash scripts/fuzz_burst.sh"
 run_stage "mirror-harness smoke" \
     env CRATEDIGGER_WORLD_DATABASE="$mirror_database" \

--- a/scripts/run_fuzz_tests.py
+++ b/scripts/run_fuzz_tests.py
@@ -380,16 +380,17 @@ def is_structurally_shallow(depth: PropertyDepth) -> bool:
     """True when a property ran out of worlds long before it ran out of budget.
 
     The disclosure #888 item 1 exists for: ``@given(a=st.booleans(),
-    b=st.booleans())`` against a 20,000-example budget is exhausted in four
-    worlds, so a mutant outside those four worlds survives however deep the
-    burst runs.
+    b=st.booleans())`` is exhausted in four worlds regardless of whether the
+    burst budget is the ordinary 500 examples or the overnight 20,000, so a
+    mutant outside those four worlds survives however deep the burst runs.
 
     **Detection ceiling.** Only a space smaller than ``shard_budget_bound``
-    can be observed at all — 150 at the deterministic tier, ``budget /
-    shards`` (2,500 on a 30-core host) at the fuzz tier. A property with more
-    worlds than that never exhausts, so it is reported as deep whatever its
-    real space is, and an empty SHALLOW section means "none found below the
-    ceiling", never "no shallow properties".
+    can be observed at all — 150 at the deterministic tier, or ``budget /
+    shards`` at the fuzz tier (62 or 63 on a 30-core host by default; 2,500
+    in the overnight run). A property with more worlds than that never
+    exhausts, so it is reported as deep whatever its real space is, and an
+    empty SHALLOW section means "none found below the ceiling", never "no
+    shallow properties".
 
     Two carve-outs keep the verdict honest:
 

--- a/tests/_hypothesis_profiles.py
+++ b/tests/_hypothesis_profiles.py
@@ -8,10 +8,11 @@ by ``CRATEDIGGER_HYPOTHESIS_PROFILE``:
   independent of local ``.hypothesis/`` state, so every ``run_tests.sh``
   run behaves identically on every machine. This is the tier used by the
   final local suite.
-* ``fuzz`` — deep randomized burst for local exploration when quality
-  policy changes. Fresh entropy per run plus the local Hypothesis example
-  database (``.hypothesis/``, gitignored), so failures found in one burst
-  replay first on the next. ``print_blob=True`` prints a
+* ``fuzz`` — randomized burst for local exploration when quality policy
+  changes. The ordinary default is 500 examples; the unattended overnight
+  gate explicitly raises it to 20,000. Fresh entropy per run plus the local
+  Hypothesis example database (``.hypothesis/``, gitignored) means failures
+  found in one burst replay first on the next. ``print_blob=True`` prints a
   ``@reproduce_failure`` blob for exact replay.
 
 Deadlines are disabled in every tier: wall-clock-per-example limits flake
@@ -28,7 +29,7 @@ import os
 from hypothesis import HealthCheck, settings
 
 _fuzz_max_examples = int(
-    os.environ.get("CRATEDIGGER_FUZZ_MAX_EXAMPLES", "20000")
+    os.environ.get("CRATEDIGGER_FUZZ_MAX_EXAMPLES", "500")
 )
 if _fuzz_max_examples < 1:
     raise ValueError("CRATEDIGGER_FUZZ_MAX_EXAMPLES must be at least 1")

--- a/tests/fakes/daily_flake_update.py
+++ b/tests/fakes/daily_flake_update.py
@@ -112,6 +112,9 @@ with state_path.with_suffix(".lock").open("a+", encoding="utf-8") as lock:
         "CRATEDIGGER_FUZZ_OUTPUT_DIR": os.environ.get(
             "CRATEDIGGER_FUZZ_OUTPUT_DIR"
         ),
+        "CRATEDIGGER_FUZZ_MAX_EXAMPLES": os.environ.get(
+            "CRATEDIGGER_FUZZ_MAX_EXAMPLES"
+        ),
     }
     if state.get("fault") == stage:
         fail(f"fake {stage} failed")

--- a/tests/test_daily_flake_update.py
+++ b/tests/test_daily_flake_update.py
@@ -103,7 +103,7 @@ class TestDailyFlakeUpdateScript(unittest.TestCase):
         self.assertEqual(state["push_count"], 0)
         self.assertIn("lock commit failed", proc.stderr)
 
-    def test_state_paths_and_mirror_budget_are_explicit(self) -> None:
+    def test_state_paths_and_unattended_budgets_are_explicit(self) -> None:
         proc = self.fake.run(SCRIPT)
         state = self.fake.state
 
@@ -123,6 +123,7 @@ class TestDailyFlakeUpdateScript(unittest.TestCase):
             fuzz["CRATEDIGGER_FUZZ_OUTPUT_DIR"],
             str(self.fake.automation_state / "fuzz-failures"),
         )
+        self.assertEqual(fuzz["CRATEDIGGER_FUZZ_MAX_EXAMPLES"], "20000")
         self.assertEqual(mirror["CRATEDIGGER_WORLD_ENGINE"], "mirror-harness")
         self.assertEqual(
             mirror["CRATEDIGGER_WORLD_MIRROR_URL"],

--- a/tests/test_fuzz_burst.py
+++ b/tests/test_fuzz_burst.py
@@ -38,7 +38,7 @@ class TestFuzzTargetPlanning(unittest.TestCase):
     def property(
         test_id: str,
         *,
-        max_examples: int = 20_000,
+        max_examples: int = 500,
         uses_default_settings: bool = True,
     ) -> FuzzPropertyManifest:
         return FuzzPropertyManifest(
@@ -237,6 +237,40 @@ class TestFuzzTargetPlanning(unittest.TestCase):
         )
         self.assertTrue(state_machine.uses_default_settings)
         self.assertEqual(state_machine.max_examples, 150)
+
+
+class TestFuzzProfileBudget(unittest.TestCase):
+    def _profile_budget(self, override: str | None) -> int:
+        env = os.environ.copy()
+        if override is None:
+            env.pop("CRATEDIGGER_FUZZ_MAX_EXAMPLES", None)
+        else:
+            env["CRATEDIGGER_FUZZ_MAX_EXAMPLES"] = override
+        completed = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                (
+                    "import tests._hypothesis_profiles; "
+                    "from hypothesis import settings; "
+                    "print(settings.get_profile('fuzz').max_examples)"
+                ),
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+        return int(completed.stdout)
+
+    def test_default_fuzz_budget_is_500_examples(self) -> None:
+        self.assertEqual(self._profile_budget(None), 500)
+
+    def test_fuzz_budget_honors_the_overnight_override(self) -> None:
+        self.assertEqual(self._profile_budget("20000"), 20_000)
 
 
 def _shard(


### PR DESCRIPTION
## Summary

- reduce the ordinary randomized fuzz profile from 20,000 to 500 examples per property
- keep the unattended daily compatibility gate at 20,000 examples explicitly
- pin both budgets in contract tests and update the generated-testing documentation

## Validation

- receipt-backed whole-repository Pyright: pass
- receipt-backed complete deterministic suite: pass (8,692 tests)
- default fuzz burst: pass (115 modules, 1,418 tests, 3,327 exact targets; 216.8s)