### PR TITLE
Scale fuzz entropy fan-out to profile depth

### DIFF
--- a/docs/generated-testing.md
+++ b/docs/generated-testing.md
@@ -120,11 +120,13 @@ source scanner.
 
 1. Preserve the accepted full-depth log as baseline.
 2. Benchmark the exact changed property/module with the production profile and
-   canonical shard count. This proves the optimization before paying for the
-   whole queue.
-3. After a material critical-path change, run the complete 20,000-example burst
+   canonical shard count. The automatic count is both host- and budget-bounded:
+   each entropy child gets at least 250 examples before another process is worth
+   starting. This proves the optimization before paying for the whole queue.
+3. After a material critical-path change, run the complete relevant profile
    once and compare wall time, targets, tests, property depth, discards,
-   infrastructure failures, ENOSPC, and slow-target rankings.
+   infrastructure failures, ENOSPC, and slow-target rankings. Changes that can
+   affect the unattended path also owe the 20,000-example burst.
 4. Continue only while the next slow cohort is dominated by removable harness
    repetition or a separately proved finite domain. Domain computation,
    PostgreSQL serialization required by ownership, and real media decoding are
@@ -457,15 +459,17 @@ Two independent gates enforce this:
 `scripts/fuzz_burst.sh` discovers the exact unittest IDs and effective
 Hypothesis settings in every generated module. Ordinary deterministic pins run
 once as a batch, and fixed per-test `@settings(max_examples=...)` budgets remain
-single-run. Each property using the default fuzz profile divides its 500
-generated examples exactly across independent entropy shards. The total budget
-does not grow: on a 30-core host, eight processes receive 62 or 63 examples.
-The overnight gate raises the combined budget to 20,000, or 2,500 per shard on
-that host. The child runner loads the owning module and selects the exact
-discovered ID, so dynamically named state-machine tests can be sharded without
-repeating the module's other properties or pins. An exact-budget check rejects
-any schedule that omits a test, repeats a pin, changes a property's combined
-example count, or invents an ID.
+single-run. Each property using the default fuzz profile divides its generated
+examples exactly across independent entropy shards. The automatic fan-out is
+bounded by both host cores and the effective budget discovered from the loaded
+profile, with at least 250 examples per entropy child. The total budget does not
+grow: on a 30-core host, the ordinary 500-example profile uses two processes of
+250 examples, while the 20,000-example overnight gate keeps eight processes of
+2,500. The child runner loads the owning module and selects the exact discovered
+ID, so dynamically named state-machine tests can be sharded without repeating
+the module's other properties or pins. An exact-budget check rejects any
+schedule that omits a test, repeats a pin, changes a property's combined example
+count, or invents an ID.
 
 The queue uses every host core by default for ordinary targets. Targets whose
 module boots an ephemeral PostgreSQL cluster are capped at two concurrent
@@ -474,11 +478,20 @@ eligible ordinary work bypasses a PostgreSQL-backed target waiting for that
 resource. Any `ENOSPC`, PostgreSQL `DiskFull`, or unexpected loss of an
 ephemeral database aborts further admission and reports that the property
 verdict is invalid. Set `CRATEDIGGER_FUZZ_JOBS` to cap all concurrent
-processes or `CRATEDIGGER_FUZZ_PROPERTY_SHARDS` to override the host-scaled
+processes or `CRATEDIGGER_FUZZ_PROPERTY_SHARDS` to override the automatic
 entropy fan-out. On doc1's 30-core VM on 2026-07-23, the complete 71-module,
 769-test overnight burst at 20,000 examples completed in 607.8 seconds. The
 worst subprocess-heavy generated module completed alone in 142.7 seconds; its
 unsharded properties had still not completed after ten minutes.
+
+On the same 30-core host on 2026-08-02, a matched 500-example run on one tree
+completed 115 modules, 1,432 tests, and 433 properties in 180.1 seconds with
+the former eight-shard fan-out (3,359 targets). The budget-aware two-shard
+default completed the same inventory in 106.0 and 106.0 seconds (935 targets),
+a 41.1% wall-time reduction. These timings justify the 250-example floor on
+this host; they are measurements, not a universal performance promise. The
+same tree's automatic 20,000-example run retained eight shards and completed
+all 3,359 targets in 1,172.3 seconds.
 
 ### Per-property depth report
 

--- a/scripts/run_fuzz_tests.py
+++ b/scripts/run_fuzz_tests.py
@@ -49,6 +49,7 @@ TARGET_RUNNER = REPO_ROOT / "scripts" / "run_python_tests.py"
 DEFAULT_PROFILE = "fuzz"
 DEFAULT_DURATIONS = 5
 EPHEMERAL_POSTGRES_TARGET_LIMIT = 2
