### PR TITLE
fix(quality): reject stale spectral evidence generations

### DIFF
--- a/docs/pipeline-db-schema.md
+++ b/docs/pipeline-db-schema.md
@@ -76,8 +76,13 @@ Key fields:
   (`ref_db(1-4kHz) - mean(20.5-22kHz slices)`, averaged across tracks) —
   PR3's proof-leg statistic; not read by any decision yet.
   `spectral_measurement_version` is `2` for rows measured by the PR1+
-  `lib/spectral_check.py` code; NULL for legacy rows (forward-only, no
-  backfill — `.claude/rules/scope.md`).
+  `lib/spectral_check.py` code; NULL marks a legacy generation. A grade is
+  reusable only when this value exactly matches the running analyzer. Exact
+  candidate and installed snapshots are remeasured on their next preview;
+  old source-subject facts from a lossless original remain stored as audit
+  history but are withheld from policy because the installed derivative
+  cannot regenerate that source observation (R19). This is on-touch
+  convergence, not a committed backfill.
 - `audio_validation JSONB NOT NULL` — the bounded typed report from the
   audio-only strict FFmpeg policy. New reports are `passed`,
   `audio_corrupt`, or `skipped`; the migration uses `legacy_failure` for

--- a/docs/quality-verification.md
+++ b/docs/quality-verification.md
@@ -1126,8 +1126,10 @@ rows carry `lineage_version=4`: spectral and V0 facts add `subject`
 verified-lossless lives only in its proof object. Migration 055 maps old field
 names best-effort; current-evidence loaders treat v1/v3 rows as rebuild-required
 rather than guessing v4 meaning. Preview reuses a decision-usable spectral fact
-only after exact-release and snapshot authorization; missing, unusable, or
-changed HAVE evidence is remeasured. The import action independently
+only after exact-release and snapshot authorization and an exact match between
+its `spectral_measurement_version` and the running analyzer generation;
+missing, old-generation, unusable, or changed HAVE evidence is remeasured. The
+import action independently
 reauthorizes the exact installed Beets album before deciding. A same-snapshot
 repair preserves its original `measured_at` and atomic neutral facts so
 historical Recents cards remain pre-attempt evidence.
@@ -1246,9 +1248,13 @@ operator one-shots must reference this canonical set rather than restating a
 subset.
 
 The same rule governs every evidence rebuild: proof and source-subject facts
-carry unconditionally with provenance `carried`; installed-subject facts are
-remeasured and can only have provenance `measured`. Proof is conceptually a
-source acquisition fact, so it needs only its provenance marker.
+carry physically with provenance `carried`; installed-subject facts are
+remeasured and can only have provenance `measured`. Carried spectral facts
+still pass the analyzer-generation gate before policy can read them. An old
+source generation remains audit history but is projected without its spectral
+tuple: scanning the installed derivative would describe different bytes and
+violate R19. Proof is conceptually a source acquisition fact, so it needs only
+its provenance marker.
 
 **A changed installed snapshot is linked before neutral enrichment, but it is
 not immediately action authority.** The new content-addressed row must exist
@@ -1365,7 +1371,8 @@ spectral fact is written:
   fill-only-if-NULL policy, which silently discarded a fresh genuine/160 audit
   and let the frozen 128 landmine keep deciding. Missing, incomplete, or
   changed evidence is measured on the next preview; complete matching evidence
