### PR TITLE
Fix exact YouTube rescue discovery and manual selection

### DIFF
--- a/docs/debugging-cli.md
+++ b/docs/debugging-cli.md
@@ -206,7 +206,7 @@ inside socket authorization, never credentials.
 - `pipeline-cli wrong-match-triage` — Converge the full Wrong Matches queue using persisted evidence.
 - `pipeline-cli youtube-album` — Resolve a release to the YouTube Music album
   matrix directly through the shared resolver service; accepts
-  `<identifier> [--refresh] [--json]`, with human-readable output by default
+  `<identifier> [--refresh] [--watch-url https://music.youtube.com/watch?v=...] [--json]`, with human-readable output by default
   and the full result available as JSON. It uses the configured database and
   mirrors and remains available when `web.enable = false`; it does not use the
   optional web Unix socket or fall back to an HTTP adapter when that socket is
@@ -216,6 +216,9 @@ inside socket authorization, never credentials.
   configured mirror first because release IDs and master IDs share the integer
   namespace; after the mirror establishes the master, the normal post-widen
   durable-cache read may return `ok` with `from_cache = true`.
+  `--watch-url` accepts only that canonical watch form, resolves the exact
+  video to its album browse ID, and replaces the complete persisted matrix;
+  the raw URL never reaches rescue or yt-dlp.
 
   Exhausting the configured HTTP status retries raises the public typed
   `requests.exceptions.RetryError` boundary. The resolver classifies that as

