### PR TITLE
Expose convergence in triage filter help

### DIFF
--- a/lib/triage_service.py
+++ b/lib/triage_service.py
@@ -107,6 +107,10 @@ VALID_FILTER_FORMS: tuple[str, ...] = (
     _FILTER_CONVERGED,
 )
 
+# Shared human-readable rendering for every discoverability surface. Keep the
+# vocabulary above machine-parseable; this value only supplies presentation.
+VALID_FILTER_FORMS_TEXT = " | ".join(VALID_FILTER_FORMS)
+
 
 class InvalidFilterError(ValueError):
     """Raised by ``parse_filter`` when the spec is garbage.

--- a/scripts/pipeline_cli/triage.py
+++ b/scripts/pipeline_cli/triage.py
@@ -32,6 +32,7 @@ from lib.convergence_service import parse_signal_token
 # remember the parameterised vocab. New filter forms get added at the
 # service layer; both wrappers auto-pick them up.
 from lib.triage_service import VALID_FILTER_FORMS as _TRIAGE_VALID_FILTER_FORMS_BASE
+from lib.triage_service import VALID_FILTER_FORMS_TEXT as _TRIAGE_FILTER_FORMS_TEXT
 from scripts.pipeline_cli._format import _format_dt, _json_default, _truncate
 
 if TYPE_CHECKING:
@@ -579,9 +580,7 @@ def add_triage_subparser(
         help="Cohort listing by filter spec")
     p_tr_list.add_argument(
         "--filter", default="all",
-        help="Filter spec: all | unfindable[:<category>] | "
-             "data_quality[:<field>] | data_quality:status=<status> | "
-             "data_quality:reason=<code> | search_not_converting")
+        help=f"Filter spec: {_TRIAGE_FILTER_FORMS_TEXT}")
     p_tr_list.add_argument(
         "--limit", type=int, default=50,
         help="Page size (default 50)")

--- a/tests/test_js_convergence.mjs
+++ b/tests/test_js_convergence.mjs
@@ -1,5 +1,6 @@
 /** Frontend convergence prompt/action contract (#978). */
 import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
 
 global.window = {};
 global.document = { querySelector() { return null; } };
@@ -30,14 +31,52 @@ assert.match(wanted, /6 peers/i);
 assert.match(wanted, /at least five qualifying observations/i);
 assert.match(wanted, /at least five distinct peers/i);
 assert.match(wanted, /3 codecs/i);
-assert.match(wanted, /raw cliffs 14\.78 kHz-15\.22 kHz \(440 Hz spread\)/i);
-assert.match(wanted, /shared 15 kHz band/i);
+assert.match(wanted, /raw cliffs 14\.8 kHz-15\.2 kHz \(440 Hz spread\)/i);
+assert.match(wanted, /shared 15\.0 kHz band/i);
 assert.match(wanted, /provisional—not proof/i);
-assert.match(wanted, />Stop searching</);
+assert.match(
+  wanted,
+  /<button class="p-btn convergence-stop"[^>]*>Stop searching<\/button>/,
+  'the convergence action remains a native button',
+);
 assert.match(wanted, /&quot;signal_token&quot;:&quot;aaaaaaaa/);
 assert.doesNotMatch(wanted, /all.*exact|identical cliff/i);
 assert.doesNotMatch(wanted, />Accept</);
 assert.match(renderConvergencePrompt(signal, 'unsearchable'), /Searching stopped/i);
+
+for (const [count, expected] of [[0, 'codecs'], [1, 'codec'], [2, 'codecs']]) {
+  const rendered = renderConvergencePrompt(
+    { ...signal, distinct_codec_count: count },
+    'wanted',
+  );
+  assert.match(
+    rendered,
+    new RegExp(`· ${count} ${expected} · raw cliffs`),
+    `${count} uses the correct codec noun`,
+  );
+}
+
+const exactBand = renderConvergencePrompt({
+  ...signal,
+  cliff_hz: 15000,
+  raw_cliff_min_hz: 15000,
+  raw_cliff_max_hz: 15000,
+  cliff_spread_hz: 0,
+}, 'wanted');
+assert.match(
+  exactBand,
+  /raw cliffs 15\.0 kHz-15\.0 kHz \(0 Hz spread\) · shared 15\.0 kHz band/i,
+  'exact raw values keep one-decimal kHz precision and the truthful spread',
+);
+
+const indexHtml = readFileSync(new URL('../web/index.html', import.meta.url), 'utf8');
+const convergenceStopRule = indexHtml.match(/\.convergence-stop\s*\{(?<rules>[^}]*)\}/);
+assert.ok(convergenceStopRule, 'the convergence action has a dedicated style rule');
+assert.match(
+  convergenceStopRule.groups.rules,
+  /min-height:\s*24px\s*;/,
+  'the convergence action has at least a 24px target height',
+);
 
 function response(status, body, { raw = null } = {}) {
   return {

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -5269,6 +5269,24 @@ class TestPipelineCliTriage(unittest.TestCase):
     our own logic, not leaf seams. See `MOCKS: LEAF-SEAM ONLY`.
     """
 