+MIN_EXAMPLES_PER_ENTROPY_SHARD = 250
 _SCHEMA_READY_ENV = "CRATEDIGGER_TEST_SCHEMA_READY"
 _DISCOVERY_DSN = "postgresql:///cratedigger_fuzz_discovery_only"
 
@@ -1019,11 +1020,41 @@ def _default_jobs() -> int:
     return os.cpu_count() or 1
 
 
-def recommended_property_shards(cpu_count: int) -> int:
-    """Keep a deep fuzz tail wide without excessive process startup."""
+def property_profile_max_examples(
+    manifests: Sequence[FuzzModuleManifest],
+) -> int | None:
+    """Return the one effective default-property budget from discovery."""
+    budgets = {
+        item.max_examples
+        for manifest in manifests
+        for item in manifest.hypothesis_tests
+        if (
+            item.uses_default_settings
+            and item.finite_domain_cardinality is None
+        )
+    }
+    if len(budgets) > 1:
+        raise ValueError(
+            f"inconsistent default property budgets: {sorted(budgets)}"
+        )
+    return next(iter(budgets), None)
+
+
+def recommended_property_shards(
+    cpu_count: int,
+    profile_max_examples: int,
+) -> int:
+    """Keep enough examples in each child to repay process startup."""
     if cpu_count < 1:
         raise ValueError("cpu_count must be at least 1")