-  with a decision-usable grade is reused. Guards preserved: a
+  with a decision-usable grade from the running analyzer generation is reused.
+  Guards preserved: a
   FAILED fresh audit never clears a persisted grade (fail-soft `incomplete`),
   and an R19 lossless-sourced row keeps its source spectral — an installed-
   derivative scan is never persisted as its grade (`preserve_existing_source_spectral`

--- a/lib/import_evidence.py
+++ b/lib/import_evidence.py
@@ -32,6 +32,8 @@ from lib.quality_evidence import (
     QualityEvidenceDB,
     audio_snapshot_matches,
     backfill_current_evidence_from_album_info,
+    current_evidence_for_policy,
+    current_evidence_preserves_source_spectral,
     current_evidence_rebuild_reasons,
     load_candidate_evidence_for_source,
     load_or_backfill_current_evidence,
@@ -265,7 +267,7 @@ def ensure_current_evidence_for_action(
         )
         if not errors and snapshot_matches:
             return CurrentEvidenceActionResult(
-                evidence=existing,
+                evidence=current_evidence_for_policy(existing),
                 provenance=ActionEvidenceProvenance(
                     current_status=CURRENT_STATUS_LOADED,
                     snapshot_guard=SNAPSHOT_GUARD_MATCHED,
@@ -385,7 +387,7 @@ def ensure_current_evidence_for_action(
                 )
             else:
                 return CurrentEvidenceActionResult(
-                    evidence=authoritative,
+                    evidence=current_evidence_for_policy(authoritative),
                     provenance=ActionEvidenceProvenance(
                         current_status=CURRENT_STATUS_BACKFILLED,
                         snapshot_guard=SNAPSHOT_GUARD_MATCHED,
@@ -438,6 +440,7 @@ def _current_action_missing_enrichment_reasons(
     if (
         measurement.spectral_grade is None
         and measurement.spectral_bitrate_kbps is None
+        and not current_evidence_preserves_source_spectral(evidence)
     ):
         reasons.append("exact current snapshot still needs installed spectral enrichment")
     if (

--- a/lib/import_preview.py
+++ b/lib/import_preview.py
@@ -65,8 +65,6 @@ from lib.processing_paths import (
     processing_preview_dir,
 )
 from lib.quality import (
-    EVIDENCE_SUBJECT_SOURCE,
-    LOSSLESS_CODECS,
     QUALITY_DECISION_IMPORT_STAGE_DECISIONS,
     AlbumQualityEvidence,
     AlbumQualityEvidenceFile,
@@ -101,6 +99,8 @@ from lib.quality_evidence import (
     QualityEvidenceDB,
     audio_snapshot_matches,
     audit_v0_probe_from_metric,
+    current_evidence_for_policy,
+    current_evidence_preserves_source_spectral,
     current_evidence_rebuild_reasons,
     evidence_from_measurement,
     load_or_backfill_current_evidence,
@@ -109,6 +109,7 @@ from lib.quality_evidence import (
     persist_candidate_evidence_from_measurement,
     snapshot_audio_files,
     snapshot_fingerprint,
+    spectral_measurement_generation_is_current,
 )
 from lib.util import repair_mp3_headers
 from lib.v0_probe import probe_installed_album_as_v0
@@ -760,6 +761,12 @@ def persist_exact_current_spectral_from_attempt(
             "incomplete",
             reason,
         )
+    if not spectral_measurement_generation_is_current(measured_existing):
+        return EvidenceBuildResult(
+            current_evidence,
+            "incomplete",
+            "attempt did not produce current-generation HAVE spectral evidence",
+        )
     if not measured_existing_path:
         return EvidenceBuildResult(
             current_evidence,
@@ -896,6 +903,12 @@ def load_persisted_existing_spectral(
         spectral_detail_from_persisted_source(
             measurement.spectral_grade,
             measurement.spectral_bitrate_kbps,
+            cliff_hz=measurement.cliff_hz,
+            codec_family=measurement.codec_family,
+            ultrasonic_deficit_db=measurement.ultrasonic_deficit_db,
+            spectral_measurement_version=(
+                measurement.spectral_measurement_version
+            ),
         ),
         True,
     )
@@ -1151,16 +1164,23 @@ def plan_current_evidence_enrichment(
 ) -> EnrichmentPlan:
     """Pure decision: measure exactly the missing HAVE pieces.
 
-    Mirrors the once-only guards of the persist/claim helpers: any spectral
-    field present means the scan already happened; a V0 metric or the
-    attempted marker means the research probe already ran. Complete rows
+    A spectral tuple is complete only under the running analyzer generation;
+    old grades are audit history, not reusable policy inputs. A V0 metric or
+    the attempted marker means the research probe already ran. Complete rows
     therefore cost nothing to re-plan.
     """
     measurement = evidence.measurement
+    preserve_source = current_evidence_preserves_source_spectral(evidence)
     return EnrichmentPlan(
         spectral=(
-            measurement.spectral_grade is None
-            and measurement.spectral_bitrate_kbps is None
+            not preserve_source
+            and (
+                (
+                    measurement.spectral_grade is None
+                    and measurement.spectral_bitrate_kbps is None
+                )
+                or not spectral_measurement_generation_is_current(measurement)
+            )
         ),
         v0=(
             evidence.v0_metric is None
@@ -1176,12 +1196,14 @@ def current_spectral_evidence_reusable(
 
     The enrichment planner records whether analysis already ran, so an
     attempted-but-failed ``"error"`` grade is intentionally complete for that
-    once-only bookkeeping. Preview reuse has a stricter contract: only one of
-    the grades the decision model understands may replace a fresh HAVE scan.
+    once-only bookkeeping. Preview reuse has a stricter contract: its
+    generation must exactly match the running analyzer and its grade must be
+    one the decision model understands. Legacy and unknown future generations
+    are audit-only and must never replace a fresh HAVE scan.
     """
     grade = evidence.measurement.spectral_grade
     return (
-        not plan_current_evidence_enrichment(evidence).spectral
+        spectral_measurement_generation_is_current(evidence.measurement)
         and grade in {
             "genuine",
             "marginal",
@@ -1488,7 +1510,7 @@ def _authorize_current_evidence_for_preview(
         )
 
     return EvidenceBuildResult(
-        current,
+        current_evidence_for_policy(current),
         "ready",
         current_album_path=current_album_path,
     )
@@ -1543,7 +1565,13 @@ def load_current_evidence_for_preview(
             enriched.status,
             f" ({enriched.reason})" if enriched.reason else "",
         )
-    return enriched
+        return enriched
+    return EvidenceBuildResult(
+        current_evidence_for_policy(enriched.evidence),
+        enriched.status,
+        enriched.reason,
+        current_album_path=current_album_path,
+    )
 
 
 def preserve_existing_source_spectral(
@@ -1560,19 +1588,9 @@ def preserve_existing_source_spectral(
     no ``was_converted_from``, which is how the #711 deploy-night rows
     were minted ``genuine/installed``).
     """
-    if current_evidence is None:
-        return False
-    converted_from = (
-        current_evidence.measurement.was_converted_from or ""
-    ).lower()
-    if converted_from in LOSSLESS_CODECS:
-        return True
-    if current_evidence.verified_lossless_proof is not None:
-        return True
-    v0_metric = current_evidence.v0_metric
     return (
-        v0_metric is not None
-        and v0_metric.subject == EVIDENCE_SUBJECT_SOURCE
+        current_evidence is not None
+        and current_evidence_preserves_source_spectral(current_evidence)
     )
 
 
@@ -2080,6 +2098,12 @@ def measure_and_persist_candidate_evidence(
         existing_spectral_evidence = spectral_detail_from_persisted_source(
             current_m.spectral_grade,
             current_m.spectral_bitrate_kbps,
+            cliff_hz=current_m.cliff_hz,
+            codec_family=current_m.codec_family,
+            ultrasonic_deficit_db=current_m.ultrasonic_deficit_db,
+            spectral_measurement_version=(
+                current_m.spectral_measurement_version
+            ),
         )
         reuse_have_evidence = current_spectral_evidence_reusable(
             current_evidence,
@@ -2727,6 +2751,14 @@ def preview_import_from_path(
         existing_spectral_evidence = spectral_detail_from_persisted_source(
             current_measurement.spectral_grade,
             current_measurement.spectral_bitrate_kbps,
+            cliff_hz=current_measurement.cliff_hz,
+            codec_family=current_measurement.codec_family,
+            ultrasonic_deficit_db=(
+                current_measurement.ultrasonic_deficit_db
+            ),
+            spectral_measurement_version=(
+                current_measurement.spectral_measurement_version
+            ),
         )
         reuse_have_evidence = current_spectral_evidence_reusable(
             current_evidence,

--- a/lib/measurement.py
+++ b/lib/measurement.py
@@ -293,8 +293,13 @@ def existing_spectral_resolver_for_config(
 def spectral_detail_from_persisted_source(
     grade: object,
     bitrate_kbps: object,
+    *,
+    cliff_hz: int | None = None,
+    codec_family: CodecFamily | None = None,
+    ultrasonic_deficit_db: float | None = None,
+    spectral_measurement_version: int | None = None,
 ) -> SpectralAnalysisDetail:
-    """Project durable pre-conversion fields into attempt-audit shape."""
+    """Project one durable spectral generation into attempt-audit shape."""
     spectral_grade = grade if isinstance(grade, str) and grade else None
     spectral_bitrate = (
         bitrate_kbps if isinstance(bitrate_kbps, int) else None
@@ -303,6 +308,10 @@ def spectral_detail_from_persisted_source(
         attempted=spectral_grade is not None or spectral_bitrate is not None,
         grade=spectral_grade,
         bitrate_kbps=spectral_bitrate,
+        cliff_hz=cliff_hz,
+        codec_family=codec_family,
+        ultrasonic_deficit_db=ultrasonic_deficit_db,
+        spectral_measurement_version=spectral_measurement_version,
     )
 
 

--- a/lib/quality_evidence.py
+++ b/lib/quality_evidence.py
@@ -16,6 +16,7 @@ from lib.quality import (
     EVIDENCE_PROVENANCE_MEASURED,
     EVIDENCE_SUBJECT_INSTALLED,
     EVIDENCE_SUBJECT_SOURCE,
+    LOSSLESS_CODECS,
     V0_PROBE_LOSSLESS_SOURCE,
     V0_PROBE_NATIVE_LOSSY_RESEARCH,
     V0_PROBE_ON_DISK_RESEARCH,
@@ -25,6 +26,7 @@ from lib.quality import (
     AudioQualityMeasurement,
     EvidenceSubject,
     ImportResult,
+    SpectralAnalysisDetail,
     V0ProbeEvidence,
     VerifiedLosslessProof,
     legacy_unrecorded_audio_validation_report,
@@ -135,6 +137,86 @@ class EvidenceBuildResult:
         return self.evidence is not None
 
 
+def spectral_measurement_generation_is_current(
+    measurement: AudioQualityMeasurement | SpectralAnalysisDetail,
+) -> bool:
+    """Whether a spectral fact was produced by this running analyzer.
+
+    Spectral grades are interpretations, not generation-independent facts.
+    An exact version match is therefore required: legacy ``NULL`` rows and
+    rows written by an unknown future analyzer are both observation-only and
+    must be measured again before current policy may reuse them.
+    """
+
+    # Keep the producer as the authority for its generation stamp without
+    # making every evidence consumer import the analyzer at module load time.
+    from lib.spectral_check import SPECTRAL_MEASUREMENT_VERSION
+
+    return (
+        measurement.spectral_measurement_version
+        == SPECTRAL_MEASUREMENT_VERSION
+    )
+
+
+def current_evidence_preserves_source_spectral(
+    evidence: AlbumQualityEvidence,
+) -> bool:
+    """Whether installed bytes cannot regenerate the row's source spectral.
+
+    Lossless-derived library files are a different spectral subject from the
+    acquisition bytes. Their source-side grade may be carried for audit, but
+    an old measurement generation cannot be recreated by scanning the lossy
+    installed derivative without violating R19.
+    """
+
+    converted_from = (evidence.measurement.was_converted_from or "").lower()
+    if converted_from in LOSSLESS_CODECS:
+        return True
+    if evidence.verified_lossless_proof is not None:
+        return True
+    metric = evidence.v0_metric
+    return metric is not None and metric.subject == EVIDENCE_SUBJECT_SOURCE
+
+
+def current_evidence_for_policy(
+    evidence: AlbumQualityEvidence,
+) -> AlbumQualityEvidence:
+    """Withhold an unregenerable old source grade from current policy.
+
+    The stored tuple remains durable audit history. Only this policy
+    projection drops it; all other current evidence facts remain usable.
+    Installed-subject and ordinary source-subject rows are not projected this
+    way because their exact current bytes can and must be measured again.
+    """
+
+    measurement = evidence.measurement
+    has_spectral = (
+        measurement.spectral_grade is not None
+        or measurement.spectral_bitrate_kbps is not None
+    )
+    if (
+        not has_spectral
+        or spectral_measurement_generation_is_current(measurement)
+        or measurement.spectral_subject != EVIDENCE_SUBJECT_SOURCE
+        or not current_evidence_preserves_source_spectral(evidence)
+    ):
+        return evidence
+    return msgspec.structs.replace(
+        evidence,
+        measurement=msgspec.structs.replace(
+            measurement,
+            spectral_grade=None,
+            spectral_bitrate_kbps=None,
+            spectral_subject=None,
+            spectral_provenance=None,
+            cliff_hz=None,
+            codec_family=None,
+            ultrasonic_deficit_db=None,
+            spectral_measurement_version=None,
+        ),
+    )
+
+
 def current_evidence_rebuild_reasons(
     evidence: AlbumQualityEvidence,
 ) -> list[str]:
@@ -143,6 +225,21 @@ def current_evidence_rebuild_reasons(
     if evidence.lineage_version != 4:
         reasons.append(
             f"lineage_version {evidence.lineage_version} must be rebuilt as 4"
+        )
+    measurement = evidence.measurement
+    if (
+        (
+            measurement.spectral_grade is not None
+            or measurement.spectral_bitrate_kbps is not None
+        )
+        and not spectral_measurement_generation_is_current(measurement)
+        and not (
+            measurement.spectral_subject == EVIDENCE_SUBJECT_SOURCE
+            and current_evidence_preserves_source_spectral(evidence)
+        )
+    ):
+        reasons.append(
+            "spectral measurement generation is not current"
         )
     return reasons
 
@@ -1254,6 +1351,15 @@ def load_candidate_evidence_for_source(
             "candidate source changed since evidence capture",
         )
     errors = evidence.policy_incomplete_reasons()
+    measurement = evidence.measurement
+    if (
+        (
+            measurement.spectral_grade is not None
+            or measurement.spectral_bitrate_kbps is not None
+        )
+        and not spectral_measurement_generation_is_current(measurement)
+    ):
+        errors.append("spectral measurement generation is not current")
     if errors:
         return EvidenceBuildResult(None, "incomplete", "; ".join(errors))
     return EvidenceBuildResult(evidence, "ready")

--- a/scripts/import_preview_worker.py
+++ b/scripts/import_preview_worker.py
@@ -1143,6 +1143,14 @@ def process_claimed_preview_job(
                     persisted_existing = spectral_detail_from_persisted_source(
                         current_evidence.measurement.spectral_grade,
                         current_evidence.measurement.spectral_bitrate_kbps,
+                        cliff_hz=current_evidence.measurement.cliff_hz,
+                        codec_family=current_evidence.measurement.codec_family,
+                        ultrasonic_deficit_db=(
+                            current_evidence.measurement.ultrasonic_deficit_db
+                        ),
+                        spectral_measurement_version=(
+                            current_evidence.measurement.spectral_measurement_version
+                        ),
                     )
                     reuse_have_evidence = (
                         current_spectral_evidence_reusable(
@@ -1200,6 +1208,14 @@ def process_claimed_preview_job(
             candidate_detail=spectral_detail_from_persisted_source(
                 front_gate_result.evidence.measurement.spectral_grade,
                 front_gate_result.evidence.measurement.spectral_bitrate_kbps,
+                cliff_hz=front_gate_result.evidence.measurement.cliff_hz,
+                codec_family=front_gate_result.evidence.measurement.codec_family,
+                ultrasonic_deficit_db=(
+                    front_gate_result.evidence.measurement.ultrasonic_deficit_db
+                ),
+                spectral_measurement_version=(
+                    front_gate_result.evidence.measurement.spectral_measurement_version
+                ),
             ),
             existing_detail=(
                 persisted_existing if reuse_have_evidence else None

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -270,6 +270,7 @@ def make_album_quality_evidence(
     lineage_version: int = 4,
     on_disk_v0_research_attempted: bool = False,
     current_enrichment_required: bool = False,
+    preserve_spectral_measurement_version: bool = False,
     audio_corrupt: bool = False,
     audio_error: str | None = None,
     audio_validation: AudioValidationReport | None = None,
@@ -313,6 +314,21 @@ def make_album_quality_evidence(
             measurement,
             spectral_subject=EVIDENCE_SUBJECT_INSTALLED,
             spectral_provenance=EVIDENCE_PROVENANCE_MEASURED,
+        )
+    if (
+        lineage_version == 4
+        and measurement.spectral_grade is not None
+        and measurement.spectral_measurement_version is None
+        and not preserve_spectral_measurement_version
+    ):
+        from lib.spectral_check import SPECTRAL_MEASUREMENT_VERSION
+
+        # This helper builds active production-shaped evidence by default.
+        # Tests of legacy generations must opt in explicitly so an accidental
+        # unstamped fixture cannot masquerade as reusable current evidence.
+        measurement = msgspec.structs.replace(
+            measurement,
+            spectral_measurement_version=SPECTRAL_MEASUREMENT_VERSION,
         )
     if audio_validation is None and audio_corrupt:
         audio_validation = make_audio_corrupt_validation_report(

--- a/tests/test_evidence_generated.py
+++ b/tests/test_evidence_generated.py
@@ -59,6 +59,7 @@ from lib.quality_evidence import (
     snapshot_audio_files,
     snapshot_fingerprint,
 )
+from lib.spectral_check import SPECTRAL_MEASUREMENT_VERSION
 from tests.fakes import FakeBeetsDB, FakePipelineDB
 from tests.helpers import (
     claim_next_import_preview_job,
@@ -304,6 +305,11 @@ class TestGeneratedEvidenceLifecycle(unittest.TestCase):
                         if spectral_subject == "installed"
                         else None
                     ),
+                    spectral_measurement_version=(
+                        SPECTRAL_MEASUREMENT_VERSION
+                        if spectral_subject is not None
+                        else None
+                    ),
                 ),
                 v0_metric=(
                     AlbumQualityV0Metric(
@@ -496,6 +502,11 @@ def _run_blank_path_world(
                     if world.spectral_grade is not None
                     and (world.was_converted_from or "").lower()
                     in {"flac", "alac", "wav"}
+                    else None
+                ),
+                spectral_measurement_version=(
+                    SPECTRAL_MEASUREMENT_VERSION
+                    if world.spectral_grade is not None
                     else None
                 ),
             ),

--- a/tests/test_import_evidence.py
+++ b/tests/test_import_evidence.py
@@ -26,11 +26,13 @@ from lib.quality import (
     AlbumQualityV0Metric,
     AudioQualityMeasurement,
     QualityRankConfig,
+    VerifiedLosslessProof,
 )
 from lib.quality_evidence import (
     EvidenceBuildResult,
     snapshot_audio_files,
 )
+from lib.spectral_check import SPECTRAL_MEASUREMENT_VERSION
 from tests.fakes import FakeBeetsDB, FakePipelineDB
 from tests.helpers import make_album_quality_evidence, make_request_row
 
@@ -228,6 +230,102 @@ class TestImportEvidenceAcquisition(unittest.TestCase):
         self.assertTrue(result.available)
         self.assertEqual(result.provenance.current_status, "loaded")
         self.assertEqual(result.provenance.snapshot_guard, "matched")
+
+    def test_old_spectral_generation_cannot_authorize_an_action(self):
+        legacy = make_album_quality_evidence(
+            preserve_spectral_measurement_version=True,
+            mb_release_id="release-1",
+            source_path=self.root,
+            files=snapshot_audio_files(self.root),
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=320,
+                avg_bitrate_kbps=320,
+                median_bitrate_kbps=320,
+                format="MP3",
+                is_cbr=True,
+                spectral_grade="suspect",
+                spectral_bitrate_kbps=128,
+                spectral_subject="installed",
+                spectral_provenance="measured",
+                spectral_measurement_version=None,
+            ),
+        )
+        self.db.upsert_album_quality_evidence(legacy)
+        stored = self.db.find_album_quality_evidence(
+            mb_release_id=legacy.mb_release_id,
+            snapshot_fingerprint=legacy.snapshot_fingerprint,
+        )
+        assert stored is not None and stored.id is not None
+        self.db.set_request_current_evidence(42, stored.id)
+
+        result = ensure_current_evidence_for_action(
+            self.db,
+            request_id=42,
+            mb_release_id="release-1",
+            current_release=self._current_release(),
+            backfill_builder=lambda *_args, **_kwargs: EvidenceBuildResult(
+                stored,
+                "ready",
+            ),
+        )
+
+        self.assertFalse(result.available)
+        self.assertEqual(result.provenance.current_status, "failed")
+        self.assertIn(
+            "spectral measurement generation",
+            result.provenance.fallback_reason or "",
+        )
+
+    def test_old_lossless_source_generation_is_audit_only_at_action_time(self):
+        legacy = make_album_quality_evidence(
+            preserve_spectral_measurement_version=True,
+            mb_release_id="release-1",
+            source_path=self.root,
+            files=snapshot_audio_files(self.root),
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=128,
+                avg_bitrate_kbps=128,
+                median_bitrate_kbps=128,
+                format="Opus",
+                spectral_grade="suspect",
+                spectral_bitrate_kbps=128,
+                spectral_subject="source",
+                spectral_provenance="carried",
+                spectral_measurement_version=None,
+            ),
+            verified_lossless_proof=VerifiedLosslessProof(
+                provenance="carried",
+                source="flac",
+                classifier="spectral_verified_lossless",
+            ),
+            codec="opus",
+            container="opus",
+            storage_format="Opus",
+        )
+        self.db.upsert_album_quality_evidence(legacy)
+        stored = self.db.find_album_quality_evidence(
+            mb_release_id=legacy.mb_release_id,
+            snapshot_fingerprint=legacy.snapshot_fingerprint,
+        )
+        assert stored is not None and stored.id is not None
+        self.db.set_request_current_evidence(42, stored.id)
+
+        result = ensure_current_evidence_for_action(
+            self.db,
+            request_id=42,
+            mb_release_id="release-1",
+            current_release=self._current_release(),
+        )
+
+        self.assertTrue(result.available)
+        assert result.evidence is not None
+        self.assertIsNone(result.evidence.measurement.spectral_grade)
+        self.assertIsNone(
+            result.evidence.measurement.spectral_measurement_version,
+        )
+        historical = self.db.load_album_quality_evidence_by_id(stored.id)
+        assert historical is not None
+        self.assertEqual(historical.measurement.spectral_grade, "suspect")
 
     def test_matching_candidate_capture_path_remains_historical(self):
         evidence = make_album_quality_evidence(
@@ -442,6 +540,7 @@ class TestImportEvidenceAcquisition(unittest.TestCase):
             expected_snapshot_fingerprint=linked.snapshot_fingerprint,
             grade="genuine",
             bitrate_kbps=230,
+            spectral_measurement_version=SPECTRAL_MEASUREMENT_VERSION,
         ))
         self.assertTrue(self.db.claim_current_v0_research_attempt(
             request_id=42,

--- a/tests/test_import_preview.py
+++ b/tests/test_import_preview.py
@@ -49,6 +49,7 @@ from lib.quality_evidence import (
     snapshot_audio_files,
     snapshot_fingerprint,
 )
+from lib.spectral_check import SPECTRAL_MEASUREMENT_VERSION
 from tests.fakes import FakeBeetsDB, FakePipelineDB
 from tests.helpers import (
     claim_next_import_preview_job,
@@ -112,6 +113,8 @@ def _preview_runtime_config(
 
 class TestSpectralAuditMerge(unittest.TestCase):
     def test_have_reuse_requires_a_decision_usable_grade(self):
+        from lib.spectral_check import SPECTRAL_MEASUREMENT_VERSION
+
         cases = (
             ("genuine", True),
             ("marginal", True),
@@ -132,12 +135,38 @@ class TestSpectralAuditMerge(unittest.TestCase):
                         spectral_provenance=(
                             "measured" if grade is not None else None
                         ),
+                        spectral_measurement_version=(
+                            SPECTRAL_MEASUREMENT_VERSION
+                            if grade is not None
+                            else None
+                        ),
                     ),
                 )
                 self.assertEqual(
                     current_spectral_evidence_reusable(evidence),
                     expected,
                 )
+
+    def test_family_in_the_armed_forces_legacy_have_is_not_reused(self):
+        """A usable old grade cannot bypass a same-generation HAVE scan."""
+
+        evidence = make_album_quality_evidence(
+            preserve_spectral_measurement_version=True,
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=320,
+                avg_bitrate_kbps=320,
+                median_bitrate_kbps=320,
+                format="MP3",
+                is_cbr=True,
+                spectral_grade="suspect",
+                spectral_bitrate_kbps=128,
+                spectral_subject="installed",
+                spectral_provenance="measured",
+                spectral_measurement_version=None,
+            ),
+        )
+
+        self.assertFalse(current_spectral_evidence_reusable(evidence))
 
     def test_lossless_candidate_requires_a_successful_usable_grade(self):
         cases = (
@@ -1003,6 +1032,9 @@ class TestImportPreviewPath(unittest.TestCase):
                     grade="genuine",
                     bitrate_kbps=96,
                     suspect_pct=52.17,
+                    spectral_measurement_version=(
+                        SPECTRAL_MEASUREMENT_VERSION
+                    ),
                 ),
                 measured_existing_path=source,
             )
@@ -1068,6 +1100,9 @@ class TestImportPreviewPath(unittest.TestCase):
                     grade="genuine",
                     bitrate_kbps=160,
                     suspect_pct=30.0,
+                    spectral_measurement_version=(
+                        SPECTRAL_MEASUREMENT_VERSION
+                    ),
                 ),
                 measured_existing_path=source,
             )
@@ -1141,6 +1176,9 @@ class TestImportPreviewPath(unittest.TestCase):
                     attempted=True,
                     grade="genuine",
                     bitrate_kbps=200,
+                    spectral_measurement_version=(
+                        SPECTRAL_MEASUREMENT_VERSION
+                    ),
                 ),
                 measured_existing_path=source,
             )
@@ -1205,6 +1243,9 @@ class TestImportPreviewPath(unittest.TestCase):
                     attempted=True,
                     grade="genuine",
                     bitrate_kbps=128,
+                    spectral_measurement_version=(
+                        SPECTRAL_MEASUREMENT_VERSION
+                    ),
                 ),
                 measured_existing_path=source,
             )
@@ -1251,6 +1292,9 @@ class TestImportPreviewPath(unittest.TestCase):
                     attempted=True,
                     grade="genuine",
                     bitrate_kbps=96,
+                    spectral_measurement_version=(
+                        SPECTRAL_MEASUREMENT_VERSION
+                    ),
                 ),
                 measured_existing_path=other,
             )
@@ -1351,6 +1395,9 @@ class TestImportPreviewPath(unittest.TestCase):
                         attempted=True,
                         grade="genuine",
                         bitrate_kbps=96,
+                        spectral_measurement_version=(
+                            SPECTRAL_MEASUREMENT_VERSION
+                        ),
                     ),
                 ),
             )
@@ -2974,6 +3021,11 @@ class TestEnrichIncompleteCurrentEvidence(unittest.TestCase):
                 format="MP3",
                 spectral_grade="genuine" if spectral_present else None,
                 spectral_bitrate_kbps=96 if spectral_present else None,
+                spectral_measurement_version=(
+                    SPECTRAL_MEASUREMENT_VERSION
+                    if spectral_present
+                    else None
+                ),
             ),
             v0_metric=None,
             on_disk_v0_research_attempted=v0_attempted,
@@ -3013,6 +3065,7 @@ class TestEnrichIncompleteCurrentEvidence(unittest.TestCase):
     def _good_scan(self) -> SpectralAnalysisDetail:
         return SpectralAnalysisDetail(
             attempted=True, grade="genuine", bitrate_kbps=96,
+            spectral_measurement_version=SPECTRAL_MEASUREMENT_VERSION,
         )
 
     def _enrich(self, db, analyzer, probe):

--- a/tests/test_import_queue.py
+++ b/tests/test_import_queue.py
@@ -65,6 +65,7 @@ from lib.quality import (
     ValidationResult,
 )
 from lib.quality_evidence import snapshot_audio_files
+from lib.spectral_check import SPECTRAL_MEASUREMENT_VERSION
 from lib.staged_album import StagedAlbum
 from tests.fakes import FakeBeetsDB, FakePipelineDB
 from tests.helpers import (
@@ -5569,6 +5570,9 @@ class TestImportPreviewWorkerFrontGate(unittest.TestCase):
                     attempted=True,
                     grade="suspect" if path == existing else "genuine",
                     bitrate_kbps=128 if path == existing else None,
+                    spectral_measurement_version=(
+                        SPECTRAL_MEASUREMENT_VERSION
+                    ),
                 )
 
             with patch(
@@ -5667,6 +5671,9 @@ class TestImportPreviewWorkerFrontGate(unittest.TestCase):
                     attempted=True,
                     grade="suspect" if path == existing else "genuine",
                     bitrate_kbps=128 if path == existing else None,
+                    spectral_measurement_version=(
+                        SPECTRAL_MEASUREMENT_VERSION
+                    ),
                 )
 
             with patch(

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -46,7 +46,7 @@ from lib.quality import (
     ValidationResult,
     legacy_unrecorded_audio_validation_report,
 )
-from lib.spectral_check import AlbumResult
+from lib.spectral_check import SPECTRAL_MEASUREMENT_VERSION, AlbumResult
 from lib.staged_album import StagedAlbum
 from tests.fakes import (
     FakeBeetsDB,
@@ -5631,9 +5631,21 @@ class TestPreviewFrontGateSlice(unittest.TestCase):
             }
             audit = SpectralDetail(
                 candidate=SpectralAnalysisDetail(
-                    attempted=True, grade="genuine", bitrate_kbps=None),
+                    attempted=True,
+                    grade="genuine",
+                    bitrate_kbps=None,
+                    spectral_measurement_version=(
+                        SPECTRAL_MEASUREMENT_VERSION
+                    ),
+                ),
                 existing=SpectralAnalysisDetail(
-                    attempted=True, grade="genuine", bitrate_kbps=None),
+                    attempted=True,
+                    grade="genuine",
+                    bitrate_kbps=None,
+                    spectral_measurement_version=(
+                        SPECTRAL_MEASUREMENT_VERSION
+                    ),
+                ),
             )
 
             def _sentinel_preview(*args, **kwargs):
@@ -6609,6 +6621,11 @@ class TestU6ImporterPreimportDecideSlice(unittest.TestCase):
                 ),
                 spectral_provenance=(
                     "measured" if spectral_grade is not None else None
+                ),
+                spectral_measurement_version=(
+                    SPECTRAL_MEASUREMENT_VERSION
+                    if spectral_grade is not None
+                    else None
                 ),
             ),
             measured_at=datetime(2026, 1, 1, 0, 0, 0, tzinfo=UTC),
@@ -7981,6 +7998,9 @@ class TestPreviewWorkerNeverDecidesSlice(unittest.TestCase):
                     estimated_bitrate_kbps=None,
                     suspect_pct=0.0,
                     tracks=[],
+                    spectral_measurement_version=(
+                        SPECTRAL_MEASUREMENT_VERSION
+                    ),
                 )
 
             def run_import(**kwargs: Any) -> ImportOneRun:
@@ -8002,6 +8022,9 @@ class TestPreviewWorkerNeverDecidesSlice(unittest.TestCase):
                         spectral_bitrate_kbps=audit.candidate.bitrate_kbps,
                         spectral_subject="source",
                         spectral_provenance="measured",
+                        spectral_measurement_version=(
+                            audit.candidate.spectral_measurement_version
+                        ),
                     ),
                     spectral=audit,
                 )
@@ -8105,6 +8128,9 @@ class TestPreviewWorkerNeverDecidesSlice(unittest.TestCase):
                     estimated_bitrate_kbps=None,
                     suspect_pct=0.0,
                     tracks=[],
+                    spectral_measurement_version=(
+                        SPECTRAL_MEASUREMENT_VERSION
+                    ),
                 )
 
             # qaac/CoreAudio's lattice, on every track: the shape the
@@ -8146,6 +8172,9 @@ class TestPreviewWorkerNeverDecidesSlice(unittest.TestCase):
                             spectral_grade="genuine",
                             spectral_subject="source",
                             spectral_provenance="measured",
+                            spectral_measurement_version=(
+                                SPECTRAL_MEASUREMENT_VERSION
+                            ),
                         ),
                     ),
                 )
@@ -8356,6 +8385,9 @@ class TestPreviewWorkerNeverDecidesSlice(unittest.TestCase):
                     spectral_bitrate_kbps=96,
                     spectral_subject="source",
                     spectral_provenance="measured",
+                    spectral_measurement_version=(
+                        SPECTRAL_MEASUREMENT_VERSION
+                    ),
                 ),
             )
 
@@ -8487,6 +8519,9 @@ class TestPreviewWorkerNeverDecidesSlice(unittest.TestCase):
                     spectral_bitrate_kbps=256,
                     spectral_subject="source",
                     spectral_provenance="measured",
+                    spectral_measurement_version=(
+                        SPECTRAL_MEASUREMENT_VERSION
+                    ),
                 ),
             )
 
@@ -8688,6 +8723,7 @@ class TestWrongMatchCleanupFKChainAvoidsRemeasurement(unittest.TestCase):
                 spectral_grade="genuine",
                 spectral_subject="source",
                 spectral_provenance="measured",
+                spectral_measurement_version=SPECTRAL_MEASUREMENT_VERSION,
             ),
             measured_at=datetime(2026, 5, 1, tzinfo=UTC),
             files=files,
@@ -8960,6 +8996,7 @@ class TestWrongMatchTriageRejectsSameSourceDuplicate(unittest.TestCase):
             spectral_bitrate_kbps=128,
             spectral_subject="source",
             spectral_provenance="measured",
+            spectral_measurement_version=SPECTRAL_MEASUREMENT_VERSION,
         )
         return AlbumQualityEvidence(
             mb_release_id=mb_release_id,

--- a/tests/test_lossless_lineage_check_generated.py
+++ b/tests/test_lossless_lineage_check_generated.py
@@ -135,6 +135,7 @@ def _run_fake_lossless_merge(
             spectral_bitrate_kbps=None,
             spectral_subject=None,
             spectral_provenance=None,
+            spectral_measurement_version=None,
             was_converted_from=(converted_from if anchor == "conversion" else None),
         ),
         v0_metric=(

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -6715,7 +6715,10 @@ class TestAlbumQualityEvidenceStorage(unittest.TestCase):
     def test_upsert_new_spectral_capture_fields_null_by_default(self):
         """Legacy/absent capture stays NULL — no fabricated defaults
         (issue #829 Phase 5 PR1, forward-only, no backfill)."""
-        evidence = self._seed(mb_release_id="mbid-spectral-capture-null")
+        evidence = self._seed(
+            mb_release_id="mbid-spectral-capture-null",
+            preserve_spectral_measurement_version=True,
+        )
 
         self.db.upsert_album_quality_evidence(evidence)
         loaded = self.db.find_album_quality_evidence(
@@ -7339,6 +7342,7 @@ class TestAlbumQualityEvidenceStorage(unittest.TestCase):
                         spectral_bitrate_kbps=None,
                         spectral_subject=None,
                         spectral_provenance=None,
+                        spectral_measurement_version=None,
                         was_converted_from=(
                             anchor
                             if anchor.lower() in ("flac", "alac", "wav")

--- a/tests/test_preview_failure_evidence_generated.py
+++ b/tests/test_preview_failure_evidence_generated.py
@@ -59,6 +59,7 @@ from lib.quality import (
     V0ProbeEvidence,
 )
 from lib.quality_evidence import EvidenceBuildResult, snapshot_audio_files
+from lib.spectral_check import SPECTRAL_MEASUREMENT_VERSION
 from scripts import import_preview_worker
 from tests.fakes import FakeBeetsDB, FakePipelineDB
 from tests.helpers import (
@@ -659,6 +660,9 @@ def _run_world(world: PreviewFailureWorld) -> PreviewFailureObservation:
                     attempted=True,
                     grade="suspect",
                     bitrate_kbps=96,
+                    spectral_measurement_version=(
+                        SPECTRAL_MEASUREMENT_VERSION
+                    ),
                 ),
                 probe_fn=lambda _path: V0ProbeEvidence(
                     kind="on_disk_research_v0",

--- a/tests/test_quality_lineage_generated.py
+++ b/tests/test_quality_lineage_generated.py
@@ -52,6 +52,7 @@ from lib.quality_evidence import (
     evidence_from_measurement,
     snapshot_audio_files,
 )
+from lib.spectral_check import SPECTRAL_MEASUREMENT_VERSION
 from lib.wrong_match_cleanup_service import (
     OUTCOME_KEPT_UNCERTAIN,
     _cleanup_audit_payload,
@@ -160,15 +161,18 @@ def assert_exact_current_spectral_persisted(
 
 
 def assert_enrichment_plan_never_remeasures(evidence, plan) -> None:
-    """Independent checker: enrichment only measures what is missing."""
+    """Independent checker: current-generation evidence is never remeasured."""
+
+    from lib.quality_evidence import spectral_measurement_generation_is_current
 
     measurement = evidence.measurement
-    if plan.spectral and (
-        measurement.spectral_grade is not None
-        or measurement.spectral_bitrate_kbps is not None
+    if (
+        plan.spectral
+        and measurement.spectral_grade is not None
+        and spectral_measurement_generation_is_current(measurement)
     ):
         raise AssertionError(
-            "enrichment plan re-measures spectral evidence that already exists"
+            "enrichment plan re-measures current-generation spectral evidence"
         )
     if plan.v0 and (
         evidence.v0_metric is not None
@@ -367,7 +371,7 @@ class TestQualityLineagePins(unittest.TestCase):
         assert_enrichment_plan_never_remeasures(evidence, plan)
         self.assertEqual(
             plan.spectral,
-            grade is None and spectral_bitrate is None,
+            grade is None,
         )
         self.assertEqual(plan.v0, not v0_present and not v0_attempted)
 
@@ -433,6 +437,9 @@ class TestQualityLineagePins(unittest.TestCase):
                             attempted=True,
                             grade="genuine",
                             bitrate_kbps=96,
+                            spectral_measurement_version=(
+                                SPECTRAL_MEASUREMENT_VERSION
+                            ),
                         ),
                         probe_fn=lambda _path: None,
                     )
@@ -534,6 +541,9 @@ class TestQualityLineagePins(unittest.TestCase):
                         attempted=True,
                         grade="genuine",
                         bitrate_kbps=96,
+                        spectral_measurement_version=(
+                            SPECTRAL_MEASUREMENT_VERSION
+                        ),
                     ),
                     probe_fn=lambda _path: None,
                 )
@@ -1398,6 +1408,9 @@ class TestQualityLineageGenerated(unittest.TestCase):
                     attempted=True,
                     grade=grade,
                     bitrate_kbps=bitrate,
+                    spectral_measurement_version=(
+                        SPECTRAL_MEASUREMENT_VERSION
+                    ),
                 ),
                 measured_existing_path=source,
             )
@@ -1474,6 +1487,9 @@ class TestQualityLineageGenerated(unittest.TestCase):
                     attempted=True,
                     grade=fresh_grade,
                     bitrate_kbps=fresh_bitrate,
+                    spectral_measurement_version=(
+                        SPECTRAL_MEASUREMENT_VERSION
+                    ),
                 ),
                 measured_existing_path=source,
             )

--- a/tests/test_spectral_attempt_audit_generated.py
+++ b/tests/test_spectral_attempt_audit_generated.py
@@ -16,6 +16,7 @@ from hypothesis import example, given
 from hypothesis import strategies as st
 
 import tests._hypothesis_profiles  # noqa: F401  (loads active profile)
+from lib.spectral_check import SPECTRAL_MEASUREMENT_VERSION
 from tests.beets_world import BeetsWorld
 from tests.helpers import claim_next_import_job, claim_next_import_preview_job
 
@@ -73,10 +74,14 @@ def _have_reuse_contract_holds(
     have_complete: bool,
     snapshot_changed: bool,
     persisted_grade: str | None,
+    persisted_generation: int | None,
 ) -> bool:
+    from lib.spectral_check import SPECTRAL_MEASUREMENT_VERSION
+
     expected = (
         have_complete
         and not snapshot_changed
+        and persisted_generation == SPECTRAL_MEASUREMENT_VERSION
         and persisted_grade in {
             "genuine",
             "marginal",
@@ -95,6 +100,7 @@ def _run_have_boundary_through_both_adapters(
     persisted_bitrate: int | None,
     scanned_grade: str,
     scanned_bitrate: int | None,
+    persisted_generation: int | None = None,
     have_complete: bool = True,
     snapshot_changed: bool = False,
 ):
@@ -124,6 +130,7 @@ def _run_have_boundary_through_both_adapters(
         SpectralAnalysisDetail,
     )
     from lib.quality_evidence import snapshot_audio_files
+    from lib.spectral_check import SPECTRAL_MEASUREMENT_VERSION
     from scripts.import_preview_worker import process_claimed_preview_job
     from tests.fakes import FakeBeetsDB, FakePipelineDB
     from tests.helpers import make_album_quality_evidence, make_request_row
@@ -151,6 +158,9 @@ def _run_have_boundary_through_both_adapters(
             ("carried" if carries_lossless_lineage else "measured")
             if have_complete
             else None
+        ),
+        spectral_measurement_version=(
+            persisted_generation if have_complete else None
         ),
     )
     current_v0_metric = (
@@ -189,6 +199,7 @@ def _run_have_boundary_through_both_adapters(
         Path(candidate, "01.mp3").write_bytes(b"candidate")
         Path(existing, "01.mp3").write_bytes(b"existing")
         current_evidence = make_album_quality_evidence(
+            preserve_spectral_measurement_version=True,
             mb_release_id=mbid,
             source_path=existing,
             files=snapshot_audio_files(existing),
@@ -243,6 +254,14 @@ def _run_have_boundary_through_both_adapters(
             ),
             grade=authorized_measurement.spectral_grade,
             bitrate_kbps=authorized_measurement.spectral_bitrate_kbps,
+            cliff_hz=authorized_measurement.cliff_hz,
+            codec_family=authorized_measurement.codec_family,
+            ultrasonic_deficit_db=(
+                authorized_measurement.ultrasonic_deficit_db
+            ),
+            spectral_measurement_version=(
+                authorized_measurement.spectral_measurement_version
+            ),
         )
         reuse_have = current_spectral_evidence_reusable(
             authorized_current,
@@ -260,6 +279,9 @@ def _run_have_boundary_through_both_adapters(
                     grade=scanned_grade if role == "existing" else "genuine",
                     bitrate_kbps=(
                         scanned_bitrate if role == "existing" else None
+                    ),
+                    spectral_measurement_version=(
+                        SPECTRAL_MEASUREMENT_VERSION
                     ),
                 )
             return analyze
@@ -363,6 +385,7 @@ PreviewJobMode = Literal["automation", "force"]
 def assert_candidate_snapshot_reuse(
     *,
     snapshot_changed: bool,
+    candidate_generation: int | None,
     has_have: bool,
     full_preview_calls: int,
     analyzer_roles: list[str],
@@ -373,11 +396,19 @@ def assert_candidate_snapshot_reuse(
 ) -> None:
     """Candidate work is once per snapshot; HAVE authority stays separate."""
 
-    if snapshot_changed:
+    must_remeasure = (
+        snapshot_changed
+        or candidate_generation != SPECTRAL_MEASUREMENT_VERSION
+    )
+    if must_remeasure:
         if full_preview_calls != 1:
-            raise AssertionError("changed candidate snapshot did not remeasure")
+            raise AssertionError(
+                "changed or old-generation candidate did not remeasure"
+            )
         if candidate_status == "reused":
-            raise AssertionError("changed candidate snapshot was marked reused")
+            raise AssertionError(
+                "changed or old-generation candidate was marked reused"
+            )
         return
 
     if full_preview_calls:
@@ -404,6 +435,7 @@ def _run_candidate_snapshot_reuse_world(
     *,
     job_mode: PreviewJobMode,
     snapshot_changed: bool,
+    candidate_generation: int | None,
     has_have: bool,
     candidate_grade: str,
     track_count: int,
@@ -506,6 +538,9 @@ def _run_candidate_snapshot_reuse_world(
                     spectral_grade="genuine",
                     spectral_subject="installed",
                     spectral_provenance="measured",
+                    spectral_measurement_version=(
+                        SPECTRAL_MEASUREMENT_VERSION
+                    ),
                 ),
             )
             db.upsert_album_quality_evidence(current)
@@ -552,6 +587,7 @@ def _run_candidate_snapshot_reuse_world(
                 raw_path=candidate,
             )
         candidate_evidence = make_album_quality_evidence(
+            preserve_spectral_measurement_version=True,
             mb_release_id=mbid,
             source_path=action_path,
             files=snapshot_audio_files(action_path),
@@ -563,6 +599,7 @@ def _run_candidate_snapshot_reuse_world(
                 spectral_grade=candidate_grade,
                 spectral_subject="source",
                 spectral_provenance="measured",
+                spectral_measurement_version=candidate_generation,
             ),
         )
         db.upsert_album_quality_evidence(candidate_evidence)
@@ -621,6 +658,9 @@ def _run_candidate_snapshot_reuse_world(
                 attempted=True,
                 grade="suspect" if role == "existing" else candidate_grade,
                 bitrate_kbps=128 if role == "existing" else None,
+                spectral_measurement_version=(
+                    SPECTRAL_MEASUREMENT_VERSION
+                ),
             )
 
         def full_preview(db_arg: Any, _job: Any) -> ImportPreviewResult:
@@ -638,6 +678,9 @@ def _run_candidate_snapshot_reuse_world(
                     spectral_grade=candidate_grade,
                     spectral_subject="source",
                     spectral_provenance="measured",
+                    spectral_measurement_version=(
+                        SPECTRAL_MEASUREMENT_VERSION
+                    ),
                 ),
             )
             db_arg.upsert_album_quality_evidence(fresh)
@@ -1098,17 +1141,30 @@ class TestAttemptAuditCheckerQualification(unittest.TestCase):
         ))
 
     def test_have_reuse_checker_rejects_error_grade_mutant(self):
+        from lib.spectral_check import SPECTRAL_MEASUREMENT_VERSION
+
         self.assertFalse(_have_reuse_contract_holds(
             reuse_have=True,
             have_complete=True,
             snapshot_changed=False,
             persisted_grade="error",
+            persisted_generation=SPECTRAL_MEASUREMENT_VERSION,
+        ))
+
+    def test_have_reuse_checker_rejects_old_generation_mutant(self):
+        self.assertFalse(_have_reuse_contract_holds(
+            reuse_have=True,
+            have_complete=True,
+            snapshot_changed=False,
+            persisted_grade="suspect",
+            persisted_generation=None,
         ))
 
     def test_candidate_reuse_checker_rejects_matching_snapshot_rescan(self):
         with self.assertRaises(AssertionError):
             assert_candidate_snapshot_reuse(
                 snapshot_changed=False,
+                candidate_generation=SPECTRAL_MEASUREMENT_VERSION,
                 has_have=False,
                 full_preview_calls=0,
                 analyzer_roles=["candidate"],
@@ -1122,6 +1178,21 @@ class TestAttemptAuditCheckerQualification(unittest.TestCase):
         with self.assertRaises(AssertionError):
             assert_candidate_snapshot_reuse(
                 snapshot_changed=True,
+                candidate_generation=SPECTRAL_MEASUREMENT_VERSION,
+                has_have=False,
+                full_preview_calls=0,
+                analyzer_roles=[],
+                candidate_status="reused",
+                persisted_candidate_grade="genuine",
+                persisted_have_grade=None,
+                expected_candidate_grade="genuine",
+            )
+
+    def test_candidate_reuse_checker_rejects_old_generation_skip(self):
+        with self.assertRaises(AssertionError):
+            assert_candidate_snapshot_reuse(
+                snapshot_changed=False,
+                candidate_generation=None,
                 has_have=False,
                 full_preview_calls=0,
                 analyzer_roles=[],
@@ -1184,6 +1255,9 @@ class TestAttemptAuditGenerated(unittest.TestCase):
     @given(
         job_mode=st.sampled_from(("automation", "force")),
         snapshot_changed=st.booleans(),
+        candidate_generation=st.one_of(
+            st.none(), st.integers(min_value=1, max_value=4),
+        ),
         has_have=st.booleans(),
         candidate_grade=st.sampled_from((
             "genuine",
@@ -1196,6 +1270,7 @@ class TestAttemptAuditGenerated(unittest.TestCase):
     @example(
         job_mode="force",
         snapshot_changed=False,
+        candidate_generation=None,
         has_have=False,
         candidate_grade="genuine",
         track_count=12,
@@ -1203,6 +1278,7 @@ class TestAttemptAuditGenerated(unittest.TestCase):
     @example(
         job_mode="automation",
         snapshot_changed=False,
+        candidate_generation=SPECTRAL_MEASUREMENT_VERSION,
         has_have=True,
         candidate_grade="suspect",
         track_count=1,
@@ -1211,6 +1287,7 @@ class TestAttemptAuditGenerated(unittest.TestCase):
         self,
         job_mode: PreviewJobMode,
         snapshot_changed: bool,
+        candidate_generation: int | None,
         has_have: bool,
         candidate_grade: str,
         track_count: int,
@@ -1224,12 +1301,14 @@ class TestAttemptAuditGenerated(unittest.TestCase):
         ) = _run_candidate_snapshot_reuse_world(
             job_mode=job_mode,
             snapshot_changed=snapshot_changed,
+            candidate_generation=candidate_generation,
             has_have=has_have,
             candidate_grade=candidate_grade,
             track_count=track_count,
         )
         assert_candidate_snapshot_reuse(
             snapshot_changed=snapshot_changed,
+            candidate_generation=candidate_generation,
             has_have=has_have,
             full_preview_calls=full_preview_calls,
             analyzer_roles=analyzer_roles,
@@ -1240,6 +1319,8 @@ class TestAttemptAuditGenerated(unittest.TestCase):
         )
 
     def test_gespenst_mp3_reuses_exact_have_through_both_adapters(self):
+        from lib.spectral_check import SPECTRAL_MEASUREMENT_VERSION
+
         (
             preserve_source,
             reuse_have,
@@ -1254,6 +1335,7 @@ class TestAttemptAuditGenerated(unittest.TestCase):
             persisted_bitrate=320,
             scanned_grade="suspect",
             scanned_bitrate=128,
+            persisted_generation=SPECTRAL_MEASUREMENT_VERSION,
         )
 
         self.assertFalse(preserve_source)
@@ -1264,6 +1346,70 @@ class TestAttemptAuditGenerated(unittest.TestCase):
             assert audit.existing is not None
             self.assertEqual(audit.existing.grade, "genuine")
             self.assertEqual(audit.existing.bitrate_kbps, 320)
+
+    def test_family_in_the_armed_forces_remeasures_legacy_have(self):
+        """Legacy suspect/128 HAVE cannot compare with a generation-2 peer."""
+
+        from lib.spectral_check import SPECTRAL_MEASUREMENT_VERSION
+
+        (
+            preserve_source,
+            reuse_have,
+            normal_calls,
+            reused_calls,
+            normal_audit,
+            reused_audit,
+        ) = _run_have_boundary_through_both_adapters(
+            converted_from=None,
+            lossless_v0_lineage=False,
+            persisted_grade="suspect",
+            persisted_bitrate=128,
+            persisted_generation=None,
+            scanned_grade="suspect",
+            scanned_bitrate=128,
+        )
+
+        self.assertFalse(preserve_source)
+        self.assertFalse(reuse_have)
+        self.assertEqual(normal_calls, ["candidate", "existing"])
+        self.assertEqual(reused_calls, ["existing"])
+        for audit in (normal_audit, reused_audit):
+            assert audit.existing is not None
+            self.assertEqual(audit.existing.grade, "suspect")
+            self.assertEqual(audit.existing.bitrate_kbps, 128)
+            self.assertEqual(
+                audit.existing.spectral_measurement_version,
+                SPECTRAL_MEASUREMENT_VERSION,
+            )
+
+    def test_old_lossless_source_generation_is_withheld_without_derivative_scan(self):
+        """R19 source history stays auditable but never becomes policy input."""
+
+        (
+            preserve_source,
+            reuse_have,
+            normal_calls,
+            reused_calls,
+            normal_audit,
+            reused_audit,
+        ) = _run_have_boundary_through_both_adapters(
+            converted_from="flac",
+            lossless_v0_lineage=True,
+            persisted_grade="suspect",
+            persisted_bitrate=128,
+            persisted_generation=None,
+            scanned_grade="genuine",
+            scanned_bitrate=320,
+        )
+
+        self.assertTrue(preserve_source)
+        self.assertFalse(reuse_have)
+        self.assertEqual(normal_calls, ["candidate"])
+        self.assertEqual(reused_calls, [])
+        for audit in (normal_audit, reused_audit):
+            assert audit.existing is not None
+            self.assertFalse(audit.existing.attempted)
+            self.assertIsNone(audit.existing.grade)
 
     @given(
         have_complete=st.booleans(),
@@ -1281,6 +1427,9 @@ class TestAttemptAuditGenerated(unittest.TestCase):
         scanned_bitrate=st.one_of(
             st.none(), st.integers(min_value=32, max_value=400),
         ),
+        persisted_generation=st.one_of(
+            st.none(), st.integers(min_value=1, max_value=4),
+        ),
     )
     @example(
         have_complete=True,
@@ -1289,6 +1438,7 @@ class TestAttemptAuditGenerated(unittest.TestCase):
         persisted_bitrate=192,
         scanned_grade="suspect",
         scanned_bitrate=96,
+        persisted_generation=None,
     )
     @example(
         have_complete=False,
@@ -1297,6 +1447,7 @@ class TestAttemptAuditGenerated(unittest.TestCase):
         persisted_bitrate=192,
         scanned_grade="suspect",
         scanned_bitrate=96,
+        persisted_generation=2,
     )
     @example(
         have_complete=True,
@@ -1305,6 +1456,7 @@ class TestAttemptAuditGenerated(unittest.TestCase):
         persisted_bitrate=192,
         scanned_grade="suspect",
         scanned_bitrate=96,
+        persisted_generation=2,
     )
     @example(
         have_complete=True,
@@ -1313,6 +1465,7 @@ class TestAttemptAuditGenerated(unittest.TestCase):
         persisted_bitrate=None,
         scanned_grade="genuine",
         scanned_bitrate=192,
+        persisted_generation=2,
     )
     def test_preview_have_reuse_requires_complete_matching_snapshot(
         self,
@@ -1322,7 +1475,10 @@ class TestAttemptAuditGenerated(unittest.TestCase):
         persisted_bitrate: int | None,
         scanned_grade: str,
         scanned_bitrate: int | None,
+        persisted_generation: int | None,
     ):
+        from lib.spectral_check import SPECTRAL_MEASUREMENT_VERSION
+
         (
             preserve_source,
             reuse_have,
@@ -1337,6 +1493,7 @@ class TestAttemptAuditGenerated(unittest.TestCase):
             persisted_bitrate=persisted_bitrate,
             scanned_grade=scanned_grade,
             scanned_bitrate=scanned_bitrate,
+            persisted_generation=persisted_generation,
             have_complete=have_complete,
             snapshot_changed=snapshot_changed,
         )
@@ -1344,6 +1501,7 @@ class TestAttemptAuditGenerated(unittest.TestCase):
         expected_reuse = (
             have_complete
             and not snapshot_changed
+            and persisted_generation == SPECTRAL_MEASUREMENT_VERSION
             and persisted_grade in {
                 "genuine",
                 "marginal",
@@ -1357,6 +1515,7 @@ class TestAttemptAuditGenerated(unittest.TestCase):
             have_complete=have_complete,
             snapshot_changed=snapshot_changed,
             persisted_grade=persisted_grade,
+            persisted_generation=persisted_generation,
         ))
         self.assertEqual(reuse_have, expected_reuse)
         self.assertEqual(
@@ -1509,6 +1668,7 @@ class TestAttemptAuditGenerated(unittest.TestCase):
             persisted_bitrate=persisted_bitrate,
             scanned_grade=scanned_grade,
             scanned_bitrate=scanned_bitrate,
+            persisted_generation=SPECTRAL_MEASUREMENT_VERSION,
         )
         # R19: a source-subject V0 anchor alone proves lossless lineage —
         # enrichment-born rows carry no was_converted_from, and their

--- a/tests/test_spectral_capture_generated.py
+++ b/tests/test_spectral_capture_generated.py
@@ -148,6 +148,7 @@ def _round_trip_through_fake_db(world: CaptureFieldsWorld) -> AudioQualityMeasur
     cliff_hz, codec_family, ultrasonic_deficit_db, version = world
     db = FakePipelineDB()
     evidence = make_album_quality_evidence(
+        preserve_spectral_measurement_version=True,
         mb_release_id=f"generated-capture-{uuid.uuid4()}",
         measurement=AudioQualityMeasurement(
             min_bitrate_kbps=192,
@@ -344,11 +345,13 @@ def _decoy_decider_reads_current_capture_fields(
         current is not None
         and current.measurement.spectral_measurement_version is not None
     ):
-        result["final_status"] = "CORRUPTED_BY_CURRENT_MEASUREMENT_VERSION"
+        result["current_measurement_version"] = (
+            current.measurement.spectral_measurement_version
+        )
     return result
 
 
-_DEFAULT_MUTATION: CaptureFieldsWorld = (17000, "mp3", 61.0, 2)
+_DEFAULT_MUTATION: CaptureFieldsWorld = (17000, "mp3", 61.0, 3)
 
 
 class TestDecisionIgnoresCaptureFieldsCheckerSelfTest(unittest.TestCase):

--- a/tests/test_wrong_match_cleanup_service.py
+++ b/tests/test_wrong_match_cleanup_service.py
@@ -33,6 +33,7 @@ from lib.quality import (
     legacy_unrecorded_audio_validation_report,
 )
 from lib.quality_evidence import snapshot_audio_files, snapshot_fingerprint
+from lib.spectral_check import SPECTRAL_MEASUREMENT_VERSION
 from lib.validation_envelope import decode_validation_envelope
 from lib.wrong_match_cleanup_service import (
     OUTCOME_DELETE_FAILED,
@@ -117,6 +118,7 @@ def _evidence(
             spectral_grade="genuine",
             spectral_subject="source",
             spectral_provenance="measured",
+            spectral_measurement_version=SPECTRAL_MEASUREMENT_VERSION,
         ),
         measured_at=datetime(2026, 5, 1, tzinfo=UTC),
         files=files,
@@ -781,6 +783,7 @@ class WrongMatchCleanupServiceTest(unittest.TestCase):
                 spectral_grade="genuine",
                 spectral_subject="source",
                 spectral_provenance="measured",
+                spectral_measurement_version=SPECTRAL_MEASUREMENT_VERSION,
             ),
         )
         self.db.set_download_log_candidate_evidence(
@@ -797,6 +800,7 @@ class WrongMatchCleanupServiceTest(unittest.TestCase):
                 spectral_grade="genuine",
                 spectral_subject="installed",
                 spectral_provenance="measured",
+                spectral_measurement_version=SPECTRAL_MEASUREMENT_VERSION,
             ),
         )
         self._set_current_evidence_helper(
@@ -839,6 +843,7 @@ class WrongMatchCleanupServiceTest(unittest.TestCase):
                 spectral_bitrate_kbps=96,
                 spectral_subject="source",
                 spectral_provenance="measured",
+                spectral_measurement_version=SPECTRAL_MEASUREMENT_VERSION,
             ),
             storage_format="OPUS 128",
             v0_metric=AlbumQualityV0Metric(

--- a/tests/world_model/support.py
+++ b/tests/world_model/support.py
@@ -84,6 +84,7 @@ from lib.quality_evidence import (
 )
 from lib.release_identity import ReleaseIdentity
 from lib.search_plan_service import SearchPlanService
+from lib.spectral_check import SPECTRAL_MEASUREMENT_VERSION
 from lib.transitions import (
     RequestTransition,
     finalize_request,
@@ -617,6 +618,7 @@ class LifecycleWorld:
                 attempted=True,
                 grade="genuine",
                 bitrate_kbps=96,
+                spectral_measurement_version=SPECTRAL_MEASUREMENT_VERSION,
             ),
             probe_fn=lambda _path: V0ProbeEvidence(
                 kind=V0_PROBE_ON_DISK_RESEARCH,
@@ -691,6 +693,7 @@ class LifecycleWorld:
                 attempted=True,
                 grade=fresh_grade,
                 bitrate_kbps=fresh_bitrate,
+                spectral_measurement_version=SPECTRAL_MEASUREMENT_VERSION,
             ),
             measured_existing_path=album.album_path,
         )
@@ -845,6 +848,7 @@ class LifecycleWorld:
             return SpectralAnalysisDetail(
                 attempted=True,
                 grade=spectral_grade,
+                spectral_measurement_version=SPECTRAL_MEASUREMENT_VERSION,
             )
 
         def full_preview(_db: Any, _job: Any) -> ImportPreviewResult:


### PR DESCRIPTION
## Summary

- require an exact spectral measurement generation match before candidate or HAVE evidence can be reused
- remeasure old native evidence while retaining unregenerable lossless-source evidence as audit-only under R19
- cover the Family in the Armed Forces loop through both preview adapters, action-time authorization, generated properties, and known-bad self-tests

## Validation

- receipt-backed Pyright on rebased commit 122b7a96: pass
- receipt-backed complete six-phase suite on the same commit: pass
- randomized fuzz burst on current main: 121 modules, 1,538 tests, 1,043 targets, all green

## Deployment

Not included; merge only per operator instruction.