### PR TITLE
Codify adapter and JavaScript presentation evidence (#979)

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -154,6 +154,20 @@ Any type that **crosses JSON** — harness stdout, an HTTP response, a JSONB blo
   a single-point mutant immediately proved was the load-bearing half).
   Subagent implementation briefs state the pair requirement verbatim and
   never offer a deterministic-only alternative.
+- **"Agree by construction" stops at the outermost real adapter, never at a
+  shared library function.** A cross-surface parity invariant owes its
+  deterministic pin and generated property through the actual boundary each
+  surface consumes: SQL row aliases and a projection, a formatter, or the
+  JavaScript-facing payload, as applicable. It also owes a known-bad adapter
+  mutant. V4 in `tests/test_verdict_tiers_generated.py` is the pattern:
+  `proof_verdict_from_evidence` and `proof_verdict_from_facts` agree, then
+  `web.classify.proof_gate_projection` receives the aliases the browser's
+  render path really gets. PR #973 proved why: reading a lineage-gated overlay
+  key instead of its evidence alias disagreed on 26,503 live rows while the
+  common library functions remained in lockstep. Do not stop the property at
+  the common function and call that parity, and do not answer this requirement
+  with a semantic source scanner; the real adapter-driving pin, property, and
+  mutant are the evidence.
 - **A decision-consequence pin must assert the decided outcome, not a proxy
   field.** If a pin claims "this world changes what the pipeline decides,"
   it must drive the real decider and assert the *decided outcome*

--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -221,6 +221,61 @@ Any type that **crosses JSON** — harness stdout, an HTTP response, a JSONB blo
   harness overhead, or when added protocol/scheduler complexity outweighs the
   measured wall-time return. Detailed workflow: `docs/generated-testing.md`.
 
+## Test execution, evidence, and hooks
+
+Choose validation timing and depth during development using engineering
+judgment based on the change, current evidence, and concrete risk. Focused
+tests, whole-tree Pyright, the complete deterministic suite, and relevant
+surface-specific checks are all available whenever they add useful feedback:
+
+```bash
+nix-shell --run "python3 -m unittest tests.test_X -v"  # focused iteration
+nix-shell --run "pyright --threads 4"                   # whole repository
+nix-shell --run "bash scripts/run_tests.sh"             # complete suite
+```
+
+Always use `nix-shell --run` for Python (`.claude/rules/nix-shell.md`). Direct
+Nix-shell runs are ordinary development feedback; fix their failures in the
+current convergence loop. They do not mint final receipts. A green complete
+suite does not replace generated, live-boundary, browser, corpus, VM, or other
+specialized evidence required by the change. Before the first branch push, use
+the `check` skill for one final receipt-backed whole-tree confirmation once the
+reviewed tree is committed and clean; it owns the receipt and unchanged-tree
+no-replay rules.
+
+`run_tests.sh` exhausts JavaScript, production-strict Pyright, Ruff, Vulture,
+and the complete Python scheduler before returning one aggregate status. Its
+terminal output is a compact complete failure index; the printed private-tmpfs
+bundle contains `summary.json`, `summary.md`, and every complete phase log.
+
+**Generated (property-based) tests** (`tests/test_*_generated.py`, Hypothesis)
+run deterministically in the suite. After changing quality policy, run the
+randomized fuzz burst: `nix-shell --run "bash scripts/fuzz_burst.sh"` (one
+process per generated module, parallelised to the host's cores — Hypothesis is
+single-threaded, so never run the burst serially). Failures shrink to minimal
+worlds — promote them to named `@example` pins or album-test-set scenarios,
+never JSON artifacts. New features start by writing their invariants down, and
+every invariant ships as a pair — deterministic pin + generated property — in
+the same PR, with known-bad self-tests. When in doubt that the harness
+constrains anything, qualify it by fault injection. See
+`docs/generated-testing.md`.
+
+### Skipped tests are an anti-pattern
+
+**A test either runs or it doesn't exist.** `tests/test_skip_audit.py` rejects
+known unittest skip markers without an allowlist; the same policy forbids
+environment gates. Supply dependencies through Nix, construct synthetic
+fixtures, use fakes, or remove the test.
+
+### Hooks
+
+- Pre-commit (`ln -sf ../../scripts/pre-commit .git/hooks/pre-commit`): threaded
+  Pyright on staged `.py` and syntax checks on staged JavaScript.
+- There is no pre-push hook and CI does not run the suite. The agent owns the
+  local validation and final pre-push confirmation described above.
+- Repository releases are not tagged. The deployed Git commit, signed
+  nixosconfig pin, and live verification evidence identify the running state.
+
 ## Authority for exceptions and bypasses
 
 Plans translate product authority; they do not create it. Any plan KTD,

