### PR TITLE
perf(fuzz): persist JavaScript and Ruff workers

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -185,6 +185,28 @@ Any type that **crosses JSON** — harness stdout, an HTTP response, a JSONB blo
   matrix in the issue/PR. Canonical run: issue #548, 2026-07-08 — 13
   mutants, incl. reverting fix `6cf26a4`, led to PR #555.
 
+### Generated-test performance is a coverage contract
+
+- Classify a generated surface as **finite** only with an independently checked
+  cardinality and canonical representation. Use
+  `tests.finite_domain.finite_generated_domain`; its proof runs during isolated
+  discovery, its exact budget is runner metadata, and the scheduler refuses to
+  multiply it into entropy shards. Keep edge `@example` pins and a known-bad
+  collapsed-domain checker. Never infer finiteness from a green `SHALLOW` report
+  or cap an arbitrary strategy because examples repeated.
+- A generated property must not launch Node once per example. Use
+  `tests.node_jsonl_worker.NodeJsonlWorker`: one strict JSON-lines child per
+  isolated Python target, with request IDs, typed frames, timeout/EOF/malformed
+  output detection, poisoned-worker failure, and target teardown. The bounded
+  AST audit in `tests/test_generated_node_worker_audit.py` rejects the historical
+  literal `subprocess.run(["node", ...])` shape.
+- Optimize from production-depth target timings, preserving the exact daily
+  budget, property count, edge pins, and target isolation. Benchmark the changed
+  target first, then run the complete burst after a material critical-path
+  improvement. Stop when the next cost is domain work rather than repeated
+  harness overhead, or when added protocol/scheduler complexity outweighs the
+  measured wall-time return. Detailed workflow: `docs/generated-testing.md`.
+
 ## Authority for exceptions and bypasses
 
 Plans translate product authority; they do not create it. Any plan KTD,

--- a/docs/generated-testing.md
+++ b/docs/generated-testing.md
@@ -47,6 +47,92 @@ fix (source exclusion + fail-closed coverage gate) merged with the property
 in PR #557. Full workflow rule: `.claude/rules/code-quality.md` § "Bug
 Hunting — Generated-First".
 
+## Performance and expansion rulebook
+
+Generated-test speed is subordinate to semantic coverage. The optimization
+loop is therefore **classify → prove → remove harness repetition → measure**,
+never "lower the daily budget until green". The unattended profile remains
+20,000 examples for entropy-driven properties.
+
+### Exact finite domains
+
+A property is finite only when its module can prove the complete semantic
+domain independently of Hypothesis. Do not infer finiteness from repeated
+examples, a `SHALLOW` report, or a strategy that happens to contain bounded
+primitives: projections, filters, dependent dimensions, and future expansion
+can make an apparent product count wrong.
+
+For a proved finite domain:
+
+1. Derive cardinality from the actual independent dimensions in code.
+2. Give every world one canonical representation. A bit mask over `n` optional
+   members is the canonical powerset representation (`0 .. 2**n - 1`).
+3. Write an independent verifier that enumerates the represented worlds and
+   compares them with the intended domain. Keep a known-bad self-test that
+   removes or collapses worlds and proves the verifier fails.
+4. Keep named minimum, maximum, empty, full, and historical edge `@example`
+   pins even when they duplicate generated endpoints.
+5. Decorate the property with
+   `@finite_generated_domain(cardinality=N, verify=verify_domain)`. The
+   decorator runs the proof during every isolated import, inherits all active
+   profile settings except `max_examples`, fixes the budget at exactly `N`, and
+   publishes typed discovery metadata.
+6. The fuzz scheduler validates `budget == cardinality` and schedules one
+   target regardless of the entropy-shard count. A metadata mismatch aborts
+   before admission; it never silently falls back to repeated shards.
+7. Pin discovery in `tests/test_fuzz_runner_generated.py`: cardinality, explicit
+   budget, one target, no profile override. Run the target under the production
+   profile and inspect Hypothesis statistics for exactly the intended valid
+   worlds.
+
+This is explicit automation rather than strategy inference. Future expansion
+changes the dimensions, so its verifier/cardinality test goes red and forces a
+deliberate new proof before the scheduler changes work.
+
+### Per-example external process startup
+
+If the slow target launches the same interpreter, browser, compiler, or helper
+for each Hypothesis example, first prove startup/module loading is the repeated
+cost. Preserve fresh **Python target** isolation, but reuse the helper inside
+that target when the operation itself can be request-local.
+
+JavaScript-backed properties use `tests.node_jsonl_worker.NodeJsonlWorker`:
+
+- one Node child is created in each test method's `setUp()` and registered with
+  `addCleanup()`, so ordinary unittest execution never shares mutable worker
+  state between methods;
+- each request carries a monotone ID, operation, and complete payload;
+- each response is exactly one typed JSON line with the matching ID;
+- malformed/extra output, wrong IDs, EOF, timeout, JavaScript exceptions, and
+  child loss poison the worker and fail closed with retained stderr;
+- a poisoned worker repeats its original failure so Hypothesis cannot turn a
+  harness death into inconsistent shrink noise;
+- no child survives the Python fuzz target, and no mutable request state is
+  shared by handlers.
+
+`tests/test_generated_node_worker_audit.py` enforces the bounded historical
+anti-pattern: a generated module cannot directly launch a literal `node` or
+`nodejs` subprocess. Other real subprocess properties (FFmpeg, git, pinned
+Beets) remain deliberate semantic boundaries and are not swept into a broad
+source scanner.
+
+### Measurement and stopping rule
+
+1. Preserve the accepted full-depth log as baseline.
+2. Benchmark the exact changed property/module with the production profile and
+   canonical shard count. This proves the optimization before paying for the
+   whole queue.
+3. After a material critical-path change, run the complete 20,000-example burst
+   once and compare wall time, targets, tests, property depth, discards,
+   infrastructure failures, ENOSPC, and slow-target rankings.
+4. Continue only while the next slow cohort is dominated by removable harness
+   repetition or a separately proved finite domain. Domain computation,
+   PostgreSQL serialization required by ownership, and real media decoding are
+   semantic costs, not automatic optimization targets.
+5. Stop when measured whole-run return is marginal relative to new protocol or
+   scheduler complexity. Never raise the PostgreSQL cap or global worker count
+   without private tmpfs/process-tree evidence.
+
 ## Modules
 
 | Module | Target | Properties |

--- a/scripts/run_fuzz_tests.py
+++ b/scripts/run_fuzz_tests.py
@@ -35,9 +35,14 @@ from scripts.run_python_tests import (
     ChildTargetResult,
     HypothesisPropertyStats,
     _iter_test_cases,
+    _test_method,
     assert_hypothesis_deadlines_disabled,
     resolve_hypothesis_settings,
     settings_max_examples,
+)
+from tests.finite_domain_metadata import (
+    FINITE_DOMAIN_ATTRIBUTE,
+    FiniteDomainSpec,
 )
 
 TARGET_RUNNER = REPO_ROOT / "scripts" / "run_python_tests.py"
@@ -62,6 +67,7 @@ class FuzzPropertyManifest(msgspec.Struct, frozen=True):
     test_id: str
     max_examples: int
     uses_default_settings: bool
+    finite_domain_cardinality: int | None = None
 
 
 class FuzzModuleManifest(msgspec.Struct, frozen=True):
