### PR TITLE
docs: align runtime guidance with live topology

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ If a design drifts toward "good enough" matches, "smart" defaults, or auto-throt
 ## Infrastructure
 
 - **doc1** (`192.168.1.29`): this repo at `/home/abl030/cratedigger`; primary dev host.
-- **doc2** (`192.168.1.35`): runs cratedigger (back-to-back timer, ~4-5 min/cycle), deployment-owned Beets, MB mirror (`:5200`), and slskd (`:5030`).
+- **doc2** (`192.168.1.35`): runs cratedigger (back-to-back timer, ~4-5 min/cycle) and deployment-owned Beets. Its dedicated dependencies are MusicBrainz + LRCLIB at `192.168.1.43`, Discogs at `192.168.1.44`, and the slskd microVM at `192.168.21.2`.
 - **Shared storage**: `/mnt/virtio` (virtiofs) — beets DB, pipeline DB data, music library reachable from both.
 - **Nix deployment**: cratedigger is a flake input (`cratedigger-src`) in `~/nixosconfig/flake.nix`; downstream wrapper at `~/nixosconfig/modules/nixos/services/cratedigger.nix` imports `nixosModules.default`. `docs/nixos-module.md`.
 

--- a/README.md
+++ b/README.md
@@ -83,9 +83,10 @@ Beets package to use that same Python package set.
 
 You need: **NixOS**, a slskd instance (`services.slskd` is in nixpkgs), an
 externally owned Beets runtime/library, and disk for music. PostgreSQL can be
-provisioned on the same host. The breaking #759 module slice cannot replace an
-older deployment until its downstream Beets owner supplies the runtime block;
-there are no compatibility aliases.
+provisioned on the same host. Deployments upgrading from the removed
+`beets.package` / `beets.config` interface must supply the external
+`beets.runtime.*` capability in the same change; there are no compatibility
+aliases.
 
 ```nix
 {

--- a/docs/beets-primer.md
+++ b/docs/beets-primer.md
@@ -112,7 +112,7 @@ directory: /mnt/virtio/Music/Beets
 library: /mnt/virtio/cratedigger/beets-db/beets-library.db
 statefile: /var/lib/beets/state.pickle
 include:
-  - /run/secrets/beets-discogs.yaml  # exactly discogs.user_token
+  - /run/beets/secrets.yaml  # exactly discogs.user_token
 
 # Import behavior
 import:
@@ -136,9 +136,9 @@ paths:
 # bracket, which is also never empty. Contract-tested against real beets
 # in tests/test_harness_beets2_contract.py.
 
-# MusicBrainz — local mirror on doc2
+# MusicBrainz — dedicated local mirror guest
 musicbrainz:
-  host: 192.168.1.35:5200
+  host: 192.168.1.43:5200
   https: false
   ratelimit: 100
 
@@ -672,10 +672,12 @@ if isinstance(raw, bytes):
 
 ## MusicBrainz Mirror
 
-Local mirror on doc2 (`192.168.1.35:5200`). Beets is configured to use this instead of the public MB API.
+The dedicated MusicBrainz guest serves the local mirror at
+`192.168.1.43:5200`. Beets is configured to use it instead of the public MB
+API.
 
-- **Web UI**: `http://192.168.1.35:5200`
-- **API**: `http://192.168.1.35:5200/ws/2/`
+- **Web UI**: `http://192.168.1.43:5200`
+- **API**: `http://192.168.1.43:5200/ws/2/`
 - **Replication**: Daily from upstream MetaBrainz at 03:00
 - **Rate limit**: 100 req/s (vs 1 req/s on public API)
 
