### PR TITLE
Run adjacent quality gates with targeted tests

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -73,10 +73,12 @@ Call the full pipeline.
 
 `scripts/run_tests.sh` owns both complementary typing contracts and they must
 have zero errors: whole-repository Pyright through `pyrightconfig.json`, plus
-production strict mode through `pyrightconfig.production.json`. Direct
-`nix-shell --run "pyright --threads 4"` and focused file checks provide faster
-development feedback but never replace or narrow the canonical suite. Never
-accept a "pre-existing" error in either contract.
+production strict mode through `pyrightconfig.production.json`. One concurrent
+`scripts/run_pyright_checks.py` phase runs both contracts and combines their
+status without hiding either output. Its hardware-aware allocation is capped at
+the measured useful 8 whole-tree + 4 strict threads. Focused file checks provide
+faster development feedback but never replace or narrow the canonical suite.
+Never accept a "pre-existing" error in either contract.
 
 - Use typed dataclasses (not dicts) for structured data crossing module boundaries
 - **No dual-interface types.** Never add `__getitem__`, `.get()`, or `isinstance(x, dict)` dispatch to a dataclass. If a function receives both dicts and dataclasses, that is a type error — fix the callers, not the receiver. Temporary bridges become permanent bugs.
@@ -233,10 +235,17 @@ tests, whole-tree Pyright, the complete deterministic suite, and relevant
 surface-specific checks are all available whenever they add useful feedback:
 
 ```bash
-nix-shell --run "python3 -m unittest tests.test_X -v"  # focused iteration
-nix-shell --run "pyright --threads 4"                   # whole repository
-nix-shell --run "bash scripts/run_tests.sh"             # complete suite
+bash scripts/test.sh tests.test_X                        # target + adjacent/ambient gates
+nix-shell --run "python3 scripts/run_pyright_checks.py"  # both typing contracts
+nix-shell --run "bash scripts/run_tests.sh"              # complete suite
 ```
+
+The targeted entrypoint pairs deterministic and generated siblings, selects
+tests adjacent to changed production surfaces, discovers every `test_*_audit`
+module plus explicitly named ratchets, and reuses the canonical JavaScript,
+Pyright, Ruff, and Vulture phases. With no explicit selector, changed paths are
+the target source. This is development feedback; the full suite remains the
+exhaustive pre-review boundary.
 
 Always use `nix-shell --run` for Python (`.claude/rules/nix-shell.md`). Direct
 Nix-shell runs are ordinary development feedback; fix their failures in the
@@ -248,8 +257,8 @@ converged tree is committed and clean; it owns the receipt and unchanged-tree
 no-replay rules. If review changes nothing, that same receipt is the final
 pre-push confirmation.
 
-`run_tests.sh` exhausts JavaScript, whole-repository Pyright,
-production-strict Pyright, Ruff, Vulture, and the complete Python scheduler
+`run_tests.sh` exhausts JavaScript, the concurrent complementary Pyright phase,
+Ruff, Vulture, and the complete Python scheduler
 before returning one aggregate status. `run_final_gate.sh` can only execute
 that exact suite; it adds clean-commit receipt semantics, not another selection
 of checks. The suite's terminal output is a compact complete failure index; the

--- a/.claude/rules/nix-shell.md
+++ b/.claude/rules/nix-shell.md
@@ -11,7 +11,8 @@ ALL Python commands must run inside `nix-shell --run "..."`. The dev shell provi
 
 ```bash
 nix-shell --run "bash scripts/run_tests.sh"           # full suite
-nix-shell --run "python3 -m unittest tests.<mod> -v"   # single module
+bash scripts/test.sh tests.<mod>                       # targeted + ambient gates
+nix-shell --run "python3 -m unittest tests.<mod> -v"   # isolated test debugging
 nix-shell --run "python3 -c '...'"                     # one-off
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,13 +176,14 @@ judgment based on the change, current evidence, and concrete risk. Always use
 `nix-shell --run` for Python:
 
 ```bash
-nix-shell --run "python3 -m unittest tests.test_X -v"  # focused iteration
-nix-shell --run "pyright --threads 4"                   # whole repository
-nix-shell --run "bash scripts/run_tests.sh"             # complete suite
+bash scripts/test.sh tests.test_X                        # target + adjacent/ambient gates
+nix-shell --run "python3 scripts/run_pyright_checks.py"  # both typing contracts
+nix-shell --run "bash scripts/run_tests.sh"              # complete suite
 ```
 
-Direct runs are development feedback; before independent-review handoff, use
-the `check` skill on the converged, clean, committed tree for the one
+`scripts/test.sh` also accepts no selector and derives targets from the current
+diff. Direct runs are development feedback; before independent-review handoff,
+use the `check` skill on the converged, clean, committed tree for the one
 receipt-backed canonical-suite confirmation. Reuse that receipt before push if
 the reviewed commit remains unchanged. The complete operational contract —
 suite bundle, specialized evidence, generated/fuzz testing, no-skips policy,

--- a/README.md
+++ b/README.md
@@ -187,16 +187,18 @@ A request can be `wanted` while intentionally skipped for a few hours: retry-wor
 ## Development
 
 ```bash