--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -155,19 +155,22 @@ Any type that **crosses JSON** — harness stdout, an HTTP response, a JSONB blo
   Subagent implementation briefs state the pair requirement verbatim and
   never offer a deterministic-only alternative.
 - **"Agree by construction" stops at the outermost real adapter, never at a
-  shared library function.** A cross-surface parity invariant owes its
-  deterministic pin and generated property through the actual boundary each
-  surface consumes: SQL row aliases and a projection, a formatter, or the
-  JavaScript-facing payload, as applicable. It also owes a known-bad adapter
-  mutant. V4 in `tests/test_verdict_tiers_generated.py` is the pattern:
+  shared library function.** Name every claimed surface's outermost real
+  adapter. Each named adapter must be exercised by the invariant's
+  deterministic pin and generated property through its actual boundary — SQL
+  row aliases and a projection, a formatter, or the JavaScript-facing payload,
+  as applicable — and must have at least one known-bad mutant at that adapter.
+  A mutant at one adapter does not qualify any other claimed adapter. V4 in
+  `tests/test_verdict_tiers_generated.py` is the pattern:
   `proof_verdict_from_evidence` and `proof_verdict_from_facts` agree, then
   `web.classify.proof_gate_projection` receives the aliases the browser's
-  render path really gets. PR #973 proved why: reading a lineage-gated overlay
-  key instead of its evidence alias disagreed on 26,503 live rows while the
-  common library functions remained in lockstep. Do not stop the property at
-  the common function and call that parity, and do not answer this requirement
-  with a semantic source scanner; the real adapter-driving pin, property, and
-  mutant are the evidence.
+  render path really gets. PR #973 proved why: the faulty lineage-gated input
+  shape occurred on 26,503 live rows, but `storage_format` covered it, so the
+  measured live verdict impact was zero; a generated counterexample proved the
+  potential divergence while the common library functions remained in lockstep.
+  Do not stop the property at the common function and call that parity, and do
+  not answer this requirement with a semantic source scanner; the real
+  adapter-driving pin, property, and mutant are the evidence.
 - **A decision-consequence pin must assert the decided outcome, not a proxy
   field.** If a pin claims "this world changes what the pipeline decides,"
   it must drive the real decider and assert the *decided outcome*

--- a/.claude/rules/test-fidelity.md
+++ b/.claude/rules/test-fidelity.md
@@ -248,6 +248,20 @@ rather than a surprise in production.
 rounds; each render is one command; the diff is instant. Writing the
 harness was the expensive part and it is already written.
 
+**Primitive fields that JavaScript turns into semantics are also operator-facing
+output.** Rule D applies when a boolean, enum, number, or nullable primitive is
+consumed by JavaScript to choose visible text, colour, icon, visibility, or an
+accusation. A Python render-differential zero for such a field does **not**
+cover the JavaScript mapping: the renderer can report its primitive unchanged
+while the browser changes what it says or shows.
+
+For each affected surface, the PR body must therefore include a live-corpus
+tally of the resulting visible states (or old-to-new visible states when they
+change), not merely the primitive values. It must also include live-db
+screenshots of changed cases and must-still-work controls. Use the existing
+recipe in `docs/solutions/ui-dev-server-screenshot-loop.md`; it is the visual
+evidence leg of Rule D, not a second differential runbook.
+
 ## Executable coverage and its boundary
 
 Rule A coverage is enforced by `tests/test_pipeline_db_write_audit.py` plus

--- a/.claude/rules/test-fidelity.md
+++ b/.claude/rules/test-fidelity.md
@@ -145,19 +145,19 @@ and `tests/test_classify_producer_audit.py`.
 **Side effect:** when the audit fails it names the literal and the producer
 that cannot emit it, which is the whole diagnosis.
 
-## Rule D — Changed operator-facing derived text owes a live-corpus differential
+## Rule D — Changed derived operator-facing presentation owes live-corpus evidence
 
