### PR TITLE
Fix verified lossless terminal routing

### DIFF
--- a/lib/quality/decisions.py
+++ b/lib/quality/decisions.py
@@ -199,14 +199,17 @@ def import_quality_decision(
     ``verified_lossless_proof=True`` still forces an import when the verdict is
     "better" or "equivalent", but NOT when it would be a downgrade — this
     blocks a deliberately too-low ``verified_lossless_target`` (e.g. Opus
-    64) from replacing a good existing album. When the bypass CHANGED the
-    outcome (an "equivalent" verdict imported), the returned basis records
-    ``verified_lossless_bypass=True`` so the persisted audit trail explains
-    the import; a "better" verdict imports on its own merits and the flag
-    stays False.
+    64) from replacing a good existing album. Proof-backed imports use the
+    ordinary ``import`` decision so dispatch runs the terminal quality gate;
+    conversion remains recorded separately on ``ImportResult``. When the
+    bypass CHANGED the outcome (an "equivalent" verdict imported), the
+    returned basis records ``verified_lossless_bypass=True`` so the persisted
+    audit trail explains the import; a "better" verdict imports on its own
+    merits and the flag stays False.
 
     Returns an ImportQualityDecision whose ``decision`` is one of:
-        "import"              — new files are better (or no existing), proceed
+        "import"              — new files are better (or no existing), proceed;
+                                also the terminal path for proof-backed targets
         "downgrade"           — new files are worse, skip (exit 5)
         "transcode_upgrade"   — transcode but better than existing, import + denylist (exit 6)
         "transcode_downgrade" — transcode and not better, skip + denylist (exit 6)
@@ -224,7 +227,12 @@ def import_quality_decision(
 
     if existing is None:
         return ImportQualityDecision(
-            decision="transcode_first" if is_transcode else "import")
+            decision=(
+                "transcode_first"
+                if is_transcode and not verified_lossless_proof
+                else "import"
+            )
+        )
 
     basis = compare_quality(
         new,
@@ -250,10 +258,14 @@ def import_quality_decision(
     # difference if it's laundered or not, is it better? if you denied
     # laundered audio you'd never get anything for this particular release."
     # — https://github.com/abl030/cratedigger/issues/829
-    if verified_lossless_proof and verdict == "equivalent":
+    if verified_lossless_proof and verdict in ("better", "equivalent"):
         return ImportQualityDecision(
-            decision="transcode_upgrade" if is_transcode else "import",
-            basis=msgspec.structs.replace(basis, verified_lossless_bypass=True),
+            decision="import",
+            basis=(
+                msgspec.structs.replace(basis, verified_lossless_bypass=True)
+                if verdict == "equivalent"
+                else basis
+            ),
         )
 
     if verdict == "better":

--- a/tests/test_cd_rip_policy.py
+++ b/tests/test_cd_rip_policy.py
@@ -201,8 +201,12 @@ class CdRipCanonicalPolicyTest(unittest.TestCase):
             ),
         )
 
-        self.assertEqual(result["stage2_import"], "transcode_upgrade")
+        self.assertEqual(result["stage2_import"], "import")
         self.assertTrue(result["imported"])
+        self.assertEqual(result["stage3_quality_gate"], "accept")
+        self.assertEqual(result["final_status"], "imported")
+        self.assertFalse(result["keep_searching"])
+        self.assertFalse(result["denylisted"])
         basis = result["comparison_basis"]
         self.assertEqual(basis["verdict"], "equivalent")
         self.assertEqual(basis["new_format"], "mp3 128")

--- a/tests/test_import_one_stages.py
+++ b/tests/test_import_one_stages.py
@@ -2225,7 +2225,7 @@ class TestDryRunMintsVerifiedLosslessProof(unittest.TestCase):
             verified_lossless_proof=True,
         )
 
-        self.assertEqual(equivalent.decision, "transcode_upgrade")
+        self.assertEqual(equivalent.decision, "import")
         self.assertFalse(equivalent.is_terminal)
         assert equivalent.comparison_basis is not None
         self.assertTrue(equivalent.comparison_basis.verified_lossless_bypass)

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -38,12 +38,15 @@ from lib.quality import (
     IMPORT_RESULT_SENTINEL,
     QUALITY_UPGRADE_TIERS,
     ActiveDownloadState,
+    AlbumQualityEvidenceDecisionFacts,
     AudioQualityMeasurement,
     ConversionInfo,
     DownloadInfo,
     ImportResult,
     PostflightInfo,
     ValidationResult,
+    VerifiedLosslessProof,
+    full_pipeline_decision_from_evidence,
     legacy_unrecorded_audio_validation_report,
 )
 from lib.spectral_check import SPECTRAL_MEASUREMENT_VERSION, AlbumResult
@@ -874,6 +877,83 @@ class TestDispatchThroughQualityGate(unittest.TestCase):
         )
         gate.assert_called_once()
         self.assertEqual(db.request(42)["status"], "imported")