-nix-shell --run "python3 -m unittest tests.test_X -v"  # focused iteration
-nix-shell --run "pyright --threads 4"                   # whole repository
-nix-shell --run "bash scripts/run_tests.sh"             # complete suite
+bash scripts/test.sh tests.test_X                        # target + adjacent/ambient gates
+nix-shell --run "python3 scripts/run_pyright_checks.py"  # both typing contracts
+nix-shell --run "bash scripts/run_tests.sh"              # complete suite
 ```
 
-These checks are available throughout development. `run_tests.sh` is the one
-canonical complete suite, including both whole-repository and production-strict
-Pyright. `run_final_gate.sh` runs that exact suite on a clean commit and adds a
-receipt; it does not select different checks. CI does not enforce this local
-workflow.
+`scripts/test.sh` expands the requested unittest selector with its generated or
+deterministic sibling, tests adjacent to every changed path, and every audit and
+ratchet. It also runs JavaScript, both Pyright contracts, Ruff, and Vulture in
+the same aggregate failure bundle. With no selector it derives targets from the
+working-tree diff. `run_tests.sh` remains the one canonical complete suite.
+`run_final_gate.sh` runs that exact suite on a clean commit and adds a receipt;
+it does not select different checks. CI does not enforce this local workflow.
 
 The dev shell resolves the same pinned nixpkgs as the default module package
 set, and `tests/test_harness_beets2_contract.py` runs real Beets so runtime drift

--- a/flake.nix
+++ b/flake.nix
@@ -250,7 +250,11 @@ EOF
           export HOME="$TMPDIR/home"
           mkdir -p "$HOME"
           cd ${source}
-          ${pkgs.pyright}/bin/pyright --threads 4
+          pyright_threads="$(${pkgs.coreutils}/bin/nproc)"
+          if (( pyright_threads > 8 )); then
+            pyright_threads=8
+          fi
+          ${pkgs.pyright}/bin/pyright --threads "$pyright_threads"
           touch "$out"
         '';
 

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -66,10 +66,10 @@ pkgs.mkShell {
 
     # Echo to stderr so the banner doesn't pollute stdout when callers do
     # ``nix-shell --run "cmd" > out`` (e.g. regenerating the vulture whitelist).
-    echo "cratedigger dev shell — run: python3 -m unittest discover -s tests -t . -v" >&2
+    echo "cratedigger dev shell — targeted: python3 scripts/run_targeted_tests.py tests.test_X" >&2
 
     # Pin the IDE's pyright to THIS interpreter so in-editor diagnostics match
-    # ``nix-shell --run "pyright --threads 4"`` (pyrightconfig.json points
+    # ``nix-shell --run "python3 scripts/run_pyright_checks.py"`` (the configs point
     # venvPath/venv here).
     # Without it, the editor's pyright falls back to the system python3 — which
     # lacks psycopg2/msgspec/pydantic/beets/... — and floods the file with

--- a/pyrightconfig.production.json
+++ b/pyrightconfig.production.json
@@ -27,7 +27,6 @@
   "reportPropertyTypeMismatch": "error",
   "reportTypeCommentUsage": "error",
   "reportMatchNotExhaustive": "error",
-  "reportShadowedImports": "error",
   "typeCheckingMode": "strict",
   "reportPrivateUsage": "none",
   "reportUnusedFunction": "none",

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 cd "$(dirname "$0")/.."
+PYRIGHT_THREADS=$(nproc)
+if (( PYRIGHT_THREADS > 8 )); then
+    PYRIGHT_THREADS=8
+fi
 
 if [ $# -eq 0 ]; then
-    nix-shell --run "pyright --threads 4 cratedigger.py lib/*.py album_source.py"
+    nix-shell --run "pyright --threads $PYRIGHT_THREADS cratedigger.py lib/*.py album_source.py"
 else
-    nix-shell --run "pyright --threads 4 $*"
+    nix-shell --run "pyright --threads $PYRIGHT_THREADS $*"
 fi

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -18,6 +18,10 @@ if [ -z "$STAGED" ]; then
 fi
 
 FILES=$(echo "$STAGED" | tr '\n' ' ')
+PYRIGHT_THREADS=$(nproc)
+if [ "$PYRIGHT_THREADS" -gt 8 ]; then
+    PYRIGHT_THREADS=8
+fi
 echo "pre-commit: pyright on $(echo "$STAGED" | wc -l) staged Python files..."
-nix-shell --run "pyright --threads 4 $FILES"
+nix-shell --run "pyright --threads $PYRIGHT_THREADS $FILES"
 echo "pre-commit: pyright OK"

--- a/scripts/run_pyright_checks.py
+++ b/scripts/run_pyright_checks.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Run whole-tree and production-strict Pyright concurrently."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TextIO
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MAX_TOTAL_THREADS = 12
+
+
+@dataclass(frozen=True)
+class PyrightCheck:
+    """One independently configured Pyright contract."""
+
+    name: str
+    project: str
+    threads: int
+
+
+@dataclass(frozen=True)
+class PyrightOutcome:
+    """Complete output and process status for one Pyright contract."""
+
+    check: PyrightCheck
+    returncode: int
+    output: str
+
+
+CheckRunner = Callable[[PyrightCheck], PyrightOutcome]
+
+
+def recommended_thread_counts(cpu_count: int) -> tuple[int, int]:
+    """Split the measured useful CPU budget between complementary checks."""
+    if cpu_count < 1:
+        raise ValueError("cpu_count must be at least 1")
+    if cpu_count == 1:
+        return 1, 1
+    total = min(cpu_count, MAX_TOTAL_THREADS)
+    strict = max(1, (total + 1) // 3)
+    whole = total - strict
+    return whole, strict
+
+
+def _run_check(check: PyrightCheck) -> PyrightOutcome:
+    completed = subprocess.run(
+        [
+            "pyright",
+            "-p",
+            check.project,
+            "--threads",
+            str(check.threads),
+        ],
+        cwd=REPO_ROOT,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    return PyrightOutcome(
+        check=check,
+        returncode=completed.returncode,
+        output=completed.stdout,
+    )
+
+
+def _run_check_fail_loud(
+    check: PyrightCheck,
+    run: CheckRunner,
+) -> PyrightOutcome:
+    try:
+        return run(check)
+    except Exception as exc:  # noqa: BLE001 - process infrastructure boundary
+        return PyrightOutcome(
+            check=check,
+            returncode=2,
+            output=f"{type(exc).__name__}: {exc}\n",
+        )
+
+
+def execute_checks(
+    checks: Sequence[PyrightCheck],
+    *,
+    run: CheckRunner = _run_check,
+) -> tuple[PyrightOutcome, ...]:
+    """Execute every configured contract concurrently and preserve order."""
+    plan = tuple(checks)
+    if not plan:
+        raise ValueError("at least one Pyright check is required")
+    if len({check.name for check in plan}) != len(plan):
+        raise ValueError("Pyright check names must be unique")
+    if any(check.threads < 1 for check in plan):
+        raise ValueError("Pyright thread counts must be positive")
+    with ThreadPoolExecutor(max_workers=len(plan)) as executor:
+        futures = tuple(
+            executor.submit(_run_check_fail_loud, check, run)
+            for check in plan
+        )
+        return tuple(future.result() for future in futures)
+
+
+def combined_exit_code(outcomes: Sequence[PyrightOutcome]) -> int:
+    """Combine all child statuses without losing infrastructure failures."""
+    if any(
+        line.startswith("Config contains unrecognized setting")
+        for outcome in outcomes
+        for line in outcome.output.splitlines()
+    ):
+        return 2
+    statuses = tuple(outcome.returncode for outcome in outcomes)
+    if statuses and all(status == 0 for status in statuses):
+        return 0
+    if statuses and all(status in {0, 1} for status in statuses):
+        return 1
+    return 2
+
+
+def write_outcomes(
+    outcomes: Sequence[PyrightOutcome],
+    stream: TextIO,
+) -> None:
+    """Publish complete child output in stable contract order."""
+    for outcome in outcomes:
+        stream.write(
+            f"=== {outcome.check.name} Pyright "
+            f"({outcome.check.threads} threads) ===\n"
+        )
+        stream.write(outcome.output)
+        if outcome.output and not outcome.output.endswith("\n"):
+            stream.write("\n")
+    stream.flush()
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be at least 1")
+    return parsed
+
+
+def _parser(cpu_count: int) -> argparse.ArgumentParser:
+    whole_default, strict_default = recommended_thread_counts(cpu_count)
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--whole-threads",
+        type=_positive_int,
+        default=whole_default,
+    )
+    parser.add_argument(
+        "--strict-threads",
+        type=_positive_int,
+        default=strict_default,
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser(os.cpu_count() or 1).parse_args(argv)
+    outcomes = execute_checks(
+        (
+            PyrightCheck("whole-tree", "pyrightconfig.json", args.whole_threads),
+            PyrightCheck(
+                "production-strict",
+                "pyrightconfig.production.json",
+                args.strict_threads,
+            ),
+        )
+    )
+    write_outcomes(outcomes, sys.stdout)
+    return combined_exit_code(outcomes)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_python_tests.py
+++ b/scripts/run_python_tests.py
@@ -599,6 +599,71 @@ def build_test_targets(
     return tuple(targets)
 
 
+def select_test_targets(
+    modules: Sequence[TestModule],
+    selectors: Sequence[str],
+    *,
+    listed_test_ids: Mapping[str, Sequence[str]] | None = None,
+    hotspot_policies: Mapping[str, str] = HOTSPOT_SHARD_POLICIES,
+) -> tuple[TestTarget, ...]:
+    """Resolve unittest selectors while retaining canonical module isolation."""
+    plan = tuple(selectors)
+    if not plan:
+        raise ValueError("at least one test selector is required")
+    module_by_name = {module.name: module for module in modules}
+    if len(module_by_name) != len(modules):
+        raise ValueError("duplicate discovered test module")
+
+    resolved: dict[str, list[str]] = {}
+    exact_modules: set[str] = set()
+    for selector in plan:
+        matches = tuple(
+            name
+            for name in module_by_name
+            if selector == name or selector.startswith(f"{name}.")
+        )
+        if not matches:
+            raise ValueError(f"unknown test selector: {selector}")
+        module_name = max(matches, key=len)
+        if selector == module_name:
+            exact_modules.add(module_name)
+        resolved.setdefault(module_name, []).append(selector)
+
+    selected_modules = schedule_modules(
+        tuple(module_by_name[name] for name in resolved)
+    )
+    manifests = listed_test_ids or {}
+    targets: list[TestTarget] = []
+    for module in selected_modules:
+        if module.name in exact_modules:
+            granularity = hotspot_policies.get(module.name)
+            if granularity is None:
+                targets.append(TestTarget(module, module.name))
+                continue
+            test_ids = manifests.get(module.name)
+            if test_ids is None:
+                raise ValueError(
+                    f"missing discovery manifest for hotspot {module.name}"
+                )
+            targets.extend(
+                shard_test_ids(module, test_ids, granularity=granularity)
+            )
+            continue
+        seen: set[str] = set()
+        for selector in resolved[module.name]:
+            if selector in seen:
+                continue
+            seen.add(selector)
+            targets.append(
+                TestTarget(
+                    module=module,
+                    test_name=selector,
+                    load_names=(selector,),
+                )
+            )
+    return tuple(targets)
+
+
 def assert_exact_target_schedule(
     expected: Sequence[TestTarget],
     actual: Sequence[TestTarget],
@@ -1072,6 +1137,13 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--top-level-directory", type=Path, default=Path("."))
     parser.add_argument("--pattern", default="test*.py")
     parser.add_argument(
+        "--test",
+        action="append",
+        default=[],
+        metavar="UNITTEST_NAME",
+        help="run one module, class, or method; may be repeated",
+    )
+    parser.add_argument(
         "--jobs", type=_parse_positive_int, default=_default_worker_count()
     )
     parser.add_argument(
@@ -1094,18 +1166,35 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"No Python tests found under {start}", file=sys.stderr)
         return 2
     modules = complete_test_modules(discovered, top)
-    module_schedule = schedule_modules(modules)
-    assert_exact_schedule(modules, module_schedule)
-    hotspot_names = HOTSPOT_SHARD_POLICIES.keys() & {module.name for module in modules}
+    selected_hotspots = {
+        selector
+        for selector in args.test
+        if selector in HOTSPOT_SHARD_POLICIES
+    }
+    hotspot_names = (
+        selected_hotspots
+        if args.test
+        else HOTSPOT_SHARD_POLICIES.keys() & {module.name for module in modules}
+    )
     listed_test_ids = {
         module_name: list_module_test_ids(module_name, top)
         for module_name in sorted(hotspot_names)
     }
-    schedule = build_test_targets(module_schedule, listed_test_ids)
+    if args.test:
+        schedule = select_test_targets(
+            modules,
+            args.test,
+            listed_test_ids=listed_test_ids,
+        )
+    else:
+        module_schedule = schedule_modules(modules)
+        assert_exact_schedule(modules, module_schedule)
+        schedule = build_test_targets(module_schedule, listed_test_ids)
     worker_count = min(args.jobs, len(schedule))
 
     print(
-        f"Python suite: {len(modules)} modules across {worker_count} workers "
+        f"Python suite: {len({target.module.name for target in schedule})} "
+        f"modules across {worker_count} workers "
         f"({os.cpu_count() or 1} host CPUs)"
     )
     sharded_target_count = sum(

--- a/scripts/run_targeted_tests.py
+++ b/scripts/run_targeted_tests.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Run explicit and adjacent tests with every ambient quality gate."""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from scripts.run_test_suite import PhaseSpec, _default_phases, run_suite
+from scripts.targeted_test_selection import (
+    changed_paths_from_git,
+    expand_test_selection,
+)
+
+
+def targeted_phases(selectors: Sequence[str]) -> tuple[PhaseSpec, ...]:
+    """Reuse canonical non-Python gates and replace only the Python plan."""
+    selected = tuple(selectors)
+    if not selected:
+        raise ValueError("targeted suite requires at least one selected test")
+    python_command = (
+        "python3",
+        "scripts/run_python_tests.py",
+        *(argument for selector in selected for argument in ("--test", selector)),
+    )
+    return (
+        *(phase for phase in _default_phases() if phase.name != "python"),
+        PhaseSpec(
+            "python",
+            python_command,
+            shlex.join(python_command),
+            "python",
+        ),
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("tests", nargs="*", metavar="UNITTEST_NAME")
+    parser.add_argument("--base-ref", default="origin/main")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    effective_argv = tuple(sys.argv[1:] if argv is None else argv)
+    args = _parser().parse_args(effective_argv)
+    try:
+        changed_paths = changed_paths_from_git(
+            REPO_ROOT,
+            base_ref=args.base_ref,
+        )
+        selectors = expand_test_selection(
+            args.tests,
+            changed_paths=changed_paths,
+            repo_root=REPO_ROOT,
+        )
+        command = shlex.join(
+            ("python3", "scripts/run_targeted_tests.py", *effective_argv)
+        )
+        print(
+            f"Targeted suite: {len(selectors)} Python selectors from "
+            f"{len(args.tests)} explicit and {len(changed_paths)} changed paths"
+        )
+        for selector in selectors:
+            print(f"  {selector}")
+        return run_suite(
+            repo_root=REPO_ROOT,
+            phases=targeted_phases(selectors),
+            command=command,
+        ).exit_code
+    except (OSError, RuntimeError, ValueError) as exc:
+        print(f"targeted-suite infrastructure failure: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_test_suite.py
+++ b/scripts/run_test_suite.py
@@ -334,14 +334,8 @@ def _default_phases() -> tuple[PhaseSpec, ...]:
         ),
         PhaseSpec(
             "pyright",
-            ("pyright", "--threads", "4"),
-            "pyright --threads 4",
-            "pyright",
-        ),
-        PhaseSpec(
-            "pyright-production-strict",
-            ("pyright", "-p", "pyrightconfig.production.json", "--threads", "4"),
-            "pyright -p pyrightconfig.production.json --threads 4",
+            ("python3", "scripts/run_pyright_checks.py"),
+            "python3 scripts/run_pyright_checks.py",
             "pyright",
         ),
         PhaseSpec(
@@ -658,6 +652,7 @@ def run_suite(
     runtime_dir: Path | None = None,
     executor: PhaseExecutor = execute_phase,
     stream: TextIO | None = None,
+    command: str = CANONICAL_COMMAND,
 ) -> SuiteRun:
     """Run every phase, preserving complete evidence and one terminal result."""
     output = stream if stream is not None else sys.stdout
@@ -675,7 +670,7 @@ def run_suite(
         schema_version=SCHEMA_VERSION,
         runner_version=RUNNER_VERSION,
         state="running",
-        command=CANONICAL_COMMAND,
+        command=command,
         repo_root=str(root),
         head=head,
         dirty=dirty,

--- a/scripts/targeted_test_selection.py
+++ b/scripts/targeted_test_selection.py
@@ -1,0 +1,260 @@
+"""Select explicit, adjacent, and repository-wide targeted tests."""
+
+from __future__ import annotations
+
+import subprocess
+from collections import Counter
+from collections.abc import Iterable, Sequence
+from pathlib import Path, PurePosixPath
+
+ALWAYS_AMBIENT_TESTS = (
+    "tests.test_typing_ratchet",
+)
+
+PIPELINE_DB_NEIGHBOURS = (
+    "tests.test_pipeline_db",
+    "tests.test_fakes",
+    "tests.test_pipeline_db_write_audit",
+    "tests.test_read_projection_audit",
+    "tests.test_pipeline_db_column_contract",
+)
+ROUTE_NEIGHBOURS = (
+    "tests.web.test_route_audit",
+    "tests.test_pydantic_route_audit",
+    "tests.test_js_payload_contract_audit",
+)
+
+EXACT_PATH_NEIGHBOURS: dict[str, tuple[str, ...]] = {
+    "pyrightconfig.json": (
+        "tests.test_pyright_checks",
+        "tests.test_pyright_checks_generated",
+    ),
+    "pyrightconfig.production.json": (
+        "tests.test_pyright_checks",
+        "tests.test_pyright_checks_generated",
+    ),
+    "scripts/run_pyright_checks.py": (
+        "tests.test_pyright_checks",
+        "tests.test_pyright_checks_generated",
+    ),
+    "scripts/run_python_tests.py": (
+        "tests.test_parallel_test_runner",
+        "tests.test_parallel_test_runner_generated",
+    ),
+    "scripts/run_test_suite.py": (
+        "tests.test_suite_coordinator",
+        "tests.test_suite_coordinator_generated",
+    ),
+    "scripts/run_targeted_tests.py": (
+        "tests.test_targeted_test_selection",
+        "tests.test_targeted_test_selection_generated",
+    ),
+    "scripts/targeted_test_selection.py": (
+        "tests.test_targeted_test_selection",
+        "tests.test_targeted_test_selection_generated",
+    ),
+    "scripts/test.sh": (
+        "tests.test_targeted_test_selection",
+        "tests.test_targeted_test_selection_generated",
+    ),
+}
+
+
+def _module_path(module: str, repo_root: Path) -> Path:
+    return repo_root.joinpath(*module.split(".")).with_suffix(".py")
+
+
+def _existing_module(module: str, repo_root: Path) -> str | None:
+    return module if _module_path(module, repo_root).is_file() else None
+
+
+def _selector_module(selector: str, repo_root: Path) -> str | None:
+    parts = selector.split(".")
+    for length in range(len(parts), 0, -1):
+        module = ".".join(parts[:length])
+        if _module_path(module, repo_root).is_file():
+            return module
+    return None
+
+
+def _paired_module(module: str, repo_root: Path) -> str | None:
+    sibling = (
+        module.removesuffix("_generated")
+        if module.endswith("_generated")
+        else f"{module}_generated"
+    )
+    return _existing_module(sibling, repo_root)
+
+
+def _path_module(path: PurePosixPath) -> str | None:
+    if path.suffix != ".py" or not path.parts:
+        return None
+    parts = (*path.parts[:-1], path.stem)
+    if any(not part.isidentifier() for part in parts):
+        return None
+    return ".".join(parts)
+
+
+def ambient_test_modules(repo_root: Path) -> tuple[str, ...]:
+    """Discover every global audit plus explicitly named ratchets."""
+    audit_modules = (
+        module
+        for path in sorted((repo_root / "tests").rglob("test_*_audit.py"))
+        if (module := _path_module(PurePosixPath(path.relative_to(repo_root))))
+        is not None
+    )
+    return tuple(dict.fromkeys((*ALWAYS_AMBIENT_TESTS, *audit_modules)))
+
+
+def _direct_test_candidates(path: PurePosixPath) -> tuple[str, ...]:
+    if path.suffix != ".py":
+        return ()
+    stem = path.stem
+    if path.parts[:1] == ("lib",):
+        return (f"tests.test_{stem}",)
+    if path.parts[:1] == ("scripts",):
+        return (f"tests.test_{stem}",)
+    if path.parts[:1] == ("web",) and path.parts[:2] != ("web", "routes"):
+        return (f"tests.test_web_{stem}", f"tests.web.test_{stem}")
+    if len(path.parts) == 1:
+        return (f"tests.test_{stem}",)
+    return ()
+
+
+def _changed_path_neighbours(
+    relative_path: str,
+    repo_root: Path,
+) -> tuple[str, ...]:
+    path = PurePosixPath(relative_path)
+    neighbours: list[str] = list(EXACT_PATH_NEIGHBOURS.get(relative_path, ()))
+    module = _path_module(path)
+    if module is not None and module.startswith("tests."):
+        neighbours.append(module)
+    for candidate in _direct_test_candidates(path):
+        if _existing_module(candidate, repo_root) is not None:
+            neighbours.append(candidate)
+    if relative_path.startswith("lib/pipeline_db/"):
+        neighbours.extend(PIPELINE_DB_NEIGHBOURS)
+    if relative_path.startswith("migrations/"):
+        neighbours.extend((*PIPELINE_DB_NEIGHBOURS, "tests.test_migrator"))
+    if relative_path.startswith("tests/fakes/"):
+        neighbours.append("tests.test_fakes")
+    if relative_path.startswith("web/routes/"):
+        neighbours.extend(ROUTE_NEIGHBOURS)
+        route_test = f"tests.web.test_routes_{path.stem}"
+        if _existing_module(route_test, repo_root) is not None:
+            neighbours.append(route_test)
+    if relative_path.startswith("nix/") or relative_path in {
+        "flake.nix",
+        "flake.lock",
+    }:
+        neighbours.append("tests.test_nix_module")
+    if relative_path.startswith("harness/") or relative_path == "lib/beets.py":
+        neighbours.append("tests.test_harness_beets2_contract")
+    if relative_path.startswith("lib/quality/"):
+        neighbours.extend(
+            (
+                "tests.test_quality_decisions",
+                "tests.test_quality_classification",
+                "tests.test_quality_generated",
+            )
+        )
+    return tuple(neighbours)
+
+
+def _ordered_unique(values: Iterable[str]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(values))
+
+
+def assert_selection_complete(
+    selection: Sequence[str],
+    required: Sequence[str],
+) -> None:
+    """Fail with exact identities when selection loses or repeats a target."""
+    duplicates = sorted(
+        value for value, count in Counter(selection).items() if count > 1
+    )
+    if duplicates:
+        raise AssertionError(f"duplicate targeted tests: {', '.join(duplicates)}")
+    missing = sorted(set(required) - set(selection))
+    if missing:
+        raise AssertionError(f"missing targeted tests: {', '.join(missing)}")
+
+
+def expand_test_selection(
+    explicit: Sequence[str],
+    *,
+    changed_paths: Sequence[str],
+    repo_root: Path,
+) -> tuple[str, ...]:
+    """Expand explicit tests with changed-path neighbours and ambient gates."""
+    selected: list[str] = []
+    paired_roots: list[str] = []
+    for selector in explicit:
+        module = _selector_module(selector, repo_root)
+        if module is None:
+            raise ValueError(f"unknown test selector: {selector}")
+        selected.append(selector)
+        paired_roots.append(module)
+    for relative_path in changed_paths:
+        neighbours = _changed_path_neighbours(relative_path, repo_root)
+        selected.extend(neighbours)
+        paired_roots.extend(neighbours)
+    for module in _ordered_unique(paired_roots):
+        sibling = _paired_module(module, repo_root)
+        if sibling is not None:
+            selected.append(sibling)
+    ambient = ambient_test_modules(repo_root)
+    selected.extend(ambient)
+    expanded = _ordered_unique(selected)
+    assert_selection_complete(expanded, ambient)
+    return expanded
+
+
+def _git_output(repo_root: Path, *args: str) -> tuple[str, ...]:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.strip()
+        raise RuntimeError(f"git {' '.join(args)} failed: {detail}")
+    return tuple(line for line in completed.stdout.splitlines() if line)
+
+
+def changed_paths_from_git(
+    repo_root: Path,
+    *,
+    base_ref: str,
+) -> tuple[str, ...]:
+    """Return committed, staged, unstaged, and untracked changed paths."""
+    return _ordered_unique(
+        (
+            *_git_output(
+                repo_root,
+                "diff",
+                "--name-only",
+                "--diff-filter=ACMR",
+                f"{base_ref}...HEAD",
+            ),
+            *_git_output(
+                repo_root,
+                "diff",
+                "--name-only",
+                "--diff-filter=ACMR",
+            ),
+            *_git_output(
+                repo_root,
+                "diff",
+                "--cached",
+                "--name-only",
+                "--diff-filter=ACMR",
+            ),
+            *_git_output(repo_root, "ls-files", "--others", "--exclude-standard"),
+        )
+    )

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -2,8 +2,5 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-if [ $# -eq 0 ]; then
-    nix-shell --run "python3 -m unittest discover -s tests -t . -v"
-else
-    nix-shell --run "python3 -m unittest $1 -v"
-fi
+printf -v command '%q ' python3 scripts/run_targeted_tests.py "$@"
+exec nix-shell --run "$command"

--- a/tests/test_parallel_test_runner.py
+++ b/tests/test_parallel_test_runner.py
@@ -36,6 +36,7 @@ from scripts.run_python_tests import (
     HypothesisStatsRecorder,
     RecordingTextTestResult,
     TestModule,
+    TestTarget,
     _classify_test_infrastructure_error,
     _iter_test_cases,
     assert_exact_schedule,
@@ -48,6 +49,7 @@ from scripts.run_python_tests import (
     recommended_worker_count,
     resolve_hypothesis_settings,
     schedule_modules,
+    select_test_targets,
     shard_test_ids,
     test_subprocess_environment,
     worker_environment,
@@ -253,6 +255,59 @@ class TestModuleScheduling(unittest.TestCase):
             tuple(target.test_name for target in targets),
             test_ids,
         )
+
+    def test_selected_module_keeps_the_canonical_hotspot_sharding(self) -> None:
+        module = TestModule("tests.test_hotspot", Path("/test_hotspot.py"), 90)
+        test_ids = (
+            "tests.test_hotspot.TestCases.test_one",
+            "tests.test_hotspot.TestCases.test_two",
+        )
+
+        targets = select_test_targets(
+            (module,),
+            (module.name,),
+            listed_test_ids={module.name: test_ids},
+            hotspot_policies={module.name: "method"},
+        )
+
+        self.assertEqual(tuple(target.test_name for target in targets), test_ids)
+
+    def test_selected_method_runs_only_that_exact_unittest_name(self) -> None:
+        module = TestModule("tests.test_alpha", Path("/test_alpha.py"), 10)
+        selector = "tests.test_alpha.TestCases.test_one"
+
+        targets = select_test_targets((module,), (selector,))
+
+        self.assertEqual(
+            targets,
+            (
+                TestTarget(
+                    module=module,
+                    test_name=selector,
+                    load_names=(selector,),
+                ),
+            ),
+        )
+
+    def test_selected_module_subsumes_duplicate_and_method_selectors(self) -> None:
+        module = TestModule("tests.test_alpha", Path("/test_alpha.py"), 10)
+
+        targets = select_test_targets(
+            (module,),
+            (
+                "tests.test_alpha.TestCases.test_one",
+                "tests.test_alpha",
+                "tests.test_alpha",
+            ),
+        )
+
+        self.assertEqual(targets, (TestTarget(module, module.name),))
+
+    def test_unknown_selected_test_fails_before_workers_start(self) -> None:
+        module = TestModule("tests.test_alpha", Path("/test_alpha.py"), 10)
+
+        with self.assertRaisesRegex(ValueError, "unknown test selector"):
+            select_test_targets((module,), ("tests.test_missing",))
 
     def test_target_coverage_rejects_an_omitted_test(self) -> None:
         module = TestModule("tests.test_hotspot", Path("/test_hotspot.py"), 1)

--- a/tests/test_pyright_checks.py
+++ b/tests/test_pyright_checks.py
@@ -1,0 +1,118 @@
+"""Contracts for the concurrent complementary Pyright runner."""
+
+from __future__ import annotations
+
+import io
+import threading
+import unittest
+from pathlib import Path
+
+from scripts.run_pyright_checks import (
+    PyrightCheck,
+    PyrightOutcome,
+    combined_exit_code,
+    execute_checks,
+    recommended_thread_counts,
+    write_outcomes,
+)
+
+
+class TestPyrightThreadAllocation(unittest.TestCase):
+    def test_measured_doc1_allocation_caps_at_eight_plus_four(self) -> None:
+        self.assertEqual(recommended_thread_counts(30), (8, 4))
+        self.assertEqual(recommended_thread_counts(12), (8, 4))
+
+    def test_smaller_hosts_share_the_available_cpu_budget(self) -> None:
+        self.assertEqual(recommended_thread_counts(8), (5, 3))
+        self.assertEqual(recommended_thread_counts(4), (3, 1))
+        self.assertEqual(recommended_thread_counts(2), (1, 1))
+        self.assertEqual(recommended_thread_counts(1), (1, 1))
+
+
+class TestConcurrentPyrightExecution(unittest.TestCase):
+    def test_both_contracts_start_before_either_is_allowed_to_finish(self) -> None:
+        barrier = threading.Barrier(2, timeout=2)
+        started: list[str] = []
+        lock = threading.Lock()
+        checks = (
+            PyrightCheck("whole-tree", "pyrightconfig.json", 8),
+            PyrightCheck("production-strict", "pyrightconfig.production.json", 4),
+        )
+
+        def run(check: PyrightCheck) -> PyrightOutcome:
+            with lock:
+                started.append(check.name)
+            barrier.wait()
+            return PyrightOutcome(check=check, returncode=0, output="clean\n")
+
+        outcomes = execute_checks(checks, run=run)
+
+        self.assertCountEqual(started, ["whole-tree", "production-strict"])
+        self.assertEqual(tuple(outcome.check for outcome in outcomes), checks)
+
+    def test_failure_does_not_cancel_the_other_contract(self) -> None:
+        executed: list[str] = []
+        checks = (
+            PyrightCheck("whole-tree", "pyrightconfig.json", 8),
+            PyrightCheck("production-strict", "pyrightconfig.production.json", 4),
+        )
+
+        def run(check: PyrightCheck) -> PyrightOutcome:
+            executed.append(check.name)
+            return PyrightOutcome(
+                check=check,
+                returncode=1 if check.name == "whole-tree" else 0,
+                output=f"{check.name} output\n",
+            )
+
+        outcomes = execute_checks(checks, run=run)
+
+        self.assertCountEqual(executed, ["whole-tree", "production-strict"])
+        self.assertEqual(combined_exit_code(outcomes), 1)
+        stream = io.StringIO()
+        write_outcomes(outcomes, stream)
+        rendered = stream.getvalue()
+        self.assertIn("=== whole-tree Pyright (8 threads) ===", rendered)
+        self.assertIn("whole-tree output", rendered)
+        self.assertIn("=== production-strict Pyright (4 threads) ===", rendered)
+        self.assertIn("production-strict output", rendered)
+
+    def test_non_diagnostic_process_failure_is_infrastructure_failure(self) -> None:
+        outcomes = (
+            PyrightOutcome(
+                PyrightCheck("whole-tree", "pyrightconfig.json", 8),
+                returncode=0,
+                output="clean\n",
+            ),
+            PyrightOutcome(
+                PyrightCheck(
+                    "production-strict",
+                    "pyrightconfig.production.json",
+                    4,
+                ),
+                returncode=127,
+                output="pyright missing\n",
+            ),
+        )
+
+        self.assertEqual(combined_exit_code(outcomes), 2)
+
+    def test_unrecognized_configuration_is_never_a_green_check(self) -> None:
+        outcomes = (
+            PyrightOutcome(
+                PyrightCheck("whole-tree", "pyrightconfig.json", 8),
+                returncode=0,
+                output='Config contains unrecognized setting "invented".\n',
+            ),
+        )
+
+        self.assertEqual(combined_exit_code(outcomes), 2)
+
+    def test_production_config_contains_only_recognized_rules(self) -> None:
+        source = Path("pyrightconfig.production.json").read_text(encoding="utf-8")
+
+        self.assertNotIn("reportShadowedImports", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pyright_checks_generated.py
+++ b/tests/test_pyright_checks_generated.py
@@ -1,0 +1,96 @@
+"""Generated allocation and outcome contracts for the Pyright runner."""
+
+from __future__ import annotations
+
+import unittest
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+import tests._hypothesis_profiles  # noqa: F401  (loads the active profile)
+from scripts.run_pyright_checks import (
+    PyrightCheck,
+    PyrightOutcome,
+    combined_exit_code,
+    recommended_thread_counts,
+)
+
+
+class TestGeneratedPyrightThreadAllocation(unittest.TestCase):
+    @given(cpu_count=st.integers(min_value=1, max_value=512))
+    def test_allocation_is_positive_bounded_and_uses_the_available_budget(
+        self,
+        cpu_count: int,
+    ) -> None:
+        whole, strict = recommended_thread_counts(cpu_count)
+
+        self.assertGreaterEqual(whole, 1)
+        self.assertGreaterEqual(strict, 1)
+        if cpu_count == 1:
+            self.assertEqual((whole, strict), (1, 1))
+        else:
+            self.assertEqual(whole + strict, min(cpu_count, 12))
+        self.assertLessEqual(whole, 8)
+        self.assertLessEqual(strict, 4)
+
+
+class TestGeneratedCombinedPyrightOutcome(unittest.TestCase):
+    @given(
+        whole_status=st.integers(min_value=0, max_value=127),
+        strict_status=st.integers(min_value=0, max_value=127),
+    )
+    def test_every_child_status_contributes_to_the_combined_result(
+        self,
+        whole_status: int,
+        strict_status: int,
+    ) -> None:
+        outcomes = (
+            PyrightOutcome(
+                PyrightCheck("whole-tree", "pyrightconfig.json", 8),
+                whole_status,
+                "",
+            ),
+            PyrightOutcome(
+                PyrightCheck(
+                    "production-strict",
+                    "pyrightconfig.production.json",
+                    4,
+                ),
+                strict_status,
+                "",
+            ),
+        )
+        if whole_status == strict_status == 0:
+            expected = 0
+        elif whole_status in {0, 1} and strict_status in {0, 1}:
+            expected = 1
+        else:
+            expected = 2
+
+        self.assertEqual(combined_exit_code(outcomes), expected)
+
+
+class TestCombinedOutcomeCheckerKnownBad(unittest.TestCase):
+    def test_checker_rejects_false_green_when_strict_failed(self) -> None:
+        outcomes = (
+            PyrightOutcome(
+                PyrightCheck("whole-tree", "pyrightconfig.json", 8),
+                0,
+                "",
+            ),
+            PyrightOutcome(
+                PyrightCheck(
+                    "production-strict",
+                    "pyrightconfig.production.json",
+                    4,
+                ),
+                1,
+                "",
+            ),
+        )
+
+        self.assertNotEqual(combined_exit_code(outcomes), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_suite_coordinator.py
+++ b/tests/test_suite_coordinator.py
@@ -55,45 +55,49 @@ class SuiteCoordinatorTestCase(unittest.TestCase):
         for bundle in self.bundles:
             shutil.rmtree(bundle, ignore_errors=True)
 
-    def _run(self, phases: tuple[PhaseSpec, ...]):
+    def _run(
+        self,
+        phases: tuple[PhaseSpec, ...],
+        *,
+        command: str = "bash scripts/run_tests.sh",
+    ):
         stream = io.StringIO()
         result = run_suite(
             repo_root=REPO_ROOT,
             phases=phases,
             runtime_dir=self.runtime,
             stream=stream,
+            command=command,
         )
         self.bundles.append(result.bundle)
         return result, stream.getvalue()
 
-    def test_default_suite_owns_both_complementary_pyright_contracts(self) -> None:
+    def test_default_suite_owns_one_concurrent_complementary_pyright_phase(
+        self,
+    ) -> None:
         pyright_phases = tuple(
             phase for phase in _default_phases() if phase.parser == "pyright"
         )
 
-        self.assertEqual(
-            tuple(phase.name for phase in pyright_phases),
-            ("pyright", "pyright-production-strict"),
-        )
+        self.assertEqual(tuple(phase.name for phase in pyright_phases), ("pyright",))
         self.assertEqual(
             pyright_phases[0].command,
-            ("pyright", "--threads", "4"),
+            ("python3", "scripts/run_pyright_checks.py"),
         )
         self.assertEqual(
             pyright_phases[0].rerun_command,
-            "pyright --threads 4",
+            "python3 scripts/run_pyright_checks.py",
         )
-        self.assertEqual(
-            pyright_phases[1].command,
-            (
-                "pyright", "-p", "pyrightconfig.production.json",
-                "--threads", "4",
-            ),
+
+    def test_summary_records_the_actual_invoked_suite_command(self) -> None:
+        command = "python3 scripts/run_targeted_tests.py tests.test_alpha"
+
+        result, _output = self._run(
+            (PhaseSpec("alpha", _python_command("ok", 0), "alpha", "generic"),),
+            command=command,
         )
-        self.assertEqual(
-            pyright_phases[1].rerun_command,
-            "pyright -p pyrightconfig.production.json --threads 4",
-        )
+
+        self.assertEqual(result.summary.command, command)
 
     def test_one_invocation_indexes_simultaneous_failures_from_every_phase(
         self,
@@ -131,7 +135,7 @@ class SuiteCoordinatorTestCase(unittest.TestCase):
                     "(reportUnknownArgumentType)",
                     1,
                 ),
-                "pyright --threads 4",
+                "python3 scripts/run_pyright_checks.py",
                 "pyright",
             ),
             PhaseSpec(

--- a/tests/test_suite_coordinator_generated.py
+++ b/tests/test_suite_coordinator_generated.py
@@ -25,7 +25,6 @@ PHASE_NAMES = (
     "js-syntax",
     "js-unit",
     "pyright",
-    "pyright-production-strict",
     "ruff",
     "vulture",
     "python",

--- a/tests/test_targeted_test_selection.py
+++ b/tests/test_targeted_test_selection.py
@@ -1,0 +1,148 @@
+"""Deterministic contracts for targeted plus adjacent test selection."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from scripts.run_targeted_tests import targeted_phases
+from scripts.targeted_test_selection import (
+    ALWAYS_AMBIENT_TESTS,
+    ambient_test_modules,
+    assert_selection_complete,
+    expand_test_selection,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+class TestTargetedTestSelection(unittest.TestCase):
+    def test_selected_test_adds_its_generated_sibling_and_global_ratchets(
+        self,
+    ) -> None:
+        selected = expand_test_selection(
+            ("tests.test_pyright_checks",),
+            changed_paths=(),
+            repo_root=REPO_ROOT,
+        )
+
+        ambient = ambient_test_modules(REPO_ROOT)
+        self.assertEqual(selected[0], "tests.test_pyright_checks")
+        self.assertIn("tests.test_pyright_checks_generated", selected)
+        self.assertTrue(set(ambient).issubset(selected))
+        self.assertEqual(len(selected), len(set(selected)))
+
+    def test_every_audit_module_is_discovered_without_a_hand_maintained_list(
+        self,
+    ) -> None:
+        ambient = ambient_test_modules(REPO_ROOT)
+
+        self.assertTrue(set(ALWAYS_AMBIENT_TESTS).issubset(ambient))
+        self.assertIn("tests.test_classify_producer_audit", ambient)
+        self.assertIn("tests.web.test_routes_world_audit", ambient)
+        self.assertEqual(len(ambient), len(set(ambient)))
+
+    def test_generated_selection_adds_its_deterministic_sibling(self) -> None:
+        selected = expand_test_selection(
+            ("tests.test_pyright_checks_generated",),
+            changed_paths=(),
+            repo_root=REPO_ROOT,
+        )
+
+        self.assertIn("tests.test_pyright_checks", selected)
+
+    def test_changed_test_and_production_module_add_direct_neighbours(self) -> None:
+        selected = expand_test_selection(
+            (),
+            changed_paths=(
+                "tests/test_pyright_checks.py",
+                "lib/artist_releases.py",
+            ),
+            repo_root=REPO_ROOT,
+        )
+
+        self.assertIn("tests.test_pyright_checks", selected)
+        self.assertIn("tests.test_pyright_checks_generated", selected)
+        self.assertIn("tests.test_artist_releases", selected)
+
+    def test_pipeline_db_change_adds_shared_boundary_contracts(self) -> None:
+        selected = expand_test_selection(
+            (),
+            changed_paths=("lib/pipeline_db/_requests.py",),
+            repo_root=REPO_ROOT,
+        )
+
+        self.assertTrue(
+            {
+                "tests.test_pipeline_db",
+                "tests.test_fakes",
+                "tests.test_pipeline_db_write_audit",
+                "tests.test_read_projection_audit",
+                "tests.test_pipeline_db_column_contract",
+            }.issubset(selected)
+        )
+
+    def test_route_and_nix_changes_add_their_structural_neighbours(self) -> None:
+        selected = expand_test_selection(
+            (),
+            changed_paths=("web/routes/youtube.py", "nix/module.nix"),
+            repo_root=REPO_ROOT,
+        )
+
+        self.assertIn("tests.web.test_routes_youtube", selected)
+        self.assertIn("tests.web.test_route_audit", selected)
+        self.assertIn("tests.test_pydantic_route_audit", selected)
+        self.assertIn("tests.test_js_payload_contract_audit", selected)
+        self.assertIn("tests.test_nix_module", selected)
+
+    def test_unknown_explicit_selector_fails_closed(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unknown test selector"):
+            expand_test_selection(
+                ("tests.test_does_not_exist",),
+                changed_paths=(),
+                repo_root=REPO_ROOT,
+            )
+
+    def test_selection_checker_names_missing_and_duplicate_targets(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "missing.*tests.test_beta"):
+            assert_selection_complete(
+                ("tests.test_alpha",),
+                ("tests.test_alpha", "tests.test_beta"),
+            )
+        with self.assertRaisesRegex(AssertionError, "duplicate.*tests.test_alpha"):
+            assert_selection_complete(
+                ("tests.test_alpha", "tests.test_alpha"),
+                ("tests.test_alpha",),
+            )
+
+
+class TestTargetedSuiteWiring(unittest.TestCase):
+    def test_targeted_suite_reuses_every_non_python_canonical_phase(self) -> None:
+        phases = targeted_phases(("tests.test_pyright_checks",))
+
+        self.assertEqual(
+            tuple(phase.name for phase in phases),
+            ("js-syntax", "js-unit", "pyright", "ruff", "vulture", "python"),
+        )
+        python_phase = phases[-1]
+        self.assertEqual(python_phase.parser, "python")
+        self.assertEqual(
+            python_phase.command,
+            (
+                "python3",
+                "scripts/run_python_tests.py",
+                "--test",
+                "tests.test_pyright_checks",
+            ),
+        )
+
+    def test_shell_entrypoint_forwards_every_selector_to_targeted_runner(self) -> None:
+        source = (REPO_ROOT / "scripts" / "test.sh").read_text(encoding="utf-8")
+
+        self.assertIn("scripts/run_targeted_tests.py", source)
+        self.assertIn('"$@"', source)
+        self.assertNotIn("python3 -m unittest discover", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_targeted_test_selection_generated.py
+++ b/tests/test_targeted_test_selection_generated.py
@@ -1,0 +1,67 @@
+"""Generated completeness contract for targeted test expansion."""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+import tests._hypothesis_profiles  # noqa: F401  (loads the active profile)
+from scripts.targeted_test_selection import (
+    ambient_test_modules,
+    assert_selection_complete,
+    expand_test_selection,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PAIRS = (
+    ("tests.test_pyright_checks", "tests.test_pyright_checks_generated"),
+    ("tests.test_suite_coordinator", "tests.test_suite_coordinator_generated"),
+    (
+        "tests.test_targeted_test_selection",
+        "tests.test_targeted_test_selection_generated",
+    ),
+)
+
+
+class TestGeneratedTargetedSelection(unittest.TestCase):
+    @given(
+        selected=st.lists(
+            st.sampled_from(tuple(module for pair in PAIRS for module in pair)),
+            max_size=12,
+        )
+    )
+    def test_expansion_is_unique_and_closes_every_selected_pair(
+        self,
+        selected: list[str],
+    ) -> None:
+        expanded = expand_test_selection(
+            selected,
+            changed_paths=(),
+            repo_root=REPO_ROOT,
+        )
+        required: set[str] = set(ambient_test_modules(REPO_ROOT))
+        for deterministic, generated in PAIRS:
+            if deterministic in selected or generated in selected:
+                required.update((deterministic, generated))
+
+        assert_selection_complete(expanded, tuple(required))
+
+
+class TestSelectionCheckerKnownBad(unittest.TestCase):
+    def test_checker_rejects_the_old_explicit_only_shape(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "missing"):
+            assert_selection_complete(
+                ("tests.test_pyright_checks",),
+                (
+                    "tests.test_pyright_checks",
+                    "tests.test_pyright_checks_generated",
+                    *ambient_test_modules(REPO_ROOT),
+                ),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- expand targeted unittest selectors with changed-path neighbours, generated/deterministic siblings, all audit modules, and the typing ratchet
- reuse JavaScript, concurrent whole-tree/strict Pyright, Ruff, and Vulture phases in one targeted failure bundle
- benchmark Pyright thread counts and use a hardware-aware 8+4 cap instead of sequential fixed four-thread passes

## Validation

- `bash scripts/test.sh` — 6 phases passed, 31 selected Python modules
- `scripts/run_final_gate.sh` — pass on `ea9f286d18bd901ec07edbd7000ac57fd11b7318`
- receipt: `/run/user/1000/cratedigger-final-gate.RMqaUV7p`