### PR TITLE
fix(tests): declare hermetic zsh runtime

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -48,6 +48,7 @@ pkgs.mkShell {
   packages = [
     pkgs.postgresql          # initdb, pg_ctl for ephemeral test DB
     pkgs.util-linux          # flock for deploy-pin concurrency tests
+    pkgs.zsh                 # executable zsh runbook contract tests
     pkgs.ruff                # flake-locked repo-wide lint toolchain
     testPythonEnv
     pkgs.sox                 # spectral analysis tests

--- a/tests/test_debugging_cli_docs.py
+++ b/tests/test_debugging_cli_docs.py
@@ -96,12 +96,18 @@ fi
                 **os.environ,
                 "FAKE_EXPORT_RC": str(export_returncode),
                 "PATH": f"{bin_dir}:{os.environ['PATH']}",
+                "RUNBOOK_TEST_PATH": f"{bin_dir}:{os.environ['PATH']}",
                 "RUNBOOK_MARKERS": str(marker_dir),
                 "RUNBOOK_TRANSFER_DIR": str(transfer_dir),
                 "RUNBOOK_WORK": str(work),
             }
             remote = subprocess.run(
-                ["zsh", "-fc", fragment or _decision_export_remote_fragment()],
+                [
+                    "zsh",
+                    "-fc",
+                    'export PATH="$RUNBOOK_TEST_PATH"; '
+                    + (fragment or _decision_export_remote_fragment()),
+                ],
                 capture_output=True,
                 check=False,
                 cwd=root,
@@ -109,7 +115,12 @@ fi
                 text=True,
             )
             local = subprocess.run(
-                ["zsh", "-fc", _decision_export_local_acceptance()],
+                [
+                    "zsh",
+                    "-fc",
+                    'export PATH="$RUNBOOK_TEST_PATH"; '
+                    + _decision_export_local_acceptance(),
+                ],
                 capture_output=True,
                 check=False,
                 cwd=root,


### PR DESCRIPTION
## Summary
- declare zsh in the test dev shell
- restore the controlled runbook-test PATH after zsh startup
- keep the executable documentation and mutant checks hermetic under the daily service environment

## Verification
- targeted repository gate: all 6 phases passed
- exact module with `__NIXOS_SET_ENVIRONMENT_DONE` absent: 4/4 methods passed
- independent Sol review: approved with no findings