@@ -182,6 +188,17 @@ def build_fuzz_targets(
     for manifest in ordered_manifests:
         if not manifest.test_ids:
             continue
+        for item in manifest.hypothesis_tests:
+            finite_cardinality = item.finite_domain_cardinality
+            if finite_cardinality is not None and (
+                finite_cardinality < 1
+                or item.max_examples != finite_cardinality
+            ):
+                raise ValueError(
+                    f"finite domain cardinality for {item.test_id} is "
+                    f"{finite_cardinality}, but its budget is "
+                    f"{item.max_examples}"
+                )
         hypothesis_ids = {
             item.test_id for item in manifest.hypothesis_tests
         }
@@ -212,11 +229,12 @@ def build_fuzz_targets(
                     f"invalid Hypothesis budget for {item.test_id}: "
                     f"{item.max_examples}"
                 )
-            shard_count = (
-                min(property_shards, item.max_examples)
-                if item.uses_default_settings
-                else 1
-            )
+            shard_count = 1
+            if (
+                item.finite_domain_cardinality is None
+                and item.uses_default_settings
+            ):
+                shard_count = min(property_shards, item.max_examples)
             quotient, remainder = divmod(item.max_examples, shard_count)
             budgets = tuple(
                 quotient + (1 if index < remainder else 0)
@@ -326,6 +344,18 @@ def assert_exact_fuzz_coverage(
         if len(shard_counts) != 1:
             raise ValueError(f"inconsistent fuzz shard count: {test_id}")
         shard_count = shard_counts.pop()
+        if item.finite_domain_cardinality is not None:
+            if item.max_examples != item.finite_domain_cardinality:
+                raise ValueError(
+                    f"finite domain cardinality changed: {test_id}"
+                )
+            if shard_count != 1 or len(scheduled) != 1:
+                raise ValueError(f"finite fuzz property was sharded: {test_id}")
+            if scheduled[0].profile_max_examples is not None:
+                raise ValueError(
+                    f"finite fuzz property received a profile override: {test_id}"
+                )
+            continue
         if shard_count != len(scheduled):
             raise ValueError(f"missing fuzz property shard: {test_id}")
         if {target.shard_index for target in scheduled} != set(
@@ -518,11 +548,27 @@ def _discover_module_child(module_name: str, result_path: Path) -> int:
             else configured is default_settings
         )
         configured_max_examples = settings_max_examples(configured)
+        method = _test_method(test)
+        if method is None:
+            raise RuntimeError(f"could not resolve fuzz test method: {test.id()}")
+        raw_finite_spec = getattr(method, FINITE_DOMAIN_ATTRIBUTE, None)
+        if raw_finite_spec is not None and not isinstance(
+            raw_finite_spec,
+            FiniteDomainSpec,
+        ):
+            raise TypeError(f"invalid finite-domain metadata: {test.id()}")
+        if raw_finite_spec is not None:
+            raw_finite_spec.verify()
         hypothesis_tests.append(
             FuzzPropertyManifest(
                 test_id=test.id(),
                 max_examples=configured_max_examples,
                 uses_default_settings=uses_default_settings,
+                finite_domain_cardinality=(
+                    raw_finite_spec.cardinality
+                    if raw_finite_spec is not None
+                    else None
+                ),
             )
         )
     result_path.write_bytes(

--- a/tests/_tests_typing_ratchet_baseline.py
+++ b/tests/_tests_typing_ratchet_baseline.py
@@ -80,7 +80,6 @@ TESTS_TYPING_RATCHET_BASELINE: dict[str, dict[str, int]] = {
     "tests/test_measurement.py": {"any": 3, "cast": 3, "type_ignore": 6},
     "tests/test_measurement_failure.py": {"type_ignore": 1},
     "tests/test_multidisc_manifest_generated.py": {"any": 2, "cast": 2},
-    "tests/test_owned_section_expansion_generated.py": {"type_ignore": 2},
     "tests/test_peer_cache.py": {"any": 9},
     "tests/test_pin_retention_generated.py": {"type_ignore": 2},
     "tests/test_pipeline_cli.py": {"any": 62, "cast": 53},

--- a/tests/finite_domain.py
+++ b/tests/finite_domain.py
@@ -1,0 +1,46 @@
+"""Explicit contracts for generated properties with proved finite domains."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import ParamSpec, TypeVar
+
+from hypothesis import settings
+
+import tests._hypothesis_profiles  # noqa: F401 - registers suite/fuzz tiers
+from tests.finite_domain_metadata import (
+    FINITE_DOMAIN_ATTRIBUTE,
+    certify_finite_domain,
+)
+
+_Args = ParamSpec("_Args")
+_Result = TypeVar("_Result")
+
+
+def finite_generated_domain(
+    *,
+    cardinality: int,
+    verify: Callable[[], None],
+) -> Callable[
+    [Callable[_Args, _Result]],
+    Callable[_Args, _Result],
+]:
+    """Prove a finite domain, fix its exact budget, and expose runner metadata.
+
+    ``verify`` must independently enumerate or otherwise prove the semantic
+    worlds represented by the strategy.  It runs while the test module is
+    imported, including isolated fuzz discovery; a broken proof therefore
+    fails before target admission.  ``settings(max_examples=...)`` inherits
+    every unnamed setting from the already-loaded suite/fuzz profile.
+    """
+    if cardinality < 1:
+        raise ValueError("finite generated-domain cardinality must be positive")
+    def decorate(
+        test: Callable[_Args, _Result],
+    ) -> Callable[_Args, _Result]:
+        spec = certify_finite_domain(cardinality, verify)
+        configured = settings(max_examples=cardinality)(test)
+        setattr(configured, FINITE_DOMAIN_ATTRIBUTE, spec)
+        return configured
+
+    return decorate

--- a/tests/finite_domain_metadata.py
+++ b/tests/finite_domain_metadata.py
@@ -1,0 +1,25 @@
+"""Wire-neutral metadata for explicitly proved finite generated domains."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+
+FINITE_DOMAIN_ATTRIBUTE = "__cratedigger_finite_domain__"
+
+
+@dataclass(frozen=True)
+class FiniteDomainSpec:
+    """Cardinality proved independently by a generated property's module."""
+
+    cardinality: int
+    verify: Callable[[], None] = field(repr=False, compare=False)
+
+
+def certify_finite_domain(
+    cardinality: int,
+    verify: Callable[[], None],
+) -> FiniteDomainSpec:
+    """Run the independent proof and retain it for discovery to rerun."""
+    verify()
+    return FiniteDomainSpec(cardinality=cardinality, verify=verify)

--- a/tests/node_jsonl_worker.py
+++ b/tests/node_jsonl_worker.py
@@ -1,0 +1,395 @@
+"""Target-scoped fail-closed Node worker for generated tests.
+
+The child imports JavaScript once, then serves one strictly framed JSON request at
+a time.  A protocol violation poisons the worker: generated tests must never keep
+exploring after losing confidence that a response belongs to the current world.
+"""
+
+from __future__ import annotations
+
+import os
+import selectors
+import subprocess
+import threading
+import time
+from pathlib import Path
+from typing import Final, Self
+
+import msgspec
+
+MAX_RESPONSE_BYTES: Final = 1024 * 1024
+MAX_REQUEST_BYTES: Final = 1024 * 1024
+_STDERR_TAIL_BYTES: Final = 16 * 1024
+
+
+class NodeJsonlWorkerError(RuntimeError):
+    """The Node worker could not return one authoritative response."""
+
+
+class _Request(msgspec.Struct, forbid_unknown_fields=True):
+    id: int
+    operation: str
+    payload: object
+
+
+class _Response(msgspec.Struct, forbid_unknown_fields=True):
+    id: int
+    ok: bool
+    result: object
+    error: str | None
+
+
+_PROTOCOL: Final = r"""
+import readline from 'node:readline';
+
+const lines = readline.createInterface({
+  input: process.stdin,
+  crlfDelay: Infinity,
+  terminal: false,
+});
+
+process.stdout.write(JSON.stringify({
+  id: 0,
+  ok: true,
+  result: 'ready',
+  error: null,
+}) + '\n');
+
+for await (const line of lines) {
+  let request = null;
+  try {
+    request = JSON.parse(line);
+    if (
+      request === null
+      || !Number.isSafeInteger(request.id)
+      || request.id < 1
+      || typeof request.operation !== 'string'
+      || !Object.hasOwn(request, 'payload')
+    ) {
+      throw new Error('invalid request frame');
+    }
+    const result = await handle(request.operation, request.payload);
+    process.stdout.write(JSON.stringify({
+      id: request.id,
+      ok: true,
+      result,
+      error: null,
+    }) + '\n');
+  } catch (error) {
+    const message = error instanceof Error ? error.stack ?? error.message : String(error);
+    process.stdout.write(JSON.stringify({
+      id: Number.isSafeInteger(request?.id) ? request.id : -1,
+      ok: false,
+      result: null,
+      error: message,
+    }) + '\n');
+  }
+}
+"""
+
+
+class NodeJsonlWorker:
+    """One reusable Node child whose lifetime is bounded by one Python target."""
+
+    def __init__(
+        self,
+        handler_source: str,
+        *,
+        cwd: Path,
+        timeout_seconds: float = 10.0,
+        command: tuple[str, ...] | None = None,
+    ) -> None:
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        self._timeout_seconds = timeout_seconds
+        self._next_id = 1
+        self._closed = False
+        self._failure: str | None = None
+        self._stdout_buffer = bytearray()
+        self._stderr_tail = bytearray()
+        self._stderr_lock = threading.Lock()
+        self._stderr_thread: threading.Thread | None = None
+        server_command = list(command or (
+            "node",
+            "--input-type=module",
+            "--eval",
+            f"{handler_source}\n{_PROTOCOL}",
+        ))
+        self._process: subprocess.Popen[bytes] = subprocess.Popen(
+            server_command,
+            cwd=cwd,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=False,
+            bufsize=0,
+        )
+        try:
+            if (
+                self._process.stdin is None
+                or self._process.stdout is None
+                or self._process.stderr is None
+            ):
+                raise NodeJsonlWorkerError("Node worker pipes were not created")
+            os.set_blocking(self._process.stdin.fileno(), False)
+            self._stderr_thread = threading.Thread(
+                target=self._drain_stderr,
+                name=f"node-jsonl-stderr-{self._process.pid}",
+                daemon=True,
+            )
+            self._stderr_thread.start()
+            deadline = time.monotonic() + self._timeout_seconds
+            startup = self._decode_response(
+                0,
+                self._read_response_line(
+                    0,
+                    self._process.stdout.fileno(),
+                    deadline,
+                ),
+            )
+            if startup.result != "ready" or self._stdout_buffer:
+                detail = self._poison("invalid Node worker startup handshake")
+                raise NodeJsonlWorkerError(detail)
+        except BaseException as exc:
+            if self._failure is None:
+                detail = self._poison(f"Node worker initialization failed: {exc}")
+                raise NodeJsonlWorkerError(detail) from exc
+            raise
+
+    @property
+    def is_running(self) -> bool:
+        return not self._closed and self._process.poll() is None
+
+    def request(self, operation: str, payload: object) -> object:
+        if self._failure is not None:
+            raise NodeJsonlWorkerError(self._failure)
+        if self._closed:
+            raise NodeJsonlWorkerError("Node worker is not running")
+        if self._process.poll() is not None:
+            detail = self._poison("Node worker exited before request")
+            raise NodeJsonlWorkerError(detail)
+        deadline = time.monotonic() + self._timeout_seconds
+        request_id = self._next_id
+        self._next_id += 1
+        frame = msgspec.json.encode(
+            _Request(id=request_id, operation=operation, payload=payload),
+        ) + b"\n"
+        if len(frame) > MAX_REQUEST_BYTES:
+            detail = self._poison(
+                f"request {request_id} exceeded {MAX_REQUEST_BYTES} bytes",
+            )
+            raise NodeJsonlWorkerError(detail)
+        stdout = self._process.stdout
+        assert stdout is not None
+        self._write_frame(frame, deadline, request_id)
+        line = self._read_response_line(request_id, stdout.fileno(), deadline)
+        response = self._decode_response(request_id, line)
+        if self._stdout_buffer:
+            detail = self._poison(
+                f"unexpected extra output after response {request_id}",
+            )
+            raise NodeJsonlWorkerError(detail)
+        return response.result
+
+    def _decode_response(self, request_id: int, line: bytes) -> _Response:
+        try:
+            line_text = line.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            detail = self._poison(
+                f"invalid UTF-8 response for request {request_id}",
+            )
+            raise NodeJsonlWorkerError(detail) from exc
+        try:
+            response = msgspec.json.decode(line_text, type=_Response)
+        except (msgspec.DecodeError, msgspec.ValidationError) as exc:
+            detail = self._poison(
+                f"malformed response for request {request_id}: {line_text[:200]!r}",
+            )
+            raise NodeJsonlWorkerError(detail) from exc
+        if response.id != request_id:
+            detail = self._poison(
+                f"response id {response.id} did not match request {request_id}",
+            )
+            raise NodeJsonlWorkerError(detail)
+        if not response.ok:
+            detail = self._poison(
+                f"JavaScript request {request_id} failed: {response.error or 'unknown error'}",
+            )
+            raise NodeJsonlWorkerError(detail)
+        if response.error is not None:
+            detail = self._poison(
+                f"successful response {request_id} carried an error",
+            )
+            raise NodeJsonlWorkerError(detail)
+        return response
+
+    def _write_frame(self, frame: bytes, deadline: float, request_id: int) -> None:
+        stdin = self._process.stdin
+        assert stdin is not None
+        stdin_fd = stdin.fileno()
+        remaining_frame = memoryview(frame)
+        with selectors.DefaultSelector() as selector:
+            selector.register(stdin_fd, selectors.EVENT_WRITE)
+            while remaining_frame:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0 or not selector.select(remaining):
+                    detail = self._poison(
+                        f"request {request_id} timed out after "
+                        f"{self._timeout_seconds:g}s",
+                    )
+                    raise NodeJsonlWorkerError(detail)
+                if self._process.poll() is not None:
+                    detail = self._poison(
+                        f"child exited while writing request {request_id}",
+                    )
+                    raise NodeJsonlWorkerError(detail)
+                try:
+                    written = os.write(stdin_fd, remaining_frame)
+                except BlockingIOError:
+                    continue
+                except (BrokenPipeError, OSError) as exc:
+                    detail = self._poison("child closed stdin")
+                    raise NodeJsonlWorkerError(detail) from exc
+                if written < 1:
+                    detail = self._poison("child accepted zero request bytes")
+                    raise NodeJsonlWorkerError(detail)
+                remaining_frame = remaining_frame[written:]
+
+    def _read_response_line(
+        self,
+        request_id: int,
+        stdout_fd: int,
+        deadline: float,
+    ) -> bytes:
+        with selectors.DefaultSelector() as selector:
+            selector.register(stdout_fd, selectors.EVENT_READ)
+            while True:
+                newline = self._stdout_buffer.find(b"\n")
+                if newline >= 0:
+                    if newline > MAX_RESPONSE_BYTES:
+                        detail = self._poison(
+                            f"response exceeded {MAX_RESPONSE_BYTES} bytes for "
+                            f"request {request_id}",
+                        )
+                        raise NodeJsonlWorkerError(detail)
+                    line = bytes(self._stdout_buffer[:newline])
+                    del self._stdout_buffer[: newline + 1]
+                    return line
+                if len(self._stdout_buffer) > MAX_RESPONSE_BYTES:
+                    detail = self._poison(
+                        f"response exceeded {MAX_RESPONSE_BYTES} bytes for "
+                        f"request {request_id}",
+                    )
+                    raise NodeJsonlWorkerError(detail)
+                remaining = deadline - time.monotonic()
+                if remaining <= 0 or not selector.select(remaining):
+                    detail = self._poison(
+                        f"request {request_id} timed out after "
+                        f"{self._timeout_seconds:g}s",
+                    )
+                    raise NodeJsonlWorkerError(detail)
+                try:
+                    chunk = os.read(stdout_fd, 64 * 1024)
+                except OSError as exc:
+                    detail = self._poison(
+                        f"failed reading response {request_id}",
+                    )
+                    raise NodeJsonlWorkerError(detail) from exc
+                if not chunk:
+                    detail = self._poison(
+                        f"child exited before response {request_id}",
+                    )
+                    raise NodeJsonlWorkerError(detail)
+                self._stdout_buffer.extend(chunk)
+
+    def _poison(self, reason: str) -> str:
+        self._kill()
+        self._join_stderr_thread()
+        stderr = self._read_stderr()
+        self._close_pipes()
+        self._failure = f"{reason}{f'; stderr: {stderr}' if stderr else ''}"
+        return self._failure
+
+    def _read_stderr(self) -> str:
+        with self._stderr_lock:
+            tail = bytes(self._stderr_tail)
+        return tail.decode("utf-8", errors="replace").strip()[-2000:]
+
+    def _drain_stderr(self) -> None:
+        stderr = self._process.stderr
+        if stderr is None:
+            return
+        while True:
+            try:
+                chunk = stderr.read(8192)
+            except (OSError, ValueError):
+                return
+            if not chunk:
+                return
+            with self._stderr_lock:
+                self._stderr_tail.extend(chunk)
+                excess = len(self._stderr_tail) - _STDERR_TAIL_BYTES
+                if excess > 0:
+                    del self._stderr_tail[:excess]
+
+    def _join_stderr_thread(self) -> None:
+        thread = self._stderr_thread
+        if thread is None or thread.ident is None:
+            return
+        thread.join(timeout=0.1)
+
+    def _kill(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self._process.poll() is None:
+            self._process.kill()
+            self._process.wait()
+
+    def _terminate(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self._process.poll() is None:
+            self._process.terminate()
+            try:
+                self._process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                self._process.kill()
+                self._process.wait(timeout=2)
+
+    def _close_pipes(self) -> None:
+        for stream in (
+            self._process.stdin,
+            self._process.stdout,
+            self._process.stderr,
+        ):
+            if stream is not None and not stream.closed:
+                try:
+                    stream.close()
+                except OSError:
+                    pass
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        stdin = self._process.stdin
+        if stdin is not None:
+            try:
+                stdin.close()
+            except OSError:
+                pass
+        self._closed = True
+        try:
+            self._process.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            self._process.kill()
+            self._process.wait(timeout=2)
+        self._join_stderr_thread()
+        self._close_pipes()
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()

--- a/tests/ruff_lsp_worker.py
+++ b/tests/ruff_lsp_worker.py
@@ -1,0 +1,523 @@
+"""Target-scoped persistent Ruff language-server transport for generated tests."""
+
+from __future__ import annotations
+
+import os
+import selectors
+import subprocess
+import tempfile
+import threading
+import time
+from pathlib import Path
+from typing import Final, Literal, Self
+
+import msgspec
+
+_MAX_FRAME_BYTES: Final = 2 * 1024 * 1024
+_MAX_HEADER_BYTES: Final = 16 * 1024
+_STDERR_TAIL_BYTES: Final = 16 * 1024
+
+
+def _is_unset(value: object) -> bool:
+    return isinstance(value, msgspec.UnsetType)
+
+
+class RuffLspWorkerError(RuntimeError):
+    """The Ruff server could not authoritatively diagnose the current world."""
+
+
+class _LspRequest(msgspec.Struct, kw_only=True):
+    id: int
+    method: str
+    params: object
+    jsonrpc: Literal["2.0"] = "2.0"
+
+
+class _LspNotification(msgspec.Struct, kw_only=True):
+    method: str
+    params: object
+    jsonrpc: Literal["2.0"] = "2.0"
+
+
+class _LspEnvelope(msgspec.Struct, forbid_unknown_fields=False):
+    jsonrpc: Literal["2.0"]
+    id: int | None | msgspec.UnsetType = msgspec.UNSET
+    method: str | msgspec.UnsetType = msgspec.UNSET
+    params: object | msgspec.UnsetType = msgspec.UNSET
+    result: object | msgspec.UnsetType = msgspec.UNSET
+    error: object | msgspec.UnsetType = msgspec.UNSET
+
+
+class _Diagnostic(msgspec.Struct, forbid_unknown_fields=False):
+    code: str | int | None = None
+
+
+class _PublishDiagnostics(msgspec.Struct, forbid_unknown_fields=False):
+    uri: str
+    diagnostics: list[_Diagnostic]
+    version: int | None = None
+
+
+class RuffLspWorker:
+    """One Ruff server reused only within one isolated Python test target."""
+
+    def __init__(
+        self,
+        relative_paths: tuple[str, ...],
+        *,
+        cwd: Path,
+        timeout_seconds: float = 10.0,
+        command: tuple[str, ...] | None = None,
+    ) -> None:
+        if not relative_paths or len(set(relative_paths)) != len(relative_paths):
+            raise ValueError("relative_paths must be unique and non-empty")
+        if timeout_seconds <= 0:
+            raise ValueError("timeout_seconds must be positive")
+        self._paths = relative_paths
+        self._timeout_seconds = timeout_seconds
+        self._request_id = 1
+        self._versions = {path: 0 for path in relative_paths}
+        self._buffer = bytearray()
+        self._closed = False
+        self._failure: str | None = None
+        self._stderr_tail = bytearray()
+        self._stderr_lock = threading.Lock()
+        self._temporary = tempfile.TemporaryDirectory(prefix="cratedigger-ruff-lsp-")
+        self._temporary_cleaned = False
+        self._root = Path(self._temporary.name)
+        for relative_path in relative_paths:
+            (self._root / relative_path).parent.mkdir(parents=True, exist_ok=True)
+        self._uris = {
+            path: (self._root / path).as_uri()
+            for path in relative_paths
+        }
+        self._paths_by_uri = {uri: path for path, uri in self._uris.items()}
+        server_command = list(command or ("ruff", "server", "--silent"))
+        if command is None:
+            config = cwd / "pyproject.toml"
+            if config.is_file():
+                server_command.extend(("--config", str(config)))
+        try:
+            self._process: subprocess.Popen[bytes] = subprocess.Popen(
+                server_command,
+                cwd=cwd,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=False,
+                bufsize=0,
+            )
+        except BaseException:
+            self._cleanup_temporary()
+            raise
+        self._stderr_thread: threading.Thread | None = None
+        try:
+            if (
+                self._process.stdin is None
+                or self._process.stdout is None
+                or self._process.stderr is None
+            ):
+                raise RuffLspWorkerError("Ruff server pipes were not created")
+            os.set_blocking(self._process.stdin.fileno(), False)
+            self._stderr_thread = threading.Thread(
+                target=self._drain_stderr,
+                name=f"ruff-lsp-stderr-{self._process.pid}",
+                daemon=True,
+            )
+            self._stderr_thread.start()
+            self._initialize()
+        except BaseException as exc:
+            if self._failure is None:
+                detail = self._poison(
+                    f"Ruff server initialization failed: {exc}",
+                )
+                raise RuffLspWorkerError(detail) from exc
+            raise
+
+    @property
+    def pid(self) -> int:
+        return self._process.pid
+
+    @property
+    def workspace_root(self) -> Path:
+        return self._root
+
+    @property
+    def is_running(self) -> bool:
+        return not self._closed and self._process.poll() is None
+
+    def findings(
+        self,
+        sources: dict[str, str],
+    ) -> tuple[dict[str, object], ...]:
+        if self._failure is not None:
+            raise RuffLspWorkerError(self._failure)
+        if self._closed:
+            raise RuffLspWorkerError("Ruff server is not running")
+        if self._process.poll() is not None:
+            detail = self._poison("Ruff server exited before request")
+            raise RuffLspWorkerError(detail)
+        if set(sources) != set(self._paths):
+            raise RuffLspWorkerError("sources must contain the exact configured paths")
+
+        deadline = time.monotonic() + self._timeout_seconds
+        expected_versions: dict[str, int] = {}
+        for path in self._paths:
+            version = self._versions[path] + 1
+            self._versions[path] = version
+            uri = self._uris[path]
+            expected_versions[uri] = version
+            if version == 1:
+                self._notify(
+                    "textDocument/didOpen",
+                    {
+                        "textDocument": {
+                            "uri": uri,
+                            "languageId": "python",
+                            "version": version,
+                            "text": sources[path],
+                        },
+                    },
+                    deadline,
+                )
+            else:
+                self._notify(
+                    "textDocument/didChange",
+                    {
+                        "textDocument": {"uri": uri, "version": version},
+                        "contentChanges": [{"text": sources[path]}],
+                    },
+                    deadline,
+                )
+
+        received: dict[str, _PublishDiagnostics] = {}
+        while len(received) < len(expected_versions):
+            message = self._read_message(deadline)
+            if message.method != "textDocument/publishDiagnostics":
+                detail = self._poison("unexpected Ruff LSP message")
+                raise RuffLspWorkerError(detail)
+            if (
+                not _is_unset(message.id)
+                or _is_unset(message.params)
+                or not _is_unset(message.result)
+                or not _is_unset(message.error)
+            ):
+                detail = self._poison("malformed Ruff diagnostics envelope")
+                raise RuffLspWorkerError(detail)
+            try:
+                published = msgspec.convert(
+                    message.params,
+                    type=_PublishDiagnostics,
+                )
+            except (TypeError, msgspec.ValidationError) as exc:
+                detail = self._poison("malformed Ruff diagnostics notification")
+                raise RuffLspWorkerError(detail) from exc
+            expected_version = expected_versions.get(published.uri)
+            if expected_version is None:
+                detail = self._poison(
+                    f"diagnostics for unknown URI: {published.uri}",
+                )
+                raise RuffLspWorkerError(detail)
+            if published.version is None or published.version > expected_version:
+                detail = self._poison(
+                    f"unexpected diagnostics version for {published.uri}: "
+                    f"{published.version!r}",
+                )
+                raise RuffLspWorkerError(detail)
+            if published.version < expected_version:
+                continue
+            received[published.uri] = published
+
+        findings: list[dict[str, object]] = []
+        for uri, published in received.items():
+            relative_path = self._paths_by_uri[uri]
+            filename = str(self._root / relative_path)
+            for diagnostic in published.diagnostics:
+                if diagnostic.code is None:
+                    detail = self._poison(
+                        f"Ruff diagnostic lacked a code for {relative_path}",
+                    )
+                    raise RuffLspWorkerError(detail)
+                findings.append({
+                    "filename": filename,
+                    "code": str(diagnostic.code),
+                })
+        return tuple(findings)
+
+    def _initialize(self) -> None:
+        deadline = time.monotonic() + self._timeout_seconds
+        root_uri = self._root.as_uri()
+        request_id = self._send_request(
+            "initialize",
+            {
+                "processId": None,
+                "rootUri": root_uri,
+                "capabilities": {},
+                "workspaceFolders": [{"uri": root_uri, "name": "generated-world"}],
+            },
+            deadline,
+        )
+        response = self._wait_for_response(request_id, deadline)
+        if not _is_unset(response.error):
+            detail = self._poison(f"Ruff initialize failed: {response.error!r}")
+            raise RuffLspWorkerError(detail)
+        self._notify("initialized", {}, deadline)
+
+    def _send_request(self, method: str, params: object, deadline: float) -> int:
+        request_id = self._request_id
+        self._request_id += 1
+        self._send(
+            _LspRequest(id=request_id, method=method, params=params),
+            deadline,
+        )
+        return request_id
+
+    def _notify(self, method: str, params: object, deadline: float) -> None:
+        self._send(_LspNotification(method=method, params=params), deadline)
+
+    def _send(
+        self,
+        message: _LspRequest | _LspNotification,
+        deadline: float,
+    ) -> None:
+        stdin = self._process.stdin
+        if stdin is None or self._closed:
+            raise RuffLspWorkerError("Ruff server is not running")
+        if self._process.poll() is not None:
+            detail = self._poison("Ruff server exited before a write")
+            raise RuffLspWorkerError(detail)
+        body = msgspec.json.encode(message)
+        frame = f"Content-Length: {len(body)}\r\n\r\n".encode("ascii") + body
+        if len(body) > _MAX_FRAME_BYTES:
+            detail = self._poison("Ruff LSP request exceeded size limit")
+            raise RuffLspWorkerError(detail)
+        stdin_fd = stdin.fileno()
+        remaining_frame = memoryview(frame)
+        with selectors.DefaultSelector() as selector:
+            selector.register(stdin_fd, selectors.EVENT_WRITE)
+            while remaining_frame:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0 or not selector.select(remaining):
+                    detail = self._poison(
+                        f"Ruff LSP request timed out after "
+                        f"{self._timeout_seconds:g}s",
+                    )
+                    raise RuffLspWorkerError(detail)
+                if self._process.poll() is not None:
+                    detail = self._poison("Ruff server exited during a write")
+                    raise RuffLspWorkerError(detail)
+                try:
+                    written = os.write(stdin_fd, remaining_frame)
+                except BlockingIOError:
+                    continue
+                except (BrokenPipeError, OSError) as exc:
+                    detail = self._poison("Ruff server closed stdin")
+                    raise RuffLspWorkerError(detail) from exc
+                if written < 1:
+                    detail = self._poison("Ruff server accepted zero request bytes")
+                    raise RuffLspWorkerError(detail)
+                remaining_frame = remaining_frame[written:]
+
+    def _wait_for_response(
+        self,
+        request_id: int,
+        deadline: float,
+    ) -> _LspEnvelope:
+        while True:
+            message = self._read_message(deadline)
+            if message.id == request_id:
+                if (
+                    not _is_unset(message.method)
+                    or not _is_unset(message.params)
+                    or (
+                        _is_unset(message.result)
+                        == _is_unset(message.error)
+                    )
+                ):
+                    detail = self._poison(
+                        f"malformed Ruff response {request_id}",
+                    )
+                    raise RuffLspWorkerError(detail)
+                return message
+            if not _is_unset(message.id):
+                detail = self._poison(
+                    f"Ruff response id {message.id} did not match {request_id}",
+                )
+                raise RuffLspWorkerError(detail)
+            if (
+                _is_unset(message.method)
+                or _is_unset(message.params)
+                or not _is_unset(message.result)
+                or not _is_unset(message.error)
+            ):
+                detail = self._poison("malformed Ruff notification envelope")
+                raise RuffLspWorkerError(detail)
+
+    def _read_message(self, deadline: float) -> _LspEnvelope:
+        header = self._read_until(b"\r\n\r\n", deadline, _MAX_HEADER_BYTES)
+        lengths: list[int] = []
+        try:
+            for line in header.split(b"\r\n"):
+                name, separator, value = line.partition(b":")
+                if separator and name.lower() == b"content-length":
+                    lengths.append(int(value.strip()))
+        except ValueError as exc:
+            detail = self._poison("invalid Ruff LSP Content-Length")
+            raise RuffLspWorkerError(detail) from exc
+        if len(lengths) != 1 or not 0 <= lengths[0] <= _MAX_FRAME_BYTES:
+            detail = self._poison("invalid Ruff LSP Content-Length")
+            raise RuffLspWorkerError(detail)
+        body = self._read_exact(lengths[0], deadline)
+        try:
+            return msgspec.json.decode(body, type=_LspEnvelope)
+        except (msgspec.DecodeError, msgspec.ValidationError) as exc:
+            detail = self._poison("malformed Ruff LSP response")
+            raise RuffLspWorkerError(detail) from exc
+
+    def _read_until(self, marker: bytes, deadline: float, limit: int) -> bytes:
+        while True:
+            index = self._buffer.find(marker)
+            if index >= 0:
+                result = bytes(self._buffer[:index])
+                del self._buffer[: index + len(marker)]
+                return result
+            if len(self._buffer) > limit:
+                detail = self._poison("Ruff LSP header exceeded size limit")
+                raise RuffLspWorkerError(detail)
+            self._read_available(deadline)
+
+    def _read_exact(self, length: int, deadline: float) -> bytes:
+        while len(self._buffer) < length:
+            self._read_available(deadline)
+        result = bytes(self._buffer[:length])
+        del self._buffer[:length]
+        return result
+
+    def _read_available(self, deadline: float) -> None:
+        stdout = self._process.stdout
+        assert stdout is not None
+        remaining = deadline - time.monotonic()
+        with selectors.DefaultSelector() as selector:
+            selector.register(stdout.fileno(), selectors.EVENT_READ)
+            if remaining <= 0 or not selector.select(remaining):
+                detail = self._poison(
+                    f"Ruff LSP response timed out after {self._timeout_seconds:g}s",
+                )
+                raise RuffLspWorkerError(detail)
+        try:
+            chunk = os.read(stdout.fileno(), 64 * 1024)
+        except OSError as exc:
+            detail = self._poison("failed reading Ruff LSP response")
+            raise RuffLspWorkerError(detail) from exc
+        if not chunk:
+            detail = self._poison("Ruff server exited before a complete response")
+            raise RuffLspWorkerError(detail)
+        self._buffer.extend(chunk)
+
+    def _drain_stderr(self) -> None:
+        stderr = self._process.stderr
+        if stderr is None:
+            return
+        while True:
+            try:
+                chunk = stderr.read(8192)
+            except (OSError, ValueError):
+                return
+            if not chunk:
+                return
+            with self._stderr_lock:
+                self._stderr_tail.extend(chunk)
+                excess = len(self._stderr_tail) - _STDERR_TAIL_BYTES
+                if excess > 0:
+                    del self._stderr_tail[:excess]
+
+    def _stderr(self) -> str:
+        with self._stderr_lock:
+            tail = bytes(self._stderr_tail)
+        return tail.decode("utf-8", errors="replace").strip()[-2000:]
+
+    def _poison(self, reason: str) -> str:
+        self._kill()
+        self._join_stderr_thread()
+        stderr = self._stderr()
+        self._close_pipes()
+        self._cleanup_temporary()
+        self._failure = f"{reason}{f'; stderr: {stderr}' if stderr else ''}"
+        return self._failure
+
+    def _cleanup_temporary(self) -> None:
+        if self._temporary_cleaned:
+            return
+        self._temporary.cleanup()
+        self._temporary_cleaned = True
+
+    def _terminate(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self._process.poll() is None:
+            self._process.terminate()
+            try:
+                self._process.wait(timeout=2)
+            except subprocess.TimeoutExpired:
+                self._process.kill()
+                self._process.wait(timeout=2)
+
+    def _kill(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self._process.poll() is None:
+            self._process.kill()
+            self._process.wait()
+
+    def _join_stderr_thread(self) -> None:
+        thread = self._stderr_thread
+        if thread is None or thread.ident is None:
+            return
+        thread.join(timeout=0.1)
+
+    def _close_pipes(self) -> None:
+        for stream in (
+            self._process.stdin,
+            self._process.stdout,
+            self._process.stderr,
+        ):
+            if stream is not None and not stream.closed:
+                try:
+                    stream.close()
+                except OSError:
+                    pass
+
+    def close(self) -> None:
+        if self._closed:
+            self._cleanup_temporary()
+            return
+        try:
+            deadline = time.monotonic() + self._timeout_seconds
+            request_id = self._send_request("shutdown", None, deadline)
+            self._wait_for_response(request_id, deadline)
+            self._notify("exit", None, deadline)
+        except RuffLspWorkerError:
+            pass
+        stdin = self._process.stdin
+        if stdin is not None and not stdin.closed:
+            try:
+                stdin.close()
+            except OSError:
+                pass
+        self._closed = True
+        try:
+            self._process.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            self._process.kill()
+            self._process.wait(timeout=2)
+        self._join_stderr_thread()
+        self._close_pipes()
+        self._cleanup_temporary()
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        self.close()

--- a/tests/test_browse_reference_generated.py
+++ b/tests/test_browse_reference_generated.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-import json
 import string
-import subprocess
 import unittest
 from dataclasses import dataclass
 from pathlib import Path
@@ -13,6 +11,7 @@ from hypothesis import example, given
 from hypothesis import strategies as st
 
 import tests._hypothesis_profiles  # noqa: F401
+from tests.node_jsonl_worker import NodeJsonlWorker
 
 ROOT = Path(__file__).resolve().parents[1]
 MB_RELEASE_ID = "c1f6a2c9-bcba-4e69-96f5-233c85b2830a"
@@ -24,22 +23,20 @@ class ReferenceWorld:
     expected: dict[str, str] | None
 
 
-def _parse_with_real_javascript(pasted: str) -> object:
-    script = """
+_REFERENCE_WORKER = """
 import { parsePastedId } from './web/js/util.js';
-let input = '';
-for await (const chunk of process.stdin) input += chunk;
-process.stdout.write(JSON.stringify(parsePastedId(JSON.parse(input))));
+async function handle(operation, payload) {
+  if (operation !== 'parse') throw new Error(`unknown operation: ${operation}`);
+  return parsePastedId(payload);
+}
 """
-    result = subprocess.run(
-        ["node", "--input-type=module", "--eval", script],
-        cwd=ROOT,
-        input=json.dumps(pasted),
-        text=True,
-        capture_output=True,
-        check=True,
-    )
-    return json.loads(result.stdout)
+
+
+def _parse_with_real_javascript(
+    worker: NodeJsonlWorker,
+    pasted: str,
+) -> object:
+    return worker.request("parse", pasted)
 
 
 @st.composite
@@ -125,6 +122,10 @@ def hostile_reference_worlds(draw: st.DrawFn) -> ReferenceWorld:
 
 
 class TestBrowseReferenceParserGenerated(unittest.TestCase):
+    def setUp(self) -> None:
+        self.worker = NodeJsonlWorker(_REFERENCE_WORKER, cwd=ROOT)
+        self.addCleanup(self.worker.close)
+
     @given(st.one_of(canonical_reference_worlds(), hostile_reference_worlds()))
     @example(ReferenceWorld(
         pasted=(
@@ -136,7 +137,10 @@ class TestBrowseReferenceParserGenerated(unittest.TestCase):
     def test_only_exact_canonical_references_produce_normalized_ids(
         self, world: ReferenceWorld,
     ) -> None:
-        self.assertEqual(_parse_with_real_javascript(world.pasted), world.expected)
+        self.assertEqual(
+            _parse_with_real_javascript(self.worker, world.pasted),
+            world.expected,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_finite_domain.py
+++ b/tests/test_finite_domain.py
@@ -1,0 +1,84 @@
+"""Contracts for explicit, proved finite generated domains."""
+
+from __future__ import annotations
+
+import unittest
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+import tests._hypothesis_profiles  # noqa: F401
+from scripts.run_python_tests import resolve_hypothesis_settings
+from tests.finite_domain import (
+    FINITE_DOMAIN_ATTRIBUTE,
+    finite_generated_domain,
+)
+from tests.finite_domain_metadata import (
+    FiniteDomainSpec,
+)
+
+
+class TestFiniteGeneratedDomain(unittest.TestCase):
+    def test_decorator_runs_proof_and_fixes_the_exact_budget(self) -> None:
+        proofs: list[str] = []
+
+        def verify() -> None:
+            proofs.append("verified")
+
+        class Generated(unittest.TestCase):
+            @finite_generated_domain(cardinality=4, verify=verify)
+            @given(value=st.integers(min_value=0, max_value=3))
+            def test_property(self, value: int) -> None:
+                self.assertIn(value, range(4))
+
+        case = Generated("test_property")
+        resolved = resolve_hypothesis_settings(case)
+        self.assertIsNotNone(resolved)
+        assert resolved is not None
+        self.assertEqual(resolved.configured.max_examples, 4)
+        self.assertEqual(proofs, ["verified"])
+        spec = getattr(Generated.test_property, FINITE_DOMAIN_ATTRIBUTE)
+        self.assertEqual(spec, FiniteDomainSpec(cardinality=4, verify=verify))
+        for field in (
+            "backend",
+            "database",
+            "deadline",
+            "derandomize",
+            "phases",
+            "print_blob",
+            "report_multiple_bugs",
+            "stateful_step_count",
+            "suppress_health_check",
+            "verbosity",
+        ):
+            self.assertEqual(
+                getattr(resolved.configured, field),
+                getattr(settings.default, field),
+                field,
+            )
+
+    def test_nonpositive_cardinality_is_rejected_before_proof(self) -> None:
+        proofs: list[str] = []
+
+        with self.assertRaisesRegex(ValueError, "cardinality must be positive"):
+            finite_generated_domain(
+                cardinality=0,
+                verify=lambda: proofs.append("should not run"),
+            )
+
+        self.assertEqual(proofs, [])
+
+    def test_failed_domain_proof_aborts_decoration(self) -> None:
+        def reject_collapsed_worlds() -> None:
+            raise AssertionError("domain collapsed")
+
+        decorator = finite_generated_domain(
+            cardinality=2,
+            verify=reject_collapsed_worlds,
+        )
+
+        with self.assertRaisesRegex(AssertionError, "domain collapsed"):
+            decorator(lambda: None)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fuzz_runner_generated.py
+++ b/tests/test_fuzz_runner_generated.py
@@ -744,6 +744,7 @@ class TestFuzzDiscoverySettingsContract(unittest.TestCase):
         )
         self.assertEqual(property_manifest.max_examples, 128)
         self.assertFalse(property_manifest.uses_default_settings)
+        self.assertEqual(property_manifest.finite_domain_cardinality, 128)
 
         targets = build_fuzz_targets(manifests, property_shards=8)
         matching = tuple(
@@ -754,6 +755,75 @@ class TestFuzzDiscoverySettingsContract(unittest.TestCase):
         self.assertEqual(len(matching), 1)
         self.assertEqual(matching[0].shard_count, 1)
         self.assertIsNone(matching[0].profile_max_examples)
+
+    def test_finite_metadata_prevents_sharding_even_if_default_flag_drifts(self) -> None:
+        property_id = "tests.test_generated_world.TestWorld.test_finite"
+        manifest = FuzzModuleManifest(
+            module_name="tests.test_generated_world",
+            test_ids=(property_id,),
+            hypothesis_tests=(
+                FuzzPropertyManifest(
+                    test_id=property_id,
+                    max_examples=4,
+                    uses_default_settings=True,
+                    finite_domain_cardinality=4,
+                ),
+            ),
+        )
+
+        targets = build_fuzz_targets((manifest,), property_shards=8)
+
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(targets[0].shard_count, 1)
+        self.assertIsNone(targets[0].profile_max_examples)
+
+    def test_finite_metadata_rejects_a_budget_cardinality_mismatch(self) -> None:
+        property_id = "tests.test_generated_world.TestWorld.test_finite"
+        manifest = FuzzModuleManifest(
+            module_name="tests.test_generated_world",
+            test_ids=(property_id,),
+            hypothesis_tests=(
+                FuzzPropertyManifest(
+                    test_id=property_id,
+                    max_examples=3,
+                    uses_default_settings=False,
+                    finite_domain_cardinality=4,
+                ),
+            ),
+        )
+
+        with self.assertRaisesRegex(ValueError, "finite domain cardinality"):
+            build_fuzz_targets((manifest,), property_shards=8)
+
+    def test_coverage_checker_rejects_sharded_finite_metadata(self) -> None:
+        property_id = "tests.test_generated_world.TestWorld.test_finite"
+        manifest = FuzzModuleManifest(
+            module_name="tests.test_generated_world",
+            test_ids=(property_id,),
+            hypothesis_tests=(
+                FuzzPropertyManifest(
+                    test_id=property_id,
+                    max_examples=4,
+                    uses_default_settings=True,
+                    finite_domain_cardinality=4,
+                ),
+            ),
+        )
+        targets = tuple(
+            FuzzTarget(
+                label=f"{property_id}::{index}",
+                module_name=manifest.module_name,
+                load_names=(manifest.module_name,),
+                expected_test_ids=(property_id,),
+                shard_index=index,
+                shard_count=2,
+                profile_max_examples=2,
+            )
+            for index in range(2)
+        )
+
+        with self.assertRaisesRegex(ValueError, "finite fuzz property was sharded"):
+            assert_exact_fuzz_coverage((manifest,), targets)
 
     def test_discovery_rejects_property_with_default_deadline(self) -> None:
         """A module that omits profile registration must fail before sharding."""
@@ -777,6 +847,43 @@ class TestFuzzDiscoverySettingsContract(unittest.TestCase):
             with self.assertRaisesRegex(RuntimeError, "non-None deadline"):
                 discover_fuzz_manifests(
                     ("unprofiled_fuzz_fixture",),
+                    worker_count=1,
+                    environment=environment,
+                    work_directory=fixture_root,
+                )
+
+    def test_discovery_rejects_finite_metadata_without_executed_proof(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            fixture_root = Path(directory)
+            fixture = fixture_root / "forged_finite_fixture.py"
+            fixture.write_text(
+                "from hypothesis import given, strategies as st\n"
+                "import unittest\n"
+                "import tests._hypothesis_profiles\n"
+                "from tests.finite_domain_metadata import (\n"
+                "    FINITE_DOMAIN_ATTRIBUTE, FiniteDomainSpec,\n"
+                ")\n\n"
+                "def proof_must_run():\n"
+                "    raise AssertionError('planted proof executed')\n\n"
+                "class TestForged(unittest.TestCase):\n"
+                "    @given(st.integers(min_value=0, max_value=0))\n"
+                "    def test_property(self, value):\n"
+                "        self.assertEqual(value, 0)\n\n"
+                "setattr(\n"
+                "    TestForged.test_property,\n"
+                "    FINITE_DOMAIN_ATTRIBUTE,\n"
+                "    FiniteDomainSpec(cardinality=1, verify=proof_must_run),\n"
+                ")\n",
+                encoding="utf-8",
+            )
+            environment = dict(os.environ)
+            old_pythonpath = environment.get("PYTHONPATH", "")
+            environment["PYTHONPATH"] = os.pathsep.join(
+                part for part in (str(fixture_root), old_pythonpath) if part
+            )
+            with self.assertRaisesRegex(RuntimeError, "planted proof executed"):
+                discover_fuzz_manifests(
+                    ("forged_finite_fixture",),
                     worker_count=1,
                     environment=environment,
                     work_directory=fixture_root,

--- a/tests/test_generated_node_worker_audit.py
+++ b/tests/test_generated_node_worker_audit.py
@@ -1,0 +1,96 @@
+"""Audit that generated properties never pay one Node startup per example.
+
+Generated modules may exercise real JavaScript, but a literal Node subprocess in
+such a module is target-amplified by Hypothesis and entropy sharding.  The
+canonical boundary is ``tests.node_jsonl_worker.NodeJsonlWorker``: one strict,
+fail-closed child per isolated Python target.
+"""
+
+from __future__ import annotations
+
+import ast
+import unittest
+from pathlib import Path
+
+TESTS_DIR = Path(__file__).resolve().parent
+_NODE_EXECUTABLES = {"node", "nodejs"}
+_SUBPROCESS_CALLS = {"run", "Popen", "check_call", "check_output"}
+
+
+def direct_node_launch_lines(source: str, *, label: str) -> list[int]:
+    """Return literal ``subprocess.<launch>(['node', ...])`` line numbers."""
+    tree = ast.parse(source, filename=label)
+    lines: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        function = node.func
+        if not (
+            isinstance(function, ast.Attribute)
+            and isinstance(function.value, ast.Name)
+            and function.value.id == "subprocess"
+            and function.attr in _SUBPROCESS_CALLS
+            and node.args
+        ):
+            continue
+        command = node.args[0]
+        if not isinstance(command, (ast.List, ast.Tuple)) or not command.elts:
+            continue
+        executable = command.elts[0]
+        if (
+            isinstance(executable, ast.Constant)
+            and isinstance(executable.value, str)
+            and Path(executable.value).name in _NODE_EXECUTABLES
+        ):
+            lines.append(node.lineno)
+    return sorted(lines)
+
+
+def audit_generated_node_launches(root: Path = TESTS_DIR) -> list[str]:
+    offenders: list[str] = []
+    for path in sorted(root.glob("test_*_generated.py")):
+        source = path.read_text(encoding="utf-8")
+        for line in direct_node_launch_lines(source, label=path.name):
+            offenders.append(f"{path.name}:{line}")
+    return offenders
+
+
+class TestGeneratedNodeWorkerAudit(unittest.TestCase):
+    def test_generated_properties_have_no_per_example_node_launches(self) -> None:
+        self.assertEqual(
+            audit_generated_node_launches(),
+            [],
+            "Generated tests must reuse one fail-closed NodeJsonlWorker per "
+            "Python target instead of launching Node in every Hypothesis world",
+        )
+
+    def test_checker_rejects_the_historical_literal_node_subprocess(self) -> None:
+        source = """
+import subprocess
+
+def real_boundary(payload):
+    return subprocess.run(
+        ["node", "--input-type=module", "--eval", "script"],
+        input=payload,
+    )
+"""
+        self.assertEqual(
+            direct_node_launch_lines(source, label="planted.py"),
+            [5],
+        )
+
+    def test_checker_accepts_the_target_scoped_worker(self) -> None:
+        source = """
+from tests.node_jsonl_worker import NodeJsonlWorker
+
+def real_boundary(worker, payload):
+    return worker.request("parse", payload)
+"""
+        self.assertEqual(
+            direct_node_launch_lines(source, label="compliant.py"),
+            [],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_node_jsonl_worker.py
+++ b/tests/test_node_jsonl_worker.py
@@ -1,0 +1,270 @@
+"""Fail-closed contracts for target-scoped Node JSON-lines workers."""
+
+from __future__ import annotations
+
+import json
+import signal
+import subprocess
+import sys
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from tests.node_jsonl_worker import NodeJsonlWorker, NodeJsonlWorkerError
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestNodeJsonlWorker(unittest.TestCase):
+    @staticmethod
+    def _fake_command(source: str) -> tuple[str, ...]:
+        return (sys.executable, "-u", "-c", source)
+
+    @staticmethod
+    def _startup_frame() -> str:
+        return json.dumps({
+            "id": 0,
+            "ok": True,
+            "result": "ready",
+            "error": None,
+        })
+
+    def test_post_spawn_setup_failure_reaps_child_and_closes_pipes(self) -> None:
+        process = subprocess.Popen(
+            self._fake_command("import time; time.sleep(60)"),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        with (
+            mock.patch(
+                "tests.node_jsonl_worker.subprocess.Popen",
+                return_value=process,
+            ),
+            mock.patch(
+                "tests.node_jsonl_worker.os.set_blocking",
+                side_effect=OSError("planted set_blocking failure"),
+            ),
+            self.assertRaisesRegex(NodeJsonlWorkerError, "set_blocking failure"),
+        ):
+            NodeJsonlWorker("", cwd=ROOT)
+
+        self.assertEqual(process.returncode, -signal.SIGKILL)
+        for stream in (process.stdin, process.stdout, process.stderr):
+            assert stream is not None
+            self.assertTrue(stream.closed)
+
+    def test_requests_reuse_one_child_without_crossing_payloads(self) -> None:
+        source = """
+let calls = 0;
+async function handle(operation, payload) {
+  calls += 1;
+  return { pid: process.pid, calls, operation, value: payload.value };
+}
+"""
+        with NodeJsonlWorker(source, cwd=ROOT) as worker:
+            first = worker.request("first", {"value": "alpha"})
+            second = worker.request("second", {"value": "beta"})
+
+        self.assertIsInstance(first, dict)
+        self.assertIsInstance(second, dict)
+        assert isinstance(first, dict)
+        assert isinstance(second, dict)
+        self.assertEqual(first["pid"], second["pid"])
+        self.assertEqual(first["calls"], 1)
+        self.assertEqual(second["calls"], 2)
+        self.assertEqual(first["operation"], "first")
+        self.assertEqual(second["operation"], "second")
+        self.assertEqual(first["value"], "alpha")
+        self.assertEqual(second["value"], "beta")
+
+    def test_malformed_stdout_fails_closed_and_poisoned_worker_stays_dead(self) -> None:
+        source = """
+async function handle(_operation, payload) {
+  process.stdout.write('not-json\\n');
+  return payload;
+}
+"""
+        worker = NodeJsonlWorker(source, cwd=ROOT)
+        self.addCleanup(worker.close)
+
+        with self.assertRaisesRegex(NodeJsonlWorkerError, "malformed response"):
+            worker.request("echo", {"value": 1})
+
+        self.assertFalse(worker.is_running)
+        with self.assertRaisesRegex(NodeJsonlWorkerError, "malformed response"):
+            worker.request("echo", {"value": 2})
+
+    def test_wrong_response_id_fails_closed(self) -> None:
+        source = """
+async function handle(_operation, payload) {
+  process.stdout.write(JSON.stringify({
+    id: 999, ok: true, result: payload, error: null,
+  }) + '\\n');
+  return payload;
+}
+"""
+        worker = NodeJsonlWorker(source, cwd=ROOT)
+        self.addCleanup(worker.close)
+
+        with self.assertRaisesRegex(NodeJsonlWorkerError, "response id"):
+            worker.request("echo", {"value": 1})
+
+        self.assertFalse(worker.is_running)
+
+    def test_child_exit_before_response_fails_closed_with_stderr(self) -> None:
+        source = """
+async function handle() {
+  process.stderr.write('planted child loss\\n');
+  process.exit(17);
+}
+"""
+        worker = NodeJsonlWorker(source, cwd=ROOT)
+        self.addCleanup(worker.close)
+
+        with self.assertRaisesRegex(NodeJsonlWorkerError, "planted child loss"):
+            worker.request("exit", None)
+
+        self.assertFalse(worker.is_running)
+
+    def test_timeout_terminates_child_and_fails_closed(self) -> None:
+        source = """
+async function handle() {
+  await new Promise(() => {});
+}
+"""
+        worker = NodeJsonlWorker(source, cwd=ROOT, timeout_seconds=0.1)
+        self.addCleanup(worker.close)
+
+        with self.assertRaisesRegex(NodeJsonlWorkerError, "timed out"):
+            worker.request("hang", None)
+
+        self.assertFalse(worker.is_running)
+
+    def test_blocked_request_write_consumes_the_transaction_deadline(self) -> None:
+        command = self._fake_command(
+            "import signal, time\n"
+            "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+            f"print({self._startup_frame()!r}, flush=True)\n"
+            "time.sleep(60)\n"
+        )
+        worker = NodeJsonlWorker(
+            "",
+            cwd=ROOT,
+            timeout_seconds=0.1,
+            command=command,
+        )
+        self.addCleanup(worker.close)
+
+        started = time.monotonic()
+        with self.assertRaisesRegex(NodeJsonlWorkerError, "timed out") as caught:
+            worker.request("blocked", {"text": "x" * (512 * 1024)})
+        self.assertLess(time.monotonic() - started, 0.75)
+        self.assertFalse(worker.is_running)
+        with self.assertRaises(NodeJsonlWorkerError) as repeated:
+            worker.request("blocked", {})
+        self.assertEqual(str(repeated.exception), str(caught.exception))
+
+    def test_child_loss_between_requests_is_poisoned_with_stderr(self) -> None:
+        command = self._fake_command(
+            "import sys, time\n"
+            f"print({self._startup_frame()!r}, flush=True)\n"
+            "time.sleep(0.05)\n"
+            "print('planted early loss', file=sys.stderr, flush=True)\n"
+            "raise SystemExit(17)\n"
+        )
+        worker = NodeJsonlWorker("", cwd=ROOT, command=command)
+        self.addCleanup(worker.close)
+        time.sleep(0.2)
+
+        with self.assertRaisesRegex(NodeJsonlWorkerError, "planted early loss") as caught:
+            worker.request("after_exit", {})
+        with self.assertRaises(NodeJsonlWorkerError) as repeated:
+            worker.request("after_exit", {})
+        self.assertEqual(str(repeated.exception), str(caught.exception))
+
+    def test_partial_line_times_out_instead_of_blocking_readline(self) -> None:
+        source = r"""
+async function handle(_operation, _payload) {
+  process.stdout.write('{"id":');
+  return await new Promise(() => {});
+}
+"""
+        worker = NodeJsonlWorker(source, cwd=ROOT, timeout_seconds=0.1)
+        self.addCleanup(worker.close)
+
+        with self.assertRaisesRegex(NodeJsonlWorkerError, "timed out"):
+            worker.request("partial", {})
+
+        self.assertFalse(worker.is_running)
+
+    def test_stderr_flood_is_drained_without_deadlocking_response(self) -> None:
+        source = r"""
+async function handle(_operation, payload) {
+  await new Promise((resolve) => {
+    process.stderr.write('diagnostic'.repeat(100000), resolve);
+  });
+  return payload;
+}
+"""
+        with NodeJsonlWorker(source, cwd=ROOT, timeout_seconds=2.0) as worker:
+            self.assertEqual(worker.request("flood", {"ok": True}), {"ok": True})
+
+    def test_oversized_response_fails_closed(self) -> None:
+        source = r"""
+async function handle(_operation, _payload) {
+  return 'x'.repeat(2 * 1024 * 1024);
+}
+"""
+        worker = NodeJsonlWorker(source, cwd=ROOT, timeout_seconds=2.0)
+        self.addCleanup(worker.close)
+
+        with self.assertRaisesRegex(NodeJsonlWorkerError, "response exceeded"):
+            worker.request("oversized", {})
+
+        self.assertFalse(worker.is_running)
+
+    def test_invalid_utf8_fails_as_a_protocol_error(self) -> None:
+        source = r"""
+async function handle(_operation, _payload) {
+  process.stdout.write(Buffer.from([0xff, 0xfe, 0x0a]));
+  return null;
+}
+"""
+        worker = NodeJsonlWorker(source, cwd=ROOT)
+        self.addCleanup(worker.close)
+
+        with self.assertRaisesRegex(NodeJsonlWorkerError, "invalid UTF-8"):
+            worker.request("invalid_utf8", {})
+
+        self.assertFalse(worker.is_running)
+
+    def test_close_is_idempotent_and_requests_after_close_fail(self) -> None:
+        source = "async function handle(_operation, payload) { return payload; }"
+        worker = NodeJsonlWorker(source, cwd=ROOT)
+
+        worker.close()
+        worker.close()
+
+        with self.assertRaisesRegex(NodeJsonlWorkerError, "not running"):
+            worker.request("closed", {})
+
+    def test_javascript_error_is_a_failed_request_not_a_result(self) -> None:
+        source = """
+async function handle() {
+  throw new Error('planted handler failure');
+}
+"""
+        worker = NodeJsonlWorker(source, cwd=ROOT)
+        self.addCleanup(worker.close)
+
+        with self.assertRaisesRegex(NodeJsonlWorkerError, "planted handler failure"):
+            worker.request("error", None)
+
+        self.assertFalse(worker.is_running)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_owned_section_expansion_generated.py
+++ b/tests/test_owned_section_expansion_generated.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import json
-import subprocess
 import unittest
 from pathlib import Path
 
@@ -11,6 +9,7 @@ from hypothesis import example, given
 from hypothesis import strategies as st
 
 import tests._hypothesis_profiles  # noqa: F401
+from tests.node_jsonl_worker import NodeJsonlWorker
 
 ROOT = Path(__file__).resolve().parents[1]
 ARTIST_ID = "artist-id"
@@ -18,31 +17,75 @@ PROVENANCE = ("ordinary", "promo", "unofficial")
 STRUCTURAL_TYPES = ("Album", "EP", "Single")
 
 
-def _run_artist_page(script_body: str, payload: object) -> object:
-    script = f"""
-import {{
+_ARTIST_PAGE_WORKER = """
+import {
   classifyArtistRows,
   composeCompareCatalogue,
   renderArtistSections,
-}} from './web/js/artist_page.js';
-import {{ classify as classifyType }} from './web/js/grouping.js';
-let input = '';
-for await (const chunk of process.stdin) input += chunk;
-const payload = JSON.parse(input);
-{script_body}
+} from './web/js/artist_page.js';
+import { classify as classifyType } from './web/js/grouping.js';
+
+async function handle(operation, payload) {
+  if (operation === 'partition') {
+    const sections = classifyArtistRows({
+      artistId: 'artist-id', artistName: 'Artist', releaseGroups: payload,
+      ungroupedReleases: [], libraryAlbums: [],
+    });
+    const html = renderArtistSections(sections, {
+      artistId: 'artist-id', artistName: 'Artist',
+    });
+    return {
+      inLibrary: sections.inLibrary.map(row => row._index),
+      missing: sections.missing.map(row => row._index),
+      other: sections.otherReleases.map(row => row._index),
+      html,
+    };
+  }
+  if (operation === 'pair_projection') {
+    const rows = composeCompareCatalogue(payload.compare, payload.source);
+    const sections = classifyArtistRows({
+      artistId: 'artist-id', artistName: 'Artist', releaseGroups: rows,
+      ungroupedReleases: [], libraryAlbums: [],
+    });
+    const bucket = sections.inLibrary.length ? 'inLibrary'
+      : sections.missing.length ? 'missing' : 'other';
+    return {...rows[0], _bucket: bucket, _type_section: classifyType(rows[0])};
+  }
+  if (operation === 'composition') {
+    const rows = composeCompareCatalogue(payload.compare, payload.source);
+    const sections = classifyArtistRows({
+      artistId: 'artist-id', artistName: 'Artist', releaseGroups: rows,
+      ungroupedReleases: [], libraryAlbums: [],
+    });
+    const bucket = new Map([
+      ...sections.inLibrary.map(row => [row, 'inLibrary']),
+      ...sections.missing.map(row => [row, 'missing']),
+      ...sections.otherReleases.map(row => [row, 'other']),
+    ]);
+    return rows.map(row => ({
+      key: `${row.source}:${row.identity_kind}:${row.id}`,
+      bucket: bucket.get(row),
+    }));
+  }
+  if (operation === 'rolling_collision') {
+    const sections = classifyArtistRows({
+      artistId: 'rolling', artistName: 'The Rolling Stones',
+      releaseGroups: [payload.row], ungroupedReleases: [],
+      libraryAlbums: [payload.library],
+    });
+    return renderArtistSections(sections, {
+      artistId: 'rolling', artistName: 'The Rolling Stones',
+    });
+  }
+  throw new Error(`unknown artist-page operation: ${operation}`);
+}
 """
-    proc = subprocess.run(
-        ["node", "--input-type=module", "--eval", script],
-        cwd=ROOT,
-        input=json.dumps(payload),
-        text=True,
-        capture_output=True,
-        check=True,
-    )
-    return json.loads(proc.stdout)
 
 
-def _real_partition(rows: list[dict[str, object]]) -> dict[str, object]:
+def _real_partition(
+    worker: NodeJsonlWorker,
+    rows: list[dict[str, object]],
+) -> dict[str, object]:
     indexed = [
         {
             "id": str(index),
@@ -57,71 +100,46 @@ def _real_partition(rows: list[dict[str, object]]) -> dict[str, object]:
         }
         for index, row in enumerate(rows)
     ]
-    return _run_artist_page("""
-const sections = classifyArtistRows({
-  artistId: 'artist-id', artistName: 'Artist', releaseGroups: payload,
-  ungroupedReleases: [], libraryAlbums: [],
-});
-const html = renderArtistSections(sections, {
-  artistId: 'artist-id', artistName: 'Artist',
-});
-process.stdout.write(JSON.stringify({
-  inLibrary: sections.inLibrary.map(row => row._index),
-  missing: sections.missing.map(row => row._index),
-  other: sections.otherReleases.map(row => row._index),
-  html,
-}));
-""", indexed)  # type: ignore[return-value]
+    result = worker.request("partition", indexed)
+    if not isinstance(result, dict):
+        raise TypeError(f"partition worker returned {type(result).__name__}")
+    return result
 
 
-def _real_pair_projection(payload: dict[str, object]) -> dict[str, object]:
-    return _run_artist_page("""
-const rows = composeCompareCatalogue(payload.compare, payload.source);
-const sections = classifyArtistRows({
-  artistId: 'artist-id', artistName: 'Artist', releaseGroups: rows,
-  ungroupedReleases: [], libraryAlbums: [],
-});
-const bucket = sections.inLibrary.length ? 'inLibrary'
-  : sections.missing.length ? 'missing' : 'other';
-process.stdout.write(JSON.stringify({
-  ...rows[0], _bucket: bucket, _type_section: classifyType(rows[0]),
-}));
-""", payload)  # type: ignore[return-value]
+def _real_pair_projection(
+    worker: NodeJsonlWorker,
+    payload: dict[str, object],
+) -> dict[str, object]:
+    result = worker.request("pair_projection", payload)
+    if not isinstance(result, dict):
+        raise TypeError(f"pair worker returned {type(result).__name__}")
+    return result
 
 
-def _real_composition(payload: dict[str, object]) -> list[dict[str, str]]:
-    result = _run_artist_page("""
-const rows = composeCompareCatalogue(payload.compare, payload.source);
-const sections = classifyArtistRows({
-  artistId: 'artist-id', artistName: 'Artist', releaseGroups: rows,
-  ungroupedReleases: [], libraryAlbums: [],
-});
-const bucket = new Map([
-  ...sections.inLibrary.map(row => [row, 'inLibrary']),
-  ...sections.missing.map(row => [row, 'missing']),
-  ...sections.otherReleases.map(row => [row, 'other']),
-]);
-process.stdout.write(JSON.stringify(rows.map(row => ({
-  key: `${row.source}:${row.identity_kind}:${row.id}`,
-  bucket: bucket.get(row),
-}))));
-""", payload)
-    assert isinstance(result, list)
-    return [value for value in result if isinstance(value, dict)]
+def _real_composition(
+    worker: NodeJsonlWorker,
+    payload: dict[str, object],
+) -> list[dict[str, str]]:
+    result = worker.request("composition", payload)
+    if not isinstance(result, list) or not all(
+        isinstance(value, dict)
+        and all(
+            isinstance(key, str) and isinstance(item, str)
+            for key, item in value.items()
+        )
+        for value in result
+    ):
+        raise AssertionError("composition worker returned a malformed row list")
+    return result
 
 
-def _real_rolling_collision(payload: dict[str, object]) -> str:
-    result = _run_artist_page("""
-const sections = classifyArtistRows({
-  artistId: 'rolling', artistName: 'The Rolling Stones',
-  releaseGroups: [payload.row], ungroupedReleases: [],
-  libraryAlbums: [payload.library],
-});
-process.stdout.write(JSON.stringify(renderArtistSections(sections, {
-  artistId: 'rolling', artistName: 'The Rolling Stones',
-})));
-""", payload)
-    assert isinstance(result, str)
+def _real_rolling_collision(
+    worker: NodeJsonlWorker,
+    payload: dict[str, object],
+) -> str:
+    result = worker.request("rolling_collision", payload)
+    if not isinstance(result, str):
+        raise TypeError(f"rolling worker returned {type(result).__name__}")
     return result
 
 
@@ -314,6 +332,10 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
 
 
 class TestGeneratedSimpleArtistCatalogue(unittest.TestCase):
+    def setUp(self) -> None:
+        self.worker = NodeJsonlWorker(_ARTIST_PAGE_WORKER, cwd=ROOT)
+        self.addCleanup(self.worker.close)
+
     @given(rows=st.lists(row_strategy, max_size=16))
     @example(rows=[{
         "type": "Album", "primary_types": ["Album"],
@@ -324,7 +346,7 @@ class TestGeneratedSimpleArtistCatalogue(unittest.TestCase):
     def test_partition_is_total_and_page_vocabulary_stays_simple(
         self, rows: list[dict[str, object]],
     ) -> None:
-        actual = _real_partition(rows)
+        actual = _real_partition(self.worker, rows)
         assert_simple_partition(rows, actual)
         html = actual["html"]
         assert isinstance(html, str)
@@ -397,7 +419,7 @@ class TestGeneratedSimpleArtistCatalogue(unittest.TestCase):
             "secondary_types": discogs_secondary,
             "format_qualifiers": discogs_qualifiers,
         }
-        row = _real_pair_projection({
+        row = _real_pair_projection(self.worker, {
             "source": source,
             "compare": {
                 "both": [{"mb": mb, "discogs": discogs}],
@@ -493,7 +515,7 @@ class TestGeneratedSimpleArtistCatalogue(unittest.TestCase):
             "id": f"dg-release-{index}", "source": "discogs",
             "identity_kind": "release", "provenance": ["ordinary"],
         } for index in range(discogs_release_count)]
-        actual = _real_composition({
+        actual = _real_composition(self.worker, {
             "source": source,
             "compare": {
                 "both": pairs,
@@ -570,7 +592,7 @@ class TestGeneratedSimpleArtistCatalogue(unittest.TestCase):
         self, qualifier: str, exact_owned: bool,
     ) -> None:
         row_id = "owned-rg" if exact_owned else "collision-rg"
-        html = _real_rolling_collision({
+        html = _real_rolling_collision(self.worker, {
             "row": {
                 "id": row_id,
                 "title": "The Rolling Stones",

--- a/tests/test_preview_manifest_generated.py
+++ b/tests/test_preview_manifest_generated.py
@@ -47,7 +47,7 @@ from unittest.mock import patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from hypothesis import example, given, settings
+from hypothesis import example, given
 from hypothesis import strategies as st
 
 import tests._hypothesis_profiles  # noqa: F401  (loads the active profile)
@@ -87,6 +87,7 @@ from lib.quality import (
 )
 from lib.staged_album import StagedAlbum
 from tests.fakes import FakeBeetsDB, FakePipelineDB
+from tests.finite_domain import finite_generated_domain
 from tests.helpers import make_ctx_with_fake_db, make_grab_list_entry, make_request_row
 
 _HARNESS = "/nix/store/fake/harness/run_beets_harness.sh"
@@ -139,6 +140,13 @@ def assert_extra_filename_mask_domain(
         raise AssertionError(
             "filename masks do not map one-to-one onto every manifest subset"
         )
+
+
+def verify_extra_filename_mask_domain() -> None:
+    assert_extra_filename_mask_domain(tuple(
+        _extra_filenames_for_mask(mask)
+        for mask in range(_EXTRA_FILENAME_WORLD_COUNT)
+    ))
 
 
 # ============================================================================
@@ -503,7 +511,10 @@ class TestPreviewManifestPurityProperty(unittest.TestCase):
     ``measure_and_persist_candidate_evidence``) over the exact finite manifest
     domain: file count, basenames with spaces/unicode, mp3/flac mix."""
 
-    @settings(max_examples=_EXTRA_FILENAME_WORLD_COUNT)
+    @finite_generated_domain(
+        cardinality=_EXTRA_FILENAME_WORLD_COUNT,
+        verify=verify_extra_filename_mask_domain,
+    )
     @given(mask=_extra_filename_mask_strategy)
     @example(mask=0)
     @example(mask=_EXTRA_FILENAME_WORLD_COUNT - 1)
@@ -598,12 +609,7 @@ class TestPreviewManifestCheckersTripOnViolations(unittest.TestCase):
 
 class TestPreviewManifestFiniteDomain(unittest.TestCase):
     def test_every_filename_subset_has_one_exact_mask(self):
-        mapped = tuple(
-            _extra_filenames_for_mask(mask)
-            for mask in range(1 << len(_EXTRA_FILENAME_POOL))
-        )
-
-        assert_extra_filename_mask_domain(mapped)
+        verify_extra_filename_mask_domain()
 
 
 if __name__ == "__main__":

--- a/tests/test_ruff_lsp_worker.py
+++ b/tests/test_ruff_lsp_worker.py
@@ -1,0 +1,347 @@
+"""Contracts for the target-scoped persistent Ruff language server."""
+
+from __future__ import annotations
+
+import ast
+import signal
+import subprocess
+import sys
+import tempfile
+import textwrap
+import time
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from tests.ruff_lsp_worker import RuffLspWorker, RuffLspWorkerError
+from tests.test_unused_import_audit import ruff_findings
+
+ROOT = Path(__file__).resolve().parents[1]
+_PATHS = ("lib/importing.py", "lib/peer.py")
+
+
+def _fake_server_command(source: str) -> tuple[str, ...]:
+    return (sys.executable, "-u", "-c", textwrap.dedent(source))
+
+
+_FAKE_PREAMBLE = r"""
+import json
+import sys
+import time
+
+def read_message():
+    length = None
+    while True:
+        line = sys.stdin.buffer.readline()
+        if not line:
+            raise EOFError
+        if line == b'\r\n':
+            break
+        name, value = line.decode('ascii').split(':', 1)
+        if name.lower() == 'content-length':
+            length = int(value.strip())
+    if length is None:
+        raise RuntimeError('missing length')
+    return json.loads(sys.stdin.buffer.read(length))
+
+def send(message):
+    body = json.dumps(message, separators=(',', ':')).encode()
+    sys.stdout.buffer.write(
+        f'Content-Length: {len(body)}\r\n\r\n'.encode() + body
+    )
+    sys.stdout.buffer.flush()
+"""
+
+
+def direct_ruff_findings_lines(source: str) -> tuple[int, ...]:
+    """Locate the bounded historical per-example Ruff CLI helper call."""
+    tree = ast.parse(source)
+    return tuple(
+        node.lineno
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "ruff_findings"
+    )
+
+
+def _codes_by_path(
+    findings: tuple[dict[str, object], ...],
+) -> frozenset[tuple[str, str]]:
+    normalized: set[tuple[str, str]] = set()
+    for finding in findings:
+        filename = Path(str(finding["filename"])).as_posix()
+        relative = next(path for path in _PATHS if filename.endswith(path))
+        normalized.add((relative, str(finding["code"])))
+    return frozenset(normalized)
+
+
+class TestRuffLspWorker(unittest.TestCase):
+    def test_reuses_one_server_and_matches_canonical_cli_findings(self) -> None:
+        redundant = {
+            "lib/importing.py": "from dependency import name as name\n",
+            "lib/peer.py": "name = object()\nprint(name)\n",
+        }
+        unused = {
+            "lib/importing.py": "from dependency import other\n",
+            "lib/peer.py": "other = object()\nprint(other)\n",
+        }
+        with RuffLspWorker(_PATHS, cwd=ROOT) as worker:
+            pid = worker.pid
+            lsp_redundant = worker.findings(redundant)
+            lsp_unused = worker.findings(unused)
+            self.assertEqual(worker.pid, pid)
+
+        self.assertEqual(
+            _codes_by_path(lsp_redundant),
+            _codes_by_path(ruff_findings(redundant)),
+        )
+        self.assertEqual(
+            _codes_by_path(lsp_unused),
+            _codes_by_path(ruff_findings(unused)),
+        )
+
+    def test_each_update_replaces_the_complete_prior_world(self) -> None:
+        world_a = {
+            "lib/importing.py": "from dependency import name as name\n",
+            "lib/peer.py": "name = object()\nprint(name)\n",
+        }
+        world_b = {
+            "lib/importing.py": "from dependency import name\nprint(name)\n",
+            "lib/peer.py": "peer = object()\nprint(peer)\n",
+        }
+        with RuffLspWorker(_PATHS, cwd=ROOT) as worker:
+            first = worker.findings(world_a)
+            worker.findings(world_b)
+            repeated = worker.findings(world_a)
+
+        self.assertEqual(_codes_by_path(first), _codes_by_path(repeated))
+
+    def test_source_paths_are_an_exact_allowlist(self) -> None:
+        with (
+            RuffLspWorker(_PATHS, cwd=ROOT) as worker,
+            self.assertRaisesRegex(RuffLspWorkerError, "exact configured paths"),
+        ):
+            worker.findings({"lib/importing.py": "pass\n"})
+
+    def test_close_is_idempotent_and_requests_after_close_fail(self) -> None:
+        worker = RuffLspWorker(_PATHS, cwd=ROOT)
+
+        worker.close()
+        worker.close()
+
+        with self.assertRaisesRegex(RuffLspWorkerError, "not running"):
+            worker.findings({path: "pass\n" for path in _PATHS})
+
+    def test_stale_diagnostic_chatter_cannot_extend_transaction_deadline(self) -> None:
+        command = _fake_server_command(
+            _FAKE_PREAMBLE
+            + r"""
+initialize = read_message()
+send({'jsonrpc': '2.0', 'id': initialize['id'], 'result': {}})
+read_message()
+opened = read_message()
+uri = opened['params']['textDocument']['uri']
+while True:
+    send({
+        'jsonrpc': '2.0',
+        'method': 'textDocument/publishDiagnostics',
+        'params': {'uri': uri, 'version': 0, 'diagnostics': []},
+    })
+    time.sleep(0.01)
+""",
+        )
+        worker = RuffLspWorker(
+            ("lib/importing.py",),
+            cwd=ROOT,
+            timeout_seconds=0.15,
+            command=command,
+        )
+        root = worker.workspace_root
+        started = time.monotonic()
+
+        with self.assertRaisesRegex(RuffLspWorkerError, "timed out") as caught:
+            worker.findings({"lib/importing.py": "pass\n"})
+
+        self.assertLess(time.monotonic() - started, 1.0)
+        self.assertFalse(root.exists())
+        with self.assertRaises(RuffLspWorkerError) as repeated:
+            worker.findings({"lib/importing.py": "pass\n"})
+        self.assertEqual(str(repeated.exception), str(caught.exception))
+        worker.close()
+
+    def test_blocked_write_consumes_the_transaction_deadline(self) -> None:
+        command = _fake_server_command(
+            _FAKE_PREAMBLE
+            + """
+initialize = read_message()
+send({'jsonrpc': '2.0', 'id': initialize['id'], 'result': {}})
+import signal
+signal.signal(signal.SIGTERM, signal.SIG_IGN)
+time.sleep(60)
+""",
+        )
+        worker = RuffLspWorker(
+            ("lib/importing.py",),
+            cwd=ROOT,
+            timeout_seconds=0.1,
+            command=command,
+        )
+        root = worker.workspace_root
+        started = time.monotonic()
+
+        with self.assertRaisesRegex(RuffLspWorkerError, "request timed out") as caught:
+            worker.findings({"lib/importing.py": "x = " + repr("x" * (512 * 1024))})
+
+        self.assertLess(time.monotonic() - started, 0.75)
+        self.assertFalse(root.exists())
+        with self.assertRaises(RuffLspWorkerError) as repeated:
+            worker.findings({"lib/importing.py": "pass\n"})
+        self.assertEqual(str(repeated.exception), str(caught.exception))
+
+    def test_child_loss_between_requests_is_poisoned_and_cleans_workspace(self) -> None:
+        command = _fake_server_command(
+            _FAKE_PREAMBLE
+            + """
+initialize = read_message()
+send({'jsonrpc': '2.0', 'id': initialize['id'], 'result': {}})
+read_message()
+print('planted Ruff child loss', file=sys.stderr, flush=True)
+raise SystemExit(17)
+""",
+        )
+        worker = RuffLspWorker(
+            ("lib/importing.py",),
+            cwd=ROOT,
+            command=command,
+        )
+        root = worker.workspace_root
+        time.sleep(0.2)
+
+        with self.assertRaisesRegex(
+            RuffLspWorkerError,
+            "planted Ruff child loss",
+        ) as caught:
+            worker.findings({"lib/importing.py": "pass\n"})
+        self.assertFalse(root.exists())
+        with self.assertRaises(RuffLspWorkerError) as repeated:
+            worker.findings({"lib/importing.py": "pass\n"})
+        self.assertEqual(str(repeated.exception), str(caught.exception))
+
+    def test_initialization_child_loss_cleans_temporary_workspace(self) -> None:
+        command = _fake_server_command(
+            "import sys\n"
+            "print('planted init loss', file=sys.stderr, flush=True)\n"
+            "raise SystemExit(17)\n"
+        )
+        temporary_root = Path(tempfile.gettempdir())
+        before = set(temporary_root.glob("cratedigger-ruff-lsp-*"))
+
+        with self.assertRaisesRegex(RuffLspWorkerError, "planted init loss"):
+            RuffLspWorker(
+                ("lib/importing.py",),
+                cwd=ROOT,
+                command=command,
+            )
+
+        self.assertEqual(
+            set(temporary_root.glob("cratedigger-ruff-lsp-*")),
+            before,
+        )
+
+    def test_stderr_thread_start_failure_cleans_temporary_workspace(self) -> None:
+        temporary_root = Path(tempfile.gettempdir())
+        before = set(temporary_root.glob("cratedigger-ruff-lsp-*"))
+
+        with (
+            mock.patch(
+                "tests.ruff_lsp_worker.threading.Thread.start",
+                side_effect=RuntimeError("planted thread start failure"),
+            ),
+            self.assertRaisesRegex(RuffLspWorkerError, "thread start failure"),
+        ):
+            RuffLspWorker(("lib/importing.py",), cwd=ROOT)
+
+        self.assertEqual(
+            set(temporary_root.glob("cratedigger-ruff-lsp-*")),
+            before,
+        )
+
+    def test_stderr_thread_construction_failure_reaps_child_and_closes_pipes(
+        self,
+    ) -> None:
+        process = subprocess.Popen(
+            _fake_server_command("import time; time.sleep(60)"),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        temporary_root = Path(tempfile.gettempdir())
+        before = set(temporary_root.glob("cratedigger-ruff-lsp-*"))
+
+        with (
+            mock.patch(
+                "tests.ruff_lsp_worker.subprocess.Popen",
+                return_value=process,
+            ),
+            mock.patch(
+                "tests.ruff_lsp_worker.threading.Thread",
+                side_effect=RuntimeError("planted thread construction failure"),
+            ),
+            self.assertRaisesRegex(RuffLspWorkerError, "thread construction failure"),
+        ):
+            RuffLspWorker(("lib/importing.py",), cwd=ROOT)
+
+        self.assertEqual(process.returncode, -signal.SIGKILL)
+        for stream in (process.stdin, process.stdout, process.stderr):
+            assert stream is not None
+            self.assertTrue(stream.closed)
+        self.assertEqual(
+            set(temporary_root.glob("cratedigger-ruff-lsp-*")),
+            before,
+        )
+
+    def test_malformed_jsonrpc_version_fails_initialization_closed(self) -> None:
+        command = _fake_server_command(
+            _FAKE_PREAMBLE
+            + """
+initialize = read_message()
+send({'jsonrpc': 'bogus', 'id': initialize['id'], 'result': {}})
+""",
+        )
+
+        with self.assertRaisesRegex(RuffLspWorkerError, "malformed Ruff LSP"):
+            RuffLspWorker(("lib/importing.py",), cwd=ROOT, command=command)
+
+    def test_response_requires_exactly_one_result_or_error(self) -> None:
+        command = _fake_server_command(
+            _FAKE_PREAMBLE
+            + """
+initialize = read_message()
+send({'jsonrpc': '2.0', 'id': initialize['id']})
+""",
+        )
+
+        with self.assertRaisesRegex(RuffLspWorkerError, "malformed Ruff response"):
+            RuffLspWorker(("lib/importing.py",), cwd=ROOT, command=command)
+
+
+class TestGeneratedRuffWorkerAudit(unittest.TestCase):
+    def test_checker_rejects_the_historical_per_example_helper(self) -> None:
+        self.assertEqual(
+            direct_ruff_findings_lines("result = ruff_findings(sources)\n"),
+            (1,),
+        )
+
+    def test_generated_unused_import_properties_use_the_persistent_server(self) -> None:
+        path = ROOT / "tests" / "test_unused_import_audit_generated.py"
+
+        self.assertEqual(
+            direct_ruff_findings_lines(path.read_text(encoding="utf-8")),
+            (),
+            "generated Ruff properties must not launch the CLI per example",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_unused_import_audit_generated.py
+++ b/tests/test_unused_import_audit_generated.py
@@ -4,17 +4,20 @@ from __future__ import annotations
 
 import keyword
 import unittest
+from pathlib import Path
 
 from hypothesis import assume, example, given
 from hypothesis import strategies as st
 
 import tests._hypothesis_profiles  # noqa: F401 - registers suite/fuzz tiers
+from tests.ruff_lsp_worker import RuffLspWorker
 from tests.test_unused_import_audit import (
     assert_import_liveness,
     assert_redundant_alias_baseline,
     redundant_aliases,
-    ruff_findings,
 )
+
+_RUFF_WORLD_PATHS = ("lib/importing.py", "lib/peer.py")
 
 _SCAFFOLDING_NAMES = frozenset({
     "__debug__",
@@ -68,6 +71,13 @@ def assert_name_only_whitelist_fresh(
 
 
 class TestGeneratedUnusedImportAudit(unittest.TestCase):
+    def setUp(self) -> None:
+        self.ruff = RuffLspWorker(
+            _RUFF_WORLD_PATHS,
+            cwd=Path(__file__).parents[1],
+        )
+        self.addCleanup(self.ruff.close)
+
     @given(
         names=st.lists(_IDENTIFIERS, min_size=2, max_size=5, unique=True),
         delta=st.sampled_from(("duplicate", "expansion", "stale_expected")),
@@ -117,7 +127,7 @@ class TestGeneratedUnusedImportAudit(unittest.TestCase):
             source += import_line(baseline_names[0])
         peer_source = f"{changed_name} = object()\nprint({changed_name})\n"
 
-        findings = ruff_findings({
+        findings = self.ruff.findings({
             "lib/importing.py": source,
             "lib/peer.py": peer_source,
         })
@@ -186,7 +196,7 @@ class TestGeneratedUnusedImportAudit(unittest.TestCase):
             source += f"def inspect(): return {imported_name}\n"
         peer_source = f"{imported_name} = object()\nprint({imported_name})\n"
 
-        findings = ruff_findings({
+        findings = self.ruff.findings({
             "lib/importing.py": source,
             "lib/peer.py": peer_source,
         })
@@ -200,7 +210,7 @@ class TestGeneratedUnusedImportAudit(unittest.TestCase):
     def test_checker_rejects_the_aggregate_name_fault(self) -> None:
         imported_name = "shared_name"
         peer_source = "shared_name = object()\nprint(shared_name)\n"
-        findings = ruff_findings({
+        findings = self.ruff.findings({
             "lib/importing.py": "from dependency import shared_name\n",
             "lib/peer.py": peer_source,
         })


### PR DESCRIPTION
## Summary

- reuse one target-scoped Node process for generated JavaScript properties
- reuse one target-scoped Ruff language server for generated unused-import properties
- execute finite-domain proofs during isolated discovery and enforce exact cardinality budgets without redundant entropy shards
- bound protocol framing, writes, reads, stderr, deadlines, poisoning, process reaping, and temporary-workspace cleanup
- document profiling and stopping rules for generated-test optimization

## Performance evidence

Canonical depth-20,000 workload:

- baseline: 1,712.7s
- finite-preview optimization: 1,405.2s
- Node-worker optimization: 1,221.6s
- exact final benchmark: 1,129.1s
- total reduction: 583.6s / 34.07%; 1.517x speedup
- 3,351/3,351 targets, 115 modules, 1,431 tests, ALL GREEN
- runtime tmpfs peak: 702.8 MiB / 6.86%; no ENOSPC

The final lifecycle hardening changes only fatal/error paths and proof execution during discovery; normal target execution is unchanged from the exact final benchmark.

## Verification

- independent final staged review: approved, no blocking findings
- final committed-tree Pyright receipt: `/run/user/1000/cratedigger-final-gate.660tp39U`
- final committed-tree complete-suite receipt: `/run/user/1000/cratedigger-final-gate.nV2QJw0x`
- signed commit: `07eec3e6569000f81d38a6d8b7eaa101ac82e61d`
