### PR TITLE
fix(fuzz): bound ephemeral PostgreSQL concurrency

### DIFF
--- a/docs/generated-testing.md
+++ b/docs/generated-testing.md
@@ -381,12 +381,18 @@ repeating the module's other properties or pins. An exact-budget check rejects
 any schedule that omits a test, repeats a pin, changes a property's combined
 example count, or invents an ID.
 
-The queue uses every host core by default. Set `CRATEDIGGER_FUZZ_JOBS` to cap
-concurrent processes or `CRATEDIGGER_FUZZ_PROPERTY_SHARDS` to override the
-host-scaled entropy fan-out. On doc1's 30-core VM on 2026-07-23, the complete
-71-module, 769-test overnight burst at 20,000 examples completed in 607.8
-seconds. The worst subprocess-heavy generated module completed alone in 142.7
-seconds; its unsharded properties had still not completed after ten minutes.
+The queue uses every host core by default for ordinary targets. Targets whose
+module boots an ephemeral PostgreSQL cluster are capped at two concurrent
+processes, bounding their tmpfs footprint independently of the queue length;
+eligible ordinary work bypasses a PostgreSQL-backed target waiting for that
+resource. Any `ENOSPC`, PostgreSQL `DiskFull`, or unexpected loss of an
+ephemeral database aborts further admission and reports that the property
+verdict is invalid. Set `CRATEDIGGER_FUZZ_JOBS` to cap all concurrent
+processes or `CRATEDIGGER_FUZZ_PROPERTY_SHARDS` to override the host-scaled
+entropy fan-out. On doc1's 30-core VM on 2026-07-23, the complete 71-module,
+769-test overnight burst at 20,000 examples completed in 607.8 seconds. The
+worst subprocess-heavy generated module completed alone in 142.7 seconds; its
+unsharded properties had still not completed after ten minutes.
 
 ### Per-property depth report
 
@@ -464,12 +470,14 @@ strategy widened, so re-run the burst rather than trusting these numbers.
 All active logs, property tempdirs, and Hypothesis database writes stay in the
 private per-shell tmpfs. A database named by
 `HYPOTHESIS_STORAGE_DIRECTORY` seeds the run read-only. A green run discards
-its active database and logs without writing persistent storage. On failure,
-the active database is copied back so the shrunk example replays, and
+its active database and logs without writing persistent storage. On a property
+failure, the active database is copied back so the shrunk example replays.
+An infrastructure abort discards that contaminated database instead.
 `CRATEDIGGER_FUZZ_OUTPUT_DIR` optionally receives the complete logs plus an
