### PR TITLE
fix(fuzz): bound ephemeral PostgreSQL checkpoint lifetime

### DIFF
--- a/lib/ephemeral_postgres.py
+++ b/lib/ephemeral_postgres.py
@@ -70,6 +70,18 @@ class EphemeralPostgres:
         assert self._socket_tmpdir is not None
         return self._socket_tmpdir
 
+    @property
+    def _server_options(self) -> tuple[str, ...]:
+        return (
+            f"-k {self._socket_dir}",
+            "-c listen_addresses=''",
+            # PostgreSQL defers unlinking relation files replaced by TRUNCATE
+            # until a checkpoint. Bound that disposable-test scratch lifetime
+            # instead of relying on the five-minute production default.
+            "-c checkpoint_timeout=30s",
+            "-c checkpoint_completion_target=0.1",
+        )
+
     def _failure_detail(self, error: subprocess.CalledProcessError) -> str:
         command = " ".join(str(part) for part in error.cmd)
         stdout = (error.stdout or b"").decode("utf-8", errors="replace")
@@ -130,7 +142,7 @@ class EphemeralPostgres:
             subprocess.run(
                 [
                     "pg_ctl", "-D", str(self._datadir), "-l", str(self._logfile),
-                    "-o", f"-k {self._socket_dir} -c listen_addresses=''", "start",
+                    "-o", " ".join(self._server_options), "start",
                 ],
                 capture_output=True,
                 check=True,

--- a/tests/test_ephemeral_pg.py
+++ b/tests/test_ephemeral_pg.py
@@ -60,6 +60,30 @@ class TestEphemeralPostgresFailures(unittest.TestCase):
 
 
 class TestEphemeralPostgresIsolation(unittest.TestCase):
+    def test_server_options_bound_delayed_relation_unlink_lifetime(self) -> None:
+        pg = EphemeralPostgres()
+        pg._socket_tmpdir = Path("/tmp/cdpg-checkpoint-contract")
+
+        self.assertEqual(
+            pg._server_options,
+            (
+                "-k /tmp/cdpg-checkpoint-contract",
+                "-c listen_addresses=''",
+                "-c checkpoint_timeout=30s",
+                "-c checkpoint_completion_target=0.1",
+            ),
+        )
+
+    def test_live_cluster_bounds_delayed_relation_unlink_lifetime(self) -> None:
+        with EphemeralPostgres() as pg:
+            assert pg.dsn is not None
+            with psycopg2.connect(pg.dsn) as connection, connection.cursor() as cursor:
+                cursor.execute(
+                    "SELECT current_setting('checkpoint_timeout'), "
+                    "current_setting('checkpoint_completion_target')"
+                )
+                self.assertEqual(cursor.fetchone(), ("30s", "0.1"))
+
     def test_long_tmpdir_keeps_socket_path_below_postgres_limit(self) -> None:
         with tempfile.TemporaryDirectory(dir="/tmp") as root:
             long_tmpdir = Path(root) / ("deep-test-scratch-" * 5)


### PR DESCRIPTION
## Summary
- bound delayed relation-file unlink with a 30-second checkpoint interval
- complete disposable-cluster checkpoints early
- pin launch options and live PostgreSQL settings in tests

## Verification
- RED: no bounded checkpoint contract
- tests.test_ephemeral_pg: 6/6 passed
- targeted repository gate: all 6 phases passed
- focused exact 20,000-example module: 9 tests GREEN; scratch 381 MB; 308,650 inodes; MemoryPeak 1000.2 MB
- independent Sol review: approved, no blockers