+
+    def test_force_import_cd_proof_target_is_terminal_without_denylist(self):
+        """A bit-proven source stored at the configured target is done."""
+        proof = VerifiedLosslessProof(
+            provenance="measured",
+            source="flac",
+            classifier="generated",
+        )
+        candidate = make_album_quality_evidence(
+            mb_release_id="mbid-123",
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=511,
+                avg_bitrate_kbps=609,
+                format="FLAC",
+            ),
+            codec="flac",
+            container="flac",
+            storage_format="FLAC",
+            target_format="mp3 128",
+            target_is_cbr=False,
+            verified_lossless_proof=proof,
+        )
+        current = make_album_quality_evidence(
+            mb_release_id="mbid-123",
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=128,
+                avg_bitrate_kbps=128,
+                format="MP3",
+            ),
+            codec="mp3",
+            container="mp3",
+            storage_format="MP3",
+        )
+        decision = full_pipeline_decision_from_evidence(
+            candidate,
+            current,
+            facts=AlbumQualityEvidenceDecisionFacts(
+                verified_lossless_target="mp3 128",
+                target_format="mp3 128",
+                converted_count=8,
+                post_conversion_min_bitrate=128,
+                post_conversion_is_cbr=False,
+            ),
+        )
+        ir = make_import_result(
+            decision=str(decision["stage2_import"]),
+            new_min_bitrate=511,
+            prev_min_bitrate=128,
+            was_converted=True,
+            original_filetype="flac",
+            target_filetype="mp3",
+            verified_lossless=True,
+            final_format="mp3 128",
+        )
+        ir.verified_lossless_proof = proof
+        beets_info = AlbumInfo(
+            album_id=1,
+            track_count=8,
+            min_bitrate_kbps=128,
+            avg_bitrate_kbps=128,
+            format="MP3",
+            is_cbr=False,
+            album_path="/Beets/Test",
+        )
+
+        db = self._run_dispatch(
+            ir,
+            beets_info,
+            force=True,
+            scenario="force_import",
+        )
+
+        self.assertEqual(decision["stage2_import"], "import")
+        row = db.request(42)
+        self.assertEqual(row["status"], "imported")
+        self.assertIsNone(row["search_filetype_override"])
+        self.assertEqual(db.denylist, [])
 
     def test_import_with_unmeasured_distance_records_null(self):
         """#550 defect #4: dispatch with distance=None (the production

--- a/tests/test_quality_generated.py
+++ b/tests/test_quality_generated.py
@@ -212,6 +212,24 @@ def assert_unverified_lossy_never_terminal(result: SimResult) -> None:
         raise AssertionError(f"retained lossy source was not denylisted: {result!r}")
 
 
+def assert_proof_backed_target_uses_terminal_gate(result: dict) -> None:
+    """A proof-backed configured target must use the terminal import path."""
+    actual = (
+        result["stage2_import"],
+        result["stage3_quality_gate"],
+        result["final_status"],
+        result["imported"],
+        result["keep_searching"],
+        result["denylisted"],
+    )
+    expected = ("import", "accept", "imported", True, False, False)
+    if actual != expected:
+        raise AssertionError(
+            f"proof-backed configured target was not terminal: "
+            f"{actual!r} != {expected!r}"
+        )
+
+
 _POST_IMPORT_EXPECTATIONS = {
     "accept": ("imported", None, False),
     "requeue_lossless": ("wanted", "lossless", True),
@@ -6211,6 +6229,55 @@ class TestStoredFormatIsProofBlindProperties(unittest.TestCase):
         )
 
 
+class TestProofBackedTargetTerminalProperties(unittest.TestCase):
+    @given(
+        source_bitrate=st.integers(min_value=400, max_value=1400),
+        current_bitrate=st.one_of(
+            st.none(), st.integers(min_value=1, max_value=130)
+        ),
+        converted_count=st.integers(min_value=1, max_value=30),
+    )
+    def test_configured_target_finishes_for_every_non_downgrade(
+        self,
+        source_bitrate,
+        current_bitrate,
+        converted_count,
+    ):
+        candidate = build_parity_candidate_evidence(
+            is_flac=True,
+            min_bitrate=source_bitrate,
+            is_cbr=False,
+        )
+        candidate = msgspec.structs.replace(
+            candidate,
+            target_format="opus 128",
+            target_is_cbr=False,
+            verified_lossless_proof=VerifiedLosslessProof(
+                provenance="measured",
+                source="flac",
+                classifier="generated",
+            ),
+        )
+        current = build_parity_current_evidence(
+            min_bitrate=current_bitrate,
+            avg_bitrate=current_bitrate,
+            format="Opus",
+        )
+        result = full_pipeline_decision_from_evidence(
+            candidate,
+            current,
+            facts=AlbumQualityEvidenceDecisionFacts(
+                verified_lossless_target="opus 128",
+                target_format="opus 128",
+                converted_count=converted_count,
+                post_conversion_min_bitrate=114,
+                post_conversion_is_cbr=False,
+            ),
+        )
+
+        assert_proof_backed_target_uses_terminal_gate(result)
+
+
 class TestStoredFormatCheckerSelfTests(unittest.TestCase):
     """Known-bad self-tests for the stored-format invariant checkers."""
 
@@ -6345,6 +6412,17 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
     def test_unverified_lossy_checker_trips_on_terminal_import(self):
         with self.assertRaises(AssertionError):
             assert_unverified_lossy_never_terminal(_planted_bad_import())
+
+    def test_proof_backed_target_checker_trips_on_transcode_routing(self):
+        with self.assertRaises(AssertionError):
+            assert_proof_backed_target_uses_terminal_gate({
+                "stage2_import": "transcode_upgrade",
+                "stage3_quality_gate": "accept",
+                "final_status": "imported",
+                "imported": True,
+                "keep_searching": False,
+                "denylisted": False,
+            })
 
     def test_action_mapping_checker_trips_on_each_output_field(self):
         for field, overrides in (


### PR DESCRIPTION
Summary:
- route proof-backed converted imports through the ordinary terminal quality gate
- preserve existing wanted/denylist behavior for unverified transcodes
- cover the live CD-proof equivalent-target shape through decision, harness, dispatch, and generated tests

Validation:
- receipt-backed canonical suite: PASS (7 phases)
- focused quality/import/dispatch suite: 250 tests passed