### PR TITLE
docs(rules): search doc prose by artifact, not only by identifier

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -603,6 +603,20 @@ rationale; never allowlist a pure decision.
 - For non-trivial changes (new structs, refactored function signatures, new pipeline paths), review the complete diff before committing.
 - Check correctness bugs, test gaps, missed callers, type errors, unfinished wiring, and production-shape drift. Use the active agent's native review capability; no specialist review workflow is required.
 - Docs freshness: does this diff make any README / `docs/` / `examples/` / CLAUDE.md statement wrong or incomplete, or ship a documented surface (a new option / plugin / CLI subcommand / behavior) undocumented? `test_docs_audit.py` catches structural gaps; the reviewer catches stale prose the audit can't see.
+  - **Search prose by the artifact, not only by the identifier.** Docs name a
+    thing the way an operator meets it — a secret path, a URL, a systemd unit,
+    a header — not by the option or symbol that governs it. A grep for the new
+    identifier therefore returns clean while a paragraph about the same
+    behaviour goes stale. Grep the artifacts the change touches too, and treat
+    an empty result as "wrong pattern" until one search has actually hit the
+    file you expect. Incident: #924's `web.externalAuth` cleared a grep for
+    `basicAuthFile|enableInsecure|externalAuth` across README, `docs/`, and
+    `examples/`, while `README.md` told every operator to provision
+    `/run/secrets/cratedigger.htpasswd` before the first switch — untrue for
+    the new mode, and found only by grepping `htpasswd`.
+  - A symlink does not widen grep scope: `grep -r` and `rg` both skip symlinks
+    during recursive traversal, so `AGENTS.md` never matches on `CLAUDE.md`'s
+    content without an explicit `-R`/`-L`. Do not rely on one for coverage.
 - Fix everything it finds before committing. This is not optional.
 
 ## Commits & PRs


### PR DESCRIPTION
Follow-up to #1040 / #1041.

## Why

#1041 fixed a stale README paragraph. This records the search rule that would
have caught it, and rules out the fix that looks obvious but doesn't work.

The miss: a grep for `basicAuthFile|enableInsecure|externalAuth` across README,
`docs/`, and `examples/` came back clean. `README.md` was inside that scope and
still told every operator to provision `/run/secrets/cratedigger.htpasswd`
before the first switch — untrue once `web.externalAuth` existed. The README
names the credential by **path**, never by option name, so an identifier grep
could not hit it wherever the file lived. Grepping `htpasswd` found it at once.

## The symlink non-fix, measured

The natural reaction is "put the README under `docs/` so doc greps see it."
Measured against this repo's existing `AGENTS.md` → `CLAUDE.md` symlink:

| search | finds content through the symlink |
|---|---|
| `grep -r` (default) | no |
| `rg` (default) | no |
| `grep -R` | yes |
| `rg -L` | yes, duplicated |

Both default recursive searches skip symlinks, so a `docs/README.md` symlink
would be invisible to exactly the greps it was meant to serve. Recorded so the
idea isn't re-attempted.

## Change

One bullet under the existing "Docs freshness" pre-commit item: search doc
prose by the artifact an operator meets (secret path, URL, unit name, header),
not only by the identifier that governs it, and treat an empty grep as "wrong
pattern" until one search has hit the file you expect.

No executable guard: deciding whether a paragraph is mode-scoped needs to infer
meaning from prose, which `.claude/rules/code-quality.md` § "Semantic source
scanners are prohibited" rules out. This is a review rule because that is what
it can honestly be.

## Verification

- `nix-shell --run "python3 -m unittest tests.test_docs_audit"` — 48 tests, pass
- `nix-shell --run "python3 tools/generate-ai-adapters.py --check"` — adapters current

🤖 Generated with [Claude Code](https://claude.com/claude-code)
