### PR TITLE
Fix zsh decision-corpus export runbook

### DIFF
--- a/docs/debugging-cli.md
+++ b/docs/debugging-cli.md
@@ -522,7 +522,7 @@ it on doc2 so the DSN stays in the deployed runtime boundary:
 ```bash
 EXPORT_DIR=/tmp/cratedigger-decision-corpus-$(date +%Y%m%d-%H%M%S)
 mkdir -p "$EXPORT_DIR"
-ssh doc2 'export PGPASSWORD=$(sudo cat /run/secrets/cratedigger-pgpass | grep "^PGPASSWORD=" | cut -d= -f2); work=$(mktemp -d /tmp/cratedigger-decision-corpus.XXXXXX); decision-differential export --dsn postgresql://cratedigger@10.20.0.11:5432/cratedigger --corpus "$work/corpus.jsonl" --coverage "$work/coverage.json"; status=$?; printf "%s\n" "$status" > "$work/export-status"; tar -C "$work" -cf - corpus.jsonl coverage.json export-status; exit 0' | tar -C "$EXPORT_DIR" -xf -
+ssh doc2 'export PGPASSWORD=$(sudo cat /run/secrets/cratedigger-pgpass | grep "^PGPASSWORD=" | cut -d= -f2); work=$(mktemp -d /tmp/cratedigger-decision-corpus.XXXXXX); decision-differential export --dsn postgresql://cratedigger@10.20.0.11:5432/cratedigger --corpus "$work/corpus.jsonl" --coverage "$work/coverage.json"; export_rc=$?; printf "%s\n" "$export_rc" > "$work/export-status"; tar -C "$work" -cf - corpus.jsonl coverage.json export-status; exit 0' | tar -C "$EXPORT_DIR" -xf -
 test "$(cat "$EXPORT_DIR/export-status")" = 0 || test "$(cat "$EXPORT_DIR/export-status")" = 2
 nix-shell --run "python3 scripts/decision_differential.py verify --corpus $EXPORT_DIR/corpus.jsonl --coverage $EXPORT_DIR/coverage.json"
 ```

--- a/tests/test_debugging_cli_docs.py
+++ b/tests/test_debugging_cli_docs.py
@@ -1,0 +1,71 @@
+"""Executable runbook pins for docs/debugging-cli.md."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEBUGGING_CLI = REPO_ROOT / "docs" / "debugging-cli.md"
+
+
+def _decision_export_remote_fragment() -> str:
+    """Extract the actual doc2 command passed through SSH by the runbook."""
+    for line in DEBUGGING_CLI.read_text(encoding="utf-8").splitlines():
+        if line.startswith("ssh doc2 '") and "export-status" in line:
+            start = len("ssh doc2 '")
+            remote, separator, _local = line[start:].partition("' | tar ")
+            if separator:
+                return remote
+    raise AssertionError("decision-corpus SSH export fragment missing from runbook")
+
+
+class TestDecisionCorpusExportRunbook(unittest.TestCase):
+    def test_remote_export_fragment_preserves_debt_exit_under_zsh(self) -> None:
+        """The documented doc2 command reaches tar after an admitted debt exit."""
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            bin_dir = root / "bin"
+            bin_dir.mkdir()
+            (bin_dir / "sudo").write_text(
+                "#!/usr/bin/env zsh\nprintf 'PGPASSWORD=test\\n'\n",
+                encoding="utf-8",
+            )
+            (bin_dir / "decision-differential").write_text(
+                """#!/usr/bin/env zsh
+while (( $# )); do
+  case "$1" in
+    --corpus|--coverage) touch "$2"; shift 2 ;;
+    *) shift ;;
+  esac
+done
+exit 2
+""",
+                encoding="utf-8",
+            )
+            (bin_dir / "tar").write_text(
+                """#!/usr/bin/env zsh
+work="$2"
+test "$(cat "$work/export-status")" = 2
+test -f "$work/corpus.jsonl"
+test -f "$work/coverage.json"
+""",
+                encoding="utf-8",
+            )
+            for command in bin_dir.iterdir():
+                command.chmod(0o755)
+            completed = subprocess.run(
+                ["zsh", "-fc", _decision_export_remote_fragment()],
+                capture_output=True,
+                cwd=root,
+                env={**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}"},
+                text=True,
+            )
+        self.assertEqual(completed.returncode, 0, completed.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_debugging_cli_docs.py
+++ b/tests/test_debugging_cli_docs.py
@@ -60,6 +60,7 @@ test -f "$work/coverage.json"
             completed = subprocess.run(
                 ["zsh", "-fc", _decision_export_remote_fragment()],
                 capture_output=True,
+                check=False,
                 cwd=root,
                 env={**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}"},
                 text=True,

--- a/tests/test_debugging_cli_docs.py
+++ b/tests/test_debugging_cli_docs.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import subprocess
 import unittest
+from dataclasses import dataclass
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -23,15 +24,45 @@ def _decision_export_remote_fragment() -> str:
     raise AssertionError("decision-corpus SSH export fragment missing from runbook")
 
 
+def _decision_export_local_acceptance() -> str:
+    """Extract the runbook's local 0/2 export-status admission check."""
+    for line in DEBUGGING_CLI.read_text(encoding="utf-8").splitlines():
+        if line.startswith('test "$(cat "$EXPORT_DIR/export-status")" = 0'):
+            return line
+    raise AssertionError("decision-corpus local export-status check missing from runbook")
+
+
+@dataclass(frozen=True)
+class _RunbookExecution:
+    remote_returncode: int
+    local_acceptance_returncode: int
+    decision_returncode: str
+    export_status: str | None
+    tar_work: str | None
+    work: Path
+
+
 class TestDecisionCorpusExportRunbook(unittest.TestCase):