-    return min(8, max(1, (cpu_count + 3) // 4))
+    if profile_max_examples < 1:
+        raise ValueError("profile_max_examples must be at least 1")
+    host_limit = min(8, max(1, (cpu_count + 3) // 4))
+    budget_limit = max(
+        1,
+        profile_max_examples // MIN_EXAMPLES_PER_ENTROPY_SHARD,
+    )
+    return min(host_limit, budget_limit)
 
 
 def _configured_property_shards() -> int | None:
@@ -1069,18 +1100,15 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     persistent_output_value = os.environ.get("CRATEDIGGER_FUZZ_OUTPUT_DIR")
     property_shards = args.property_shards
-    if property_shards is None:
-        property_shards = (
-            recommended_property_shards(os.cpu_count() or 1)
-            if args.profile == DEFAULT_PROFILE
-            else 1
-        )
-    if args.profile != DEFAULT_PROFILE and property_shards != 1:
-        print(
-            "Property entropy sharding is supported only by the fuzz profile",
-            file=sys.stderr,
-        )
-        return 2
+    if args.profile != DEFAULT_PROFILE:
+        if property_shards is None:
+            property_shards = 1
+        elif property_shards != 1:
+            print(
+                "Property entropy sharding is supported only by the fuzz profile",
+                file=sys.stderr,
+            )
+            return 2
 
     with tempfile.TemporaryDirectory(prefix="cratedigger_fuzz_") as tempdir:
         active_root = Path(tempdir)
@@ -1102,6 +1130,16 @@ def main(argv: Sequence[str] | None = None) -> int:
             environment=child_environment,
             work_directory=discovery_directory,
         )
+        if property_shards is None:
+            profile_max_examples = property_profile_max_examples(manifests)
+            property_shards = (
+                recommended_property_shards(
+                    os.cpu_count() or 1,
+                    profile_max_examples,
+                )
+                if profile_max_examples is not None
+                else 1
+            )
         targets = build_fuzz_targets(
             manifests,
             property_shards=property_shards,

--- a/tests/test_fuzz_burst.py
+++ b/tests/test_fuzz_burst.py
@@ -24,6 +24,7 @@ from scripts.run_fuzz_tests import (
     discover_fuzz_manifests,
     format_depth_report,
     is_structurally_shallow,
+    property_profile_max_examples,
     recommended_property_shards,
     select_fuzz_admissions,
 )
@@ -289,8 +290,52 @@ class TestFuzzTargetPlanning(unittest.TestCase):
         self.assertEqual(admitted, (2,))
         self.assertEqual(EPHEMERAL_POSTGRES_TARGET_LIMIT, 2)
 
-    def test_30_core_host_uses_eight_entropy_shards(self) -> None:
-        self.assertEqual(recommended_property_shards(30), 8)
+    def test_30_core_500_example_profile_uses_two_entropy_shards(self) -> None:
+        self.assertEqual(recommended_property_shards(30, 500), 2)
+
+    def test_30_core_overnight_profile_keeps_eight_entropy_shards(self) -> None:
+        self.assertEqual(recommended_property_shards(30, 20_000), 8)
+
+    def test_discovered_profile_budget_ignores_explicit_properties(self) -> None:
+        manifest = FuzzModuleManifest(
+            module_name="tests.test_generated_world",
+            test_ids=("default", "explicit"),
+            hypothesis_tests=(
+                FuzzPropertyManifest(
+                    test_id="default",
+                    max_examples=500,
+                    uses_default_settings=True,
+                ),
+                FuzzPropertyManifest(
+                    test_id="explicit",
+                    max_examples=20_000,
+                    uses_default_settings=False,
+                ),
+            ),
+        )
+
+        self.assertEqual(property_profile_max_examples((manifest,)), 500)
+
+    def test_discovered_profile_budget_must_be_consistent(self) -> None:
+        manifest = FuzzModuleManifest(
+            module_name="tests.test_generated_world",
+            test_ids=("first", "second"),
+            hypothesis_tests=(
+                FuzzPropertyManifest(
+                    test_id="first",
+                    max_examples=500,
+                    uses_default_settings=True,
+                ),
+                FuzzPropertyManifest(
+                    test_id="second",
+                    max_examples=501,
+                    uses_default_settings=True,
+                ),
+            ),
+        )
+
+        with self.assertRaisesRegex(ValueError, "inconsistent default"):
+            property_profile_max_examples((manifest,))
 
     def test_generated_state_machine_inherits_the_profile_budget(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:

--- a/tests/test_fuzz_runner_generated.py
+++ b/tests/test_fuzz_runner_generated.py
@@ -31,6 +31,7 @@ from scripts.run_fuzz_tests import (
     discover_fuzz_manifests,
     format_depth_report,
     is_structurally_shallow,
+    recommended_property_shards,
     select_fuzz_admissions,
 )
 from scripts.run_python_tests import (
@@ -261,6 +262,25 @@ def assert_report_names_exactly_the_discarding_properties(
 
 
 class TestGeneratedFuzzTargetPlanning(unittest.TestCase):
+    @given(
+        cpu_count=st.integers(min_value=1, max_value=256),
+        max_examples=st.integers(min_value=1, max_value=100_000),
+    )
+    def test_automatic_sharding_respects_host_and_example_capacity(
+        self,
+        cpu_count: int,
+        max_examples: int,
+    ) -> None:
+        shards = recommended_property_shards(cpu_count, max_examples)
+
+        self.assertGreaterEqual(shards, 1)
+        self.assertLessEqual(shards, min(8, max(1, (cpu_count + 3) // 4)))
+        if shards > 1:
+            self.assertGreaterEqual(max_examples // shards, 250)
+        host_limit = min(8, max(1, (cpu_count + 3) // 4))
+        if shards < host_limit:
+            self.assertLess(max_examples // (shards + 1), 250)
+
     @given(
         property_count=st.integers(min_value=0, max_value=40),
         pin_count=st.integers(min_value=0, max_value=40),


### PR DESCRIPTION
## Summary

- derive automatic entropy fan-out from the effective default-property budget discovered from the loaded Hypothesis profile
- keep at least 250 examples in each entropy child, selecting two shards at depth 500 while retaining eight shards at depth 20,000 on a 30-core host
- preserve explicit shard overrides, finite-domain handling, exact IDs, pins, and combined property budgets
- add deterministic pins, a generated capacity property, and current host-specific benchmark documentation

## Performance

Matched A/B on the edited tree, 30-core doc1, empty replay database, depth 500:

| Fan-out | Targets | Modules / tests / properties | External wall |
| --- | ---: | --- | ---: |
| explicit 8-shard control | 3,359 | 115 / 1,432 / 433 | 180.068s |
| automatic 2-shard run 1 | 935 | 115 / 1,432 / 433 | 106.049s |
| automatic 2-shard run 2 | 935 | 115 / 1,432 / 433 | 105.965s |

Both automatic repeats round to 106.0s, a 41.1% wall-clock reduction from the matched control. An independent pre-edit eight-shard baseline was 177.584s.

Every default property retained a combined 500 examples. Explicit settings and proved finite domains stayed single-run, and ordinary pins ran once.

The automatic depth-20,000 path selected eight shards and passed all 3,359 targets: 115 modules, 1,432 tests, 433 properties, 1,172.250s external wall time.

## Validation

- focused fuzz-runner modules: 64 tests passed
- Ruff: passed
- full-repository Pyright: 0 errors
- depth-500 complete bursts: green (control plus two automatic repeats)
- depth-20,000 complete burst: green
- clean-HEAD final Pyright receipt: passed
- clean-HEAD complete deterministic-suite receipt: passed