@@ -683,13 +685,13 @@ Local mirror on doc2 (`192.168.1.35:5200`). Beets is configured to use this inst
 
 ```bash
 # Search for a release
-curl -s "http://192.168.1.35:5200/ws/2/release?query=artist:Artist+AND+release:Album&fmt=json"
+curl -s "http://192.168.1.43:5200/ws/2/release?query=artist:Artist+AND+release:Album&fmt=json"
 
 # Get release with tracks
-curl -s "http://192.168.1.35:5200/ws/2/release/MBID?inc=recordings+media&fmt=json"
+curl -s "http://192.168.1.43:5200/ws/2/release/MBID?inc=recordings+media&fmt=json"
 
 # Get all releases in a release group
-curl -s "http://192.168.1.35:5200/ws/2/release-group/RGID?inc=releases&fmt=json"
+curl -s "http://192.168.1.43:5200/ws/2/release-group/RGID?inc=releases&fmt=json"
 ```
 
 **Newly seeded releases**: If you seed a release on upstream musicbrainz.org, it won't appear in the local mirror until the next daily replication. Use `--upstream` flag on the harness to query upstream directly for fresh seeds.
@@ -800,8 +802,8 @@ Beets remembers every directory it's imported from. Use `--noincremental` flag o
 
 ### Harness hangs with no output
 Usually means beets is waiting for a network request (MB lookup, cover art fetch). Check that:
-- MB mirror is reachable: `curl -s http://192.168.1.35:5200/ws/2/release?query=test&fmt=json | head`
-- No firewall blocking doc2
+- MB mirror is reachable: `curl -s http://192.168.1.43:5200/ws/2/release?query=test&fmt=json | head`
+- No firewall blocking the application host from the dedicated mirror guest
 - Not stuck on chroma fingerprinting (disabled by default, but check `chroma.auto`)
 
 ### Files with special characters in paths

--- a/docs/discogs-mirror.md
+++ b/docs/discogs-mirror.md
@@ -14,14 +14,16 @@ A self-hosted mirror of the Discogs music database, serving a JSON API at `https
 
 | What | Value |
 |------|-------|
-| Host | doc2 (192.168.1.35, Proxmox VM) |
+| Guest | dedicated unprivileged Proxmox CT 102 (`192.168.1.44`) |
 | API port | 8086 |
 | External URL | https://discogs.ablz.au |
-| PostgreSQL | nspawn container `discogs-db`, hostNum=6, IP 192.168.100.13:5432 |
-| DSN | `postgresql://discogs@192.168.100.13:5432/discogs` |
-| Data dir | `/mnt/mirrors/discogs` (re-downloadable, NOT backed up) |
-| Postgres data | `/mnt/mirrors/discogs/postgres` |
-| Dump files | `/mnt/mirrors/discogs/dumps` (cleaned up after each import) |
+| PostgreSQL | native `postgresql.service` inside CT 102 |
+| Import coordination | doc2 `discogs-import.service` through the metadata gate |
+
+The exact guest storage, deployment, and rollback layout is owned by
+`nixosconfig/docs/wiki/services/discogs.md` and its linked metadata-mirror
+migration runbook. Do not use the retired doc2 nspawn database as the active
+endpoint.
 
 ## API Endpoints
 