-**A PR that changes derived operator-facing text — a verdict, a summary, a
-badge, any string a renderer computes from persisted rows — must measure
-the change against the real corpus before it ships: the old renderer and
-the new one, over every live row, reporting changed-row counts BY CHANGED
-FIELD. Put the numbers in the PR body.**
+**A PR that changes derived operator-facing presentation or output — a verdict,
+summary, badge, renderer-computed string, or primitive JavaScript turns into a
+visible state — must measure the change against the real corpus before it
+ships: the old renderer and the new one, over every live row, reporting
+changed-row counts BY CHANGED FIELD. Put the numbers in the PR body.**
 
 Rules A–C keep a test from describing a world production never produces.
 Rule D answers the question no test can: on the rows that actually exist,
-what does this change? A copy PR makes a claim about a live population,
-and the only instrument that settles it is the real renderer over real
-rows.
+what does this change? A presentation PR makes a claim about a live
+population, and the only instrument that settles it is the real renderer over
+real rows.
 
 **Forbidden anti-pattern:**
 
@@ -235,14 +235,14 @@ one in `verdict` + `summary`, with `badge` / `badge_class` /
 `border_color` / `downloaded_label` byte-identical. Half that evidence is
 in the four zeros — which is exactly why a zero has to be earned.
 
-**What this catches:** copy keyed on a scenario no producer emits reports
-0 changed rows — a fluent sentence nothing can reach, which is exactly the
-`no_candidates` defect #885 found. Copy whose blast radius was
+**What this catches:** presentation keyed on a scenario no producer emits
+reports 0 changed rows — a fluent sentence nothing can reach, which is exactly
+the `no_candidates` defect #885 found. Presentation whose blast radius was
 mis-reasoned reports a row count that contradicts the PR description. A
-one-line fallback change made alongside it moves rows the PR never
-mentioned — #885's `_humanize_token` unification moved 123 rows on top of
-the 50 under discussion, and the differential is what made that visible
-rather than a surprise in production.
+one-line fallback change made alongside it moves rows the PR never mentioned —
+#885's `_humanize_token` unification moved 123 rows on top of the 50 under
+discussion, and the differential is what made that visible rather than a
+surprise in production.
 
 **Cost, honestly:** the corpus export takes minutes and is reusable across
 rounds; each render is one command; the diff is instant. Writing the
@@ -270,7 +270,7 @@ contracts in `tests/test_pipeline_db_column_contract.py`. Rule B's narrow
 adapter-fake pattern is guarded by `tests/test_mirror_contracts.py` and
 `tests/test_lambda_audit.py`. Rule C's producer audits name an unproducible
 literal; Rule D remains a PR-time live-corpus procedure because no test can
-decide which derived text is operator-facing.
+decide which derived operator-facing presentation or output matters.
 
 These gates enforce their declared shapes, not every semantic equivalent. The
 rules above retain the judgement the executable checks cannot supply.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,9 +171,8 @@ Schema lives in `migrations/NNN_name.sql`; the migrate oneshot runs them on ever
 ## Running tests
 
 Choose validation timing and depth during development using engineering
-judgment based on the change, current evidence, and concrete risk. Focused
-tests, whole-tree Pyright, the complete deterministic suite, and relevant
-surface-specific checks are all available whenever they add useful feedback:
+judgment based on the change, current evidence, and concrete risk. Always use
+`nix-shell --run` for Python:
 
 ```bash
 nix-shell --run "python3 -m unittest tests.test_X -v"  # focused iteration
@@ -181,39 +180,11 @@ nix-shell --run "pyright --threads 4"                   # whole repository
 nix-shell --run "bash scripts/run_tests.sh"             # complete suite
 ```
 