-exact target manifest beneath a unique `run.*` directory. The ordinary burst
-uses 500 examples; the daily unattended gate preserves the 20,000-example
-depth. The serial equivalent, when you need one module's live output:
+exact target manifest beneath a unique `run.*` directory for either kind of
+failure. The ordinary burst uses 500 examples; the daily unattended gate
+preserves the 20,000-example depth. The serial equivalent, when you need one
+module's live output:
 
 ```bash
 nix-shell --run "CRATEDIGGER_HYPOTHESIS_PROFILE=fuzz \

--- a/scripts/run_fuzz_tests.py
+++ b/scripts/run_fuzz_tests.py
@@ -13,7 +13,13 @@ import time
 import unittest
 from collections import Counter
 from collections.abc import Mapping, Sequence
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import (
+    FIRST_COMPLETED,
+    Future,
+    ThreadPoolExecutor,
+    as_completed,
+    wait,
+)
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -37,6 +43,9 @@ from scripts.run_python_tests import (
 TARGET_RUNNER = REPO_ROOT / "scripts" / "run_python_tests.py"
 DEFAULT_PROFILE = "fuzz"
 DEFAULT_DURATIONS = 5
+EPHEMERAL_POSTGRES_TARGET_LIMIT = 2
+_SCHEMA_READY_ENV = "CRATEDIGGER_TEST_SCHEMA_READY"
+_DISCOVERY_DSN = "postgresql:///cratedigger_fuzz_discovery_only"
 
 #: Ranked depth-report lines printed per section before truncation.
 DEPTH_REPORT_LIMIT = 20
@@ -61,6 +70,7 @@ class FuzzModuleManifest(msgspec.Struct, frozen=True):
     module_name: str
     test_ids: tuple[str, ...]
     hypothesis_tests: tuple[FuzzPropertyManifest, ...]
+    uses_ephemeral_postgres: bool = False
 
 
 @dataclass(frozen=True)
@@ -74,6 +84,7 @@ class FuzzTarget:
     shard_index: int = 0
     shard_count: int = 1
     profile_max_examples: int | None = None
+    uses_ephemeral_postgres: bool = False
 
 
 @dataclass(frozen=True)
@@ -123,6 +134,15 @@ class FuzzInfrastructureFailure:
     log_path: Path
 
 
+@dataclass(frozen=True)
+class FuzzTargetBatch:
+    """Completed target outcomes plus work withheld after infrastructure loss."""
+
+    results: tuple[FuzzRunResult, ...]
+    infrastructure_failures: tuple[FuzzInfrastructureFailure, ...]
+    not_started: tuple[FuzzTarget, ...]
+
+
 class PersistedFuzzTarget(msgspec.Struct, frozen=True):
     """Failure-artifact mapping from a log file to its exact target."""
 
@@ -133,6 +153,7 @@ class PersistedFuzzTarget(msgspec.Struct, frozen=True):
     shard_index: int
     shard_count: int
     profile_max_examples: int | None
+    uses_ephemeral_postgres: bool
 
 
 class PersistedFuzzManifest(msgspec.Struct, frozen=True):
@@ -178,6 +199,9 @@ def build_fuzz_targets(
                     module_name=manifest.module_name,
                     load_names=(manifest.module_name,),
                     expected_test_ids=manifest.test_ids,
+                    uses_ephemeral_postgres=(
+                        manifest.uses_ephemeral_postgres
+                    ),
                 )
             )
             continue
@@ -216,6 +240,9 @@ def build_fuzz_targets(
                         profile_max_examples=(
                             budget if shard_count > 1 else None
                         ),
+                        uses_ephemeral_postgres=(
+                            manifest.uses_ephemeral_postgres
+                        ),
                     )
                 )
         pin_ids = tuple(
@@ -230,6 +257,9 @@ def build_fuzz_targets(
                     module_name=manifest.module_name,
                     load_names=(manifest.module_name,),
                     expected_test_ids=pin_ids,
+                    uses_ephemeral_postgres=(
+                        manifest.uses_ephemeral_postgres
+                    ),
                 )
             )
 
@@ -501,6 +531,10 @@ def _discover_module_child(module_name: str, result_path: Path) -> int:
                 module_name=module_name,
                 test_ids=test_ids,
                 hypothesis_tests=tuple(hypothesis_tests),
+                uses_ephemeral_postgres=(
+                    "conftest" in sys.modules
+                    or "tests.conftest" in sys.modules
+                ),
             )
         )
     )
@@ -516,6 +550,13 @@ def _discover_one_manifest(
 ) -> FuzzModuleManifest:
     result_path = work_directory / f"discover-{index:04d}.json"
     log_path = work_directory / f"discover-{index:04d}.log"
+    discovery_environment = dict(environment)
+    discovery_environment.update(
+        {
+            "TEST_DB_DSN": _DISCOVERY_DSN,
+            _SCHEMA_READY_ENV: "1",
+        }
+    )
     with log_path.open("wb") as raw_output:
         completed = subprocess.run(
             [
@@ -526,7 +567,7 @@ def _discover_one_manifest(
                 str(result_path),
             ],
             cwd=REPO_ROOT,
-            env=environment,
+            env=discovery_environment,
             stdout=raw_output,
             stderr=subprocess.STDOUT,
             check=False,
@@ -618,6 +659,16 @@ def _execute_fuzz_target(
     )
     with log_path.open("a", encoding="utf-8") as output:
         output.write(child.output)
+    if child.infrastructure_errors:
+        detail = "\n".join(
+            f"{error.test_id}: {error.kind}: {error.detail}"
+            for error in child.infrastructure_errors
+        )
+        return FuzzInfrastructureFailure(
+            target=target,
+            detail=detail,
+            log_path=log_path,
+        )
     if child.test_ids != target.expected_test_ids:
         return FuzzInfrastructureFailure(
             target=target,
@@ -637,61 +688,187 @@ def _execute_fuzz_target(
     )
 
 
+def assert_fuzz_admission(
+    pending: Sequence[FuzzTarget],
+    active: Sequence[FuzzTarget],
+    admitted_indexes: Sequence[int],
+    *,
+    worker_count: int,
+    postgres_worker_count: int,
+) -> None:
+    """Prove one queue admission fills safe worker and PostgreSQL capacity."""
+    if worker_count < 1 or postgres_worker_count < 1:
+        raise ValueError("worker limits must be at least 1")
+    if len(active) > worker_count:
+        raise ValueError("active targets exceed worker capacity")
+    active_postgres = sum(
+        target.uses_ephemeral_postgres for target in active
+    )
+    if active_postgres > postgres_worker_count:
+        raise ValueError("active targets exceed PostgreSQL capacity")
+    if len(set(admitted_indexes)) != len(admitted_indexes):
+        raise AssertionError("duplicate fuzz admission")
+    if any(index < 0 or index >= len(pending) for index in admitted_indexes):
+        raise AssertionError("fuzz admission index is out of range")
+
+    admitted = tuple(pending[index] for index in admitted_indexes)
+    if len(active) + len(admitted) > worker_count:
+        raise AssertionError("fuzz admission exceeds worker capacity")
+    admitted_postgres = sum(
+        target.uses_ephemeral_postgres for target in admitted
+    )
+    if active_postgres + admitted_postgres > postgres_worker_count:
+        raise AssertionError("fuzz admission exceeds PostgreSQL capacity")
+
+    admitted_set = set(admitted_indexes)
+    remaining = tuple(
+        target
+        for index, target in enumerate(pending)
+        if index not in admitted_set
+    )
+    total_slots = worker_count - len(active) - len(admitted)
+    postgres_slots = (
+        postgres_worker_count - active_postgres - admitted_postgres
+    )
+    has_eligible_remaining = any(
+        not target.uses_ephemeral_postgres or postgres_slots > 0
+        for target in remaining
+    )
+    if total_slots > 0 and has_eligible_remaining:
+        raise AssertionError("fuzz admission left eligible worker capacity idle")
+
+
+def select_fuzz_admissions(
+    pending: Sequence[FuzzTarget],
+    active: Sequence[FuzzTarget],
+    *,
+    worker_count: int,
+    postgres_worker_count: int,
+) -> tuple[int, ...]:
+    """Select a work-conserving queue prefix under a separate PG ceiling."""
+    total_slots = worker_count - len(active)
+    postgres_slots = postgres_worker_count - sum(
+        target.uses_ephemeral_postgres for target in active
+    )
+    admitted: list[int] = []
+    for index, target in enumerate(pending):
+        if len(admitted) >= total_slots:
+            break
+        if target.uses_ephemeral_postgres:
+            if postgres_slots < 1:
+                continue
+            postgres_slots -= 1
+        admitted.append(index)
+    selected = tuple(admitted)
+    assert_fuzz_admission(
+        pending,
+        active,
+        selected,
+        worker_count=worker_count,
+        postgres_worker_count=postgres_worker_count,
+    )
+    return selected
+
+
 def run_fuzz_targets(
     targets: Sequence[FuzzTarget],
     *,
     worker_count: int,
+    postgres_worker_count: int,
     environment: Mapping[str, str],
     log_directory: Path,
-) -> tuple[
-    tuple[FuzzRunResult, ...],
-    tuple[FuzzInfrastructureFailure, ...],
-]:
-    """Drain every exact fuzz target and aggregate all failures."""
+) -> FuzzTargetBatch:
+    """Run a bounded queue and stop admission after infrastructure loss."""
     results: list[FuzzRunResult] = []
     infrastructure_failures: list[FuzzInfrastructureFailure] = []
+    pending = list(enumerate(targets))
+    infrastructure_aborted = False
     completed_count = 0
     with ThreadPoolExecutor(max_workers=worker_count) as executor:
-        futures = {
-            executor.submit(
-                _execute_fuzz_target,
-                index,
-                target,
-                environment=environment,
-                log_directory=log_directory,
-            ): (index, target)
-            for index, target in enumerate(targets)
-        }
-        for future in as_completed(futures):
-            index, target = futures[future]
-            completed_count += 1
-            try:
-                outcome = future.result()
-            except Exception as exc:  # noqa: BLE001 - boundary converts or isolates collaborator failures
-                outcome = FuzzInfrastructureFailure(
-                    target=target,
-                    detail=f"{type(exc).__name__}: {exc}",
-                    log_path=log_directory / f"{index:04d}.log",
+        futures: dict[
+            Future[FuzzRunResult | FuzzInfrastructureFailure],
+            tuple[int, FuzzTarget],
+        ] = {}
+        while futures or (pending and not infrastructure_aborted):
+            if not infrastructure_aborted:
+                active = tuple(target for _index, target in futures.values())
+                admitted_positions = select_fuzz_admissions(
+                    tuple(target for _index, target in pending),
+                    active,
+                    worker_count=worker_count,
+                    postgres_worker_count=postgres_worker_count,
                 )
-            if isinstance(outcome, FuzzInfrastructureFailure):
-                infrastructure_failures.append(outcome)
-                print(f"FAIL {outcome.target.label}", flush=True)
-                continue
-            results.append(outcome)
-            if (
-                outcome.successful
-                and (
-                    completed_count % 25 == 0
-                    or completed_count == len(targets)
+                admitted_position_set = set(admitted_positions)
+                admitted = tuple(
+                    item
+                    for position, item in enumerate(pending)
+                    if position in admitted_position_set
                 )
-            ):
-                print(
-                    f"PROGRESS {completed_count}/{len(targets)} targets",
-                    flush=True,
-                )
-            elif not outcome.successful:
-                print(f"FAIL {outcome.target.label}", flush=True)
-    return tuple(results), tuple(infrastructure_failures)
+                pending = [
+                    item
+                    for position, item in enumerate(pending)
+                    if position not in admitted_position_set
+                ]
+                for index, target in admitted:
+                    future = executor.submit(
+                        _execute_fuzz_target,
+                        index,
+                        target,
+                        environment=environment,
+                        log_directory=log_directory,
+                    )
+                    futures[future] = (index, target)
+            if not futures:
+                break
+
+            done, _not_done = wait(
+                tuple(futures),
+                return_when=FIRST_COMPLETED,
+            )
+            completed = sorted(
+                (
+                    (futures[future][0], future)
+                    for future in done
+                ),
+                key=lambda item: item[0],
+            )
+            for _completed_index, future in completed:
+                index, target = futures.pop(future)
+                completed_count += 1
+                try:
+                    outcome = future.result()
+                except Exception as exc:  # noqa: BLE001 - boundary converts or isolates collaborator failures
+                    outcome = FuzzInfrastructureFailure(
+                        target=target,
+                        detail=f"{type(exc).__name__}: {exc}",
+                        log_path=log_directory / f"{index:04d}.log",
+                    )
+                if isinstance(outcome, FuzzInfrastructureFailure):
+                    infrastructure_failures.append(outcome)
+                    infrastructure_aborted = True
+                    print(
+                        f"INFRASTRUCTURE FAIL {outcome.target.label}",
+                        flush=True,
+                    )
+                    continue
+                results.append(outcome)
+                if (
+                    outcome.successful
+                    and (
+                        completed_count % 25 == 0
+                        or completed_count == len(targets)
+                    )
+                ):
+                    print(
+                        f"PROGRESS {completed_count}/{len(targets)} targets",
+                        flush=True,
+                    )
+
+    return FuzzTargetBatch(
+        results=tuple(results),
+        infrastructure_failures=tuple(infrastructure_failures),
+        not_started=tuple(target for _index, target in pending),
+    )
 
 
 def _failure_tail(log_path: Path) -> str:
@@ -721,6 +898,8 @@ def _test_subprocess_environment(
     active_database: Path,
 ) -> dict[str, str]:
     environment = dict(base)
+    environment.pop("TEST_DB_DSN", None)
+    environment.pop(_SCHEMA_READY_ENV, None)
     python_paths = [str(REPO_ROOT), str(REPO_ROOT / "tests")]
     inherited_python_path = environment.get("PYTHONPATH")
     if inherited_python_path:
@@ -761,6 +940,7 @@ def _persist_failure_logs(
                 shard_index=target.shard_index,
                 shard_count=target.shard_count,
                 profile_max_examples=target.profile_max_examples,
+                uses_ephemeral_postgres=target.uses_ephemeral_postgres,
             )
             for index, target in enumerate(targets)
         )
@@ -898,52 +1078,73 @@ def main(argv: Sequence[str] | None = None) -> int:
             f"fuzz burst: {len(module_names)} generated modules, "
             f"{len(targets)} targets ({property_targets} property targets, "
             f"up to {property_shards} entropy shards), "
-            f"up to {worker_count} parallel "
+            f"up to {worker_count} parallel, "
+            f"up to {min(EPHEMERAL_POSTGRES_TARGET_LIMIT, worker_count)} "
+            "PostgreSQL-backed "
             f"({os.cpu_count() or 1} host cores), profile={args.profile}",
             flush=True,
         )
         started_at = time.monotonic()
-        results, infrastructure_failures = run_fuzz_targets(
+        batch = run_fuzz_targets(
             targets,
             worker_count=worker_count,
+            postgres_worker_count=min(
+                EPHEMERAL_POSTGRES_TARGET_LIMIT,
+                worker_count,
+            ),
             environment=child_environment,
             log_directory=log_directory,
         )
+        results = batch.results
+        infrastructure_failures = batch.infrastructure_failures
         wall_seconds = time.monotonic() - started_at
 
         failed_results = [result for result in results if not result.successful]
-        for result in sorted(
-            results,
-            key=lambda item: item.elapsed_seconds,
-            reverse=True,
-        )[:12]:
-            print(
-                f"SLOW {result.elapsed_seconds:.1f}s {result.target.label}"
-            )
-        for line in format_depth_report(
-            aggregate_property_depth(
-                tuple(
-                    record
-                    for result in results
-                    for record in result.hypothesis_stats
-                )
-            )
-        ):
-            print(line)
-        if failed_results or infrastructure_failures:
+        if not infrastructure_failures:
             for result in sorted(
-                failed_results,
-                key=lambda item: item.target.label,
+                results,
+                key=lambda item: item.elapsed_seconds,
+                reverse=True,
+            )[:12]:
+                print(
+                    f"SLOW {result.elapsed_seconds:.1f}s {result.target.label}"
+                )
+            for line in format_depth_report(
+                aggregate_property_depth(
+                    tuple(
+                        record
+                        for result in results
+                        for record in result.hypothesis_stats
+                    )
+                )
             ):
-                print(f"\n--- FAIL {result.target.label} ---")
-                print(_failure_tail(result.log_path))
+                print(line)
+        if failed_results or infrastructure_failures:
+            if infrastructure_failures:
+                if failed_results:
+                    print(
+                        f"\n{len(failed_results)} unittest-failed "
+                        "target withheld from property reporting because "
+                        "the burst's infrastructure failed."
+                    )
+            else:
+                for result in sorted(
+                    failed_results,
+                    key=lambda item: item.target.label,
+                ):
+                    print(f"\n--- FAIL {result.target.label} ---")
+                    print(_failure_tail(result.log_path))
             for failure in sorted(
                 infrastructure_failures,
                 key=lambda item: item.target.label,
             ):
                 print(f"\n--- INFRASTRUCTURE FAIL {failure.target.label} ---")
                 print(failure.detail)
-            _persist_failure_database(active_database, persistent_database)
+            if not infrastructure_failures:
+                _persist_failure_database(
+                    active_database,
+                    persistent_database,
+                )
             if persistent_output_value is not None:
                 retained = _persist_failure_logs(
                     log_directory,
@@ -951,10 +1152,20 @@ def main(argv: Sequence[str] | None = None) -> int:
                     targets,
                 )
                 print(f"fuzz burst: complete module logs retained at {retained}")
-            print(
-                f"fuzz burst: FAILURES after {wall_seconds:.1f}s "
-                f"({len(failed_results) + len(infrastructure_failures)} targets)"
-            )
+            completed_targets = len(results) + len(infrastructure_failures)
+            if infrastructure_failures:
+                print(
+                    f"fuzz burst: INFRASTRUCTURE ABORT after "
+                    f"{wall_seconds:.1f}s ({completed_targets} completed of "
+                    f"{len(targets)}; {len(batch.not_started)} not started; "
+                    "property verdict invalid)"
+                )
+            else:
+                print(
+                    f"fuzz burst: FAILURES after {wall_seconds:.1f}s "
+                    f"({len(failed_results)} failed targets; "
+                    f"{len(results)} completed)"
+                )
             return 1
 
         if Counter(result.target for result in results) != Counter(targets):

--- a/scripts/run_python_tests.py
+++ b/scripts/run_python_tests.py
@@ -4,9 +4,11 @@
 from __future__ import annotations
 
 import argparse
+import errno
 import io
 import multiprocessing
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -17,10 +19,15 @@ from collections.abc import Callable, Iterator, Mapping, Sequence
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
+from types import TracebackType
+from typing import Literal, TypeIs
 
 import msgspec
 from hypothesis import is_hypothesis_test, settings
 from hypothesis.statistics import collector
+from psycopg2 import Error as PsycopgError
+from psycopg2 import OperationalError
+from psycopg2.errors import DiskFull
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(REPO_ROOT) not in sys.path:
@@ -32,6 +39,11 @@ from scripts.run_test_suite import (
     METRICS_MARKER_PREFIX,
     CheckFailureMarker,
     CheckMetricsMarker,
+)
+
+ExcInfo = (
+    tuple[type[BaseException], BaseException, TracebackType]
+    | tuple[None, None, None]
 )
 
 DEFAULT_MAX_WORKERS = 12
@@ -56,6 +68,10 @@ STRATEGY_SPACE_EXHAUSTED = "nothing left to do"
 #: ``tests/test_parallel_test_runner.py`` against the live ``Status`` enum: a
 #: new status would otherwise be silently uncounted in the depth report.
 HYPOTHESIS_CASE_STATUSES = ("valid", "invalid", "overrun", "interesting")
+
+# Once a disposable database fails below this floor, the surrounding test
+# cannot produce a trustworthy property verdict even if ENOSPC was swallowed.
+_MIN_VALID_TEMP_HEADROOM_BYTES = 64 * 1024 * 1024
 
 
 @dataclass(frozen=True)
@@ -118,6 +134,14 @@ class HypothesisPropertyStats(msgspec.Struct, frozen=True):
     stopped_because: str
 
 
+class ChildInfrastructureError(msgspec.Struct, frozen=True):
+    """One infrastructure failure detected inside a unittest result."""
+
+    test_id: str
+    kind: Literal["disk_full", "database_unavailable"]
+    detail: str
+
+
 class ChildTargetResult(msgspec.Struct, frozen=True):
     """Wire result written by one fresh target interpreter."""
 
@@ -127,6 +151,7 @@ class ChildTargetResult(msgspec.Struct, frozen=True):
     output: str
     failed_test_ids: tuple[str, ...]
     hypothesis_stats: tuple[HypothesisPropertyStats, ...] = ()
+    infrastructure_errors: tuple[ChildInfrastructureError, ...] = ()
 
 
 class ListedTestIds(msgspec.Struct, frozen=True):
@@ -139,12 +164,140 @@ class RecordingTextTestResult(unittest.TextTestResult):
     """Text result that proves which exact unittest IDs executed."""
 
     test_ids: list[str] | None = None
+    infrastructure_errors: list[ChildInfrastructureError] | None = None
 
     def startTest(self, test: unittest.TestCase) -> None:
         if self.test_ids is None:
             self.test_ids = []
         self.test_ids.append(test.id())
         super().startTest(test)
+
+    def _record_infrastructure_error(
+        self,
+        test: unittest.TestCase,
+        error: BaseException,
+    ) -> None:
+        infrastructure = _classify_test_infrastructure_error(error)
+        if infrastructure is None:
+            return
+        kind, detail = infrastructure
+        if self.infrastructure_errors is None:
+            self.infrastructure_errors = []
+        self.infrastructure_errors.append(
+            ChildInfrastructureError(
+                test_id=test.id(),
+                kind=kind,
+                detail=detail,
+            )
+        )
+
+    def addError(
+        self,
+        test: unittest.TestCase,
+        err: ExcInfo,
+    ) -> None:
+        if err[1] is not None:
+            self._record_infrastructure_error(test, err[1])
+        super().addError(test, err)
+
+    def addFailure(
+        self,
+        test: unittest.TestCase,
+        err: ExcInfo,
+    ) -> None:
+        if err[1] is not None:
+            self._record_infrastructure_error(test, err[1])
+        super().addFailure(test, err)
+
+    def addSubTest(
+        self,
+        test: unittest.TestCase,
+        subtest: unittest.TestCase,
+        err: ExcInfo | None,
+    ) -> None:
+        if err is not None and err[1] is not None:
+            self._record_infrastructure_error(subtest, err[1])
+        super().addSubTest(test, subtest, err)
+
+
+def _find_disk_full_exception(
+    error: BaseException,
+) -> BaseException | None:
+    """Find ENOSPC through database and exception-wrapper boundaries."""
+    for current in _walk_exception_chain(error):
+        if isinstance(current, OSError) and current.errno == errno.ENOSPC:
+            return current
+        if isinstance(current, DiskFull):
+            return current
+        if isinstance(current, PsycopgError) and current.pgcode == "53100":
+            return current
+    return None
+
+
+def _walk_exception_chain(error: BaseException) -> Iterator[BaseException]:
+    """Yield one exception graph once across groups, causes, and contexts."""
+    pending = [error]
+    visited: set[int] = set()
+    while pending:
+        current = pending.pop()
+        identity = id(current)
+        if identity in visited:
+            continue
+        visited.add(identity)
+        yield current
+        if _is_exception_group(current):
+            pending.extend(current.exceptions)
+        if current.__cause__ is not None:
+            pending.append(current.__cause__)
+        if current.__context__ is not None:
+            pending.append(current.__context__)
+
+
+def _is_exception_group(
+    error: BaseException,
+) -> TypeIs[ExceptionGroup[Exception]]:
+    """Narrow stdlib's otherwise-unknown ExceptionGroup parameter."""
+    return isinstance(error, ExceptionGroup)
+
+
+def _classify_test_infrastructure_error(
+    error: BaseException,
+    *,
+    available_temp_bytes: int | None = None,
+) -> tuple[Literal["disk_full", "database_unavailable"], str] | None:
+    """Classify capacity and disposable-database loss before JSON encoding."""
+    disk_full = _find_disk_full_exception(error)
+    if disk_full is not None:
+        return "disk_full", f"{type(disk_full).__name__}: {disk_full}"
+    available = available_temp_bytes
+    if available is None:
+        try:
+            available = shutil.disk_usage(tempfile.gettempdir()).free
+        except OSError:
+            available = None
+    if (
+        available is not None
+        and available < _MIN_VALID_TEMP_HEADROOM_BYTES
+    ):
+        detail = (
+            f"temporary filesystem has {available} bytes free; "
+            f"{type(error).__name__}: {error}"
+        )
+        return "disk_full", detail
+    operational = next(
+        (
+            current
+            for current in _walk_exception_chain(error)
+            if isinstance(current, OperationalError)
+        ),
+        None,
+    )
+    if operational is None:
+        return None
+    return (
+        "database_unavailable",
+        f"{type(operational).__name__}: {operational}",
+    )
 
 
 class HypothesisStatsRecorder:
@@ -753,6 +906,9 @@ def _run_test_target_child(
                 )
                 + tuple(test.id() for test in result.unexpectedSuccesses),
                 hypothesis_stats=recorder.records,
+                infrastructure_errors=tuple(
+                    result.infrastructure_errors or ()
+                ),
             )
         )
     )

--- a/tests/test_fuzz_burst.py
+++ b/tests/test_fuzz_burst.py
@@ -11,17 +11,21 @@ from pathlib import Path
 
 from scripts.run_fuzz_tests import (
     DEPTH_REPORT_LIMIT,
+    EPHEMERAL_POSTGRES_TARGET_LIMIT,
     FuzzModuleManifest,
     FuzzPropertyManifest,
+    FuzzTarget,
     PropertyDepth,
     aggregate_property_depth,
     assert_exact_fuzz_coverage,
+    assert_fuzz_admission,
     build_fuzz_targets,
     discard_rate,
     discover_fuzz_manifests,
     format_depth_report,
     is_structurally_shallow,
     recommended_property_shards,
+    select_fuzz_admissions,
 )
 from scripts.run_python_tests import (
     STRATEGY_SPACE_EXHAUSTED,
@@ -214,6 +218,77 @@ class TestFuzzTargetPlanning(unittest.TestCase):
             )
         )
 
+    def test_postgres_resource_flag_reaches_every_module_target(self) -> None:
+        property_id = "tests.test_pg_generated.TestWorld.test_property"
+        manifest = FuzzModuleManifest(
+            module_name="tests.test_pg_generated",
+            test_ids=(
+                property_id,
+                "tests.test_pg_generated.TestWorld.test_pin",
+            ),
+            hypothesis_tests=(self.property(property_id),),
+            uses_ephemeral_postgres=True,
+        )
+
+        targets = build_fuzz_targets((manifest,), property_shards=2)
+
+        self.assertTrue(targets)
+        self.assertTrue(
+            all(target.uses_ephemeral_postgres for target in targets)
+        )
+
+    def test_postgres_limit_bypasses_blocked_pg_targets_for_ordinary_work(
+        self,
+    ) -> None:
+        active = (
+            FuzzTarget(
+                label="active-pg",
+                module_name="active-pg",
+                load_names=("active-pg",),
+                expected_test_ids=("active-pg.test",),
+                uses_ephemeral_postgres=True,
+            ),
+        )
+        pending = (
+            FuzzTarget(
+                label="pending-pg-one",
+                module_name="pending-pg-one",
+                load_names=("pending-pg-one",),
+                expected_test_ids=("pending-pg-one.test",),
+                uses_ephemeral_postgres=True,
+            ),
+            FuzzTarget(
+                label="pending-pg-two",
+                module_name="pending-pg-two",
+                load_names=("pending-pg-two",),
+                expected_test_ids=("pending-pg-two.test",),
+                uses_ephemeral_postgres=True,
+            ),
+            FuzzTarget(
+                label="ordinary",
+                module_name="ordinary",
+                load_names=("ordinary",),
+                expected_test_ids=("ordinary.test",),
+            ),
+        )
+
+        admitted = select_fuzz_admissions(
+            pending,
+            active,
+            worker_count=3,
+            postgres_worker_count=1,
+        )
+
+        assert_fuzz_admission(
+            pending,
+            active,
+            admitted,
+            worker_count=3,
+            postgres_worker_count=1,
+        )
+        self.assertEqual(admitted, (2,))
+        self.assertEqual(EPHEMERAL_POSTGRES_TARGET_LIMIT, 2)
+
     def test_30_core_host_uses_eight_entropy_shards(self) -> None:
         self.assertEqual(recommended_property_shards(30), 8)
 
@@ -237,6 +312,25 @@ class TestFuzzTargetPlanning(unittest.TestCase):
         )
         self.assertTrue(state_machine.uses_default_settings)
         self.assertEqual(state_machine.max_examples, 150)
+
+    def test_real_pg_module_discovery_records_the_resource(self) -> None:
+        environment = {
+            **os.environ,
+            "CRATEDIGGER_HYPOTHESIS_PROFILE": "suite",
+            "PYTHONPATH": str(REPO_ROOT),
+        }
+        environment.pop("TEST_DB_DSN", None)
+        environment.pop("CRATEDIGGER_TEST_SCHEMA_READY", None)
+        with tempfile.TemporaryDirectory() as tempdir:
+            manifest = discover_fuzz_manifests(
+                ("tests.test_cleanup_journal_generated",),
+                worker_count=1,
+                environment=environment,
+                work_directory=Path(tempdir),
+            )[0]
+
+        self.assertTrue(manifest.uses_ephemeral_postgres)
+        self.assertNotIn("TEST_DB_DSN", environment)
 
 
 class TestFuzzProfileBudget(unittest.TestCase):
@@ -568,6 +662,53 @@ class TestFuzzRunnerProcess(unittest.TestCase):
             "        self.assertIsInstance(second, bool)\n",
             encoding="utf-8",
         )
+        (package / "test_capacity_generated.py").write_text(
+            "import errno\n"
+            "import os\n"
+            "import time\n"
+            "import unittest\n"
+            "from pathlib import Path\n"
+            "from types import SimpleNamespace\n"
+            "from unittest.mock import patch\n"
+            "from hypothesis import given, settings\n"
+            "from hypothesis import strategies as st\n"
+            "from psycopg2 import OperationalError\n"
+            "from psycopg2.errors import DiskFull\n"
+            "import tests._hypothesis_profiles\n\n"
+            "class CapacityWorld(unittest.TestCase):\n"
+            "    @settings(max_examples=1, database=None, deadline=None)\n"
+            "    @given(value=st.none())\n"
+            "    def test_a_capacity_failure(self, value):\n"
+            "        self.assertIsNone(value)\n"
+            "        database = Path(os.environ['HYPOTHESIS_STORAGE_DIRECTORY'])\n"
+            "        (database / 'invalid-infrastructure-marker').write_text('x')\n"
+            "        if os.environ['FUZZ_INFRA_KIND'] == 'postgres':\n"
+            "            raise DiskFull('could not extend file: No space left')\n"
+            "        if os.environ['FUZZ_INFRA_KIND'] == 'database':\n"
+            "            raise OperationalError('ephemeral database stopped')\n"
+            "        if os.environ['FUZZ_INFRA_KIND'] == 'swallowed':\n"
+            "            patch('shutil.disk_usage', "
+            "return_value=SimpleNamespace(free=1)).start()\n"
+            "            self.fail('preview swallowed ENOSPC')\n"
+            "        if os.environ['FUZZ_INFRA_KIND'] == 'subtest':\n"
+            "            with self.subTest(stage='snapshot'):\n"
+            "                raise OSError(errno.ENOSPC, "
+            "'No space left on device')\n"
+            "            return\n"
+            "        raise OSError(errno.ENOSPC, 'No space left on device')\n\n"
+            "    @settings(max_examples=1, database=None, deadline=None)\n"
+            "    @given(value=st.none())\n"
+            "    def test_b_contaminated_failure(self, value):\n"
+            "        self.assertIsNone(value)\n"
+            "        time.sleep(1)\n"
+            "        self.fail('must not become a property report')\n\n"
+            "    @settings(max_examples=1, database=None, deadline=None)\n"
+            "    @given(value=st.none())\n"
+            "    def test_z_pending_target(self, value):\n"
+            "        self.assertIsNone(value)\n"
+            "        print('pending-target-ran')\n",
+            encoding="utf-8",
+        )
         self.module = "fuzz_fixture.test_example_generated"
         self.output_dir = self.root / "failures"
         self.database = self.root / "persistent-database"
@@ -634,6 +775,63 @@ class TestFuzzRunnerProcess(unittest.TestCase):
             )
         )
         self.assertIn(str(run_directories[0]), completed.stdout)
+
+    def test_capacity_errors_abort_without_becoming_property_failures(
+        self,
+    ) -> None:
+        for kind in (
+            "filesystem",
+            "postgres",
+            "database",
+            "swallowed",
+            "subtest",
+        ):
+            with self.subTest(kind=kind):
+                env = {
+                    **os.environ,
+                    "PYTHONPATH": os.pathsep.join(
+                        (
+                            str(self.root),
+                            str(REPO_ROOT),
+                            os.environ.get("PYTHONPATH", ""),
+                        )
+                    ),
+                    "HYPOTHESIS_STORAGE_DIRECTORY": str(self.database),
+                    "FUZZ_INFRA_KIND": kind,
+                }
+                completed = subprocess.run(
+                    [
+                        sys.executable,
+                        str(RUNNER),
+                        "--jobs",
+                        "2",
+                        "--profile",
+                        "suite",
+                        "fuzz_fixture.test_capacity_generated",
+                    ],
+                    cwd=REPO_ROOT,
+                    env=env,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                )
+
+                self.assertEqual(completed.returncode, 1)
+                self.assertIn("INFRASTRUCTURE ABORT", completed.stdout)
+                self.assertIn("property verdict invalid", completed.stdout)
+                self.assertIn("2 completed of 3", completed.stdout)
+                self.assertIn("1 not started", completed.stdout)
+                self.assertIn(
+                    "1 unittest-failed target withheld from property reporting",
+                    completed.stdout,
+                )
+                self.assertIn("--- INFRASTRUCTURE FAIL", completed.stdout)
+                self.assertNotIn("--- FAIL ", completed.stdout)
+                self.assertNotIn("DEPTH ", completed.stdout)
+                self.assertNotIn("pending-target-ran", completed.stdout)
+                self.assertFalse(
+                    (self.database / "invalid-infrastructure-marker").exists()
+                )
 
     def test_external_property_id_runs_through_filtered_module_load(self) -> None:
         env = {

--- a/tests/test_fuzz_runner_generated.py
+++ b/tests/test_fuzz_runner_generated.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import errno
+import io
 import os
 import tempfile
 import unittest
@@ -9,8 +11,9 @@ from collections.abc import Sequence
 from dataclasses import replace
 from pathlib import Path
 
-from hypothesis import example, given
+from hypothesis import assume, example, given
 from hypothesis import strategies as st
+from psycopg2.errors import DiskFull
 
 import tests._hypothesis_profiles  # noqa: F401 - registers active profile
 from scripts.run_fuzz_tests import (
@@ -18,18 +21,25 @@ from scripts.run_fuzz_tests import (
     DISCARD_RATE_THRESHOLD,
     FuzzModuleManifest,
     FuzzPropertyManifest,
+    FuzzTarget,
     PropertyDepth,
     aggregate_property_depth,
     assert_exact_fuzz_coverage,
+    assert_fuzz_admission,
     build_fuzz_targets,
     discard_rate,
     discover_fuzz_manifests,
     format_depth_report,
     is_structurally_shallow,
+    select_fuzz_admissions,
 )
 from scripts.run_python_tests import (
+    _MIN_VALID_TEMP_HEADROOM_BYTES,
     STRATEGY_SPACE_EXHAUSTED,
     HypothesisPropertyStats,
+    RecordingTextTestResult,
+    _classify_test_infrastructure_error,
+    _find_disk_full_exception,
 )
 
 #: Reasons Hypothesis reports, exhaustion plus the ordinary budget endings.
@@ -150,6 +160,44 @@ def _assert_section_truncation(
             f"{prefix} truncation line is {actual}, expected {expected} "
             f"for {total} properties"
         )
+
+
+def fuzz_target(index: int, uses_ephemeral_postgres: bool) -> FuzzTarget:
+    """One generated scheduler target."""
+    label = f"target-{index}"
+    return FuzzTarget(
+        label=label,
+        module_name=label,
+        load_names=(label,),
+        expected_test_ids=(f"{label}.test",),
+        uses_ephemeral_postgres=uses_ephemeral_postgres,
+    )
+
+
+def wrap_exception(error: Exception, wrappers: Sequence[int]) -> Exception:
+    """Nest a capacity failure through the shapes Hypothesis may produce."""
+    wrapped = error
+    for index, wrapper in enumerate(wrappers):
+        if wrapper == 0:
+            outer = RuntimeError(f"cause-{index}")
+            outer.__cause__ = wrapped
+            wrapped = outer
+        elif wrapper == 1:
+            outer = RuntimeError(f"context-{index}")
+            outer.__context__ = wrapped
+            wrapped = outer
+        else:
+            wrapped = ExceptionGroup(
+                f"group-{index}",
+                [ValueError("noise"), wrapped],
+            )
+    return wrapped
+
+
+def assert_capacity_error_is_detected(error: BaseException) -> None:
+    """A capacity failure must survive arbitrary supported wrappers."""
+    if _find_disk_full_exception(error) is None:
+        raise AssertionError("capacity failure was not detected")
 
 
 def assert_report_names_exactly_the_shallow_properties(
@@ -276,6 +324,129 @@ class TestGeneratedFuzzTargetPlanning(unittest.TestCase):
                 sum(pin_id in target.expected_test_ids for target in targets),
                 1,
             )
+
+    @given(
+        active_pg=st.integers(min_value=0, max_value=4),
+        active_ordinary=st.integers(min_value=0, max_value=4),
+        pending=st.lists(st.booleans(), min_size=0, max_size=20),
+        worker_count=st.integers(min_value=1, max_value=12),
+        postgres_worker_count=st.integers(min_value=1, max_value=4),
+    )
+    def test_admission_is_work_conserving_with_a_separate_pg_ceiling(
+        self,
+        active_pg: int,
+        active_ordinary: int,
+        pending: list[bool],
+        worker_count: int,
+        postgres_worker_count: int,
+    ) -> None:
+        assume(active_pg <= postgres_worker_count)
+        assume(active_pg + active_ordinary <= worker_count)
+        active = tuple(
+            fuzz_target(index, True)
+            for index in range(active_pg)
+        ) + tuple(
+            fuzz_target(active_pg + index, False)
+            for index in range(active_ordinary)
+        )
+        queued = tuple(
+            fuzz_target(len(active) + index, uses_pg)
+            for index, uses_pg in enumerate(pending)
+        )
+
+        admitted = select_fuzz_admissions(
+            queued,
+            active,
+            worker_count=worker_count,
+            postgres_worker_count=postgres_worker_count,
+        )
+
+        assert_fuzz_admission(
+            queued,
+            active,
+            admitted,
+            worker_count=worker_count,
+            postgres_worker_count=postgres_worker_count,
+        )
+
+    @given(
+        postgres=st.booleans(),
+        wrappers=st.lists(
+            st.integers(min_value=0, max_value=2),
+            min_size=0,
+            max_size=6,
+        ),
+    )
+    def test_capacity_classification_survives_exception_wrappers(
+        self,
+        postgres: bool,
+        wrappers: list[int],
+    ) -> None:
+        leaf: Exception = (
+            DiskFull("could not extend file: No space left")
+            if postgres
+            else OSError(errno.ENOSPC, "No space left on device")
+        )
+
+        assert_capacity_error_is_detected(wrap_exception(leaf, wrappers))
+
+    @given(
+        available=st.integers(
+            min_value=0,
+            max_value=2 * _MIN_VALID_TEMP_HEADROOM_BYTES,
+        ),
+        message=st.text(max_size=80),
+    )
+    def test_plain_failure_is_invalid_only_below_the_headroom_floor(
+        self,
+        available: int,
+        message: str,
+    ) -> None:
+        classified = _classify_test_infrastructure_error(
+            AssertionError(message),
+            available_temp_bytes=available,
+        )
+
+        if available < _MIN_VALID_TEMP_HEADROOM_BYTES:
+            self.assertIsNotNone(classified)
+            assert classified is not None
+            self.assertEqual(classified[0], "disk_full")
+        else:
+            self.assertIsNone(classified)
+
+    @given(
+        wrappers=st.lists(
+            st.integers(min_value=0, max_value=2),
+            min_size=0,
+            max_size=6,
+        ),
+    )
+    def test_subtest_capacity_failure_uses_infrastructure_channel(
+        self,
+        wrappers: list[int],
+    ) -> None:
+        wrapped = wrap_exception(
+            OSError(errno.ENOSPC, "No space left on device"),
+            wrappers,
+        )
+
+        class CapacitySubtest(unittest.TestCase):
+            def runTest(self) -> None:
+                with self.subTest(stage="generated"):
+                    raise wrapped
+
+        result = unittest.TextTestRunner(
+            stream=io.StringIO(),
+            resultclass=RecordingTextTestResult,  # pyright: ignore[reportArgumentType]
+        ).run(CapacitySubtest())
+
+        self.assertIsInstance(result, RecordingTextTestResult)
+        assert isinstance(result, RecordingTextTestResult)
+        self.assertEqual(len(result.infrastructure_errors or ()), 1)
+        self.assertEqual(
+            (result.infrastructure_errors or [])[0].kind,
+            "disk_full",
+        )
 
 
 class TestGeneratedBurstDepthReport(unittest.TestCase):
@@ -522,6 +693,27 @@ class TestFuzzCoverageCheckerKnownBad(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "changed fuzz property budget"):
             assert_exact_fuzz_coverage((manifest,), targets)
+
+    def test_admission_checker_rejects_too_many_pg_targets(self) -> None:
+        pending = (fuzz_target(0, True), fuzz_target(1, True))
+
+        with self.assertRaisesRegex(AssertionError, "PostgreSQL"):
+            assert_fuzz_admission(
+                pending,
+                (),
+                (0, 1),
+                worker_count=2,
+                postgres_worker_count=1,
+            )
+
+    def test_capacity_checker_rejects_an_unrelated_io_error(self) -> None:
+        with self.assertRaisesRegex(
+            AssertionError,
+            "capacity failure was not detected",
+        ):
+            assert_capacity_error_is_detected(
+                OSError(errno.EIO, "input/output error")
+            )
 
 
 class TestFuzzDiscoverySettingsContract(unittest.TestCase):

--- a/tests/test_parallel_test_runner.py
+++ b/tests/test_parallel_test_runner.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import datetime
+import errno
+import io
 import os
 import subprocess
 import sys
@@ -31,7 +33,9 @@ from scripts.run_python_tests import (
     ChildTargetResult,
     HypothesisPropertyStats,
     HypothesisStatsRecorder,
+    RecordingTextTestResult,
     TestModule,
+    _classify_test_infrastructure_error,
     _iter_test_cases,
     assert_exact_schedule,
     assert_exact_target_coverage,
@@ -52,6 +56,50 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 RUNNER = REPO_ROOT / "scripts" / "run_python_tests.py"
 RUN_TESTS_SH = REPO_ROOT / "scripts" / "run_tests.sh"
 RUN_SUITE = REPO_ROOT / "scripts" / "run_test_suite.py"
+
+
+class TestInfrastructureFailureClassification(unittest.TestCase):
+    def test_low_headroom_invalidates_a_failure_after_enospc_was_swallowed(
+        self,
+    ) -> None:
+        classified = _classify_test_infrastructure_error(
+            AssertionError("preview manifest was incomplete"),
+            available_temp_bytes=1,
+        )
+
+        self.assertIsNotNone(classified)
+        assert classified is not None
+        self.assertEqual(classified[0], "disk_full")
+        self.assertIn("1 bytes free", classified[1])
+        self.assertIn("AssertionError", classified[1])
+
+    def test_ordinary_failure_with_headroom_stays_a_property_failure(
+        self,
+    ) -> None:
+        classified = _classify_test_infrastructure_error(
+            AssertionError("real counterexample"),
+            available_temp_bytes=1024 * 1024 * 1024,
+        )
+
+        self.assertIsNone(classified)
+
+    def test_subtest_enospc_uses_the_infrastructure_channel(self) -> None:
+        class CapacitySubtest(unittest.TestCase):
+            def runTest(self) -> None:
+                with self.subTest(stage="snapshot"):
+                    raise OSError(errno.ENOSPC, "No space left on device")
+
+        result = unittest.TextTestRunner(
+            stream=io.StringIO(),
+            resultclass=RecordingTextTestResult,  # pyright: ignore[reportArgumentType]
+        ).run(CapacitySubtest())
+
+        self.assertIsInstance(result, RecordingTextTestResult)
+        assert isinstance(result, RecordingTextTestResult)
+        self.assertEqual(len(result.infrastructure_errors or ()), 1)
+        error = (result.infrastructure_errors or [])[0]
+        self.assertEqual(error.kind, "disk_full")
+        self.assertIn("stage='snapshot'", error.test_id)
 
 
 class TestModuleDiscovery(unittest.TestCase):
@@ -798,6 +846,27 @@ class TestHypothesisStatsRecorder(unittest.TestCase):
                 stopped_because=STRATEGY_SPACE_EXHAUSTED,
             ),
         )
+
+    def test_child_result_rejects_wrong_infrastructure_error_types(self) -> None:
+        payload = msgspec.json.encode(
+            {
+                "successful": False,
+                "tests_run": 1,
+                "test_ids": ["fixture.World.test_property"],
+                "output": "failure",
+                "failed_test_ids": ["fixture.World.test_property"],
+                "infrastructure_errors": [
+                    {
+                        "test_id": "fixture.World.test_property",
+                        "kind": 53100,
+                        "detail": "disk full",
+                    }
+                ],
+            }
+        )
+
+        with self.assertRaises(msgspec.ValidationError):
+            msgspec.json.decode(payload, type=ChildTargetResult)
 
 
 class TestRunTestsWiring(unittest.TestCase):


### PR DESCRIPTION
## Summary

- rescue signed commit `845185f5` onto current main after the local-500/overnight-20,000 depth split
- prevent fuzz discovery from booting one shared PostgreSQL cluster whose state grows for the whole burst
- give PostgreSQL-backed targets disposable child-owned clusters and cap that resource separately at two concurrent targets
- stop admitting targets on infrastructure loss and distinguish ENOSPC/database loss from property failures
- preserve exact target coverage, budgets, replay-state policy, and work-conserving ordinary concurrency

Closes #939.

## Verification

- commit signature valid (`abl030@proxmox-vm`)
- focused fuzz/runner tests: 92 passed
- daily-depth/profile tests: 21 passed
- independent Python suite: 8,706 tests passed
- independent Ruff and Pyright: clean
- two independent reviews: no security concerns or logic errors
- receipt-backed whole-tree Pyright: pass (`/run/user/1000/cratedigger-final-gate.bxMx0eKJ`)
- receipt-backed complete suite: pass (`/run/user/1000/cratedigger-final-gate.RZCYlqck`)
- full acceptance: `CRATEDIGGER_FUZZ_MAX_EXAMPLES=20000 nix-shell --run 'bash scripts/fuzz_burst.sh'`
  - exit 0
  - 3,359/3,359 targets
  - 115 modules / 1,424 tests
  - 1,712.7 seconds
  - zero ENOSPC
  - zero infrastructure failures
  - `fuzz burst: ALL GREEN`