@@ -120,23 +122,22 @@ Search uses PostgreSQL GIN full-text indexes. Artist search does an EXISTS subqu
 ```
 data.discogs.com (monthly XML dumps, ~12 GB compressed)
         |
-        v  systemd timer (2nd of month, 04:00)
+        v  doc2 coordinator + metadata hold
 +-----------------------------+
-| discogs-import (oneshot)    |
+| CT 102 discogs-import       |
 | Rust: quick-xml streaming   |
 | -> binary COPY into PG     |
 | 10K batch, channel pipeline |
 +-------------+---------------+
               v
 +-----------------------------+
-| container@discogs-db        |
-| nspawn, PostgreSQL 16       |
-| hostNum=6                   |
-| 192.168.100.12 / .13       |
+| native PostgreSQL           |
+| dedicated unprivileged LXC  |
+| 192.168.1.44                |
 +-------------+---------------+
               v
 +-----------------------------+
-| discogs-api (systemd)       |
+| CT 102 discogs-api          |
 | Rust: axum HTTP server      |
 | port 8086                   |
 | discogs.ablz.au             |
@@ -172,20 +173,11 @@ docs/
 
 Module: `nixosconfig/modules/nixos/services/discogs.nix`
 
-```nix
-homelab.services.discogs = {
-  enable = true;
-  mirrorDir = "/mnt/mirrors/discogs";  # dumps + postgres data
-  apiPort = 8086;                       # default
-};
-```
-
-The module creates:
-- `containers.discogs-db` -- nspawn PG container via `mk-pg-container.nix` (hostNum=6)
-- `discogs-import.service` -- oneshot importer
-- `discogs-import.timer` -- monthly trigger (`*-*-02 04:00:00`)
-- `discogs-api.service` -- long-running API server
-- `localProxy` entry for `discogs.ablz.au` (auto ACME + Cloudflare DNS)
+The dedicated guest module owns native PostgreSQL, `discogs-api.service`, and
+`discogs-import.service`. The guest-local import timer is disabled: doc2 owns
+the monthly schedule, enters the durable `discogs-import` metadata hold, and
+invokes the guest through a restricted forced-command SSH boundary. Cratedigger
+resumes only after both Discogs and MusicBrainz representative probes pass.
 
 Flake input: `discogs-src` (non-flake, `github:abl030/discogs-api`). The Rust crate is built with `pkgs.rustPlatform.buildRustPackage`.
 
@@ -227,49 +219,45 @@ git add -A && git commit -m "description" && git push
 # Update nixosconfig flake lock to pick up the new commit
 cd ~/nixosconfig
 nix flake update discogs-src
-git add flake.lock && git commit -m "discogs: description" && git push
-
-# Deploy to doc2
-ssh doc2 'sudo nixos-rebuild switch --flake github:abl030/nixosconfig#doc2 --refresh'
+git add flake.lock
+git commit -S -m "discogs: description"
+# Push the signed commit to the Forgejo deployment root.
 ```
 
