### PR TITLE
Authorize force import for staged YouTube wrong matches

### DIFF
--- a/lib/fs_authority.py
+++ b/lib/fs_authority.py
@@ -577,7 +577,7 @@ def open_configured_quarantine_directory(
         ),
         (
             getattr(cfg, "beets_staging_dir"),  # noqa: B009 - structural config boundary
-            frozenset({"failed_imports"}),
+            frozenset({"failed_imports", "wrong_matches"}),
         ),
         (
             processing_albums_dir(

--- a/tests/test_force_import_service.py
+++ b/tests/test_force_import_service.py
@@ -97,7 +97,9 @@ class TestForceImportService(unittest.TestCase):
         db.download_logs[log_id - 1].validation_result = {
             "scenario": "high_distance", "failed_path": path,
             "soulseek_username": soulseek_username,
-            "source_dirs": source_dirs or ["peer\\Artist\\Album"],
+            "source_dirs": (
+                ["peer\\Artist\\Album"] if source_dirs is None else source_dirs
+            ),
         }
 
     def _assert_queued(
@@ -143,6 +145,29 @@ class TestForceImportService(unittest.TestCase):
             failed_path=album,
             source_username="peer",
             source_dirs=["peer\\Artist\\Album"],
+        )
+
+    def test_youtube_wrong_match_under_staging_enqueues(self) -> None:
+        db, cfg, staging, log_id = self._world()
+        album = os.path.join(
+            staging,
+            "auto-import",
+            "wrong_matches",
+            "Loon_Lake-Low_Res-playlist-request-111-log-39310",
+        )
+        os.makedirs(album)
+        db.download_logs[log_id - 1].soulseek_username = None
+        self._set_path(db, log_id, album, source_dirs=[])
+
+        result = enqueue_force_import(db, cfg, log_id)
+
+        self._assert_queued(
+            db, result,
+            download_log_id=log_id,
+            request_id=867,
+            failed_path=album,
+            source_username=None,
+            source_dirs=[],
         )
 
     def test_missing_download_log_returns_exact_outcome_without_job(self) -> None:

--- a/tests/test_force_import_service_generated.py
+++ b/tests/test_force_import_service_generated.py
@@ -15,12 +15,11 @@ from tests.helpers import make_request_row
 
 # Stated here rather than imported from lib.fs_authority: an oracle derived
 # from the production table cannot detect that table widening. The three
-# configured quarantine roots carry DELIBERATELY ASYMMETRIC marker sets —
-# staging authorizes ``failed_imports`` only, because a wrong-match rejection
-# is never staged there.
+# configured quarantine roots all authorize the two exact quarantine markers.
+# This includes YouTube rejects under staging/auto-import/wrong_matches.
 MARKERS_BY_ROOT: dict[str, frozenset[str]] = {
     "slskd": frozenset({"failed_imports", "wrong_matches"}),
-    "staging": frozenset({"failed_imports"}),
+    "staging": frozenset({"failed_imports", "wrong_matches"}),
     "processing": frozenset({"failed_imports", "wrong_matches"}),
 }
 
@@ -39,9 +38,8 @@ def assert_force_import_authority_invariant(
 
 class TestForceImportAuthorityGenerated(unittest.TestCase):
     def test_only_existing_configured_quarantine_sources_enqueue(self) -> None:
-        # Exhaustive finite authority table. It includes the decisive staging
-        # asymmetry, ordinary staging authorization, and component-lookalike
-        # worlds that were previously pinned with @example.
+        # Exhaustive finite authority table. It includes both staging
+        # quarantine markers and component-lookalike worlds.
         worlds = product(
             sorted(MARKERS_BY_ROOT),
             _MARKERS,

--- a/tests/web/test_routes_pipeline_mutations.py
+++ b/tests/web/test_routes_pipeline_mutations.py
@@ -1218,7 +1218,12 @@ class TestPipelineMutationRouteContracts(_FakeDbWebServerCase):
             staging = os.path.join(root, "Incoming")
             slskd = os.path.join(root, "slskd")
             processing = os.path.join(root, "processing")
-            album = os.path.join(staging, "failed_imports", "Test")
+            album = os.path.join(
+                staging,
+                "auto-import",
+                "wrong_matches",
+                "Loon_Lake-Low_Res-playlist-request-111-log-39310",
+            )
             os.makedirs(album)
             os.makedirs(slskd)
             os.makedirs(processing)


### PR DESCRIPTION
Follow-up for #1016.

The live Loon Lake rescue downloaded and preserved all ten tracks, then correctly entered Wrong Matches at distance 0.4151. The Force Import action returned HTTP 422 before creating a job because filesystem authority admitted wrong_matches under slskd/private processing roots but not beneath the configured Beets staging root used by YouTube.

This change admits the exact wrong_matches path component beneath that already configured root. No-follow traversal, configured-root containment, exact-component matching, directory existence checks, and symlink refusal are unchanged.

Evidence:
- exact production path pinned: Incoming/auto-import/wrong_matches/Loon_Lake-Low_Res-playlist-request-111-log-39310
- real HTTP route contract changes from 422 to 202
- exhaustive finite authority matrix covers all configured roots, exact markers, lookalikes, missing paths, and nested/non-nested shapes
- canonical suite passed on clean commit 2ea91efaa90a99ce1c748358b78ccf0058ba0b98; receipt /run/user/1000/cratedigger-final-gate.CgOkKBNz
- independent Sol review: no findings