+    def test_list_help_advertises_every_filter_form(self) -> None:
+        from scripts.pipeline_cli.routes_meta import _build_parser
+
+        parser, _, _ = _build_parser()
+        output = io.StringIO()
+        with redirect_stdout(output), self.assertRaises(SystemExit) as raised:
+            parser.parse_args(["triage", "list", "--help"])
+
+        self.assertEqual(raised.exception.code, 0)
+        normalized_help = " ".join(output.getvalue().split())
+        self.assertIn(
+            "Filter spec: all | unfindable | unfindable:<category> | "
+            "data_quality | data_quality:<field> | "
+            "data_quality:status=<status> | data_quality:reason=<code> | "
+            "search_not_converting | converged",
+            normalized_help,
+        )
+
     def _seed_healthy(self, db, rid: int) -> None:
         from tests.helpers import make_request_row
         db.seed_request(make_request_row(

--- a/tests/web/test_route_audit.py
+++ b/tests/web/test_route_audit.py
@@ -110,6 +110,23 @@ class TestApiIndexRouteContract(_WebServerCase):
         "method", "path", "description", "request_model",
     }
 
+    def test_triage_list_description_advertises_every_filter_form(self):
+        status, data = self._get("/api/_index")
+        self.assertEqual(status, 200)
+        triage_list = next(
+            entry
+            for entry in data
+            if entry["method"] == "GET"
+            and entry["path"] == "/api/triage/list"
+        )
+        self.assertIn(
+            "filter spec: all | unfindable | unfindable:<category> | "
+            "data_quality | data_quality:<field> | "
+            "data_quality:status=<status> | data_quality:reason=<code> | "
+            "search_not_converting | converged",
+            triage_list["description"],
+        )
+
     def test_api_index_returns_classified_routes_with_pydantic_models(self):
         status, data = self._get("/api/_index")
         self.assertEqual(status, 200)

--- a/web/index.html
+++ b/web/index.html
@@ -413,7 +413,7 @@
   .p-actions { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; }
   .convergence-prompt { margin-top: 8px; padding: 9px 10px; border: 1px solid #685b25; border-radius: 5px; background: #24200f; color: #d8cc9b; font-size: 0.8em; line-height: 1.45; }
   .convergence-prompt strong { color: #f0cf68; }
-  .convergence-stop { margin-top: 7px; border-color: #9b7e22; color: #f0cf68; }
+  .convergence-stop { min-height: 24px; margin-top: 7px; border-color: #9b7e22; color: #f0cf68; }
   .convergence-stopped { display: inline-block; margin-top: 5px; color: #aaa; }
   /* Forensic block — collapsed by default summary of the most recent search
      row (variant + final_state + top-3 candidates). Click toggles open. */

--- a/web/js/convergence.js
+++ b/web/js/convergence.js
@@ -15,7 +15,7 @@ export function convergenceBadge(signal) {
 
 /** @param {number} value */
 function formatKhz(value) {
-  return `${Number((value / 1000).toFixed(2))} kHz`;
+  return `${(value / 1000).toFixed(1)} kHz`;
 }
 
 /**
@@ -31,11 +31,12 @@ export function renderConvergencePrompt(signal, requestStatus, origin = 'unknown
   const cliffHz = Number(signal.cliff_hz);
   const rawMinHz = Number(signal.raw_cliff_min_hz);
   const rawMaxHz = Number(signal.raw_cliff_max_hz);
+  const codecCount = Number(signal.distinct_codec_count);
   const details = [
     `${Number(signal.distinct_peer_count)} peers`,
     `${Number(signal.observation_count)} observations`,
     `${Number(signal.distinct_candidate_snapshot_count)} snapshots`,
-    `${Number(signal.distinct_codec_count)} codecs`,
+    `${codecCount} ${codecCount === 1 ? 'codec' : 'codecs'}`,
     `raw cliffs ${formatKhz(rawMinHz)}-${formatKhz(rawMaxHz)} (${Number(signal.cliff_spread_hz)} Hz spread)`,
     `shared ${formatKhz(cliffHz)} band`,
   ].join(' · ');

--- a/web/routes/triage.py
+++ b/web/routes/triage.py
@@ -64,6 +64,9 @@ from lib.triage_service import (
 from lib.triage_service import (
     VALID_FILTER_FORMS as _TRIAGE_VALID_FILTER_FORMS_API,
 )
+from lib.triage_service import (
+    VALID_FILTER_FORMS_TEXT as _TRIAGE_FILTER_FORMS_TEXT,
+)
 from web.routes._pydantic import parse_body
 from web.routes._registry import RouteHandler, RouteRegistration, pattern_route, route
 from web.routes._server_access import _server
@@ -302,9 +305,8 @@ ROUTES: list[RouteRegistration] = [
         # U17: /api/triage HTTP endpoints. Per-request composition and
         # cohort listing both wrap ``lib.triage_service`` (U15) — same
         # service as ``pipeline-cli triage`` (U16) per CLI ⇄ API symmetry.
-        "Cohort triage listing — filter by unfindable category, "
-        "field-quality field/status/reason, or search-not-converting "
-        "state. ``data_quality:status=<status>`` filters on the "
+        f"Cohort triage listing — filter spec: {_TRIAGE_FILTER_FORMS_TEXT}. "
+        "``data_quality:status=<status>`` filters on the "
         "resolver-status column (e.g. unresolved_4xx_client); "
         "``data_quality:reason=<code>`` filters on the reason_code "
         "column (e.g. http_400).",


### PR DESCRIPTION
## Summary

- derive the advertised triage filter forms from the canonical accepted filter tuple
- include converged in pipeline-cli triage list help
- include converged in the API route-index description
- pin both real discovery surfaces with regressions

## Verification

- canonical seven-phase check passes on 15de9cfb06982517e79be0c29e7c39c7e2b83c0c
- receipt: /run/user/1000/cratedigger-final-gate.wduzfiAZ
- independent Sol review: no findings
- live defect reproduced on deployed PR #1008 before this patch

Refs #978
Follow-up to #1008