-The API service restarts automatically on deploy. The import service does NOT restart (it's a timer-triggered oneshot).
+Deploy the dedicated metadata guest from doc1 using the current procedure in
+`nixosconfig/docs/wiki/services/discogs.md` and
+`nixosconfig/docs/wiki/infrastructure/metadata-mirror-lxc-migration.md`. Do not rebuild
+doc2 from GitHub or reactivate its frozen nspawn rollback source. The API
+service restarts on guest deployment; the importer remains coordinator-driven.
 
 ### Debugging
 
 ```bash
-# Check service status
-ssh doc2 'systemctl status discogs-api.service'
-ssh doc2 'systemctl status container@discogs-db.service'
+# Probe the active guest from the Cratedigger host.
+ssh doc2 'curl -fsS http://192.168.1.44:8086/health | jq'
 
-# API logs
-ssh doc2 'journalctl -u discogs-api.service -f'
-
-# Import logs (if running)
+# Inspect the doc2-side coordinator and durable hold.
+ssh doc2 'systemctl status discogs-import.service discogs-import.timer'
+ssh doc2 'sudo cratedigger-metadata-gate status'
 ssh doc2 'journalctl -u discogs-import.service -f'
 
-# Test API directly on doc2
-ssh doc2 'curl -s http://127.0.0.1:8086/health'
-
-# Query Postgres directly
-ssh doc2 'psql -h 192.168.100.13 -U discogs -d discogs -c "SELECT count(*) FROM release"'
-
-# Restart the API
-ssh doc2 'sudo systemctl restart discogs-api.service'
-
-# Run a manual import (drops all data and re-imports)
-ssh doc2 'sudo systemctl start discogs-import'
-ssh doc2 'journalctl -u discogs-import -f'  # watch progress
+# Start a coordinated manual import without blocking SSH. This enters the
+# hold before invoking CT 102 and releases only after representative probes.
+ssh doc2 'sudo systemctl start discogs-import.service --no-block'
 ```
+
+For guest-local `discogs-api.service`, `discogs-import.service`, PostgreSQL,
+and database diagnostics, enter CT 102 through the nixosconfig metadata-guest
+runbook. Do not query or restart the frozen doc2 rollback database.
 
 ### Common issues
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| Health returns `{"status":"awaiting_import"}` | No data imported yet | Run `sudo systemctl start discogs-import` on doc2 |
-| Import fails with "unexpected end of file" | Truncated download from a previous interrupted run | Delete the corrupt file in `/mnt/mirrors/discogs/dumps/` and re-run. Downloads are now atomic (`.partial` rename) so this shouldn't recur. |
+| Health returns `{"status":"awaiting_import"}` | CT 102 has no admitted release data | Start the coordinated doc2 remote-import service and keep the metadata hold until it succeeds. |
+| Import fails with "unexpected end of file" | Truncated download from a previous interrupted run | Follow the CT 102 storage runbook, delete only the named corrupt guest dump, and re-run through the doc2 coordinator. Downloads use atomic `.partial` rename. |
 | Import fails with "no dumps found" | data.discogs.com HTML format changed | Check `curl https://data.discogs.com/` and fix `discover_latest_dump()` in `src/import.rs` |
-| API returns 500 on search | Postgres connection lost or tables missing | Check `container@discogs-db.service` is running, restart `discogs-api` |
+| API returns 500 on search | Guest PostgreSQL is unavailable or tables are missing | Check native PostgreSQL and `discogs-api.service` inside CT 102. |
 | VACUUM warnings about `pg_authid` | Non-superuser can't vacuum system catalogs | Harmless. VACUUM is scoped to owned tables in latest code. |
 
 ### Key files to edit
@@ -287,8 +275,8 @@ ssh doc2 'journalctl -u discogs-import -f'  # watch progress
 
 | Aspect | MusicBrainz | Discogs |
 |--------|-------------|---------|
-| Deployment | Podman-compose (PG + Solr + RabbitMQ) | nspawn PG + Rust API |
-| DB size | ~30 GB | ~80-120 GB |
+| Deployment | dedicated CT 100: native PG + explicit Podman app units | dedicated CT 102: native PG + Rust API |
+| DB size | ~100 GB+ including search indexes | ~80-120 GB |
 | Replication | Daily | Monthly full re-import |
 | API | Included (Perl webapp) | Custom Rust (this project) |
 | Search | Solr | Postgres FTS (GIN) |

--- a/docs/generated-testing.md
+++ b/docs/generated-testing.md
@@ -375,7 +375,7 @@ an explicitly supplied MusicBrainz mirror origin:
 ```bash
 nix-shell --run "scripts/world_model_burst.sh \
   --engine mirror-harness \
-  --mirror-url http://192.168.1.35:5200 \
+  --mirror-url http://192.168.1.43:5200 \
   --examples 2 --steps 5"
 ```
 

--- a/docs/mirrors.md
+++ b/docs/mirrors.md
@@ -33,8 +33,8 @@ metadata lookups slow down.
 
 ## MusicBrainz mirror (the operator's setup)
 
-The operator runs the official MusicBrainz mirror stack (musicbrainz-docker,
-podman on doc2, serving `http://192.168.1.35:5200`):
+The operator runs the official MusicBrainz mirror stack in dedicated CT 100
+(`192.168.1.43`), serving `http://192.168.1.43:5200`:
 
 - Follow <https://github.com/metabrainz/musicbrainz-docker>: postgres +
   the WS/2 web service + search indexes, plus live data replication.
@@ -63,10 +63,11 @@ deliberate stance, not a gap — a translation adapter for public Discogs
 belongs to the mirror project, not cratedigger.
 
 The mirror is the `discogs-api` repo (~19M releases, Rust JSON API over
-PostgreSQL loaded from the monthly Discogs data dumps, running in an
-nspawn container on doc2, served at `https://discogs.ablz.au`).
-**Follow-up plan:** packaging it as a flake + generic NixOS module (the
-same pattern as this repo's tier-2 work) lives in the discogs-api repo.
+PostgreSQL loaded from the monthly Discogs data dumps), running in dedicated
+CT 102 (`192.168.1.44`) and served at `https://discogs.ablz.au`.
+The active NixOS ownership and coordinated import boundary are documented in
+[`docs/discogs-mirror.md`](discogs-mirror.md) and the downstream nixosconfig
+service wiki.
 
 Wire Cratedigger browse and pipeline track population with
 `services.cratedigger.discogs.apiBase`. To make Beets imports use the same
@@ -79,7 +80,8 @@ overlay. Restart guarded applications after token rotation.
 
 ## LRCLIB (optional)
 
-The operator runs a local LRCLIB instance (`http://192.168.1.35:3300`). The
+The operator runs LRCLIB beside MusicBrainz in CT 100
+(`http://192.168.1.43:3300`). The
 external Beets owner instantiates `nix/beets.nix` with
 `lrclibUrl = "http://<host>:3300/api"` to build-time-patch the lyrics plugin.
 Unset means public lrclib.net (stock behavior).

--- a/docs/musicbrainz-mirror.md
+++ b/docs/musicbrainz-mirror.md
@@ -1,18 +1,19 @@
 # MusicBrainz Mirror
 
-Local mirror on doc2 at `http://192.168.1.35:5200`. Used by the web UI browse tab and by beets.
+The dedicated MusicBrainz guest serves the local mirror at
+`http://192.168.1.43:5200`. It is used by the web UI browse tab and Beets.
 
 ## Common queries
 
 ```bash
 # Search releases
-curl -s "http://192.168.1.35:5200/ws/2/release?query=artist:ARTIST+AND+release:ALBUM&fmt=json"
+curl -s "http://192.168.1.43:5200/ws/2/release?query=artist:ARTIST+AND+release:ALBUM&fmt=json"
 
 # Get release with tracks
-curl -s "http://192.168.1.35:5200/ws/2/release/MBID?inc=recordings+media&fmt=json"
+curl -s "http://192.168.1.43:5200/ws/2/release/MBID?inc=recordings+media&fmt=json"
 
 # Get release group
-curl -s "http://192.168.1.35:5200/ws/2/release-group/RGID?inc=releases&fmt=json"
+curl -s "http://192.168.1.43:5200/ws/2/release-group/RGID?inc=releases&fmt=json"
 ```
 
 ## Notes

--- a/docs/nixos-module.md
+++ b/docs/nixos-module.md
@@ -15,12 +15,18 @@ host. The escape hatch is `services.cratedigger.packageSet = pkgs;` (or another
 package set), which also changes the Python identity the supplied Beets package
 must use and forfeits the tested-closure guarantee.
 
-> **Held series slice:** the public module interface below is the issue #759
-> ownership inversion. A deployment using the removed `beets.package` or
-> `beets.config` interface must land its external Beets owner and new runtime
-> capability before pinning this revision. There are no compatibility aliases.
+> **Breaking interface:** the public module consumes an externally owned Beets
+> runtime. A deployment using the removed `beets.package` or `beets.config`
+> interface must supply the new runtime capability in the same change. There
+> are no compatibility aliases.
 
-`~/nixosconfig/modules/nixos/services/cratedigger.nix` is a thin homelab wrapper (~150 lines) that imports the upstream module and adds:
+The homelab deployment composes this upstream module with two downstream
+modules. `~/nixosconfig/modules/nixos/services/beets.nix` owns the system Beets
+package, config, state, secret include, storage readiness, and plain operator
+command. `~/nixosconfig/modules/nixos/services/cratedigger.nix` imports the
+upstream module and adds:
+
+- the exact runtime capability exported by the sibling Beets owner
 - sops-nix per-key secret materialization (`cratedigger-secrets-split` oneshot — see below)
 - the nspawn PostgreSQL container for the pipeline DB
 - the `homelab.localProxy.hosts` entry for `music.ablz.au`

--- a/docs/quality-ranks.md
+++ b/docs/quality-ranks.md
@@ -549,8 +549,10 @@ For the abl030 homelab (this project's reference deployment):
 # On doc1 — has git push credentials for nixosconfig
 cd ~/nixosconfig
 $EDITOR hosts/doc2/configuration.nix          # tweak services.cratedigger.qualityRanks.*
-git commit -am "cratedigger: retune <what>" && git push
-ssh doc2 'sudo nixos-rebuild switch --flake github:abl030/nixosconfig#doc2 --refresh'
+git add hosts/doc2/configuration.nix
+git commit -S -m "fix(cratedigger): retune <what>"
+# Push the signed commit to the Forgejo deployment root, then:
+env -u SSH_AUTH_SOCK fleet-deploy doc2
 ```
 
 ### How to verify the new config is live

--- a/docs/search-plan-iter2-deploy.md
+++ b/docs/search-plan-iter2-deploy.md
@@ -1,5 +1,11 @@
 # Search-Plan Iteration 2 — Deploy Runbook
 
+> **Historical rollout record (completed 2026-05-26).** Preserve the commands
+> below as evidence of the original PR-by-PR deployment; do not execute them as
+> the current fleet procedure. New deployments use the repository `deploy`
+> skill: GitHub Cratedigger merge, signed Forgejo nixosconfig pin, then doc1's
+> locked-sibling `fleet-deploy doc2` path with exact-source verification.
+
 Operator runbook for the search-plan iteration 2 PR series (issue
 [#369](https://github.com/abl030/cratedigger/issues/369)). One section
 per PR. PR1 has a non-trivial deploy procedure (controlled window for a

--- a/docs/web-dev-server.md
+++ b/docs/web-dev-server.md
@@ -26,7 +26,7 @@ Canonical remote-dev flow from any machine with SSH access:
    PIPELINE_DB_DSN=postgresql://cratedigger@127.0.0.1:15432/cratedigger \
      nix-shell --run "python3 scripts/web_dev_server.py --data live-db \
        --host 127.0.0.1 --port 8096 \
-       --mb-api http://192.168.1.35:5200/ws/2 \
+       --mb-api http://192.168.1.43:5200/ws/2 \
        --discogs-api https://discogs.ablz.au"
    ```
    Before inspecting cross-source UI pixels, require its real route to pass:

--- a/docs/webui-primer.md
+++ b/docs/webui-primer.md
@@ -19,7 +19,7 @@ Browser → https://music.ablz.au
                    → web/server.py (stdlib http.server, inherited AF_UNIX fd)
                      → PostgreSQL (pipeline DB, nspawn container 10.20.0.11)
                      → SQLite (beets library, /mnt/virtio/cratedigger/beets-db/beets-library.db, read-only)
-                     → MusicBrainz API (local mirror, 192.168.1.35:5200)
+                     → MusicBrainz API (dedicated mirror, 192.168.1.43:5200)
 ```
 
 - **No build step, no npm, no framework** — stdlib `http.server`, vanilla JS, single HTML file
@@ -572,7 +572,7 @@ A practical "develop anywhere" loop is:
 PIPELINE_DB_DSN=postgresql://cratedigger@127.0.0.1:15432/cratedigger \
   nix-shell --run "python3 scripts/web_dev_server.py --data live-db \
     --host 127.0.0.1 --port 8096 \
-    --mb-api http://192.168.1.35:5200/ws/2 \
+    --mb-api http://192.168.1.43:5200/ws/2 \
     --discogs-api https://discogs.ablz.au"
 
 # Required from a second backend-host shell before accepting screenshots.
@@ -712,7 +712,7 @@ print credentials in argv or logs while probing.
 
 ## MusicBrainz API Usage
 
-All queries hit the local mirror at `http://192.168.1.35:5200/ws/2`.
+All queries hit the dedicated mirror at `http://192.168.1.43:5200/ws/2`.
 
 Key endpoints used:
 - `artist?query=NAME&fmt=json` — artist search

--- a/examples/cratedigger.nix
+++ b/examples/cratedigger.nix
@@ -14,9 +14,9 @@
 # Cratedigger consumes Beets; the deployment instantiates and owns the
 # package, immutable config, catalog, library, host-local state, token-only
 # include, readiness unit, and plain operator `beet` below.
-# This is the required downstream cutover shape for issue #759's held module
-# slice. Land the external owner before advancing an older Cratedigger pin;
-# removed beets.package/beets.config options have no compatibility aliases.
+# Deployments upgrading from the removed beets.package/beets.config interface
+# must supply this external runtime capability in the same change; there are no
+# compatibility aliases.
 { config, pkgs, ... }:
 
 let

--- a/nix/beets.nix
+++ b/nix/beets.nix
@@ -9,14 +9,14 @@
 # the same store path can serve the Cratedigger Python environment, checker,
 # harness, and a deployment-owned plain `beet` command.
 #
-# The two mirror patches are ported from the operator's Home Manager module
-# (~/nixosconfig/modules/home-manager/services/beets.nix) as opt-in knobs,
-# null/off by default so a stranger gets stock plugin behaviour:
+# The two mirror patches originated in the operator's retired Home Manager
+# Beets module and remain available here as opt-in deployment knobs, null/off
+# by default so a stranger gets stock plugin behaviour:
 #   - discogsMirrorUrl: point the discogs plugin's python3-discogs-client at
 #     a Discogs mirror (e.g. https://discogs.ablz.au) instead of
 #     api.discogs.com.
 #   - lrclibUrl: point the lyrics plugin's LRCLIB base at a local instance
-#     (e.g. http://192.168.1.35:3300/api) instead of lrclib.net.
+#     (e.g. http://192.168.1.43:3300/api) instead of lrclib.net.
 # `--replace-fail` is the drift alarm: if a future `nix flake update` ships
 # a beets whose plugin source no longer contains these strings, the build
 # fails loudly instead of silently reverting to the public APIs.

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1489,7 +1489,7 @@ in {
       apiBase = mkOption {
         type = types.str;
         default = "https://musicbrainz.org";
-        example = "http://192.168.1.35:5200";
+        example = "http://mb-mirror.lan:5200";
         description = ''
           MusicBrainz API origin (scheme://host[:port], no path) — ONE value
           threaded to all consumers (tier-2 plan U6/KTD6): web/mb.py
@@ -1974,7 +1974,7 @@ in {
       }
       {
         assertion = lib.hasPrefix "http://" cfg.musicbrainz.apiBase || lib.hasPrefix "https://" cfg.musicbrainz.apiBase;
-        message = "services.cratedigger.musicbrainz.apiBase must be an origin URL (scheme://host[:port], no path), e.g. https://musicbrainz.org or http://192.168.1.35:5200.";
+        message = "services.cratedigger.musicbrainz.apiBase must be an origin URL (scheme://host[:port], no path), e.g. https://musicbrainz.org or http://mb-mirror.lan:5200.";
       }
       {
         assertion = cfg.discogs.apiBase == null || lib.hasPrefix "http://" cfg.discogs.apiBase || lib.hasPrefix "https://" cfg.discogs.apiBase;


### PR DESCRIPTION
## Summary

- remove stale issue #759 hold/cutover language now that the interface is live
- align Beets, mirror, slskd, and deployment guidance with the active guest topology
- correct downstream operator paths and retain historical runbooks as explicitly historical evidence

## Validation

- receipt-backed Pyright final gate: pass
- receipt-backed complete suite: pass (9,042 tests across 401 targets)
- nix flake check --no-build
- live health and systemd probes for MusicBrainz, Discogs, slskd, and the Discogs importer coordinator