-    def test_remote_export_fragment_preserves_debt_exit_under_zsh(self) -> None:
-        """The documented doc2 command reaches tar after an admitted debt exit."""
+    def _run_remote_fragment(
+        self,
+        export_returncode: int,
+        fragment: str | None = None,
+    ) -> _RunbookExecution:
         with TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             bin_dir = root / "bin"
+            marker_dir = root / "markers"
+            transfer_dir = root / "transfer"
+            work = root / "work"
             bin_dir.mkdir()
+            marker_dir.mkdir()
+            transfer_dir.mkdir()
             (bin_dir / "sudo").write_text(
                 "#!/usr/bin/env zsh\nprintf 'PGPASSWORD=test\\n'\n",
+                encoding="utf-8",
+            )
+            (bin_dir / "mktemp").write_text(
+                "#!/usr/bin/env zsh\nmkdir -p \"$RUNBOOK_WORK\"\nprintf '%s\\n' \"$RUNBOOK_WORK\"\n",
                 encoding="utf-8",
             )
             (bin_dir / "decision-differential").write_text(
@@ -42,30 +73,109 @@ while (( $# )); do
     *) shift ;;
   esac
 done
-exit 2
+printf '%s\\n' "$FAKE_EXPORT_RC" > "$RUNBOOK_MARKERS/export-returncode"
+exit "$FAKE_EXPORT_RC"
 """,
                 encoding="utf-8",
             )
             (bin_dir / "tar").write_text(
                 """#!/usr/bin/env zsh
 work="$2"
-test "$(cat "$work/export-status")" = 2
-test -f "$work/corpus.jsonl"
-test -f "$work/coverage.json"
+printf '%s\\n' "$work" > "$RUNBOOK_MARKERS/tar-work"
+if [[ -f "$work/export-status" ]]; then
+  cp "$work/export-status" "$RUNBOOK_TRANSFER_DIR/export-status"
+else
+  : > "$RUNBOOK_MARKERS/status-missing"
+fi
 """,
                 encoding="utf-8",
             )
             for command in bin_dir.iterdir():
                 command.chmod(0o755)
-            completed = subprocess.run(
-                ["zsh", "-fc", _decision_export_remote_fragment()],
+            env = {
+                **os.environ,
+                "FAKE_EXPORT_RC": str(export_returncode),
+                "PATH": f"{bin_dir}:{os.environ['PATH']}",
+                "RUNBOOK_MARKERS": str(marker_dir),
+                "RUNBOOK_TRANSFER_DIR": str(transfer_dir),
+                "RUNBOOK_WORK": str(work),
+            }
+            remote = subprocess.run(
+                ["zsh", "-fc", fragment or _decision_export_remote_fragment()],
                 capture_output=True,
                 check=False,
                 cwd=root,
-                env={**os.environ, "PATH": f"{bin_dir}:{os.environ['PATH']}"},
+                env=env,
                 text=True,
             )
-        self.assertEqual(completed.returncode, 0, completed.stderr)
+            local = subprocess.run(
+                ["zsh", "-fc", _decision_export_local_acceptance()],
+                capture_output=True,
+                check=False,
+                cwd=root,
+                env={**env, "EXPORT_DIR": str(transfer_dir)},
+                text=True,
+            )
+            status_path = transfer_dir / "export-status"
+            return _RunbookExecution(
+                remote_returncode=remote.returncode,
+                local_acceptance_returncode=local.returncode,
+                decision_returncode=(marker_dir / "export-returncode").read_text(
+                    encoding="utf-8"
+                ).strip(),
+                export_status=(
+                    status_path.read_text(encoding="utf-8").strip()
+                    if status_path.exists()
+                    else None
+                ),
+                tar_work=(marker_dir / "tar-work").read_text(encoding="utf-8").strip()
+                if (marker_dir / "tar-work").exists()
+                else None,
+                work=work,
+            )
+
+    def _assert_complete_transfer(
+        self,
+        result: _RunbookExecution,
+        expected_export_returncode: int,
+        expected_local_acceptance: int,
+    ) -> None:
+        self.assertEqual(result.remote_returncode, 0)
+        self.assertEqual(result.decision_returncode, str(expected_export_returncode))
+        self.assertEqual(result.export_status, str(expected_export_returncode))
+        self.assertEqual(result.tar_work, str(result.work))
+        self.assertEqual(result.local_acceptance_returncode, expected_local_acceptance)
+
+    def test_remote_export_fragment_preserves_every_exit_before_tar_under_zsh(self) -> None:
+        """The actual doc2 fragment records export exit before the transfer."""
+        for export_returncode, local_acceptance in ((0, 0), (2, 0), (7, 1)):
+            with self.subTest(export_returncode=export_returncode):
+                self._assert_complete_transfer(
+                    self._run_remote_fragment(export_returncode),
+                    export_returncode,
+                    local_acceptance,
+                )
+
+    def test_forced_export_status_mutant_is_rejected(self) -> None:
+        fragment = _decision_export_remote_fragment().replace(
+            "export_rc=$?", "export_rc=0"
+        )
+        with self.assertRaises(AssertionError):
+            self._assert_complete_transfer(self._run_remote_fragment(2, fragment), 2, 0)
+
+    def test_missing_export_status_mutant_is_rejected(self) -> None:
+        fragment = _decision_export_remote_fragment().replace(
+            'printf "%s\\n" "$export_rc" > "$work/export-status"; ', ":; "
+        )
+        with self.assertRaises(AssertionError):
+            self._assert_complete_transfer(self._run_remote_fragment(2, fragment), 2, 0)
+
+    def test_tar_not_reached_mutant_is_rejected(self) -> None:
+        fragment = _decision_export_remote_fragment().replace(
+            'tar -C "$work" -cf - corpus.jsonl coverage.json export-status;', "false;"
+        )
+        with self.assertRaises(AssertionError):
+            self._assert_complete_transfer(self._run_remote_fragment(2, fragment), 2, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Refs #999

## Summary

- rename the remote export receipt variable from zsh-reserved `status` to portable `export_rc`
- add an executable regression that extracts the literal documented SSH fragment and local 0/2 admission check
- qualify green 0, debt 2, unexpected 7, tar reachability, exact transferred status, hostile quoted paths, and temporary-directory cleanup
- pin known-bad mutations for a forced wrong receipt, omitted receipt write, and tar never reached

## Live discovery

After #1004 deployed, the real exporter completed correctly with debt exit 2 and 265 named debt items, but doc2 zsh rejected `status=$?` as a read-only parameter before the transfer tar ran. Re-running the literal workflow with `export_rc` transferred the exact pair, and local verification succeeded.

The live corpus contained 22,720 evidence rows and 16,825 valid candidates (16,801 paired, 24 unpaired). Both persisted and counterfactual decision replays emitted 16,825 rows, while a corpus-only replay failed closed because `--coverage` is mandatory.

## Validation

Exact reviewed HEAD: `e28a854bcf9fb9b9a9d440694c1294ba5297dcf7`

- final-gate receipt: `/run/user/1000/cratedigger-final-gate.KdJ7FZee`
- bundle: `/run/user/1000/cratedigger-checks.snpowarm`
- all seven canonical phases passed
- fresh independent Sol re-review approved with no findings after independently testing 0/2/7 paths, all three bad mutations, quote-stressing paths, and cleanup

No Nix module or production code changed, so the existing module VM qualification remains applicable.
