### PR TITLE
perf(tests): shard deterministic suite stragglers

### DIFF
--- a/scripts/run_python_tests.py
+++ b/scripts/run_python_tests.py
@@ -51,8 +51,14 @@ DEFAULT_DURATIONS = 15
 _FAILURE_MARKER = "=" * 70
 _SCHEMA_READY_ENV = "CRATEDIGGER_TEST_SCHEMA_READY"
 WORLD_MODEL_MODULE = "tests.world_model.state_machine"
+# Method profiling showed the dominant Nix evaluation was otherwise admitted
+# late enough to become the deterministic suite's tail.
+AUDITED_FRONTLOAD_MODULES = frozenset({"tests.test_nix_module"})
 HOTSPOT_SHARD_POLICIES = {
     "tests.test_beets_destructive_configs_generated": "method_batch",
+    "tests.test_deploy_pin_generated": "method_batch",
+    "tests.test_deploy_pin_script": "method_batch",
+    "tests.test_nix_module": "method_batch",
     "tests.test_pipeline_db": "class_batch",
 }
 HOTSPOT_CLASS_BATCHES = 8
@@ -394,7 +400,15 @@ def discover_test_modules(
         relative = path.relative_to(top).with_suffix("")
         if any(not part.isidentifier() for part in relative.parts):
             raise ValueError(f"test path is not importable as a module: {path}")
-        modules.append(TestModule(".".join(relative.parts), path, _line_weight(path)))
+        module_name = ".".join(relative.parts)
+        modules.append(
+            TestModule(
+                module_name,
+                path,
+                _line_weight(path),
+                frontload=module_name in AUDITED_FRONTLOAD_MODULES,
+            )
+        )
     return tuple(modules)
 
 

--- a/tests/test_parallel_test_runner.py
+++ b/tests/test_parallel_test_runner.py
@@ -26,6 +26,7 @@ from scripts.run_fuzz_tests import (
     is_structurally_shallow,
 )
 from scripts.run_python_tests import (
+    AUDITED_FRONTLOAD_MODULES,
     HOTSPOT_SHARD_POLICIES,
     HYPOTHESIS_CASE_STATUSES,
     STRATEGY_SPACE_EXHAUSTED,
@@ -130,6 +131,25 @@ class TestModuleDiscovery(unittest.TestCase):
             ],
         )
 
+    def test_only_the_audited_nix_straggler_is_frontloaded(self) -> None:
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            tests_dir = root / "tests"
+            tests_dir.mkdir()
+            (tests_dir / "__init__.py").write_text("", encoding="utf-8")
+            (tests_dir / "test_nix_module.py").write_text("# nix\n", encoding="utf-8")
+            (tests_dir / "test_ordinary.py").write_text("# ordinary\n", encoding="utf-8")
+
+            modules = discover_test_modules(tests_dir, root, "test*.py")
+
+        self.assertEqual(
+            {module.name: module.frontload for module in modules},
+            {
+                "tests.test_nix_module": True,
+                "tests.test_ordinary": False,
+            },
+        )
+
 
 class TestModuleScheduling(unittest.TestCase):
     def test_worker_policy_scales_with_host_without_chasing_diminishing_returns(
@@ -187,9 +207,16 @@ class TestModuleScheduling(unittest.TestCase):
 
     def test_audited_hotspots_split_at_the_narrowest_safe_boundary(self) -> None:
         self.assertEqual(
+            AUDITED_FRONTLOAD_MODULES,
+            frozenset({"tests.test_nix_module"}),
+        )
+        self.assertEqual(
             HOTSPOT_SHARD_POLICIES,
             {
                 "tests.test_beets_destructive_configs_generated": "method_batch",
+                "tests.test_deploy_pin_generated": "method_batch",
+                "tests.test_deploy_pin_script": "method_batch",
+                "tests.test_nix_module": "method_batch",
                 "tests.test_pipeline_db": "class_batch",
             },
         )


### PR DESCRIPTION
## Summary

- method-batch the three measured deterministic-suite stragglers
- frontload only the dominant Nix module so its longest evaluation cannot enter late
- preserve exact test-ID accounting, fresh target interpreters, failure aggregation, and infrastructure classification

## Performance evidence

Recent merged-tree Python baseline: 122.8–131.0s.

Accepted implementation:

- sharding only: 96.5s
- sharding plus audited Nix frontload: 88.4s, 89.2s, and 90.1s
- 8,747/8,747 test IDs preserved across 391 targets
- peak process-tree RSS: 4.35–4.56 GiB
- `/run` growth: no more than 8 KiB
- no ENOSPC and no PostgreSQL concurrency change

A broader seven-module sharding experiment regressed the Python phase to 122.7s and was reverted. The final workload profile showed all 12 workers balanced within 78.5–83.5s, establishing the stopping point.

## Verification

- independent exact staged-diff review: approved with no findings
- focused runner contracts: passed
- canonical complete suite: passed, `/run/user/1000/cratedigger-checks.rx7rv_sa`
- committed-tree Pyright receipt: `/run/user/1000/cratedigger-final-gate.KeNlSkre`
- committed-tree complete-suite receipt: `/run/user/1000/cratedigger-final-gate.rWvFffPK`
- signed commit: `c127e9961a0dfbfab59be4f7baac195c20396e73`