--- a/lib/youtube_album_service.py
+++ b/lib/youtube_album_service.py
@@ -613,8 +613,11 @@ def resolve_youtube_album(
         else:
             search_results = _cached_search(
                 yt_client, cache, query, "albums", 10, refresh=refresh)
-            song_results = _cached_search(
-                yt_client, cache, query, "songs", 10, refresh=refresh)
+            try:
+                song_results = _cached_search(
+                    yt_client, cache, query, "songs", 10, refresh=refresh)
+            except (YTMusicError, requests.RequestException, KeyError, IndexError):
+                song_results = []
             seed_browse_id = _pick_yt_seed(search_results, seed_release)
             song_browse_ids = _song_album_browse_ids(song_results)
             if seed_browse_id is None and not song_browse_ids:
@@ -628,11 +631,17 @@ def resolve_youtube_album(
                 seed_album = _cached_get_album(
                     yt_client, cache, seed_browse_id, refresh=refresh)
                 yt_album_responses[seed_browse_id] = seed_album
-            for song_browse_id in song_browse_ids:
-                if song_browse_id in yt_album_responses:
-                    continue
-                yt_album_responses[song_browse_id] = _cached_get_album(
-                    yt_client, cache, song_browse_id, refresh=refresh)
+            song_browse_id = next(
+                (value for value in song_browse_ids if value not in yt_album_responses),
+                None)
+            if song_browse_id is not None and not _deadline_breached():
+                try:
+                    yt_album_responses[song_browse_id] = _cached_get_album(
+                        yt_client, cache, song_browse_id, refresh=refresh)
+                except (YTMusicError, requests.RequestException, KeyError, IndexError):
+                    # Song search augments an already valid album discovery;
+                    # it must not discard that result when its optional leg fails.
+                    pass
             if seed_browse_id is None:
                 seed_browse_id = song_browse_ids[0]
                 seed_album = yt_album_responses[seed_browse_id]
@@ -1219,9 +1228,10 @@ def _watch_url_album_browse_id(yt_client: Any, watch_url: str) -> str:
         raise ValueError("watch_url must be canonical https://music.youtube.com/watch?v=<video-id>")
     response = yt_client.get_watch_playlist(videoId=match.group(1))
     tracks = _json_list(_json_dict(response).get("tracks"))
-    if not tracks:
-        raise KeyError("watch response has no track")
-    album_id = _json_dict(_json_dict(tracks[0]).get("album")).get("id")
+    track = next((candidate for candidate in tracks if _json_dict(candidate).get("videoId") == match.group(1)), None)
+    if track is None:
+        raise KeyError("watch response has no matching video")
+    album_id = _json_dict(_json_dict(track).get("album")).get("id")
     if not isinstance(album_id, str) or not album_id:
         raise KeyError("watch response has no album browse id")
     return album_id

--- a/lib/youtube_album_service.py
+++ b/lib/youtube_album_service.py
@@ -415,6 +415,7 @@ def resolve_youtube_album(
     jitter_range: tuple[float, float] = (
         _JITTER_MIN_SECONDS_DEFAULT, _JITTER_MAX_SECONDS_DEFAULT),
     deadline_seconds: int = 60,
+    watch_url: str | None = None,
 ) -> YoutubeAlbumResolverResult:
     """Resolve a release identifier to the YT Music distance matrix.
 
@@ -469,7 +470,7 @@ def resolve_youtube_album(
     # MBIDs are drawn from disjoint UUID space. The asymmetry is
     # documented and tested below; the cost is one extra mirror call on
     # cold-cache Discogs resolves.
-    if not refresh and source_label == "mb":
+    if watch_url is None and not refresh and source_label == "mb":
         speculative = pdb.get_youtube_album_mapping(identifier, source_label)
         if speculative is not None:
             return _final(
@@ -538,7 +539,7 @@ def resolve_youtube_album(
     # this, an empty-search release group would re-fetch YT on every
     # resolve, defeating R14.
     cached_rows = pdb.get_youtube_album_mapping(rg_id, source_label)
-    if not refresh and cached_rows is not None:
+    if watch_url is None and not refresh and cached_rows is not None:
         return _final(
             outcome="ok",
             release_group_identifier=rg_id,
@@ -580,7 +581,9 @@ def resolve_youtube_album(
             started=started,
         )
 
-    seed_release = _pick_mb_seed(fetched_siblings)
+    # A release-level request must discover from that exact pressing.  Group
+    # and master inputs retain the established deterministic representative.
+    seed_release = widen.discovery_release or _pick_mb_seed(fetched_siblings)
     query = _build_search_query(seed_release)
 
     # Step 5-8: search YT, expand siblings, fetch per-YT-album track lists.
@@ -602,23 +605,39 @@ def resolve_youtube_album(
         return (time.monotonic() - started) > float(deadline_seconds)
 
     try:
-        search_results = _cached_search(
-            yt_client, cache, query, "albums", 10, refresh=refresh)
-        seed_browse_id = _pick_yt_seed(search_results, seed_release)
-        if seed_browse_id is None:
-            # AE2: search returned empty → ok + empty matrix.
-            pdb.upsert_youtube_album_mapping(rg_id, source_label, [])
-            return _final(
-                outcome="ok",
-                release_group_identifier=rg_id,
-                source=source_label,
-                from_cache=False,
-                youtube_releases=[],
-                started=started,
-            )
-        seed_album = _cached_get_album(
-            yt_client, cache, seed_browse_id, refresh=refresh)
-        yt_album_responses[seed_browse_id] = seed_album
+        if watch_url is not None:
+            seed_browse_id = _watch_url_album_browse_id(yt_client, watch_url)
+            seed_album = _cached_get_album(
+                yt_client, cache, seed_browse_id, refresh=True)
+            yt_album_responses[seed_browse_id] = seed_album
+        else:
+            search_results = _cached_search(
+                yt_client, cache, query, "albums", 10, refresh=refresh)
+            song_results = _cached_search(
+                yt_client, cache, query, "songs", 10, refresh=refresh)
+            seed_browse_id = _pick_yt_seed(search_results, seed_release)
+            song_browse_ids = _song_album_browse_ids(song_results)
+            if seed_browse_id is None and not song_browse_ids:
+                # Both observed discovery paths found no albums.
+                pdb.upsert_youtube_album_mapping(rg_id, source_label, [])
+                return _final(
+                    outcome="ok", release_group_identifier=rg_id,
+                    source=source_label, from_cache=False,
+                    youtube_releases=[], started=started)
+            if seed_browse_id is not None:
+                seed_album = _cached_get_album(
+                    yt_client, cache, seed_browse_id, refresh=refresh)
+                yt_album_responses[seed_browse_id] = seed_album
+            for song_browse_id in song_browse_ids:
+                if song_browse_id in yt_album_responses:
+                    continue
+                yt_album_responses[song_browse_id] = _cached_get_album(
+                    yt_client, cache, song_browse_id, refresh=refresh)
+            if seed_browse_id is None:
+                seed_browse_id = song_browse_ids[0]
+                seed_album = yt_album_responses[seed_browse_id]
+            else:
+                seed_album = yt_album_responses[seed_browse_id]
         for other_raw in _json_list(seed_album.get("other_versions")):
             if _deadline_breached():
                 deadline_message = (
@@ -912,6 +931,7 @@ class _GroupResolution(msgspec.Struct, kw_only=True):
     )
     failure_outcome: str | None = None
     is_orphan: bool = False
+    discovery_release: dict[str, object] | None = None
 
 
 def _safe_leaf_lookup(
@@ -1000,6 +1020,7 @@ def _resolve_mb_group(
         return _GroupResolution(
             rg_id=rg_id,
             sibling_summaries=_json_list(group.get("releases")),
+            discovery_release=leaf,
         )
 
     # Leaf miss → treat identifier as RG MBID.
@@ -1043,6 +1064,7 @@ def _resolve_discogs_group(
         return _GroupResolution(
             rg_id=master_id,
             sibling_summaries=_json_list(group.get("releases")),
+            discovery_release=leaf,
         )
 
     group = _safe_group_lookup(discogs_get_master_releases, identifier)
@@ -1172,6 +1194,37 @@ def _pick_yt_seed(
         return None
     chosen = search_results[best_idx]
     return str(chosen["browseId"])
+
+
+def _song_album_browse_ids(results: list[dict[str, Any]]) -> list[str]:
+    """Return the album browse IDs surfaced by the observed song search shape."""
+    out: list[str] = []
+    for result in results:
+        album = _json_dict(result.get("album"))
+        browse_id = album.get("id")
+        if isinstance(browse_id, str) and browse_id and browse_id not in out:
+            out.append(browse_id)
+    return out
+
+
+_CANONICAL_WATCH_URL = re.compile(
+    r"^https://music\.youtube\.com/watch\?v=([A-Za-z0-9_-]+)$"
+)
+
+
+def _watch_url_album_browse_id(yt_client: Any, watch_url: str) -> str:
+    """Resolve only the report's canonical watch URL to its album browse ID."""
+    match = _CANONICAL_WATCH_URL.fullmatch(watch_url)
+    if match is None:
+        raise ValueError("watch_url must be canonical https://music.youtube.com/watch?v=<video-id>")
+    response = yt_client.get_watch_playlist(videoId=match.group(1))
+    tracks = _json_list(_json_dict(response).get("tracks"))
+    if not tracks:
+        raise KeyError("watch response has no track")
+    album_id = _json_dict(_json_dict(tracks[0]).get("album")).get("id")
+    if not isinstance(album_id, str) or not album_id:
+        raise KeyError("watch response has no album browse id")
+    return album_id
 
 
 def _parse_year(raw: Any) -> int | None:

--- a/lib/youtube_album_service.py
+++ b/lib/youtube_album_service.py
@@ -741,7 +741,7 @@ def resolve_youtube_album(
 
     if yt_failure is not None:
         failure_outcome, failure_msg = yt_failure
-        if cached_rows:
+        if watch_url is None and cached_rows:
             # Cache fallback: outcome stays ok, but flag the upstream failure.
             return _final(
                 outcome="ok",

--- a/lib/youtube_album_service.py
+++ b/lib/youtube_album_service.py
@@ -613,12 +613,18 @@ def resolve_youtube_album(
         else:
             search_results = _cached_search(
                 yt_client, cache, query, "albums", 10, refresh=refresh)
-            try:
+            seed_browse_id = _pick_yt_seed(search_results, seed_release)
+            if seed_browse_id is None:
+                # With no valid album path, song discovery is primary and its
+                # failure must not be cached as a false empty resolution.
                 song_results = _cached_search(
                     yt_client, cache, query, "songs", 10, refresh=refresh)
-            except (YTMusicError, requests.RequestException, KeyError, IndexError):
-                song_results = []
-            seed_browse_id = _pick_yt_seed(search_results, seed_release)
+            else:
+                try:
+                    song_results = _cached_search(
+                        yt_client, cache, query, "songs", 10, refresh=refresh)
+                except (YTMusicError, requests.RequestException, KeyError, IndexError):
+                    song_results = []
             song_browse_ids = _song_album_browse_ids(song_results)
             if seed_browse_id is None and not song_browse_ids:
                 # Both observed discovery paths found no albums.

--- a/lib/youtube_ingest_service.py
+++ b/lib/youtube_ingest_service.py
@@ -1123,6 +1123,12 @@ class YoutubeIngestService:
         if source == "discogs":
             distance_count = self._distance_total_tracks(
                 mapping_row, target_release_id)
+            if distance_count is None:
+                raise _TrackCountPrecheckFailure(
+                    f"resolver mapping for browse_id="
+                    f"{mapping_row.get('yt_browse_id')!r} has no admissible "
+                    f"exact evidence for release_id={target_release_id!r}"
+                )
             try:
                 stored_count = self._stored_track_count(request_id)
             except Exception as exc:
@@ -1130,13 +1136,6 @@ class YoutubeIngestService:
                     f"DB error reading stored tracklist for request "
                     f"{request_id}: {exc}"
                 ) from exc
-            if stored_count is None and distance_count is None:
-                raise _TrackCountPrecheckFailure(
-                    f"Discogs request {request_id} has no stored tracklist "
-                    f"and resolver mapping browse_id="
-                    f"{mapping_row.get('yt_browse_id')!r} has no exact "
-                    f"total track count for release_id={target_release_id!r}"
-                )
             if (
                 stored_count is not None
                 and distance_count is not None

--- a/lib/youtube_ingest_service.py
+++ b/lib/youtube_ingest_service.py
@@ -1247,7 +1247,7 @@ class YoutubeIngestService:
             return None
         entry = matches[0]
         distance = entry.get("distance")
-        if not isinstance(distance, (int, float)) or not math.isfinite(distance):
+        if isinstance(distance, bool) or not isinstance(distance, (int, float)) or not math.isfinite(distance):
             return None
         if entry.get("outcome") != "ok":
             return None

--- a/lib/youtube_ingest_service.py
+++ b/lib/youtube_ingest_service.py
@@ -34,6 +34,7 @@ deterministically.
 from __future__ import annotations
 
 import logging
+import math
 import shutil
 from collections.abc import Callable, Mapping
 from datetime import UTC, datetime
@@ -1221,25 +1222,39 @@ class YoutubeIngestService:
                 return value
         return None
 
-    @staticmethod
+    @classmethod
     def _distance_entry(
+        cls,
         mapping_row: dict[str, Any],
         target_release_id: str,
     ) -> dict[str, Any] | None:
         """Look up the resolver distance entry for one release id.
 
-        Walks the row's ``distances`` array, returning the first entry
-        whose historical ``mbid`` key matches ``target_release_id``. The
-        key name is retained by the resolver for both MB and Discogs rows.
+        Rescue is admitted only from one exact successful finite distance
+        entry with usable exact track-count evidence.  This is deliberately
+        checked at the final pre-yt-dlp boundary, not inferred from a sibling
+        matrix row or a URL.
         """
         distances = _json_list(mapping_row.get("distances"))
+        matches: list[dict[str, Any]] = []
         for entry_raw in distances:
             if not _is_dict_like(entry_raw):
                 continue
             entry = _json_dict(entry_raw)
             if str(entry.get("mbid") or "") == target_release_id:
-                return entry
-        return None
+                matches.append(entry)
+        if len(matches) != 1:
+            return None
+        entry = matches[0]
+        distance = entry.get("distance")
+        if not isinstance(distance, (int, float)) or not math.isfinite(distance):
+            return None
+        if entry.get("outcome") != "ok":
+            return None
+        count = cls._positive_int(entry.get("total_mb_tracks"))
+        if count is None:
+            return None
+        return entry
 
     @classmethod
     def _distance_total_tracks(
@@ -1251,13 +1266,17 @@ class YoutubeIngestService:
         entry = cls._distance_entry(mapping_row, target_release_id)
         if entry is None:
             return None
-        tmb = entry.get("total_mb_tracks")
-        if isinstance(tmb, int):
-            return tmb
+        return cls._positive_int(entry.get("total_mb_tracks"))
+
+    @staticmethod
+    def _positive_int(value: Any) -> int | None:
+        if isinstance(value, bool):
+            return None
         try:
-            return int(tmb) if tmb is not None else None
+            parsed = int(value)
         except (TypeError, ValueError):
             return None
+        return parsed if parsed > 0 else None
 
     def _cleanup_ytdlp_run(self, run: YtdlpRunResult) -> str | None:
         """Best-effort delete the scratch paths used by one yt-dlp run."""

--- a/scripts/pipeline_cli/youtube.py
+++ b/scripts/pipeline_cli/youtube.py
@@ -216,6 +216,7 @@ def cmd_youtube_album(db: YoutubeResolverDB, args: argparse.Namespace) -> int:
             distance_fn=compute_beets_distance,
             cache=cache,
             refresh=bool(getattr(args, "refresh", False)),
+            watch_url=getattr(args, "watch_url", None),
         )
     finally:
         # Close the requests Session even when the resolver raises so
@@ -346,6 +347,11 @@ def add_youtube_subparsers(
              "AND the in-process Redis HTTP accelerator, forcing a "
              "fresh YouTube Music fetch. The fresh response is then "
              "written back to both layers. (Default: serve from cache.)",
+    )
+    p_ya.add_argument(
+        "--watch-url",
+        help="Canonical https://music.youtube.com/watch?v=<video-id>; "
+             "resolves that video to an album and replaces this full matrix.",
     )
     p_ya.add_argument(
         "--json", action="store_true",

--- a/tests/fakes/ytmusic.py
+++ b/tests/fakes/ytmusic.py
@@ -23,20 +23,24 @@ class FakeYTMusic:
     """
 
     def __init__(self) -> None:
-        self._search_results: dict[str, list[dict[str, Any]]] = {}
+        self._search_results: dict[tuple[str, str | None], list[dict[str, Any]]] = {}
         self._album_results: dict[str, dict[str, Any]] = {}
-        self._search_errors: dict[str, Exception] = {}
+        self._search_errors: dict[tuple[str, str | None], Exception] = {}
         self._album_errors: dict[str, Exception] = {}
+        self._watch_results: dict[str, dict[str, Any]] = {}
         self.search_calls: list[dict[str, Any]] = []
         self.get_album_calls: list[dict[str, Any]] = []
+        self.get_watch_playlist_calls: list[dict[str, Any]] = []
 
     def set_search(
         self,
         query: str,
         results: list[dict[str, Any]],
+        *,
+        filter: str | None = None,
     ) -> None:
         """Configure ``search(query, ...)`` to return ``results``."""
-        self._search_results[query] = copy.deepcopy(results)
+        self._search_results[(query, filter)] = copy.deepcopy(results)
 
     def set_album(
         self,
@@ -46,6 +50,10 @@ class FakeYTMusic:
         """Configure ``get_album(browseId)`` to return ``response``."""
         self._album_results[browseId] = copy.deepcopy(response)
 
+    def set_watch_playlist(self, video_id: str, response: dict[str, Any]) -> None:
+        """Configure the narrow ``get_watch_playlist(videoId=...)`` response."""
+        self._watch_results[video_id] = copy.deepcopy(response)
+
     def set_search_error(
         self,
         query: str,
@@ -54,7 +62,7 @@ class FakeYTMusic:
         """Queue a single exception to raise on the next ``search(query, ...)``
         call. One-shot: subsequent matching calls fall through to the canned
         result (or the empty default)."""
-        self._search_errors[query] = error
+        self._search_errors[(query, None)] = error
 
     def set_album_error(
         self,
@@ -84,10 +92,13 @@ class FakeYTMusic:
             "limit": limit,
             "ignore_spelling": ignore_spelling,
         })
-        queued_error = self._search_errors.pop(query, None)
+        queued_error = self._search_errors.pop((query, filter), None)
+        if queued_error is None:
+            queued_error = self._search_errors.pop((query, None), None)
         if queued_error is not None:
             raise queued_error
-        return copy.deepcopy(self._search_results.get(query, []))
+        return copy.deepcopy(self._search_results.get(
+            (query, filter), self._search_results.get((query, None), [])))
 
     def get_album(self, browseId: str) -> dict[str, Any]:
         """Mirror ``ytmusicapi.YTMusic.get_album``. Returns the canned dict
@@ -107,6 +118,10 @@ class FakeYTMusic:
                 f"Server returned HTTP 400: no album for browseId={browseId!r}"
             )
         return copy.deepcopy(self._album_results[browseId])
+
+    def get_watch_playlist(self, videoId: str) -> dict[str, Any]:
+        self.get_watch_playlist_calls.append({"videoId": videoId})
+        return copy.deepcopy(self._watch_results.get(videoId, {}))
 
     @staticmethod
     def make_album_fixture(
@@ -181,4 +196,3 @@ class FakeYTMusic:
 # seed known releases; any un-seeded id raises ``HTTPError(404)`` by
 # default. See ``.claude/rules/test-fidelity.md`` § "Rule B".
 # ---------------------------------------------------------------------------
-

--- a/tests/test_js_discography.mjs
+++ b/tests/test_js_discography.mjs
@@ -14,9 +14,19 @@ import {
   splitPressings,
   statusChipHtml,
 } from '../web/js/discography.js';
+import { renderYoutubeRescueControl } from '../web/js/youtube_rescue_control.js';
 
 let passed = 0;
 let failed = 0;
+
+console.log('shared YouTube rescue control');
+{
+  const html = renderYoutubeRescueControl('release-7', 7, '129bebd8-a7b9-4099-b0bc-545b704e7a95');
+  assertContains(html, 'yt-rescue-release-7', 'release detail uses a surface-keyed control id');
+  assertContains(html, 'window.checkYoutubeRescue(', 'inline handler uses the shared generic entry point');
+  assertExcludes(html, '"window.checkYoutubeRescue("release-7"', 'inline handler does not break its HTML attribute quoting');
+  assertContains(html, 'music.youtube.com/watch?v=', 'control carries canonical watch input');
+}
 
 function assertEqual(actual, expected, msg) {
   if (actual === expected) {

--- a/tests/test_js_long_tail_console.mjs
+++ b/tests/test_js_long_tail_console.mjs
@@ -42,6 +42,7 @@ const {
   consoleSetYoutubeResult,
   consoleOpenIds,
   renderSpectralFragment,
+  renderYoutubeBody,
 } = __test__;
 
 let passed = 0;

--- a/tests/test_js_youtube_rescue_control.mjs
+++ b/tests/test_js_youtube_rescue_control.mjs
@@ -9,7 +9,7 @@ ok(JSON.stringify(youtubeResolverPayload(identifier, 'https://music.youtube.com/
 
 const failedHtml = renderYoutubeRescueControl('release-1', 1, identifier, { outcome: 'transient', error_message: 'mirror down' });
 ok(failedHtml.includes('mirror down'), 'resolver failures remain visible');
-const matrixHtml = renderYoutubeRescueControl('release-1', 1, identifier, { outcome: 'ok', youtube_releases: [{ yt_browse_id: 'MPREb_kb5fohQCJ6d', year: 2026, track_count: 1, distances: [{ mbid: identifier, distance: 0 }] }] });
+const matrixHtml = renderYoutubeRescueControl('release-1', 1, identifier, { outcome: 'ok', youtube_releases: [{ yt_browse_id: 'MPREb_kb5fohQCJ6d', year: 2026, track_count: 1, distances: [{ mbid: identifier, outcome: 'ok', distance: 0, total_mb_tracks: 1 }] }] });
 ok(matrixHtml.includes('window.pickYoutubeRescue(1,'), 'matrix choice remains confirm-routed');
 ok(!matrixHtml.includes('"window.checkYoutubeRescue("release-1"'), 'inline handler quoting remains safe');
 ok(matrixHtml.includes('event.stopPropagation()'), 'all inline control interactions stop parent propagation');
@@ -60,7 +60,7 @@ let confirms = false; globalThis.window = { confirm: () => confirms };
 const requests = []; let releaseSubmit;
 globalThis.fetch = (url, options) => {
   requests.push({ url, options });
-  if (url.endsWith('youtube-album')) return Promise.resolve({ ok: true, status: 200, json: async () => ({ outcome: 'ok', youtube_releases: [{ yt_browse_id: button.dataset.browseId }] }) });
+  if (url.endsWith('youtube-album')) return Promise.resolve({ ok: true, status: 200, json: async () => ({ outcome: 'ok', youtube_releases: [{ yt_browse_id: button.dataset.browseId, distances: [{ mbid: identifier, outcome: 'ok', distance: 0, total_mb_tracks: 1 }] }] }) });
   return new Promise((resolve) => { releaseSubmit = resolve; });
 };
 await checkYoutubeRescue('release-submit', 1, identifier);

--- a/tests/test_js_youtube_rescue_control.mjs
+++ b/tests/test_js_youtube_rescue_control.mjs
@@ -32,5 +32,40 @@ ok(calls === 2 && !host.result.innerHTML.includes('No YouTube album foundNo YouT
 delete globalThis.document;
 delete globalThis.fetch;
 
+// A deferred response from an old generation must not repaint its replacement.
+const staleHost = fakeHost();
+globalThis.document = { getElementById: () => staleHost };
+let releaseDeferred;
+globalThis.fetch = () => new Promise((resolve) => { releaseDeferred = resolve; });
+const staleRun = checkYoutubeRescue('release-stale', 1, identifier);
+staleHost.dataset.generation = '99';
+releaseDeferred({ ok: true, status: 200, json: async () => ({ outcome: 'ok', youtube_releases: [] }) });
+await staleRun;
+ok(staleHost.result.innerHTML === '', 'stale detached generation cannot overwrite current result');
+
+// Button cancellation is reusable; accepted submit carries browse_id only and
+// the submitting guard admits one concurrent POST.
+const button = { dataset: { browseId: 'MPREb_kb5fohQCJ6d' }, addEventListener: (_name, listener) => { button.listener = listener; } };
+const submitHost = fakeHost(); submitHost.result.querySelectorAll = () => [button];
+globalThis.document = { getElementById: (id) => id === 'yt-rescue-release-submit' ? submitHost : { style: {}, textContent: '' } };
+let confirms = false; globalThis.window = { confirm: () => confirms };
+const requests = []; let releaseSubmit;
+globalThis.fetch = (url, options) => {
+  requests.push({ url, options });
+  if (url.endsWith('youtube-album')) return Promise.resolve({ ok: true, status: 200, json: async () => ({ outcome: 'ok', youtube_releases: [{ yt_browse_id: button.dataset.browseId }] }) });
+  return new Promise((resolve) => { releaseSubmit = resolve; });
+};
+await checkYoutubeRescue('release-submit', 1, identifier);
+await button.listener({ stopPropagation() {} });
+ok(requests.length === 1, 'cancel keeps choice active without submit');
+confirms = true;
+const submitA = button.listener({ stopPropagation() {} });
+const submitB = button.listener({ stopPropagation() {} });
+await Promise.resolve();
+ok(requests.length === 2 && requests[1].url === '/api/pipeline/1/youtube-rescue' && requests[1].options.body === JSON.stringify({ browse_id: 'MPREb_kb5fohQCJ6d' }), 'accept submits exact browse_id once');
+releaseSubmit({ ok: true, json: async () => ({ outcome: 'accepted' }) });
+await Promise.all([submitA, submitB]);
+delete globalThis.document; delete globalThis.fetch; delete globalThis.window;
+
 if (failed) process.exit(1);
-console.log('8 passed, 0 failed');
+console.log('11 passed, 0 failed');

--- a/tests/test_js_youtube_rescue_control.mjs
+++ b/tests/test_js_youtube_rescue_control.mjs
@@ -14,6 +14,8 @@ ok(matrixHtml.includes('window.pickYoutubeRescue(1,'), 'matrix choice remains co
 ok(!matrixHtml.includes('"window.checkYoutubeRescue("release-1"'), 'inline handler quoting remains safe');
 ok(matrixHtml.includes('event.stopPropagation()'), 'all inline control interactions stop parent propagation');
 ok(matrixHtml.includes('https://music.youtube.com/browse/MPREb_kb5fohQCJ6d') && matrixHtml.includes('2026 · 1t · exact dist 0.000'), 'choices retain exact pressing evidence');
+const duplicateHtml = renderYoutubeRescueControl('release-dup', 1, identifier, { outcome: 'ok', youtube_releases: [{ yt_browse_id: 'MPREb_dup', distances: [{ mbid: identifier, outcome: 'ok', distance: 0, total_mb_tracks: 1 }, { mbid: identifier, outcome: 'ok', distance: 0, total_mb_tracks: 1 }] }] });
+ok(duplicateHtml.includes('disabled') && duplicateHtml.includes('Exact evidence required'), 'duplicate exact evidence disables rescue');
 
 function fakeHost(watchUrl = '') {
   const buttons = [];

--- a/tests/test_js_youtube_rescue_control.mjs
+++ b/tests/test_js_youtube_rescue_control.mjs
@@ -9,10 +9,11 @@ ok(JSON.stringify(youtubeResolverPayload(identifier, 'https://music.youtube.com/
 
 const failedHtml = renderYoutubeRescueControl('release-1', 1, identifier, { outcome: 'transient', error_message: 'mirror down' });
 ok(failedHtml.includes('mirror down'), 'resolver failures remain visible');
-const matrixHtml = renderYoutubeRescueControl('release-1', 1, identifier, { outcome: 'ok', youtube_releases: [{ yt_browse_id: 'MPREb_kb5fohQCJ6d' }] });
+const matrixHtml = renderYoutubeRescueControl('release-1', 1, identifier, { outcome: 'ok', youtube_releases: [{ yt_browse_id: 'MPREb_kb5fohQCJ6d', year: 2026, track_count: 1, distances: [{ mbid: identifier, distance: 0 }] }] });
 ok(matrixHtml.includes('window.pickYoutubeRescue(1,'), 'matrix choice remains confirm-routed');
 ok(!matrixHtml.includes('"window.checkYoutubeRescue("release-1"'), 'inline handler quoting remains safe');
 ok(matrixHtml.includes('event.stopPropagation()'), 'all inline control interactions stop parent propagation');
+ok(matrixHtml.includes('https://music.youtube.com/browse/MPREb_kb5fohQCJ6d') && matrixHtml.includes('2026 · 1t · exact dist 0.000'), 'choices retain exact pressing evidence');
 
 function fakeHost(watchUrl = '') {
   const buttons = [];
@@ -75,4 +76,4 @@ await Promise.all([submitA, submitB]);
 delete globalThis.document; delete globalThis.fetch; delete globalThis.window;
 
 if (failed) process.exit(1);
-console.log('11 passed, 0 failed');
+console.log('12 passed, 0 failed');

--- a/tests/test_js_youtube_rescue_control.mjs
+++ b/tests/test_js_youtube_rescue_control.mjs
@@ -1,4 +1,4 @@
-import { renderYoutubeRescueControl, youtubeResolverPayload } from '../web/js/youtube_rescue_control.js';
+import { checkYoutubeRescue, renderYoutubeRescueControl, youtubeResolverPayload } from '../web/js/youtube_rescue_control.js';
 
 let failed = 0;
 function ok(value, message) { if (!value) { failed++; console.error(`FAIL: ${message}`); } }
@@ -12,6 +12,25 @@ ok(failedHtml.includes('mirror down'), 'resolver failures remain visible');
 const matrixHtml = renderYoutubeRescueControl('release-1', 1, identifier, { outcome: 'ok', youtube_releases: [{ yt_browse_id: 'MPREb_kb5fohQCJ6d' }] });
 ok(matrixHtml.includes('window.pickYoutubeRescue(1,'), 'matrix choice remains confirm-routed');
 ok(!matrixHtml.includes('"window.checkYoutubeRescue("release-1"'), 'inline handler quoting remains safe');
+ok(matrixHtml.includes('event.stopPropagation()'), 'all inline control interactions stop parent propagation');
+
+function fakeHost(watchUrl = '') {
+  const buttons = [];
+  const result = { innerHTML: '', querySelectorAll: () => buttons };
+  const input = { value: watchUrl };
+  return { dataset: {}, querySelector: (s) => s === 'input' ? input : result, result, buttons };
+}
+const host = fakeHost('https://music.youtube.com/watch?v=dGYXkhMAvLk');
+globalThis.document = { getElementById: () => host };
+let calls = 0;
+globalThis.fetch = async (_url, options) => { calls++; return { ok: true, status: 200, json: async () => ({ outcome: 'ok', youtube_releases: [] }) }; };
+await Promise.all([checkYoutubeRescue('release-1', 1, identifier), checkYoutubeRescue('release-1', 1, identifier)]);
+ok(calls === 1, 'same-instance busy guard suppresses double resolver fire');
+ok(host.result.innerHTML.includes('No YouTube album found'), 'successful result replaces result region');
+await checkYoutubeRescue('release-1', 1, identifier);
+ok(calls === 2 && !host.result.innerHTML.includes('No YouTube album foundNo YouTube album found'), 'repeated resolver check replaces rather than appends');
+delete globalThis.document;
+delete globalThis.fetch;
 
 if (failed) process.exit(1);
-console.log('4 passed, 0 failed');
+console.log('8 passed, 0 failed');

--- a/tests/test_js_youtube_rescue_control.mjs
+++ b/tests/test_js_youtube_rescue_control.mjs
@@ -1,0 +1,17 @@
+import { renderYoutubeRescueControl, youtubeResolverPayload } from '../web/js/youtube_rescue_control.js';
+
+let failed = 0;
+function ok(value, message) { if (!value) { failed++; console.error(`FAIL: ${message}`); } }
+
+const identifier = '129bebd8-a7b9-4099-b0bc-545b704e7a95';
+ok(JSON.stringify(youtubeResolverPayload(identifier, '')) === JSON.stringify({ identifier }), 'blank watch URL omitted');
+ok(JSON.stringify(youtubeResolverPayload(identifier, 'https://music.youtube.com/watch?v=dGYXkhMAvLk')) === JSON.stringify({ identifier, watch_url: 'https://music.youtube.com/watch?v=dGYXkhMAvLk' }), 'canonical watch URL forwarded exactly');
+
+const failedHtml = renderYoutubeRescueControl('release-1', 1, identifier, { outcome: 'transient', error_message: 'mirror down' });
+ok(failedHtml.includes('mirror down'), 'resolver failures remain visible');
+const matrixHtml = renderYoutubeRescueControl('release-1', 1, identifier, { outcome: 'ok', youtube_releases: [{ yt_browse_id: 'MPREb_kb5fohQCJ6d' }] });
+ok(matrixHtml.includes('window.pickYoutubeRescue(1,'), 'matrix choice remains confirm-routed');
+ok(!matrixHtml.includes('"window.checkYoutubeRescue("release-1"'), 'inline handler quoting remains safe');
+
+if (failed) process.exit(1);
+console.log('4 passed, 0 failed');

--- a/tests/test_js_youtube_rescue_control.mjs
+++ b/tests/test_js_youtube_rescue_control.mjs
@@ -32,6 +32,13 @@ ok(calls === 2 && !host.result.innerHTML.includes('No YouTube album foundNo YouT
 delete globalThis.document;
 delete globalThis.fetch;
 
+const networkHost = fakeHost();
+globalThis.document = { getElementById: () => networkHost };
+globalThis.fetch = async () => { throw new Error('offline'); };
+await checkYoutubeRescue('release-network', 1, identifier);
+ok(networkHost.result.innerHTML.includes('Could not reach the resolver'), 'resolver network rejection is visible');
+delete globalThis.document; delete globalThis.fetch;
+
 // A deferred response from an old generation must not repaint its replacement.
 const staleHost = fakeHost();
 globalThis.document = { getElementById: () => staleHost };

--- a/tests/test_js_youtube_rescue_control.mjs
+++ b/tests/test_js_youtube_rescue_control.mjs
@@ -75,5 +75,18 @@ releaseSubmit({ ok: true, json: async () => ({ outcome: 'accepted' }) });
 await Promise.all([submitA, submitB]);
 delete globalThis.document; delete globalThis.fetch; delete globalThis.window;
 
+const rejectButton = { dataset: { browseId: 'MPREb_kb5fohQCJ6d' }, addEventListener: (_name, listener) => { rejectButton.listener = listener; } };
+const rejectHost = fakeHost(); rejectHost.result.querySelectorAll = () => [rejectButton];
+const toastNode = { style: {}, textContent: '' };
+globalThis.document = { getElementById: (id) => id === 'yt-rescue-release-reject' ? rejectHost : toastNode };
+globalThis.window = { confirm: () => true };
+globalThis.fetch = (url) => url.endsWith('youtube-album')
+  ? Promise.resolve({ ok: true, status: 200, json: async () => ({ outcome: 'ok', youtube_releases: [{ yt_browse_id: rejectButton.dataset.browseId, distances: [{ mbid: identifier, outcome: 'ok', distance: 0, total_mb_tracks: 1 }] }] }) })
+  : Promise.reject(new Error('offline'));
+await checkYoutubeRescue('release-reject', 1, identifier);
+await rejectButton.listener({ stopPropagation() {} });
+ok(toastNode.textContent.includes('network unavailable') && rejectHost.dataset.submitting === 'false', 'rescue rejection toasts visibly and clears submit guard for retry');
+delete globalThis.document; delete globalThis.fetch; delete globalThis.window;
+
 if (failed) process.exit(1);
-console.log('12 passed, 0 failed');
+console.log('13 passed, 0 failed');

--- a/tests/test_js_youtube_rescue_control.mjs
+++ b/tests/test_js_youtube_rescue_control.mjs
@@ -16,6 +16,8 @@ ok(matrixHtml.includes('event.stopPropagation()'), 'all inline control interacti
 ok(matrixHtml.includes('https://music.youtube.com/browse/MPREb_kb5fohQCJ6d') && matrixHtml.includes('2026 · 1t · exact dist 0.000'), 'choices retain exact pressing evidence');
 const duplicateHtml = renderYoutubeRescueControl('release-dup', 1, identifier, { outcome: 'ok', youtube_releases: [{ yt_browse_id: 'MPREb_dup', distances: [{ mbid: identifier, outcome: 'ok', distance: 0, total_mb_tracks: 1 }, { mbid: identifier, outcome: 'ok', distance: 0, total_mb_tracks: 1 }] }] });
 ok(duplicateHtml.includes('disabled') && duplicateHtml.includes('Exact evidence required'), 'duplicate exact evidence disables rescue');
+const mixedDuplicateHtml = renderYoutubeRescueControl('release-mixed', 1, identifier, { outcome: 'ok', youtube_releases: [{ yt_browse_id: 'MPREb_mixed', distances: [{ mbid: identifier, outcome: 'ok', distance: 0, total_mb_tracks: 1 }, { mbid: identifier, outcome: 'distance_failed', distance: null, total_mb_tracks: null }] }] });
+ok(mixedDuplicateHtml.includes('disabled') && mixedDuplicateHtml.includes('Exact evidence required'), 'one valid plus one invalid exact entry stays disabled');
 
 function fakeHost(watchUrl = '') {
   const buttons = [];

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -4955,13 +4955,13 @@ class TestCmdYoutubeAlbum(unittest.TestCase):
         ]
 
     def _run(self, *, outcome: Any = None, result: Any = None,
-             refresh: bool = False, json_out: bool = False,
+             refresh: bool = False, watch_url: str | None = None, json_out: bool = False,
              resolver_side_effect: Exception | None = None):
         if result is None:
             assert outcome is not None, "must pass outcome= or result="
             result = self._make_result(outcome=outcome)
         args = SimpleNamespace(
-            identifier=self.IDENT, refresh=refresh, json=json_out,
+            identifier=self.IDENT, refresh=refresh, watch_url=watch_url, json=json_out,
         )
         stdout = io.StringIO()
         # cmd_youtube_album's first arg is the PipelineDB instance; the
@@ -5014,6 +5014,11 @@ class TestCmdYoutubeAlbum(unittest.TestCase):
             pipeline_cli.OUTCOME_EXIT_CODE,
             svc.OUTCOME_EXIT_CODE,
         )
+
+    def test_watch_url_is_forwarded_to_shared_resolver(self):
+        url = "https://music.youtube.com/watch?v=dGYXkhMAvLk"
+        _rc, _out, resolve = self._run(outcome="ok", watch_url=url)
+        self.assertEqual(resolve.call_args.kwargs["watch_url"], url)
 
     def test_exit_0_on_ok_text_mode_shows_matrix(self):
         result = self._make_result(

--- a/tests/test_youtube_album_service.py
+++ b/tests/test_youtube_album_service.py
@@ -157,9 +157,9 @@ class TestNarrowDiscoveryAdmissions(unittest.TestCase):
     """Issue #1003: song and operator-watch discovery enter the normal matrix."""
 
     def _resolve(self, yt: FakeYTMusic, *, watch_url: str | None = None,
-                 identifier: str = MB_REL_A):
+                 identifier: str = MB_REL_A, pdb: FakePipelineDB | None = None):
         return resolve_youtube_album(
-            identifier, pdb=FakePipelineDB(),
+            identifier, pdb=pdb or FakePipelineDB(),
             mb_get_release=lambda value: _ok_mb_release(mbid=value),
             mb_get_release_group_releases=lambda _rg: _ok_mb_rg_releases((identifier, 2024)),
             discogs_get_release=lambda _value: None,
@@ -183,14 +183,23 @@ class TestNarrowDiscoveryAdmissions(unittest.TestCase):
 
     def test_canonical_watch_url_resolves_and_replaces_matrix(self):
         yt = FakeYTMusic()
-        yt.set_watch_playlist("dGYXkhMAvLk", {"tracks": [{"album": {"id": "MPREb_kb5fohQCJ6d"}}]})
+        yt.set_watch_playlist("dGYXkhMAvLk", {"tracks": [
+            {"videoId": "other", "album": {"id": "MPREb_wrong"}},
+            {"videoId": "dGYXkhMAvLk", "album": {"id": "MPREb_kb5fohQCJ6d"}},
+        ]})
         yt.set_album("MPREb_kb5fohQCJ6d", FakeYTMusic.make_album_fixture(
             "OLAK-dice", "Reality", [{"name": "DICE"}], "2024", _yt_tracks(["Reality"])))
-        result = self._resolve(yt, identifier=DICE_REALITY,
+        pdb = FakePipelineDB()
+        result = self._resolve(yt, identifier=DICE_REALITY, pdb=pdb,
                                watch_url="https://music.youtube.com/watch?v=dGYXkhMAvLk")
         self.assertEqual(result.outcome, "ok")
         self.assertEqual([r.yt_browse_id for r in result.youtube_releases], ["MPREb_kb5fohQCJ6d"])
         self.assertEqual(yt.get_watch_playlist_calls, [{"videoId": "dGYXkhMAvLk"}])
+        stored = pdb.get_youtube_album_mapping(MB_RG, "mb")
+        self.assertIsNotNone(stored)
+        assert stored is not None
+        self.assertEqual(stored[0]["yt_browse_id"], "MPREb_kb5fohQCJ6d")
+        self.assertEqual(stored[0]["distances"][0]["mbid"], DICE_REALITY)
 
 
 def _canned_distance(

--- a/tests/test_youtube_album_service.py
+++ b/tests/test_youtube_album_service.py
@@ -181,6 +181,26 @@ class TestNarrowDiscoveryAdmissions(unittest.TestCase):
         self.assertEqual([r.yt_browse_id for r in result.youtube_releases], ["MPREb_song"])
         self.assertEqual(yt.search_calls[0]["query"], "Dr. Octagon Dr. Octagonecologyst")
 
+    def test_exact_leaf_is_the_dice_song_discovery_seed_not_earliest_sibling(self):
+        earlier = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"
+        yt = FakeYTMusic()
+        yt.set_search("DICE Reality", [])
+        yt.set_search("DICE Reality", [{"album": {"id": "MPREb_kb5fohQCJ6d"}}], filter="songs")
+        yt.set_album("MPREb_kb5fohQCJ6d", FakeYTMusic.make_album_fixture(
+            "OLAK-dice", "Reality", [{"name": "DICE"}], "2026", _yt_tracks(["Reality"])))
+        def lookup(value: str):
+            if value == DICE_REALITY:
+                return _ok_mb_release(mbid=value, title="Reality", artist="DICE", year=2026,
+                                      tracks=[{"title": "Reality"}])
+            return _ok_mb_release(mbid=value, title="Old noise", artist="Other", year=1990)
+        result = resolve_youtube_album(DICE_REALITY, pdb=FakePipelineDB(),
+            mb_get_release=lookup,
+            mb_get_release_group_releases=lambda _rg: _ok_mb_rg_releases((earlier, 1990), (DICE_REALITY, 2026)),
+            discogs_get_release=lambda _value: None, discogs_get_master_releases=lambda _value: None,
+            yt_client=yt, distance_fn=_canned_distance(distance=0.0), sleep_fn=_noop_sleep)
+        self.assertEqual(yt.search_calls[0]["query"], "DICE Reality")
+        self.assertEqual([r.yt_browse_id for r in result.youtube_releases], ["MPREb_kb5fohQCJ6d"])
+
     def test_canonical_watch_url_resolves_and_replaces_matrix(self):
         yt = FakeYTMusic()
         yt.set_watch_playlist("dGYXkhMAvLk", {"tracks": [

--- a/tests/test_youtube_album_service.py
+++ b/tests/test_youtube_album_service.py
@@ -48,6 +48,7 @@ MB_REL_B = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
 MB_REL_C = "cccccccc-cccc-cccc-cccc-cccccccccccc"
 MB_RG_MISSING = "22222222-2222-2222-2222-222222222222"
 MB_NO_RG = "33333333-3333-3333-3333-333333333333"
+DICE_REALITY = "129bebd8-a7b9-4099-b0bc-545b704e7a95"
 
 
 def _ok_mb_release(
@@ -150,6 +151,46 @@ def _yt_other_version(browse_id: str, *, year: str = "1996",
         "thumbnails": [],
         "isExplicit": False,
     }
+
+
+class TestNarrowDiscoveryAdmissions(unittest.TestCase):
+    """Issue #1003: song and operator-watch discovery enter the normal matrix."""
+
+    def _resolve(self, yt: FakeYTMusic, *, watch_url: str | None = None,
+                 identifier: str = MB_REL_A):
+        return resolve_youtube_album(
+            identifier, pdb=FakePipelineDB(),
+            mb_get_release=lambda value: _ok_mb_release(mbid=value),
+            mb_get_release_group_releases=lambda _rg: _ok_mb_rg_releases((identifier, 2024)),
+            discogs_get_release=lambda _value: None,
+            discogs_get_master_releases=lambda _value: None,
+            yt_client=yt, distance_fn=_canned_distance(distance=0.0),
+            sleep_fn=_noop_sleep, watch_url=watch_url,
+        )
+
+    def test_song_album_browse_id_is_scored_when_album_search_misses(self):
+        yt = FakeYTMusic()
+        yt.set_search("Dr. Octagon Dr. Octagonecologyst", [])
+        yt.set_search("Dr. Octagon Dr. Octagonecologyst", [{
+            "resultType": "song", "album": {"id": "MPREb_song"},
+        }], filter="songs")
+        yt.set_album("MPREb_song", FakeYTMusic.make_album_fixture(
+            "OLAK-song", "Dr. Octagonecologyst", [{"name": "Dr. Octagon"}],
+            "2024", _yt_tracks(["Intro", "3000"])))
+        result = self._resolve(yt)
+        self.assertEqual([r.yt_browse_id for r in result.youtube_releases], ["MPREb_song"])
+        self.assertEqual(yt.search_calls[0]["query"], "Dr. Octagon Dr. Octagonecologyst")
+
+    def test_canonical_watch_url_resolves_and_replaces_matrix(self):
+        yt = FakeYTMusic()
+        yt.set_watch_playlist("dGYXkhMAvLk", {"tracks": [{"album": {"id": "MPREb_kb5fohQCJ6d"}}]})
+        yt.set_album("MPREb_kb5fohQCJ6d", FakeYTMusic.make_album_fixture(
+            "OLAK-dice", "Reality", [{"name": "DICE"}], "2024", _yt_tracks(["Reality"])))
+        result = self._resolve(yt, identifier=DICE_REALITY,
+                               watch_url="https://music.youtube.com/watch?v=dGYXkhMAvLk")
+        self.assertEqual(result.outcome, "ok")
+        self.assertEqual([r.yt_browse_id for r in result.youtube_releases], ["MPREb_kb5fohQCJ6d"])
+        self.assertEqual(yt.get_watch_playlist_calls, [{"videoId": "dGYXkhMAvLk"}])
 
 
 def _canned_distance(

--- a/tests/test_youtube_album_service.py
+++ b/tests/test_youtube_album_service.py
@@ -221,6 +221,24 @@ class TestNarrowDiscoveryAdmissions(unittest.TestCase):
         self.assertEqual(stored[0]["yt_browse_id"], "MPREb_kb5fohQCJ6d")
         self.assertEqual(stored[0]["distances"][0]["mbid"], DICE_REALITY)
 
+    def test_manual_watch_failure_never_serves_or_replaces_old_matrix(self):
+        pdb = FakePipelineDB()
+        old = [{"yt_browse_id": "MPREb_old", "yt_audio_playlist_id": None,
+                "yt_url": "https://music.youtube.com/browse/MPREb_old",
+                "yt_year": 2000, "yt_track_count": 1, "album_title": "Old",
+                "album_artist": "Old", "yt_tracks": [], "distances": []}]
+        pdb.seed_youtube_album_mapping(MB_RG, "mb", old)
+        yt = FakeYTMusic()
+        yt.set_watch_playlist("dGYXkhMAvLk", {"tracks": [
+            {"videoId": "other", "album": {"id": "MPREb_old"}},
+        ]})
+        result = self._resolve(yt, pdb=pdb,
+            watch_url="https://music.youtube.com/watch?v=dGYXkhMAvLk")
+        self.assertNotEqual(result.outcome, "ok")
+        self.assertFalse(result.from_cache)
+        self.assertFalse(result.youtube_releases)
+        self.assertEqual(pdb.get_youtube_album_mapping(MB_RG, "mb"), old)
+
 
 def _canned_distance(
     *,

--- a/tests/test_youtube_ingest_service.py
+++ b/tests/test_youtube_ingest_service.py
@@ -512,6 +512,28 @@ class TestSubmitNoResolverMapping(unittest.TestCase):
 
 
 class TestSubmitTrackCountPrecheckFailed(unittest.TestCase):
+    def test_discogs_stored_tracks_do_not_substitute_for_bad_exact_evidence(self) -> None:
+        for override, duplicate in (
+            ({"outcome": "distance_failed"}, False),
+            ({"distance": float("nan")}, False),
+            ({"distance": float("inf")}, False),
+            ({"total_mb_tracks": 0}, False),
+            ({}, True),
+        ):
+            with self.subTest(override=override, duplicate=duplicate):
+                pdb = FakePipelineDB()
+                _seed_discogs_request(request_id=77, pdb=pdb, mb_release_id=DISCOGS_REL)
+                pdb.set_tracks(77, _tracks(EXPECTED_TRACKS))
+                _seed_resolver_row(pdb, rg=DISCOGS_MASTER, source="discogs",
+                                   distances_for_mbid=DISCOGS_REL,
+                                   total_mb_tracks=EXPECTED_TRACKS)
+                entry = pdb._youtube_album_mappings[(DISCOGS_MASTER, "discogs")][0]["distances"][0]
+                entry.update(override)
+                if duplicate:
+                    pdb._youtube_album_mappings[(DISCOGS_MASTER, "discogs")][0]["distances"].append(dict(entry))
+                result = _make_service(pdb).submit(77, BROWSE)
+                self.assertEqual(result.outcome, "track_count_precheck_failed")
+                self.assertFalse(any(row.outcome == "youtube_running" for row in pdb.download_logs))
     def test_resolver_cache_drifted_from_mb(self) -> None:
         """Resolver cache total_mb_tracks=10, MB now says 11 → mismatch."""
         pdb = FakePipelineDB()

--- a/tests/test_youtube_ingest_service.py
+++ b/tests/test_youtube_ingest_service.py
@@ -569,7 +569,7 @@ class TestSubmitTrackCountPrecheckFailed(unittest.TestCase):
         self.assertEqual(result.outcome, "track_count_precheck_failed")
         self.assertIsNotNone(result.detail)
         assert result.detail is not None
-        self.assertIn("no stored tracklist", result.detail)
+        self.assertIn("no admissible exact evidence", result.detail)
 
     def test_discogs_stored_count_mismatch_rejects(self) -> None:
         pdb = FakePipelineDB()

--- a/tests/test_youtube_ingest_service.py
+++ b/tests/test_youtube_ingest_service.py
@@ -237,6 +237,21 @@ class TestSubmitHappyPath(unittest.TestCase):
             [f"vid-{i + 1}" for i in range(EXPECTED_TRACKS)],
         )
 
+    def test_exact_distance_must_be_one_successful_finite_entry(self) -> None:
+        for override in (
+            {"outcome": "distance_failed", "distance": None},
+            {"outcome": "ok", "distance": float("nan")},
+            {"outcome": "ok", "distance": float("inf")},
+            {"outcome": "ok", "distance": 0.05, "total_mb_tracks": None},
+        ):
+            with self.subTest(override=override):
+                pdb = FakePipelineDB()
+                _seed_wanted_request(pdb)
+                _seed_resolver_row(pdb)
+                pdb._youtube_album_mappings[(MB_RG, "mb")][0]["distances"][0].update(override)
+                result = _make_service(pdb).submit(42, BROWSE)
+                self.assertEqual(result.outcome, "track_count_precheck_failed")
+
     def test_unsearchable_request_accepted_covers_ae9(self) -> None:
         """AE9: rescue from ``unsearchable`` is identical to wanted."""
         pdb = FakePipelineDB()

--- a/tests/test_youtube_rescue_generated.py
+++ b/tests/test_youtube_rescue_generated.py
@@ -1,0 +1,42 @@
+"""Narrow generated guard for #1003's exact-evidence rescue boundary.
+
+The deterministic DICE/payload pin is in ``test_youtube_ingest_service``.
+This property varies only the evidence axes that matter at the final
+pre-yt-dlp gate; it deliberately does not model arbitrary upstream schemas.
+"""
+
+from __future__ import annotations
+
+import math
+import unittest
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from lib.youtube_ingest_service import YoutubeIngestService
+
+
+class TestExactRescueEvidenceGenerated(unittest.TestCase):
+    @given(
+        outcome=st.sampled_from(["ok", "distance_failed"]),
+        distance=st.sampled_from([0.0, 0.15, float("nan"), float("inf")]),
+        tracks=st.sampled_from([None, 0, 1, 13]),
+        duplicate=st.booleans(),
+    )
+    def test_only_one_finite_ok_exact_distance_with_tracks_is_admitted(
+        self, outcome: str, distance: float, tracks: int | None, duplicate: bool,
+    ) -> None:
+        entry = {"mbid": "exact", "outcome": outcome, "distance": distance,
+                 "total_mb_tracks": tracks}
+        row = {"distances": [entry] * (2 if duplicate else 1)}
+        accepted = YoutubeIngestService._distance_entry(row, "exact")
+        expected = (
+            not duplicate and outcome == "ok" and math.isfinite(distance)
+            and isinstance(tracks, int) and tracks > 0
+        )
+        self.assertEqual(accepted is not None, expected)
+
+    def test_known_bad_checker_self_test_rejects_nan(self) -> None:
+        row = {"distances": [{"mbid": "exact", "outcome": "ok",
+                              "distance": float("nan"), "total_mb_tracks": 1}]}
+        self.assertIsNone(YoutubeIngestService._distance_entry(row, "exact"))

--- a/tests/test_youtube_rescue_generated.py
+++ b/tests/test_youtube_rescue_generated.py
@@ -13,10 +13,13 @@ import unittest
 from hypothesis import given
 from hypothesis import strategies as st
 
-from lib.youtube_ingest_service import YoutubeIngestService
 from tests.fakes import FakePipelineDB
 from tests.test_youtube_ingest_service import (
-    BROWSE, MB_RG, _make_service, _seed_resolver_row, _seed_wanted_request,
+    BROWSE,
+    MB_RG,
+    _make_service,
+    _seed_resolver_row,
+    _seed_wanted_request,
 )
 
 

--- a/tests/test_youtube_rescue_generated.py
+++ b/tests/test_youtube_rescue_generated.py
@@ -14,6 +14,10 @@ from hypothesis import given
 from hypothesis import strategies as st
 
 from lib.youtube_ingest_service import YoutubeIngestService
+from tests.fakes import FakePipelineDB
+from tests.test_youtube_ingest_service import (
+    BROWSE, MB_RG, _make_service, _seed_resolver_row, _seed_wanted_request,
+)
 
 
 class TestExactRescueEvidenceGenerated(unittest.TestCase):
@@ -26,17 +30,22 @@ class TestExactRescueEvidenceGenerated(unittest.TestCase):
     def test_only_one_finite_ok_exact_distance_with_tracks_is_admitted(
         self, outcome: str, distance: float, tracks: int | None, duplicate: bool,
     ) -> None:
-        entry = {"mbid": "exact", "outcome": outcome, "distance": distance,
-                 "total_mb_tracks": tracks}
-        row = {"distances": [entry] * (2 if duplicate else 1)}
-        accepted = YoutubeIngestService._distance_entry(row, "exact")
+        pdb = FakePipelineDB()
+        _seed_wanted_request(pdb)
+        _seed_resolver_row(pdb)
+        entry = pdb._youtube_album_mappings[(MB_RG, "mb")][0]["distances"][0]
+        entry.update({"outcome": outcome, "distance": distance, "total_mb_tracks": tracks})
+        if duplicate:
+            pdb._youtube_album_mappings[(MB_RG, "mb")][0]["distances"].append(dict(entry))
+        result = _make_service(pdb, mb_count=tracks).submit(42, BROWSE)
         expected = (
             not duplicate and outcome == "ok" and not isinstance(distance, bool) and math.isfinite(distance)
             and isinstance(tracks, int) and tracks > 0
         )
-        self.assertEqual(accepted is not None, expected)
+        self.assertEqual(result.outcome == "accepted", expected)
+        self.assertEqual(any(row.outcome == "youtube_running" for row in pdb.download_logs), expected)
 
     def test_known_bad_checker_self_test_rejects_nan(self) -> None:
-        row = {"distances": [{"mbid": "exact", "outcome": "ok",
-                              "distance": float("nan"), "total_mb_tracks": 1}]}
-        self.assertIsNone(YoutubeIngestService._distance_entry(row, "exact"))
+        pdb = FakePipelineDB(); _seed_wanted_request(pdb); _seed_resolver_row(pdb)
+        pdb._youtube_album_mappings[(MB_RG, "mb")][0]["distances"][0]["distance"] = float("nan")
+        self.assertEqual(_make_service(pdb).submit(42, BROWSE).outcome, "track_count_precheck_failed")

--- a/tests/test_youtube_rescue_generated.py
+++ b/tests/test_youtube_rescue_generated.py
@@ -19,7 +19,7 @@ from lib.youtube_ingest_service import YoutubeIngestService
 class TestExactRescueEvidenceGenerated(unittest.TestCase):
     @given(
         outcome=st.sampled_from(["ok", "distance_failed"]),
-        distance=st.sampled_from([0.0, 0.15, float("nan"), float("inf")]),
+        distance=st.sampled_from([0.0, 0.15, float("nan"), float("inf"), True]),
         tracks=st.sampled_from([None, 0, 1, 13]),
         duplicate=st.booleans(),
     )
@@ -31,7 +31,7 @@ class TestExactRescueEvidenceGenerated(unittest.TestCase):
         row = {"distances": [entry] * (2 if duplicate else 1)}
         accepted = YoutubeIngestService._distance_entry(row, "exact")
         expected = (
-            not duplicate and outcome == "ok" and math.isfinite(distance)
+            not duplicate and outcome == "ok" and not isinstance(distance, bool) and math.isfinite(distance)
             and isinstance(tracks, int) and tracks > 0
         )
         self.assertEqual(accepted is not None, expected)

--- a/tests/web/test_routes_youtube.py
+++ b/tests/web/test_routes_youtube.py
@@ -263,6 +263,14 @@ class TestYoutubeRouteContracts(_FakeDbWebServerCase):
             "distances[0] entry",
         )
 
+    def test_watch_url_is_forwarded_to_shared_resolver(self):
+        url = "https://music.youtube.com/watch?v=dGYXkhMAvLk"
+        with self._patch_service(self._ok_result()) as resolve:
+            status, _data = self._post("/api/youtube-album", {
+                "identifier": self.UUID_A, "watch_url": url})
+        self.assertEqual(status, 200)
+        self.assertEqual(resolve.call_args.kwargs["watch_url"], url)
+
     def test_ok_from_cache_with_error_message_still_200(self):
         """AE6: cache fallback path — service returns ``ok`` with
         ``from_cache=True`` and a non-empty ``error_message`` (the YT

--- a/web/index.html
+++ b/web/index.html
@@ -206,6 +206,12 @@
   .lt-yt-matrix .lt-yt-check { margin-top: 8px; }
   .lt-yt-rescue { margin-left: auto; padding: 3px 10px; background: #2a3a2a; color: #9c9; border: 1px solid #3a4a3a; border-radius: 6px; cursor: pointer; font-size: 0.8em; }
   .lt-yt-rescue:hover { background: #344a34; color: #beb; border-color: #5a8; }
+  .yt-rescue-control { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-top: 6px; }
+  .yt-rescue-watch { flex: 1 1 360px; min-width: 220px; max-width: 100%; box-sizing: border-box; background: #222; color: #eee; border: 1px solid #555; border-radius: 4px; padding: 5px 8px; font: inherit; font-size: .85em; }
+  .yt-rescue-watch:focus { border-color: #6af; outline: none; }
+  .yt-rescue-result { flex-basis: 100%; display: grid; gap: 5px; }
+  .yt-rescue-choice { display: flex; align-items: center; gap: 7px; flex-wrap: wrap; color: #aaa; font-size: .85em; }
+  .yt-rescue-choice a { color: #6af; overflow-wrap: anywhere; }
   .lt-yt-checking .lt-yt-msg { color: #ca8; }
   .lt-link-btn { background: none; border: none; color: #6af; cursor: pointer; font-size: 0.82em; padding: 4px 0; }
   .lt-link-btn:hover { text-decoration: underline; }

--- a/web/js/discography.js
+++ b/web/js/discography.js
@@ -664,7 +664,7 @@ export function renderReleaseDetail(targetEl, releaseId, data, opts = {}) {
     hideDisabled: true,
   });
   if (['wanted', 'unsearchable'].includes(data.pipeline_status) && data.pipeline_id) {
-    html += renderYoutubeRescueControl(data.pipeline_id, releaseId);
+    html += renderYoutubeRescueControl(`release-${data.pipeline_id}`, data.pipeline_id, releaseId);
   }
   html += '</div>';
 

--- a/web/js/discography.js
+++ b/web/js/discography.js
@@ -664,7 +664,7 @@ export function renderReleaseDetail(targetEl, releaseId, data, opts = {}) {
     hideDisabled: true,
   });
   if (['wanted', 'unsearchable'].includes(data.pipeline_status) && data.pipeline_id) {
-    html += renderYoutubeRescueControl(`release-${data.pipeline_id}`, data.pipeline_id, releaseId);
+    html += renderYoutubeRescueControl(`release-${data.pipeline_id}`, data.pipeline_id, releaseId, null);
   }
   html += '</div>';
 

--- a/web/js/discography.js
+++ b/web/js/discography.js
@@ -11,6 +11,7 @@ import { invalidateBrowseArtist } from './browse.js';
 import { applyAnalysisToExpansion } from './analysis.js';
 import { renderLabelLinks } from './labels.js';
 import { renderSearchPlanButton } from './search_plan.js';
+import { renderYoutubeRescueControl } from './youtube_rescue_control.js';
 import { convergenceBadge } from './convergence.js';
 import { loadActiveRgs, hasActiveRg, invalidateActiveRgs } from './active_rgs.js';
 import {
@@ -662,6 +663,9 @@ export function renderReleaseDetail(targetEl, releaseId, data, opts = {}) {
     stopPropagation: true,
     hideDisabled: true,
   });
+  if (['wanted', 'unsearchable'].includes(data.pipeline_status) && data.pipeline_id) {
+    html += renderYoutubeRescueControl(data.pipeline_id, releaseId);
+  }
   html += '</div>';
 
   // Deep library detail (path, download history, status / min-bitrate /

--- a/web/js/long_tail_console.js
+++ b/web/js/long_tail_console.js
@@ -848,15 +848,13 @@ export function youtubeRescueTargets(result) {
  * @returns {string}
  */
 function renderYoutubeBody(result, id) {
-  const row = consoleRow(id);
-  const manualControl = renderYoutubeRescueControl(
-    `long-tail-${id}`, id, row && (row.mb_release_id || row.discogs_release_id));
-  if (manualControl) return `<div class="lt-yt">${manualControl}</div>`;
   const cls = youtubeSectionState(result);
-  const checkBtn = `<button class="lt-yt-check" type="button" onclick="event.stopPropagation(); window.checkYoutube(${id})">Check YouTube</button>`;
-  if (cls.state === 'never_run') return `<div class="lt-yt">${checkBtn}</div>`;
-  if (cls.state === 'resolver_failed') return `<div class="lt-yt">${esc(cls.message)} ${checkBtn.replace('Check YouTube', 'Retry')}</div>`;
-  if (cls.state === 'resolved_empty') return `<div class="lt-yt">${esc(cls.message)} ${checkBtn.replace('Check YouTube', 'Re-check')}</div>`;
+  const checkLabel = (cls.state === 'resolver_failed') ? 'Retry' : (cls.state === 'resolved_empty') ? 'Re-check' : 'Check YouTube';
+  const input = `<input id="yt-watch-long-tail-${id}" placeholder="https://music.youtube.com/watch?v=…" aria-label="YouTube Music watch URL">`;
+  const checkBtn = `<button class="lt-yt-check" type="button" onclick="event.stopPropagation(); window.checkYoutube(${id})">${checkLabel}</button>`;
+  if (cls.state === 'never_run') return `<div class="lt-yt lt-yt-never-run"><div class="lt-yt-prompt">Resolve this release against YouTube Music.</div>${input}${checkBtn}</div>`;
+  if (cls.state === 'resolver_failed') return `<div class="lt-yt lt-yt-failed"><div class="lt-yt-msg">${esc(cls.message)}</div>${input}${checkBtn}</div>`;
+  if (cls.state === 'resolved_empty') return `<div class="lt-yt lt-yt-empty"><div class="lt-yt-msg">${esc(cls.message)}</div>${input}${checkBtn}</div>`;
   // resolved_with_matrix — each release is a pickable rescue target (U5).
   const staleFlag = cls.stale
     ? `<div class="lt-yt-stale">${esc(cls.message)}</div>`
@@ -884,7 +882,7 @@ function renderYoutubeBody(result, id) {
   return `<div class="lt-yt lt-yt-matrix">
     ${staleFlag}
     <div class="lt-yt-rows">${rows}</div>
-    ${checkBtn}${manualControl}
+    ${input}${checkBtn}
   </div>`;
 }
 
@@ -1426,7 +1424,7 @@ export async function checkYoutube(id) {
     const r = await fetch(`${API}/api/youtube-album`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ identifier, refresh: false }),
+      body: JSON.stringify({ identifier, refresh: false, ...(document.getElementById(`yt-watch-long-tail-${id}`)?.value.trim() ? { watch_url: document.getElementById(`yt-watch-long-tail-${id}`).value.trim() } : {}) }),
     });
     // 404/503 still carry a typed body; the classifier maps any non-`ok`
     // outcome to `resolver_failed`, so we read the body regardless of

--- a/web/js/long_tail_console.js
+++ b/web/js/long_tail_console.js
@@ -850,32 +850,13 @@ export function youtubeRescueTargets(result) {
 function renderYoutubeBody(result, id) {
   const row = consoleRow(id);
   const manualControl = renderYoutubeRescueControl(
-    id, row && (row.mb_release_id || row.discogs_release_id));
+    `long-tail-${id}`, id, row && (row.mb_release_id || row.discogs_release_id));
+  if (manualControl) return `<div class="lt-yt">${manualControl}</div>`;
   const cls = youtubeSectionState(result);
-  const checkLabel = (cls.state === 'resolver_failed') ? 'Retry'
-    : (cls.state === 'resolved_empty') ? 'Re-check'
-    : 'Check YouTube';
-  const checkBtn = `<button class="lt-yt-check" type="button" onclick="event.stopPropagation(); window.checkYoutube(${id})">${checkLabel}</button>`;
-  if (cls.state === 'never_run') {
-    return `<div class="lt-yt lt-yt-never-run">
-      <div class="lt-yt-prompt">Resolve this release against YouTube Music.</div>
-      ${checkBtn}${manualControl}
-    </div>`;
-  }
-  if (cls.state === 'resolver_failed') {
-    return `<div class="lt-yt lt-yt-failed">
-      <div class="lt-yt-msg">${esc(cls.message)}</div>
-      ${checkBtn}${manualControl}
-    </div>`;
-  }
-  if (cls.state === 'resolved_empty') {
-    // Not on YouTube Music — HIDE the rescue affordance (nothing to pick),
-    // offer only a re-check.
-    return `<div class="lt-yt lt-yt-empty">
-      <div class="lt-yt-msg">${esc(cls.message)}</div>
-      ${checkBtn}${manualControl}
-    </div>`;
-  }
+  const checkBtn = `<button class="lt-yt-check" type="button" onclick="event.stopPropagation(); window.checkYoutube(${id})">Check YouTube</button>`;
+  if (cls.state === 'never_run') return `<div class="lt-yt">${checkBtn}</div>`;
+  if (cls.state === 'resolver_failed') return `<div class="lt-yt">${esc(cls.message)} ${checkBtn.replace('Check YouTube', 'Retry')}</div>`;
+  if (cls.state === 'resolved_empty') return `<div class="lt-yt">${esc(cls.message)} ${checkBtn.replace('Check YouTube', 'Re-check')}</div>`;
   // resolved_with_matrix — each release is a pickable rescue target (U5).
   const staleFlag = cls.stale
     ? `<div class="lt-yt-stale">${esc(cls.message)}</div>`

--- a/web/js/long_tail_console.js
+++ b/web/js/long_tail_console.js
@@ -849,6 +849,13 @@ export function youtubeRescueTargets(result) {
  */
 function renderYoutubeBody(result, id) {
   const cls = youtubeSectionState(result);
+  const row = consoleRow(id);
+  const identifier = row && (row.mb_release_id || row.discogs_release_id);
+  if (identifier) {
+    return `<div class="lt-yt">${renderYoutubeRescueControl(
+      `long-tail-${id}`, id, identifier, result,
+      { check: `window.checkYoutube(${id})`, pick: 'window.pickYoutubeRescue' })}</div>`;
+  }
   const checkLabel = (cls.state === 'resolver_failed') ? 'Retry' : (cls.state === 'resolved_empty') ? 'Re-check' : 'Check YouTube';
   const input = `<input id="yt-watch-long-tail-${id}" placeholder="https://music.youtube.com/watch?v=…" aria-label="YouTube Music watch URL">`;
   const checkBtn = `<button class="lt-yt-check" type="button" onclick="event.stopPropagation(); window.checkYoutube(${id})">${checkLabel}</button>`;
@@ -1424,7 +1431,7 @@ export async function checkYoutube(id) {
     const r = await fetch(`${API}/api/youtube-album`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ identifier, refresh: false, ...(document.getElementById(`yt-watch-long-tail-${id}`)?.value.trim() ? { watch_url: document.getElementById(`yt-watch-long-tail-${id}`).value.trim() } : {}) }),
+      body: JSON.stringify({ identifier, refresh: false, ...((typeof document !== 'undefined' && document.getElementById(`yt-watch-long-tail-${id}`)?.value.trim()) ? { watch_url: document.getElementById(`yt-watch-long-tail-${id}`).value.trim() } : {}) }),
     });
     // 404/503 still carry a typed body; the classifier maps any non-`ok`
     // outcome to `resolver_failed`, so we read the body regardless of

--- a/web/js/long_tail_console.js
+++ b/web/js/long_tail_console.js
@@ -140,6 +140,7 @@ import {
   youtubeBrowseUrl,
 } from './util.js';
 import { openReplacePicker, pressingMeta } from './replace_picker.js';
+import { renderYoutubeRescueControl } from './youtube_rescue_control.js';
 import { bandLabel, renderLongTail, loadLongTail } from './long_tail.js';
 import {
   qualityRankBadgeClass,
@@ -847,6 +848,9 @@ export function youtubeRescueTargets(result) {
  * @returns {string}
  */
 function renderYoutubeBody(result, id) {
+  const row = consoleRow(id);
+  const manualControl = renderYoutubeRescueControl(
+    id, row && (row.mb_release_id || row.discogs_release_id));
   const cls = youtubeSectionState(result);
   const checkLabel = (cls.state === 'resolver_failed') ? 'Retry'
     : (cls.state === 'resolved_empty') ? 'Re-check'
@@ -855,13 +859,13 @@ function renderYoutubeBody(result, id) {
   if (cls.state === 'never_run') {
     return `<div class="lt-yt lt-yt-never-run">
       <div class="lt-yt-prompt">Resolve this release against YouTube Music.</div>
-      ${checkBtn}
+      ${checkBtn}${manualControl}
     </div>`;
   }
   if (cls.state === 'resolver_failed') {
     return `<div class="lt-yt lt-yt-failed">
       <div class="lt-yt-msg">${esc(cls.message)}</div>
-      ${checkBtn}
+      ${checkBtn}${manualControl}
     </div>`;
   }
   if (cls.state === 'resolved_empty') {
@@ -869,7 +873,7 @@ function renderYoutubeBody(result, id) {
     // offer only a re-check.
     return `<div class="lt-yt lt-yt-empty">
       <div class="lt-yt-msg">${esc(cls.message)}</div>
-      ${checkBtn}
+      ${checkBtn}${manualControl}
     </div>`;
   }
   // resolved_with_matrix — each release is a pickable rescue target (U5).
@@ -899,7 +903,7 @@ function renderYoutubeBody(result, id) {
   return `<div class="lt-yt lt-yt-matrix">
     ${staleFlag}
     <div class="lt-yt-rows">${rows}</div>
-    ${checkBtn}
+    ${checkBtn}${manualControl}
   </div>`;
 }
 

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -12,6 +12,7 @@ import { loadRecents, setRecentsFilter, setRecentsSub, renderRecentsItems } from
 import { loadPipeline, loadPipelineDashboard, setPipelineView, renderPipeline, toggleCoverageMatchGraph, toggleDetail, deleteRequest, updateStatus } from './pipeline.js';
 import { loadLongTail, setLongTailBand, onLongTailSearchInput } from './long_tail.js';
 import { toggleLongTailDetail, toggleLongTailPeers, checkYoutube, pickYoutubeRescue, longTailAcceptSibling, longTailSetIntent, longTailSetImported, longTailDeleteRequest } from './long_tail_console.js';
+import { checkYoutubeRescue } from './youtube_rescue_control.js';
 import { toggleLibDetail, toggleReleaseLibDetail, banSource, setLibQuality, upgradeAlbum, setIntent, confirmDeleteBeets, executeBeetsDeletion } from './library.js';
 import { disambRemove } from './analysis.js';
 import { loadWrongMatches, toggleWrongMatchGroup, toggleWrongMatchEntry, reloadWrongMatchExplorer, maybeLoadWrongMatchExplorer, refreshWrongMatches, forceImportWrongMatch, deleteWrongMatch, deleteWrongMatchGroup, bulkTriageWrongMatches, convergeWrongMatches, setWrongMatchConvergeThreshold, toggleWrongMatchesReplacedFilter } from './wrong-matches.js';
@@ -243,6 +244,7 @@ Object.assign(window, {
   // panel in `never_run` until the operator clicks).
   checkYoutube,
   pickYoutubeRescue,
+  checkYoutubeRescue,
   // Long-tail secondary actions (U6), all wired to EXISTING endpoints:
   // set-imported (accept on-disk quality → POST /api/pipeline/update),
   // accept-a-sibling-pressing (the Replace operator action, MB-only per

--- a/web/js/youtube_rescue_control.js
+++ b/web/js/youtube_rescue_control.js
@@ -13,12 +13,12 @@ export function renderYoutubeRescueControl(key, requestId, identifier, result = 
   const pick = handlers.pick || `window.pickYoutubeRescue`;
   const label = state.state === 'resolver_failed' ? 'Retry' : state.state === 'resolved_empty' ? 'Re-check' : 'Check YouTube';
   const choices = state.state === 'resolved_with_matrix'
-    ? (result.youtube_releases || []).map((release) => `<button class="p-btn" type="button" onclick="${pick}(${Number(requestId)}, ${jsArg(release.yt_browse_id)})">Rescue from ${esc(release.yt_browse_id)}</button>`).join('')
+    ? (result.youtube_releases || []).map((release) => `<button class="p-btn" type="button" onclick="event.stopPropagation(); ${pick}(${Number(requestId)}, ${jsArg(release.yt_browse_id)})">Rescue from ${esc(release.yt_browse_id)}</button>`).join('')
     : state.state === 'resolver_failed' || state.state === 'resolved_empty'
       ? `<span>${esc(state.message)}</span>` : '';
   return `<div class="yt-rescue-control" id="yt-rescue-${esc(key)}">
-    <button class="p-btn" type="button" onclick="${check}">${label}</button>
-    <input id="yt-watch-${esc(key)}" placeholder="https://music.youtube.com/watch?v=…" aria-label="YouTube Music watch URL">
+    <button class="p-btn" type="button" onclick="event.stopPropagation(); ${check}">${label}</button>
+    <input id="yt-watch-${esc(key)}" onclick="event.stopPropagation()" placeholder="https://music.youtube.com/watch?v=…" aria-label="YouTube Music watch URL">
     <div class="yt-rescue-result">${choices}</div>
   </div>`;
 }
@@ -40,7 +40,8 @@ export async function checkYoutubeRescue(key, requestId, identifier) {
       return;
     }
     resultHost.innerHTML = (result.youtube_releases || []).map((release) => `<button class="p-btn" type="button" data-browse-id="${esc(release.yt_browse_id)}">Rescue from ${esc(release.yt_browse_id)}</button>`).join('') || '<span>No YouTube album found.</span>';
-    resultHost.querySelectorAll('[data-browse-id]').forEach((button) => button.addEventListener('click', async () => {
+    resultHost.querySelectorAll('[data-browse-id]').forEach((button) => button.addEventListener('click', async (event) => {
+      event.stopPropagation();
       if (host.dataset.submitting === 'true' || !window.confirm('Queue this YouTube Music rescue?')) return;
       host.dataset.submitting = 'true';
       try {

--- a/web/js/youtube_rescue_control.js
+++ b/web/js/youtube_rescue_control.js
@@ -2,6 +2,10 @@
 import { API, toast } from './state.js';
 import { esc, jsArg, youtubeSectionState } from './util.js';
 
+export function youtubeResolverPayload(identifier, watchUrl) {
+  return { identifier, ...(watchUrl ? { watch_url: watchUrl } : {}) };
+}
+
 export function renderYoutubeRescueControl(key, requestId, identifier, result = null, handlers = {}) {
   if (!Number.isInteger(Number(requestId)) || !identifier) return '';
   const state = youtubeSectionState(result);
@@ -28,7 +32,7 @@ export async function checkYoutubeRescue(key, requestId, identifier) {
   const resultHost = host.querySelector('.yt-rescue-result');
   const watchUrl = host.querySelector('input')?.value.trim();
   try {
-    const r = await fetch(`${API}/api/youtube-album`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ identifier, ...(watchUrl ? { watch_url: watchUrl } : {}) }) });
+    const r = await fetch(`${API}/api/youtube-album`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(youtubeResolverPayload(identifier, watchUrl)) });
     const result = await r.json().catch(() => ({ error_message: `HTTP ${r.status}` }));
     if (host.dataset.generation !== generation || !resultHost) return;
     if (!r.ok || result.outcome !== 'ok') {

--- a/web/js/youtube_rescue_control.js
+++ b/web/js/youtube_rescue_control.js
@@ -9,8 +9,8 @@ export function youtubeResolverPayload(identifier, watchUrl) {
 function renderCandidateChoices(result, identifier, requestId, pick) {
   return (result.youtube_releases || []).map((release) => {
     const distances = Array.isArray(release.distances) ? release.distances : [];
-    const exactMatches = distances.filter((distance) => distance.mbid === identifier && distance.outcome === 'ok' && typeof distance.distance === 'number' && Number.isFinite(distance.distance) && Number.isInteger(distance.total_mb_tracks) && distance.total_mb_tracks > 0);
-    const exact = exactMatches.length === 1 ? exactMatches[0] : null;
+    const exactEntries = distances.filter((distance) => distance.mbid === identifier);
+    const exact = exactEntries.length === 1 && exactEntries[0].outcome === 'ok' && typeof exactEntries[0].distance === 'number' && Number.isFinite(exactEntries[0].distance) && Number.isInteger(exactEntries[0].total_mb_tracks) && exactEntries[0].total_mb_tracks > 0 ? exactEntries[0] : null;
     const finite = distances.filter((distance) => Number.isFinite(distance.distance));
     const best = finite.length ? Math.min(...finite.map((distance) => distance.distance)) : null;
     const distanceLabel = exact ? `exact dist ${exact.distance.toFixed(3)}` : best != null ? `best sibling dist ${best.toFixed(3)}` : 'no distance';

--- a/web/js/youtube_rescue_control.js
+++ b/web/js/youtube_rescue_control.js
@@ -45,10 +45,18 @@ export async function checkYoutubeRescue(key, requestId, identifier) {
       if (host.dataset.submitting === 'true' || !window.confirm('Queue this YouTube Music rescue?')) return;
       host.dataset.submitting = 'true';
       try {
-        const rescue = await fetch(`${API}/api/pipeline/${requestId}/youtube-rescue`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ browse_id: button.dataset.browseId }) });
-        const payload = await rescue.json().catch(() => ({ outcome: 'transient' }));
-        toast(payload.outcome === 'accepted' ? 'YouTube rescue queued.' : (payload.detail || payload.error || 'YouTube rescue failed.'), payload.outcome !== 'accepted');
+        try {
+          const rescue = await fetch(`${API}/api/pipeline/${requestId}/youtube-rescue`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ browse_id: button.dataset.browseId }) });
+          const payload = await rescue.json().catch(() => ({ outcome: 'transient' }));
+          toast(payload.outcome === 'accepted' ? 'YouTube rescue queued.' : (payload.detail || payload.error || 'YouTube rescue failed.'), payload.outcome !== 'accepted');
+        } catch (_error) {
+          toast('YouTube rescue failed: network unavailable.', true);
+        }
       } finally { host.dataset.submitting = 'false'; }
     }));
+  } catch (_error) {
+    if (host.dataset.generation === generation && resultHost) {
+      resultHost.innerHTML = '<span>Could not reach the resolver. Retry.</span>';
+    }
   } finally { if (host.dataset.generation === generation) host.dataset.busy = 'false'; }
 }

--- a/web/js/youtube_rescue_control.js
+++ b/web/js/youtube_rescue_control.js
@@ -1,6 +1,6 @@
 /* The one bounded check / watch-url / choose / confirm rescue control (#1003). */
 import { API, toast } from './state.js';
-import { esc, jsArg, youtubeSectionState } from './util.js';
+import { esc, jsArg, youtubeBrowseUrl, youtubeSectionState } from './util.js';
 
 export function youtubeResolverPayload(identifier, watchUrl) {
   return { identifier, ...(watchUrl ? { watch_url: watchUrl } : {}) };
@@ -13,7 +13,16 @@ export function renderYoutubeRescueControl(key, requestId, identifier, result = 
   const pick = handlers.pick || `window.pickYoutubeRescue`;
   const label = state.state === 'resolver_failed' ? 'Retry' : state.state === 'resolved_empty' ? 'Re-check' : 'Check YouTube';
   const choices = state.state === 'resolved_with_matrix'
-    ? (result.youtube_releases || []).map((release) => `<button class="p-btn" type="button" onclick="event.stopPropagation(); ${pick}(${Number(requestId)}, ${jsArg(release.yt_browse_id)})">Rescue from ${esc(release.yt_browse_id)}</button>`).join('')
+    ? (result.youtube_releases || []).map((release) => {
+      const distances = Array.isArray(release.distances) ? release.distances : [];
+      const exact = distances.find((distance) => distance.mbid === identifier && Number.isFinite(distance.distance));
+      const finite = distances.filter((distance) => Number.isFinite(distance.distance));
+      const best = finite.length ? Math.min(...finite.map((distance) => distance.distance)) : null;
+      const distanceLabel = exact ? `exact dist ${exact.distance.toFixed(3)}` : best != null ? `best sibling dist ${best.toFixed(3)}` : 'no distance';
+      const evidence = [release.year != null ? String(release.year) : '', release.track_count != null ? `${release.track_count}t` : '', distanceLabel].filter(Boolean).join(' · ');
+      const url = youtubeBrowseUrl(release.yt_browse_id);
+      return `<div class="yt-rescue-choice"><a href="${esc(url)}" target="_blank" rel="noopener" onclick="event.stopPropagation()">${esc(release.yt_browse_id)}</a> <span>${esc(evidence)}</span> <button class="p-btn" type="button" onclick="event.stopPropagation(); ${pick}(${Number(requestId)}, ${jsArg(release.yt_browse_id)})">Rescue from this</button></div>`;
+    }).join('')
     : state.state === 'resolver_failed' || state.state === 'resolved_empty'
       ? `<span>${esc(state.message)}</span>` : '';
   return `<div class="yt-rescue-control" id="yt-rescue-${esc(key)}">

--- a/web/js/youtube_rescue_control.js
+++ b/web/js/youtube_rescue_control.js
@@ -32,7 +32,7 @@ export function renderYoutubeRescueControl(key, requestId, identifier, result = 
       ? `<span>${esc(state.message)}</span>` : '';
   return `<div class="yt-rescue-control" id="yt-rescue-${esc(key)}">
     <button class="p-btn" type="button" onclick="event.stopPropagation(); ${check}">${label}</button>
-    <input id="yt-watch-${esc(key)}" onclick="event.stopPropagation()" placeholder="https://music.youtube.com/watch?v=…" aria-label="YouTube Music watch URL">
+    <input class="yt-rescue-watch" type="text" id="yt-watch-${esc(key)}" onclick="event.stopPropagation()" placeholder="https://music.youtube.com/watch?v=…" aria-label="YouTube Music watch URL">
     <div class="yt-rescue-result">${choices}</div>
   </div>`;
 }

--- a/web/js/youtube_rescue_control.js
+++ b/web/js/youtube_rescue_control.js
@@ -1,29 +1,41 @@
-/* Compact shared rescue control for release-detail surfaces (#1003). */
-import { API } from './state.js';
-import { esc } from './util.js';
+/* The one bounded check / watch-url / choose / confirm rescue control (#1003). */
+import { API, toast } from './state.js';
+import { esc, jsArg } from './util.js';
 
-export function renderYoutubeRescueControl(requestId, identifier) {
+export function renderYoutubeRescueControl(key, requestId, identifier) {
   if (!Number.isInteger(Number(requestId)) || !identifier) return '';
-  const id = Number(requestId);
-  return `<div class="yt-rescue-control" id="yt-rescue-${id}">
-    <button class="p-btn" type="button" onclick="window.checkYoutubeRescue(${id}, ${JSON.stringify(String(identifier))})">Check YouTube</button>
-    <input id="yt-watch-${id}" placeholder="https://music.youtube.com/watch?v=…" aria-label="YouTube Music watch URL">
+  return `<div class="yt-rescue-control" id="yt-rescue-${esc(key)}">
+    <button class="p-btn" type="button" onclick="window.checkYoutubeRescue(${jsArg(key)}, ${Number(requestId)}, ${jsArg(String(identifier))})">Check YouTube</button>
+    <input id="yt-watch-${esc(key)}" placeholder="https://music.youtube.com/watch?v=…" aria-label="YouTube Music watch URL">
+    <div class="yt-rescue-result"></div>
   </div>`;
 }
 
-export async function checkYoutubeRescue(requestId, identifier) {
-  const host = document.getElementById(`yt-rescue-${requestId}`);
+export async function checkYoutubeRescue(key, requestId, identifier) {
+  const host = document.getElementById(`yt-rescue-${key}`);
   if (!host || host.dataset.busy === 'true') return;
+  const generation = String(Number(host.dataset.generation || '0') + 1);
+  host.dataset.generation = generation;
   host.dataset.busy = 'true';
-  const watchUrl = document.getElementById(`yt-watch-${requestId}`)?.value.trim();
+  const resultHost = host.querySelector('.yt-rescue-result');
+  const watchUrl = host.querySelector('input')?.value.trim();
   try {
     const r = await fetch(`${API}/api/youtube-album`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ identifier, ...(watchUrl ? { watch_url: watchUrl } : {}) }) });
-    const result = await r.json();
-    const choices = (result.youtube_releases || []).map((release) => `<button class="p-btn" type="button" data-browse-id="${esc(release.yt_browse_id)}">Rescue from ${esc(release.yt_browse_id)}</button>`).join('');
-    host.insertAdjacentHTML('beforeend', choices || `<span>${esc(result.error_message || 'No YouTube album found.')}</span>`);
-    host.querySelectorAll('[data-browse-id]').forEach((button) => button.addEventListener('click', async () => {
-      if (!window.confirm('Queue this YouTube Music rescue?')) return;
-      await fetch(`${API}/api/pipeline/${requestId}/youtube-rescue`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ browse_id: button.dataset.browseId }) });
-    }, { once: true }));
-  } finally { host.dataset.busy = 'false'; }
+    const result = await r.json().catch(() => ({ error_message: `HTTP ${r.status}` }));
+    if (host.dataset.generation !== generation || !resultHost) return;
+    if (!r.ok || result.outcome !== 'ok') {
+      resultHost.innerHTML = `<span>${esc(result.error_message || `Resolver failed (HTTP ${r.status}).`)}</span>`;
+      return;
+    }
+    resultHost.innerHTML = (result.youtube_releases || []).map((release) => `<button class="p-btn" type="button" data-browse-id="${esc(release.yt_browse_id)}">Rescue from ${esc(release.yt_browse_id)}</button>`).join('') || '<span>No YouTube album found.</span>';
+    resultHost.querySelectorAll('[data-browse-id]').forEach((button) => button.addEventListener('click', async () => {
+      if (host.dataset.submitting === 'true' || !window.confirm('Queue this YouTube Music rescue?')) return;
+      host.dataset.submitting = 'true';
+      try {
+        const rescue = await fetch(`${API}/api/pipeline/${requestId}/youtube-rescue`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ browse_id: button.dataset.browseId }) });
+        const payload = await rescue.json().catch(() => ({ outcome: 'transient' }));
+        toast(payload.outcome === 'accepted' ? 'YouTube rescue queued.' : (payload.detail || payload.error || 'YouTube rescue failed.'), payload.outcome !== 'accepted');
+      } finally { host.dataset.submitting = 'false'; }
+    }));
+  } finally { if (host.dataset.generation === generation) host.dataset.busy = 'false'; }
 }

--- a/web/js/youtube_rescue_control.js
+++ b/web/js/youtube_rescue_control.js
@@ -1,0 +1,29 @@
+/* Compact shared rescue control for release-detail surfaces (#1003). */
+import { API } from './state.js';
+import { esc } from './util.js';
+
+export function renderYoutubeRescueControl(requestId, identifier) {
+  if (!Number.isInteger(Number(requestId)) || !identifier) return '';
+  const id = Number(requestId);
+  return `<div class="yt-rescue-control" id="yt-rescue-${id}">
+    <button class="p-btn" type="button" onclick="window.checkYoutubeRescue(${id}, ${JSON.stringify(String(identifier))})">Check YouTube</button>
+    <input id="yt-watch-${id}" placeholder="https://music.youtube.com/watch?v=…" aria-label="YouTube Music watch URL">
+  </div>`;
+}
+
+export async function checkYoutubeRescue(requestId, identifier) {
+  const host = document.getElementById(`yt-rescue-${requestId}`);
+  if (!host || host.dataset.busy === 'true') return;
+  host.dataset.busy = 'true';
+  const watchUrl = document.getElementById(`yt-watch-${requestId}`)?.value.trim();
+  try {
+    const r = await fetch(`${API}/api/youtube-album`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ identifier, ...(watchUrl ? { watch_url: watchUrl } : {}) }) });
+    const result = await r.json();
+    const choices = (result.youtube_releases || []).map((release) => `<button class="p-btn" type="button" data-browse-id="${esc(release.yt_browse_id)}">Rescue from ${esc(release.yt_browse_id)}</button>`).join('');
+    host.insertAdjacentHTML('beforeend', choices || `<span>${esc(result.error_message || 'No YouTube album found.')}</span>`);
+    host.querySelectorAll('[data-browse-id]').forEach((button) => button.addEventListener('click', async () => {
+      if (!window.confirm('Queue this YouTube Music rescue?')) return;
+      await fetch(`${API}/api/pipeline/${requestId}/youtube-rescue`, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ browse_id: button.dataset.browseId }) });
+    }, { once: true }));
+  } finally { host.dataset.busy = 'false'; }
+}

--- a/web/js/youtube_rescue_control.js
+++ b/web/js/youtube_rescue_control.js
@@ -9,7 +9,8 @@ export function youtubeResolverPayload(identifier, watchUrl) {
 function renderCandidateChoices(result, identifier, requestId, pick) {
   return (result.youtube_releases || []).map((release) => {
     const distances = Array.isArray(release.distances) ? release.distances : [];
-    const exact = distances.find((distance) => distance.mbid === identifier && distance.outcome === 'ok' && typeof distance.distance === 'number' && Number.isFinite(distance.distance) && Number.isInteger(distance.total_mb_tracks) && distance.total_mb_tracks > 0);
+    const exactMatches = distances.filter((distance) => distance.mbid === identifier && distance.outcome === 'ok' && typeof distance.distance === 'number' && Number.isFinite(distance.distance) && Number.isInteger(distance.total_mb_tracks) && distance.total_mb_tracks > 0);
+    const exact = exactMatches.length === 1 ? exactMatches[0] : null;
     const finite = distances.filter((distance) => Number.isFinite(distance.distance));
     const best = finite.length ? Math.min(...finite.map((distance) => distance.distance)) : null;
     const distanceLabel = exact ? `exact dist ${exact.distance.toFixed(3)}` : best != null ? `best sibling dist ${best.toFixed(3)}` : 'no distance';

--- a/web/js/youtube_rescue_control.js
+++ b/web/js/youtube_rescue_control.js
@@ -1,13 +1,21 @@
 /* The one bounded check / watch-url / choose / confirm rescue control (#1003). */
 import { API, toast } from './state.js';
-import { esc, jsArg } from './util.js';
+import { esc, jsArg, youtubeSectionState } from './util.js';
 
-export function renderYoutubeRescueControl(key, requestId, identifier) {
+export function renderYoutubeRescueControl(key, requestId, identifier, result = null, handlers = {}) {
   if (!Number.isInteger(Number(requestId)) || !identifier) return '';
+  const state = youtubeSectionState(result);
+  const check = handlers.check || `window.checkYoutubeRescue(${jsArg(key)}, ${Number(requestId)}, ${jsArg(String(identifier))})`;
+  const pick = handlers.pick || `window.pickYoutubeRescue`;
+  const label = state.state === 'resolver_failed' ? 'Retry' : state.state === 'resolved_empty' ? 'Re-check' : 'Check YouTube';
+  const choices = state.state === 'resolved_with_matrix'
+    ? (result.youtube_releases || []).map((release) => `<button class="p-btn" type="button" onclick="${pick}(${Number(requestId)}, ${jsArg(release.yt_browse_id)})">Rescue from ${esc(release.yt_browse_id)}</button>`).join('')
+    : state.state === 'resolver_failed' || state.state === 'resolved_empty'
+      ? `<span>${esc(state.message)}</span>` : '';
   return `<div class="yt-rescue-control" id="yt-rescue-${esc(key)}">
-    <button class="p-btn" type="button" onclick="window.checkYoutubeRescue(${jsArg(key)}, ${Number(requestId)}, ${jsArg(String(identifier))})">Check YouTube</button>
+    <button class="p-btn" type="button" onclick="${check}">${label}</button>
     <input id="yt-watch-${esc(key)}" placeholder="https://music.youtube.com/watch?v=…" aria-label="YouTube Music watch URL">
-    <div class="yt-rescue-result"></div>
+    <div class="yt-rescue-result">${choices}</div>
   </div>`;
 }
 

--- a/web/js/youtube_rescue_control.js
+++ b/web/js/youtube_rescue_control.js
@@ -6,6 +6,20 @@ export function youtubeResolverPayload(identifier, watchUrl) {
   return { identifier, ...(watchUrl ? { watch_url: watchUrl } : {}) };
 }
 
+function renderCandidateChoices(result, identifier, requestId, pick) {
+  return (result.youtube_releases || []).map((release) => {
+    const distances = Array.isArray(release.distances) ? release.distances : [];
+    const exact = distances.find((distance) => distance.mbid === identifier && distance.outcome === 'ok' && typeof distance.distance === 'number' && Number.isFinite(distance.distance) && Number.isInteger(distance.total_mb_tracks) && distance.total_mb_tracks > 0);
+    const finite = distances.filter((distance) => Number.isFinite(distance.distance));
+    const best = finite.length ? Math.min(...finite.map((distance) => distance.distance)) : null;
+    const distanceLabel = exact ? `exact dist ${exact.distance.toFixed(3)}` : best != null ? `best sibling dist ${best.toFixed(3)}` : 'no distance';
+    const evidence = [release.year != null ? String(release.year) : '', release.track_count != null ? `${release.track_count}t` : '', distanceLabel].filter(Boolean).join(' · ');
+    const url = youtubeBrowseUrl(release.yt_browse_id);
+    const action = exact ? (pick ? `onclick="event.stopPropagation(); ${pick}(${Number(requestId)}, ${jsArg(release.yt_browse_id)})"` : `data-browse-id="${esc(release.yt_browse_id)}"`) : 'disabled';
+    return `<div class="yt-rescue-choice"><a href="${esc(url)}" target="_blank" rel="noopener" onclick="event.stopPropagation()">${esc(release.yt_browse_id)}</a> <span>${esc(evidence)}</span> <button class="p-btn" type="button" ${action}>${exact ? 'Rescue from this' : 'Exact evidence required'}</button></div>`;
+  }).join('');
+}
+
 export function renderYoutubeRescueControl(key, requestId, identifier, result = null, handlers = {}) {
   if (!Number.isInteger(Number(requestId)) || !identifier) return '';
   const state = youtubeSectionState(result);
@@ -13,16 +27,7 @@ export function renderYoutubeRescueControl(key, requestId, identifier, result = 
   const pick = handlers.pick || `window.pickYoutubeRescue`;
   const label = state.state === 'resolver_failed' ? 'Retry' : state.state === 'resolved_empty' ? 'Re-check' : 'Check YouTube';
   const choices = state.state === 'resolved_with_matrix'
-    ? (result.youtube_releases || []).map((release) => {
-      const distances = Array.isArray(release.distances) ? release.distances : [];
-      const exact = distances.find((distance) => distance.mbid === identifier && Number.isFinite(distance.distance));
-      const finite = distances.filter((distance) => Number.isFinite(distance.distance));
-      const best = finite.length ? Math.min(...finite.map((distance) => distance.distance)) : null;
-      const distanceLabel = exact ? `exact dist ${exact.distance.toFixed(3)}` : best != null ? `best sibling dist ${best.toFixed(3)}` : 'no distance';
-      const evidence = [release.year != null ? String(release.year) : '', release.track_count != null ? `${release.track_count}t` : '', distanceLabel].filter(Boolean).join(' · ');
-      const url = youtubeBrowseUrl(release.yt_browse_id);
-      return `<div class="yt-rescue-choice"><a href="${esc(url)}" target="_blank" rel="noopener" onclick="event.stopPropagation()">${esc(release.yt_browse_id)}</a> <span>${esc(evidence)}</span> <button class="p-btn" type="button" onclick="event.stopPropagation(); ${pick}(${Number(requestId)}, ${jsArg(release.yt_browse_id)})">Rescue from this</button></div>`;
-    }).join('')
+    ? renderCandidateChoices(result, identifier, requestId, pick)
     : state.state === 'resolver_failed' || state.state === 'resolved_empty'
       ? `<span>${esc(state.message)}</span>` : '';
   return `<div class="yt-rescue-control" id="yt-rescue-${esc(key)}">
@@ -48,7 +53,7 @@ export async function checkYoutubeRescue(key, requestId, identifier) {
       resultHost.innerHTML = `<span>${esc(result.error_message || `Resolver failed (HTTP ${r.status}).`)}</span>`;
       return;
     }
-    resultHost.innerHTML = (result.youtube_releases || []).map((release) => `<button class="p-btn" type="button" data-browse-id="${esc(release.yt_browse_id)}">Rescue from ${esc(release.yt_browse_id)}</button>`).join('') || '<span>No YouTube album found.</span>';
+    resultHost.innerHTML = renderCandidateChoices(result, identifier, requestId, '') || '<span>No YouTube album found.</span>';
     resultHost.querySelectorAll('[data-browse-id]').forEach((button) => button.addEventListener('click', async (event) => {
       event.stopPropagation();
       if (host.dataset.submitting === 'true' || !window.confirm('Queue this YouTube Music rescue?')) return;

--- a/web/routes/youtube.py
+++ b/web/routes/youtube.py
@@ -118,6 +118,7 @@ class YoutubeAlbumRequest(BaseModel):
 
     identifier: str
     refresh: bool = Field(default=False, strict=True)
+    watch_url: str | None = None
 
 
 def post_youtube_album(
@@ -178,6 +179,7 @@ def post_youtube_album(
             distance_fn=compute_beets_distance,
             cache=cache,
             refresh=req.refresh,
+            watch_url=req.watch_url,
         )
     finally:
         # Close the requests.Session to release its connection pool.
@@ -276,7 +278,9 @@ ROUTES: list[RouteRegistration] = [
         "release-or-group identifier, returns the typed "
         "(yt_release × mb_release) distance matrix. Body: "
         "{\"identifier\": \"<release-or-group-id>\", \"refresh\": "
-        "false}. refresh=true bypasses BOTH the durable cache "
+        "false, \"watch_url\": \"https://music.youtube.com/watch?v=...\"}. "
+        "The optional canonical watch URL replaces the complete cached matrix. "
+        "refresh=true bypasses BOTH the durable cache "
         "(youtube_album_mappings) and the in-process Redis HTTP "
         "accelerator, forcing a fresh YT Music fetch; the fresh "
         "response is then written back to both layers.",


### PR DESCRIPTION
## Summary

- preserve the exact requested pressing as the YouTube discovery seed
- admit one song-search album browse ID through the existing bounded scoring and persistence path
- accept only canonical `https://music.youtube.com/watch?v=...` operator input, resolve video to album, and keep raw URLs out of `yt-dlp`
- require exactly one successful finite exact-release evidence entry with a positive exact track count before rescue, for both MusicBrainz and Discogs requests
- share one compact check / paste URL / exact-evidence / confirm control across Long-tail and unified Browse/Library release detail

## Limited scope

This implements the [authoritative scope reset](https://github.com/abl030/cratedigger/issues/1003#issuecomment-5165431046). It deliberately does not add playlist or `/browse/` URL admission, pagination or mixed-playlist machinery, generalized resolver/cache/deadline rewrites, exhaustive malformed-upstream modeling, or unrelated hardening.

Manual watch resolution replaces the complete existing mapping only after the selected album has been scored. A failed manual lookup cannot fall back to or replace a stale automatic matrix. Rescue admission rechecks exact cardinality, successful finite distance evidence, and positive exact track-count evidence at the final pre-`yt-dlp` boundary.

## Validation

- 417 focused Python tests: resolver, ingestion, generated exact-evidence boundary, HTTP route, and CLI
- affected JavaScript suites: shared rescue control, Long-tail console, unified discography, and utilities
- changed-module JavaScript syntax checks
- whole-repository Pyright: 0 errors
- full Ruff surface: all checks passed
- independent Sol review: three initial exact-boundary findings fixed and pinned; final re-review reported no findings
- live-db screenshot loop: dark responsive control verified in Long-tail and unified Browse/Library release detail
- visible-state tally at the screenshot pass: 1,336 Long-tail-eligible `wanted` requests; 1,338 release-detail-eligible `wanted|unsearchable` requests

Per the scope-reset comment, validation is focused and proportional rather than an exact-HEAD full-suite receipt ceremony. DICE was temporarily `downloading` during the pre-push screenshot pass, so the issue remains open pending post-deploy verification of the exact DICE resolver result and Library surface.

Refs #1003
