### PR TITLE
Fix nightly PostgreSQL socket and audit compatibility

### DIFF
--- a/lib/ephemeral_postgres.py
+++ b/lib/ephemeral_postgres.py
@@ -22,8 +22,12 @@ class EphemeralPostgresError(RuntimeError):
 class EphemeralPostgres:
     """Own one temporary PostgreSQL cluster for replay or test isolation."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, temp_directory: str | Path | None = None) -> None:
+        self._temp_directory = (
+            str(temp_directory) if temp_directory is not None else None
+        )
         self.tmpdir: Path | None = None
+        self._socket_tmpdir: Path | None = None
         self.dsn: str | None = None
         self._server_started = False
         self._started = False
@@ -63,8 +67,8 @@ class EphemeralPostgres:
 
     @property
     def _socket_dir(self) -> Path:
-        assert self.tmpdir is not None
-        return self.tmpdir / "socket"
+        assert self._socket_tmpdir is not None
+        return self._socket_tmpdir
 
     def _failure_detail(self, error: subprocess.CalledProcessError) -> str:
         command = " ".join(str(part) for part in error.cmd)
@@ -91,6 +95,9 @@ class EphemeralPostgres:
         if self.tmpdir is not None:
             shutil.rmtree(self.tmpdir, ignore_errors=True)
         self.tmpdir = None
+        if self._socket_tmpdir is not None:
+            shutil.rmtree(self._socket_tmpdir, ignore_errors=True)
+        self._socket_tmpdir = None
 
     def start(self) -> None:
         if self._started:
@@ -100,10 +107,18 @@ class EphemeralPostgres:
                 "initdb/pg_ctl not found; run inside nix-shell"
             )
 
-        self.tmpdir = Path(tempfile.mkdtemp(prefix="cratedigger_ephemeral_pg_"))
-        self._socket_dir.mkdir()
         user = os.getenv("USER", "root")
         try:
+            self.tmpdir = Path(tempfile.mkdtemp(
+                prefix="cratedigger_ephemeral_pg_",
+                dir=self._temp_directory,
+            ))
+            # PostgreSQL's sockaddr_un path is limited to 107 bytes on Linux.
+            # Keep the data and logs under the caller's (possibly long) TMPDIR,
+            # but allocate the tiny private socket directory beneath a stable,
+            # short path. systemd's PrivateTmp still isolates /tmp for the
+            # unattended gate.
+            self._socket_tmpdir = Path(tempfile.mkdtemp(prefix="cdpg-", dir="/tmp"))
             subprocess.run(
                 [
                     "initdb", "-D", str(self._datadir), "--no-locale", "-E", "UTF8",

--- a/lib/validation_envelope.py
+++ b/lib/validation_envelope.py
@@ -104,6 +104,14 @@ DISTANCE_KEY = "distance"
 SCENARIO_KEY = "scenario"
 WRONG_MATCH_TRIAGE_KEY = "wrong_match_triage"
 
+_TRIAGE_NESTED_STRUCT_FIELDS = {
+    "candidate_measurement": AudioQualityMeasurement.__struct_fields__,
+    "current_measurement": AudioQualityMeasurement.__struct_fields__,
+    "candidate_v0_probe": V0ProbeEvidence.__struct_fields__,
+    "current_v0_probe": V0ProbeEvidence.__struct_fields__,
+    "comparison_basis": QualityComparisonBasis.__struct_fields__,
+}
+
 
 @dataclass(frozen=True)
 class ValidationProjectionUnset:
@@ -190,4 +198,20 @@ def decode_validation_envelope(raw: Any) -> ValidationResultEnvelope:
         return ValidationResultEnvelope()
     if isinstance(raw, (str, bytes)):
         raw = json.loads(raw)
+    if isinstance(raw, dict):
+        raw_object = msgspec.convert(raw, type=dict[str, object])
+        triage = raw_object.get(WRONG_MATCH_TRIAGE_KEY)
+        if isinstance(triage, dict):
+            normalized_triage = msgspec.convert(triage, type=dict[str, object])
+            for field, known_fields in _TRIAGE_NESTED_STRUCT_FIELDS.items():
+                nested = normalized_triage.get(field)
+                if isinstance(nested, dict):
+                    nested_object = msgspec.convert(nested, type=dict[str, object])
+                    normalized_triage[field] = {
+                        key: value
+                        for key, value in nested_object.items()
+                        if key in known_fields
+                    }
+            raw_object[WRONG_MATCH_TRIAGE_KEY] = normalized_triage
+        raw = raw_object
     return msgspec.convert(raw, type=ValidationResultEnvelope)

--- a/tests/test_ephemeral_pg.py
+++ b/tests/test_ephemeral_pg.py
@@ -32,10 +32,12 @@ class TestEphemeralPostgresFailures(unittest.TestCase):
         with tempfile.TemporaryDirectory() as directory:
             base = Path(directory)
             failed_dir = base / "failed-cluster"
+            socket_dir = base / "socket"
 
             def make_tempdir(*_args: object, **_kwargs: object) -> str:
-                failed_dir.mkdir()
-                return str(failed_dir)
+                target = socket_dir if _kwargs.get("dir") == "/tmp" else failed_dir
+                target.mkdir()
+                return str(target)
 
             with (
                 patch("lib.ephemeral_postgres.shutil.which", return_value="/bin/tool"),
@@ -54,9 +56,25 @@ class TestEphemeralPostgresFailures(unittest.TestCase):
                 EphemeralPostgres().start()
 
             self.assertFalse(failed_dir.exists())
+            self.assertFalse(socket_dir.exists())
 
 
 class TestEphemeralPostgresIsolation(unittest.TestCase):
+    def test_long_tmpdir_keeps_socket_path_below_postgres_limit(self) -> None:
+        with tempfile.TemporaryDirectory(dir="/tmp") as root:
+            long_tmpdir = Path(root) / ("deep-test-scratch-" * 5)
+            long_tmpdir.mkdir()
+            with EphemeralPostgres(temp_directory=long_tmpdir) as pg:
+                assert pg.tmpdir is not None
+                self.assertTrue(pg.tmpdir.is_relative_to(long_tmpdir))
+                socket_path = pg._socket_dir / ".s.PGSQL.5432"
+                self.assertLessEqual(len(str(socket_path).encode()), 107)
+                data_dir = pg.tmpdir
+                socket_dir = pg._socket_dir
+
+            self.assertFalse(data_dir.exists())
+            self.assertFalse(socket_dir.exists())
+
     def test_multiple_instances_have_isolated_live_unix_socket_clusters(self) -> None:
         def start_query_stop(_: int) -> str:
             with EphemeralPostgres() as pg:

--- a/tests/test_validation_envelope.py
+++ b/tests/test_validation_envelope.py
@@ -89,6 +89,25 @@ class TestDecodeValidationEnvelope(unittest.TestCase):
         self.assertEqual(triage.stage_chain, ["preview", "decide"])
         self.assertEqual(triage.cleared_rows, 2)
 
+    def test_triage_tolerates_legacy_nested_measurement_extra_keys(self) -> None:
+        env = decode_validation_envelope({
+            "valid": False,
+            "wrong_match_triage": {
+                "candidate_measurement": {
+                    "format": "MP3",
+                    "avg_bitrate_kbps": 256,
+                    "verified_lossless": False,
+                },
+            },
+        })
+
+        self.assertFalse(env.valid)
+        triage = env.wrong_match_triage
+        assert triage is not None
+        assert triage.candidate_measurement is not None
+        self.assertEqual(triage.candidate_measurement.format, "MP3")
+        self.assertEqual(triage.candidate_measurement.avg_bitrate_kbps, 256)
+
     def test_wrong_typed_failed_path_raises(self) -> None:
         with self.assertRaises(msgspec.ValidationError):
             decode_validation_envelope({"failed_path": 123})

--- a/tests/test_world_invariants.py
+++ b/tests/test_world_invariants.py
@@ -249,6 +249,25 @@ class TestWorldInvariantPins(unittest.TestCase):
         )
         self.assertEqual(
             derive_denylist_authorities(
+                username="validation-peer",
+                reason="beets validation rejected",
+                history=[{
+                    **history[0],
+                    "validation_result": {
+                        "valid": False,
+                        "wrong_match_triage": {
+                            "candidate_measurement": {
+                                "format": "MP3",
+                                "verified_lossless": False,
+                            },
+                        },
+                    },
+                }],
+            ),
+            ("validation_reject",),
+        )
+        self.assertEqual(
+            derive_denylist_authorities(
                 username="legacy-secondary-peer",
                 reason="beets validation rejected",
                 history=[{


### PR DESCRIPTION
## Summary
- keep ephemeral PostgreSQL data in the configured test scratch directory while allocating Unix sockets under a short private `/tmp` path
- preserve strict typed validation while ignoring retired fields inside historical nested wrong-match triage snapshots
- restore denylist authority for the five production rows whose valid rejection records currently fail nested decoding

No production database mutation is required.

## Verification
- full deterministic gate: all 7 phases passed; Python phase 9,366 tests
- bounded PostgreSQL-backed fuzz smoke under intentionally long `TMPDIR`: 1 module, 2 tests, all green
- Ruff and focused/full Pyright: clean
- focused regression suite: passed
- independent final review: no security or logic findings