### PR TITLE
Document targeted-plus as the default test loop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,14 +176,20 @@ judgment based on the change, current evidence, and concrete risk. Always use
 `nix-shell --run` for Python:
 
 ```bash
-bash scripts/test.sh tests.test_X                        # target + adjacent/ambient gates
-nix-shell --run "python3 scripts/run_pyright_checks.py"  # both typing contracts
-nix-shell --run "bash scripts/run_tests.sh"              # complete suite
+bash scripts/test.sh tests.test_X                       # explicit target + adjacent/ambient gates
+bash scripts/test.sh                                    # derive targets from the current diff
+nix-shell --run "python3 -m unittest tests.test_X -v"    # isolated test debugging only
+nix-shell --run "bash scripts/run_tests.sh"              # exhaustive suite
 ```
 
-`scripts/test.sh` also accepts no selector and derives targets from the current
-diff. Direct runs are development feedback; before independent-review handoff,
-use the `check` skill on the converged, clean, committed tree for the one
+Use `scripts/test.sh` for normal development validation. It adds the selected
+test's deterministic/generated sibling, tests adjacent to changed production
+surfaces, every repository audit and ratchet, JavaScript checks, both Pyright
+contracts, Ruff, and Vulture to one failure bundle. Use direct `unittest` only
+to debug an isolated failure, not as local convergence evidence.
+
+Direct runs are development feedback; before independent-review handoff, use
+the `check` skill on the converged, clean, committed tree for the one
 receipt-backed canonical-suite confirmation. Reuse that receipt before push if
 the reviewed commit remains unchanged. The complete operational contract —
 suite bundle, specialized evidence, generated/fuzz testing, no-skips policy,


### PR DESCRIPTION
## Summary

- make `scripts/test.sh` the documented default development-validation entrypoint
- distinguish explicit-target and diff-derived usage
- reserve direct `unittest` for isolated debugging and `run_tests.sh` for exhaustive validation

## Validation

- `bash scripts/test.sh tests.test_docs_audit` — all 6 phases passed
- `scripts/run_final_gate.sh` — pass on `67a171ff429169efa2402eb51f848cea352469a6`
- receipt: `/run/user/1000/cratedigger-final-gate.7bVuiGbf`