### PR TITLE
Guard runtime code from test-only imports

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -6,9 +6,22 @@ target-version = "py313"
 [lint]
 extend-select = [
   "B905",
+  "TID251",
 ]
 
+[lint.flake8-tidy-imports.banned-api]
+"tests".msg = "Runtime code must not import test-only modules."
+
 [lint.per-file-ignores]
+"scripts/run_fuzz_tests.py" = [
+  "TID251", # Deliberate adapter that discovers and runs tests.
+]
+"scripts/run_python_tests.py" = [
+  "TID251", # Deliberate adapter that discovers and runs tests.
+]
+"tests/**" = [
+  "TID251",
+]
 "tools/vulture/whitelist.py" = [
   "B018",
   "F821",

--- a/tests/test_unused_import_audit.py
+++ b/tests/test_unused_import_audit.py
@@ -453,6 +453,41 @@ class TestUnusedImportAudit(unittest.TestCase):
         self.assertIn('set -- .', runner)
         self.assertIn("ruff check", runner)
 
+    def test_test_only_import_ban_uses_real_ruff(self) -> None:
+        findings = ruff_findings({
+            "lib/import_shapes.py": (
+                "import tests.aliased as alias\n"
+                "import tests.direct\n\n"
+                "print(alias, tests.direct)\n\n\n"
+                "def load():\n"
+                "    from tests import nested\n\n"
+                "    return nested\n"
+            ),
+        })
+        self.assertEqual(
+            [finding["code"] for finding in findings],
+            ["TID251", "TID251", "TID251"],
+        )
+        test_control = subprocess.run(
+            [
+                "bash",
+                "scripts/run_ruff.sh",
+                "--stdin-filename",
+                "tests/test_control.py",
+                "-",
+            ],
+            cwd=REPO_ROOT,
+            input="from tests import ephemeral_pg\n\nprint(ephemeral_pg)\n",
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+        self.assertEqual(
+            test_control.returncode,
+            0,
+            test_control.stdout + test_control.stderr,
+        )
+
     def test_ruff_toolchain_comes_from_locked_nixpkgs(self) -> None:
         result = subprocess.run(
             ["ruff", "--version"],
@@ -474,11 +509,27 @@ class TestUnusedImportAudit(unittest.TestCase):
         self.assertGreaterEqual(version, (0, 16, 0))
         self.assertEqual(config["required-version"], ">=0.16.0")
         self.assertEqual(config["target-version"], "py313")
-        self.assertEqual(config["lint"]["extend-select"], ["B905"])
+        self.assertEqual(
+            config["lint"]["extend-select"],
+            ["B905", "TID251"],
+        )
         self.assertNotIn("ignore", config["lint"])
         self.assertEqual(
             config["lint"]["per-file-ignores"],
-            {"tools/vulture/whitelist.py": ["B018", "F821"]},
+            {
+                "scripts/run_fuzz_tests.py": ["TID251"],
+                "scripts/run_python_tests.py": ["TID251"],
+                "tests/**": ["TID251"],
+                "tools/vulture/whitelist.py": ["B018", "F821"],
+            },
+        )
+        self.assertEqual(
+            config["lint"]["flake8-tidy-imports"]["banned-api"],
+            {
+                "tests": {
+                    "msg": "Runtime code must not import test-only modules.",
+                },
+            },
         )
         self.assertFalse(Path("nix/ruff.nix").exists())
         self.assertIn("pkgs.ruff", shell)


### PR DESCRIPTION
## Summary

- reject static `tests.*` imports from non-test Python through Ruff's maintained `TID251` rule
- exempt only the test tree and the two deliberate test-runner adapters
- qualify direct, aliased, and function-local imports through the existing canonical Ruff helper
- keep arbitrary dynamic-import inference outside this guard; focused filtered-runtime execution remains responsible for genuine lazy entrypoints

## Complexity boundary

The issue's original custom AST-audit shape was replaced before implementation with the narrower contract recorded in [the issue scope comment](https://github.com/abl030/cratedigger/issues/1032#issuecomment-5175809637). This PR adds no parser, semantic scanner, source-root registry, generated property, or new test harness.

The Ruff gate is repository-wide rather than coupled to an enumerated `runtimeSrc` list, so a new non-test production root is covered by default. The only non-test exemptions are `scripts/run_fuzz_tests.py` and `scripts/run_python_tests.py`, whose purpose is to run `tests.*`.

## Verification

Exact commit: `cf6544502170b2c1817f0c041577acd00e42e458`

- direct, nested-function, and aliased known-bad probes: rejected with `TID251`
- test-tree control: accepted
- focused Ruff audit module: 23 tests green
- canonical receipt: `/run/user/1000/cratedigger-final-gate.h4Z2MdsX`
- canonical bundle: `/run/user/1000/cratedigger-checks.ksz9h12e`
- 7/7 phases; 9,359 Python tests; 427/427 targets; JavaScript, both Pyright modes, Ruff, and Vulture green
- independent review found one missing durable qualification; corrected exact commit independently re-reviewed with no findings

Refs #1032