### PR TITLE
Speed up the module VM test

### DIFF
--- a/docs/nixos-module.md
+++ b/docs/nixos-module.md
@@ -605,9 +605,14 @@ The flake exposes separate NixOS VM checks for module wiring and the real
 Jellyfin integration contract:
 
 ```bash
-nix build .#checks.x86_64-linux.moduleVm    # ~30s after first build
+nix build .#checks.x86_64-linux.moduleVm
 nix build .#checks.x86_64-linux.jellyfinMetadataVm
 ```
+
+The module VM builds a guest-local Nix store image just in time for every run,
+with an ephemeral writable overlay for its closure queries. This avoids routing
+the test's Python- and Beets-heavy store reads through the host's 9p mount; the
+image construction time is included in the check's wall clock.
 
 This catches option-surface breakage, immutable runtime-capability wiring,
 systemd dependency cycles, wrapper `PYTHONPATH` errors, and missing Python

--- a/nix/tests/module-vm.nix
+++ b/nix/tests/module-vm.nix
@@ -1012,8 +1012,13 @@ pkgs.testers.nixosTest {
     # createLocally is set, and every app unit requires the migrate unit —
     # transitively serialising first boot behind role/database provisioning.
 
-    # Speed up the VM
+    # Python-heavy services repeatedly read their closures during this test.
+    # A guest-local store image avoids making those reads cross 9p. Keep its
+    # default tmpfs-backed writable overlay because the test queries closures
+    # with nix-store, which maintains store bookkeeping while it runs.
     virtualisation.memorySize = 2048;
+    virtualisation.useNixStoreImage = true;
+    virtualisation.writableStore = true;
   };
 
   # Keep the large Python program in its own store file. Nix otherwise places
@@ -2881,12 +2886,15 @@ pkgs.testers.nixosTest {
     machine.wait_until_succeeds(
         "systemctl is-active --quiet cratedigger-web.service"
     )
-    machine.succeed(
+    # Type=simple becomes active before its shell wrapper has exec'd the
+    # production server, so wait for the exact restored process identity.
+    machine.wait_until_succeeds(
         "pid=$(systemctl show cratedigger-web.service -p MainPID --value); "
         "! tr '\\0' '\\n' < /proc/$pid/cmdline | grep -F '${headerRecorder}'; "
         "tr '\\0' '\\n' < /proc/$pid/cmdline "
         "| grep -A1 -Fx -- '--canonical-origin' "
-        "| tail -n1 | grep -Fx 'https://music.vm.test'"
+        "| tail -n1 | grep -Fx 'https://music.vm.test'",
+        timeout=10,
     )
     _assert_basic_auth_matrix()
     machine.succeed(

--- a/tests/test_nix_module.py
+++ b/tests/test_nix_module.py
@@ -1285,6 +1285,13 @@ class TestWebAuthenticationModuleContract(unittest.TestCase):
         )
 
 
+class TestModuleVmPerformanceContract(unittest.TestCase):
+    def test_guest_reads_the_nix_store_from_a_local_image(self) -> None:
+        text = MODULE_VM_NIX.read_text(encoding="utf-8")
+        self.assertIn("virtualisation.useNixStoreImage = true;", text)
+        self.assertIn("virtualisation.writableStore = true;", text)
+
+
 class TestImporterServiceContract(unittest.TestCase):
     def test_importer_wrapper_and_service_are_defined(self) -> None:
         text = MODULE_NIX.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- run the module VM from a guest-local Nix store image instead of the host 9p mount
- retain a tmpfs-backed writable overlay for the test's `nix-store` closure queries
- wait for the restored production web process identity, closing the readiness race exposed by faster startup
- document the VM store topology and pin it with a structural contract test

## Wall-clock evidence

Measured on `proxmox-vm` with the full `checks.x86_64-linux.moduleVm` scenario intact:

| Run | Baseline | Candidate | Improvement |
|---|---:|---:|---:|
| Initial realization | 334.64s | 211.61s | 36.8% |
| Forced rebuild | 319.53s | 166.73s | 47.8% |
| Rebased on current main | 334.64s baseline | 180.14s | 46.2% |

The candidate wall clock includes just-in-time Nix store image construction.

## Validation

- `nix build .#checks.x86_64-linux.moduleVm --no-link --print-build-logs` (153.19s test script, 180.14s wall clock on rebased HEAD)
- `python3 -m unittest tests.test_nix_module` (43 tests)
- Pyright: 0 errors
- canonical receipt-backed final gate: pass (`/run/user/1000/cratedigger-final-gate.GUxyGbPt`)
- signed clean HEAD: `8396770d5f2f9a6bc5da20ead52171851463208f`
