### PR TITLE
test(fuzz): exhaust finite preview manifests once

### DIFF
--- a/tests/test_fuzz_runner_generated.py
+++ b/tests/test_fuzz_runner_generated.py
@@ -717,6 +717,44 @@ class TestFuzzCoverageCheckerKnownBad(unittest.TestCase):
 
 
 class TestFuzzDiscoverySettingsContract(unittest.TestCase):
+    def test_finite_preview_manifest_property_is_not_entropy_sharded(self) -> None:
+        environment = dict(os.environ)
+        environment.update({
+            "CRATEDIGGER_HYPOTHESIS_PROFILE": "fuzz",
+            "CRATEDIGGER_FUZZ_MAX_EXAMPLES": "20000",
+        })
+        property_id = (
+            "tests.test_preview_manifest_generated."
+            "TestPreviewManifestPurityProperty."
+            "test_owned_canonical_album_stays_pure_after_preview"
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            manifests = discover_fuzz_manifests(
+                ("tests.test_preview_manifest_generated",),
+                worker_count=1,
+                environment=environment,
+                work_directory=Path(directory),
+            )
+
+        manifest = manifests[0]
+        property_manifest = next(
+            item
+            for item in manifest.hypothesis_tests
+            if item.test_id == property_id
+        )
+        self.assertEqual(property_manifest.max_examples, 128)
+        self.assertFalse(property_manifest.uses_default_settings)
+
+        targets = build_fuzz_targets(manifests, property_shards=8)
+        matching = tuple(
+            target
+            for target in targets
+            if property_id in target.expected_test_ids
+        )
+        self.assertEqual(len(matching), 1)
+        self.assertEqual(matching[0].shard_count, 1)
+        self.assertIsNone(matching[0].profile_max_examples)
+
     def test_discovery_rejects_property_with_default_deadline(self) -> None:
         """A module that omits profile registration must fail before sharding."""
         with tempfile.TemporaryDirectory() as directory:

--- a/tests/test_preview_manifest_generated.py
+++ b/tests/test_preview_manifest_generated.py
@@ -42,11 +42,12 @@ import sys
 import tempfile
 import unittest
 from dataclasses import dataclass
+from itertools import combinations
 from unittest.mock import patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from hypothesis import example, given
+from hypothesis import example, given, settings
 from hypothesis import strategies as st
 
 import tests._hypothesis_profiles  # noqa: F401  (loads the active profile)
@@ -103,9 +104,41 @@ _EXTRA_FILENAME_POOL: tuple[str, ...] = (
     "07 - Été à Paris.flac",
     "08 - ☆Star☆.mp3",
 )
-_extra_filenames_strategy = st.sets(
-    st.sampled_from(_EXTRA_FILENAME_POOL), max_size=len(_EXTRA_FILENAME_POOL),
+# This is an exact finite domain, not an entropy surface. A bounded integer
+# gives Hypothesis one canonical representation per subset; the matching fixed
+# budget also keeps the fuzz runner from repeating the same domain in eight
+# shards after every subset has already been exercised.
+_EXTRA_FILENAME_WORLD_COUNT = 1 << len(_EXTRA_FILENAME_POOL)
+_extra_filename_mask_strategy = st.integers(
+    min_value=0,
+    max_value=_EXTRA_FILENAME_WORLD_COUNT - 1,
 )
+
+
+def _extra_filenames_for_mask(mask: int) -> frozenset[str]:
+    if not 0 <= mask < _EXTRA_FILENAME_WORLD_COUNT:
+        raise ValueError(f"filename mask is outside the finite domain: {mask}")
+    return frozenset(
+        filename
+        for index, filename in enumerate(_EXTRA_FILENAME_POOL)
+        if mask & (1 << index)
+    )
+
+
+def assert_extra_filename_mask_domain(
+    mapped: tuple[frozenset[str], ...],
+) -> None:
+    """Every subset of the filename pool must have one exact mask."""
+    expected = {
+        frozenset(selected)
+        for size in range(len(_EXTRA_FILENAME_POOL) + 1)
+        for selected in combinations(_EXTRA_FILENAME_POOL, size)
+    }
+    actual = set(mapped)
+    if len(mapped) != len(expected) or actual != expected:
+        raise AssertionError(
+            "filename masks do not map one-to-one onto every manifest subset"
+        )
 
 
 # ============================================================================
@@ -467,13 +500,15 @@ class TestPreviewSidecarManifestPurityPin(unittest.TestCase):
 
 class TestPreviewManifestPurityProperty(unittest.TestCase):
     """Patrols the same composed path (``_materialize_canonical_album`` +
-    ``measure_and_persist_candidate_evidence``) over generated manifests:
-    file count, basenames with spaces/unicode, mp3/flac mix."""
+    ``measure_and_persist_candidate_evidence``) over the exact finite manifest
+    domain: file count, basenames with spaces/unicode, mp3/flac mix."""
 
-    @given(extra=_extra_filenames_strategy)
-    @example(extra=frozenset())
-    @example(extra=frozenset(_EXTRA_FILENAME_POOL))
-    def test_owned_canonical_album_stays_pure_after_preview(self, extra):
+    @settings(max_examples=_EXTRA_FILENAME_WORLD_COUNT)
+    @given(mask=_extra_filename_mask_strategy)
+    @example(mask=0)
+    @example(mask=_EXTRA_FILENAME_WORLD_COUNT - 1)
+    def test_owned_canonical_album_stays_pure_after_preview(self, mask: int):
+        extra = _extra_filenames_for_mask(mask)
         basenames = frozenset({_MANDATORY_FLAC}) | frozenset(extra)
         request_id = 8590100
         mb_release_id = "mbid-issue-859-gen"
@@ -551,6 +586,24 @@ class TestPreviewManifestCheckersTripOnViolations(unittest.TestCase):
                 canonical_dir,
                 label="known-bad",
             )
+
+    def test_filename_mask_domain_checker_trips_on_a_collapsed_world(self):
+        collapsed = tuple(
+            frozenset()
+            for _mask in range(1 << len(_EXTRA_FILENAME_POOL))
+        )
+        with self.assertRaises(AssertionError):
+            assert_extra_filename_mask_domain(collapsed)
+
+
+class TestPreviewManifestFiniteDomain(unittest.TestCase):
+    def test_every_filename_subset_has_one_exact_mask(self):
+        mapped = tuple(
+            _extra_filenames_for_mask(mask)
+            for mask in range(1 << len(_EXTRA_FILENAME_POOL))
+        )
+
+        assert_extra_filename_mask_domain(mapped)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- encode the preview-manifest property's seven optional filenames as one canonical 7-bit mask
- fix its generated budget at the exact 128-world finite domain
- prevent the fuzz runner from entropy-sharding and repeating that exhausted domain eight times
- prove the mask mapping is bijective and keep empty/full explicit examples plus a known-bad checker

## Coverage preservation

- the filename pool has seven distinct optional names: `2^7 = 128` exact subsets
- an independent combinations-based oracle proves masks `0..127` map one-to-one onto every subset
- the known-bad test proves a collapsed mapping fails
- direct Hypothesis probes under both suite and fuzz profiles reached all 128 distinct masks
- child evidence: `max_examples=128`, `valid=128`, `invalid=0`, `overrun=0`, `interesting=0`
- discovery evidence: explicit settings, one target, `shard_count=1`, no profile budget override

## Performance evidence

Accepted pre-change production-depth log:

- eight entropy shards of this property
- 580.7–585.9 seconds each
- 4,666.6 aggregate target-seconds

Optimized targeted production-depth execution (`CRATEDIGGER_FUZZ_MAX_EXAMPLES=20000`):

- one module target
- 16.7 seconds
- all 128 finite worlds valid
- 97.1% reduction in the slowest target duration
- 99.6% reduction in aggregate target-seconds for this property

The unchanged complete 20,000-example burst was not replayed solely for presentation; the exact affected production-depth target was exercised through the canonical runner.

## Verification

- RED failures observed for missing finite-domain mapping and old 20,000/8-shard discovery
- focused preview/runner suite: 34 tests passed
- canonical module fuzz target: passed in 16.7 seconds
- whole-tree Pyright: passed
- whole-tree Ruff: passed
- complete repository gate: all 6 phases passed
- committed-tree Pyright receipt: `/run/user/1000/cratedigger-final-gate.4LO2rvi2`
- committed-tree test receipt: `/run/user/1000/cratedigger-final-gate.7JaRnpDF`
- independent review: passed with no security concerns, logic errors, or suggestions