-Direct Nix-shell runs are ordinary development feedback; fix their failures in
-the current convergence loop. They do not mint final receipts. A green complete
-suite does not replace generated, live-boundary, browser, corpus, VM, or other
-specialized evidence required by the change. Before the first branch push, use
-the `check` skill for one final receipt-backed whole-tree confirmation once the
-reviewed tree is committed and clean; it owns the receipt and unchanged-tree
-no-replay rules.
-
-**Always use `nix-shell --run` for Python** (`.claude/rules/nix-shell.md`).
-`run_tests.sh` exhausts JavaScript, production-strict Pyright, Ruff, Vulture,
-and the complete Python scheduler before returning one aggregate status. Its
-terminal output is a compact complete failure index; the printed private-tmpfs
-bundle contains `summary.json`, `summary.md`, and every complete phase log.
-`.claude/rules/code-quality.md` owns the testing conventions that those gates
-cannot infer.
-
-**Generated (property-based) tests** (`tests/test_*_generated.py`, Hypothesis) run deterministically in the suite; after changing quality policy, run the randomized fuzz burst: `nix-shell --run "bash scripts/fuzz_burst.sh"` (one process per generated module, parallelised to the host's cores — Hypothesis is single-threaded, so never run the burst serially). Failures shrink to minimal worlds — promote them to named `@example` pins or album-test-set scenarios, never JSON artifacts. **New features start by writing their invariants down, and every invariant ships as a PAIR — deterministic pin + generated property — in the same PR, with known-bad self-tests** (`.claude/rules/code-quality.md` § Red/Green TDD). When in doubt that the harness constrains anything, qualify it by fault injection. `docs/generated-testing.md`.
-
-### Skipped tests are an anti-pattern
-
-**A test either runs or it doesn't exist.** `tests/test_skip_audit.py` rejects
-known unittest skip markers without an allowlist; the same policy forbids
-environment gates. Supply dependencies through Nix, construct synthetic
-fixtures, use fakes, or remove the test.
-
-### Hooks
-
-- Pre-commit (`ln -sf ../../scripts/pre-commit .git/hooks/pre-commit`): threaded
-  Pyright on staged `.py` and syntax checks on staged JavaScript.
-- There is no pre-push hook and CI does not run the suite. The agent owns the
-  local validation and final pre-push confirmation described above.
-- Repository releases are not tagged. The deployed Git commit, signed
-  nixosconfig pin, and live verification evidence identify the running state.
+Direct runs are development feedback; before the first branch push, use the
+`check` skill on the reviewed, clean, committed tree for the receipt-backed
+whole-tree confirmation. The complete operational contract — suite bundle,
+specialized evidence, generated/fuzz testing, no-skips policy, and hooks — is
+in `.claude/rules/code-quality.md` § "Test execution, evidence, and hooks".
 
 ## Shared AI surfaces
 

--- a/docs/solutions/ui-dev-server-screenshot-loop.md
+++ b/docs/solutions/ui-dev-server-screenshot-loop.md
@@ -72,6 +72,12 @@ For artist-comparison work, run the HTTP precondition against the exact artist
 used for the screenshots before every acceptance round. A plausible MB-only
 page is not evidence that the Discogs half of the route ran.
 
+When JavaScript maps a primitive field to visible text, colour, an icon,
+visibility, or an accusation, this loop supplies the screenshot leg of Rule D
+in `.claude/rules/test-fidelity.md`: capture changed cases and must-still-work
+controls from the live DB, and record that evidence with Rule D's per-surface
+visible-state tally in the PR body.
+
 ## Gotchas (each cost a debugging detour once)
 
 - **Screenshot save roots**: the playwright MCP only writes inside its


### PR DESCRIPTION
## Summary

- require every cross-surface parity claim to exercise each surface's outermost real adapter with its deterministic pin, generated property, and an adapter-local known-bad mutant
- extend Rule D to cover primitive values that JavaScript turns into visible presentation, requiring per-surface live-corpus state tallies and live-db screenshots
- move the detailed test execution, fuzz, no-skips, and hooks contract from `CLAUDE.md` into the always-loaded code-quality rule

Item 3 was already completed by PR #983 and is intentionally unchanged here.

## Why

PR #973 showed that shared library functions can agree while a row-alias projection is still wrong. Its faulty lineage-gated input shape existed on 26,503 live rows; the measured live verdict impact was zero because `storage_format` covered those rows, while a generated counterexample proved the latent divergence.

Rule D's Python renderer also intentionally leaves primitive booleans and numbers unwatched, even when JavaScript maps them to operator-visible text, colour, icons, visibility, or accusations. The new rule names the missing corpus and screenshot evidence.

Finally, `CLAUDE.md` was 32,756 bytes, twelve bytes below Codex's 32 KiB limit. It is now 30,460 bytes, leaving 2,308 bytes of headroom without losing the moved instructions.

## Impact

Documentation and agent-process rules only. There is no product, schema, test-behaviour, or runtime change.

## Validation

- both implementation commits and the review-fix commit have valid repository signatures
- `git diff --check origin/main..HEAD`
- `nix-shell --run "python3 tools/generate-ai-adapters.py --check"`
- `nix-shell --run "python3 -m unittest tests.test_ai_portability tests.test_docs_audit -v"` — 47 passed
- receipt-backed whole-tree Pyright — pass
- receipt-backed complete suite — pass
- independent Sol review found three documentation defects; all were corrected
- fresh uninvolved Sol re-review of the complete tree — no findings

Refs #979
