### PR TITLE
Instrument daily resource high-water by phase

### DIFF
--- a/docs/generated-testing.md
+++ b/docs/generated-testing.md
@@ -163,6 +163,7 @@ source scanner.
 | `tests/test_convergence_pipeline_db_generated.py` | the real migration-070 PostgreSQL request-local derivation and atomic stop CAS, differentially checked against `derive_convergence_signal` | genuine Hypothesis worlds cross direct/cross-walk attribution, structured peer arrays including comma and punctuation usernames, empty contributor sets, timestamp ties resolved by log ID, null/different cliff breaks, raw within-band spread, codec diversity, current-evidence replacement, and ineligible worlds; generated late-link, contributor, current-authority, and spectral mutations invalidate captured tokens before mutation, while one-observation/five-peer mosaic and cross-walk mutants qualify the checker. The bounded domain is sampled, not falsely certified as exhaustive |
 | `tests/test_audio_validation_generated.py` | `lib.util.validate_audio` through the real pinned FFmpeg full-decode subprocess plus mocked process-outcome leaves | every generated FLAC audio-frame mutation fails the fixed audio-only strict policy even when the former command returns zero; a real unset STREAMINFO MD5 remains byte-identical and leaves no diagnostic; every positive FFmpeg exit on stable readable bytes is typed bad audio, while arbitrary exit-zero stderr has no policy or audit meaning; diagnostics remain bounded. The real-subprocess property executes 18 mutations in the suite and 96 fresh mutations in the randomized fuzz tier; the former `rc=0` contract is pinned as a known-bad checker input |
 | `tests/test_test_tmpfs_generated.py` | the real `scripts/test_tmpfs.sh` setup subprocess | a low-headroom setup failure stays nonzero, prints no selected directory, and retains the exact headroom diagnostic for generated safe inherited `TMPDIR` values; zero-status, inherited-stdout, and diagnostic-loss inputs are independently qualified as known-bad checker inputs |
+| `tests/test_daily_resource_monitor_generated.py` | the real `scripts/daily_resource_monitor.sh` boundary in its summarize mode over generated phase/sample timelines | every phase retains its true cgroup and scratch maxima, monotonic peak start/end and swap metrics, plus the anon/file/shmem/kernel/scratch values from the same memory-current peak sample; kernel peaks may exceed every sampled current, and the terminal receipt names the first phase to establish that exact peak. Deterministic pins exercise the serialized live phase/sampler boundary and reject zero scratch limits, impossible breakdowns, and regressing kernel peaks, while sampled-current ownership, companion-sample, last-value, and missing-terminal mutations qualify the checker |
 | `tests/test_suite_coordinator_generated.py` | `scripts.run_test_suite.run_suite` over generated all-phase outcome worlds through its real state/persistence loop and a process-free phase executor leaf | every scheduled phase executes exactly once and contributes its pass/fail state to the single terminal result; deterministic process pins cover simultaneous cross-tool failures, private typed bundles, exact failure identities and reruns, command-start infrastructure failure, and signal interruption; old fail-fast and false-green shapes qualify the checker |
 | `tests/test_final_gate_receipt_generated.py` | the real `scripts/run_final_gate.sh` with a PATH-injected canonical-argv fake `nix-shell` over tiny clean Git fixtures | every generated ordinary command exit code has an atomically recorded matching pass/fail terminal state and is returned unchanged while the fake observes only `nix-shell --run "bash scripts/run_tests.sh"`; deterministic pins cover rejection of alternate gate labels, signal-shaped incomplete outcomes, exact active PID/start-tick recovery, changed-tree incomplete publication, output preservation, and the validated suite-bundle path; known-bad command, signal, stale-identity, missing-terminal, and tree-mismatch inputs qualify the checker |
 | `tests/test_web_request_security_generated.py` | the pure request authorizer plus the real HTTP pre-dispatch boundary for the cache-writing YouTube resolver | generated channel, method, canonical-origin, Origin, and Referer worlds match the fail-closed authorization oracle; browser POSTs with missing or mismatched provenance return 403 before resolver dispatch or DB access. Missing-provenance, mismatched-origin, future-unsafe-method, resolver-call, and DB-touch mutants independently qualify the checkers |
@@ -659,6 +660,27 @@ module's live output:
 nix-shell --run "CRATEDIGGER_HYPOTHESIS_PROFILE=fuzz \
     python3 -m unittest tests.test_quality_generated -v"
 ```
+
+The daily gate measures its existing top-level phases from inside the service's
+own mount namespace and cgroup. `scripts/daily_resource_monitor.sh` reads the
+unit's cgroup-v2 `memory.current`, monotonic `memory.peak`, swap, and
+`memory.stat` categories while sampling the private scratch mount with
+`statfs`. Each `CRATEDIGGER_DAILY_RESOURCE_PHASE` line retains the complete
+time-correlated sample at that phase's largest observed `memory.current`, plus
+its independent scratch byte/inode high-water. The terminal
+`CRATEDIGGER_DAILY_RESOURCE_RECEIPT` names the first phase that established the
+exact kernel memory peak. `shmem_at_memory_current_peak_bytes` and
+`non_shmem_at_memory_current_peak_bytes` are from the same sample; never
+subtract independently observed maxima to attribute working memory.
+
+The monitor does not enumerate processes, enter the namespace from outside,
+reset cgroup state, or change phase commands, worker counts, shard counts,
+PostgreSQL admission, example budgets, or tmpfs limits. Missing cgroup files,
+a disk-backed scratch root, zero limits, malformed samples, and regressing
+kernel peaks produce one terminal `status=invalid` receipt rather than zeros.
+The runner's EXIT path emits the terminal receipt after its owned checkout
+cleanup even when a test stage fails or the later live-world post-step makes
+the systemd unit red.
 
 It is pure and safe: no prod DB, no slskd, no beets, no network. Green runs
 write disposable state only to tmpfs. Repeat runs add entropy; there is

--- a/scripts/daily_flake_update.sh
+++ b/scripts/daily_flake_update.sh
@@ -6,6 +6,39 @@
 # The caller owns scheduling, persistent state, and failure notification.
 set -euo pipefail
 
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+# shellcheck source=scripts/daily_resource_monitor.sh
+source "$script_dir/daily_resource_monitor.sh"
+
+work_root=""
+
+finalize() {
+    local command_status="$?"
+    local resource_status=0
+    trap - EXIT INT TERM
+    set +e
+    # A signal may interrupt a phase transition while the parent owns the
+    # sample lock. Release that descriptor before the cleanup transition so
+    # the EXIT path cannot deadlock itself.
+    _daily_resource_unlock
+    if [[ "${_CRATEDIGGER_RESOURCE_STARTED:-0}" == 1 ]]; then
+        daily_resource_monitor_set_phase cleanup
+    fi
+    if [[ -n "$work_root" && -d "$work_root" ]]; then
+        rm -rf -- "$work_root"
+    fi
+    daily_resource_monitor_finish
+    resource_status=$?
+    if ((command_status == 0 && resource_status != 0)); then
+        command_status=$resource_status
+    fi
+    exit "$command_status"
+}
+
+trap finalize EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
 repository="${CRATEDIGGER_UPDATE_REPOSITORY:-https://github.com/abl030/cratedigger.git}"
 branch="${CRATEDIGGER_UPDATE_BRANCH:-main}"
 state_dir="${CRATEDIGGER_AUTOMATION_STATE_DIR:?CRATEDIGGER_AUTOMATION_STATE_DIR is required}"
@@ -27,18 +60,15 @@ mkdir -p \
     "$fuzz_database" \
     "$fuzz_output_dir"
 
+if ! daily_resource_monitor_start; then
+    exit 1
+fi
+
+daily_resource_monitor_set_phase checkout_setup
 work_root=$(mktemp -d "${TMPDIR:-/tmp}/cratedigger-daily-update.XXXXXX")
 checkout="$work_root/repo"
 
-cleanup() {
-    if [[ -n "${work_root:-}" && -d "$work_root" ]]; then
-        rm -rf -- "$work_root"
-    fi
-}
-trap cleanup EXIT
-trap 'exit 130' INT
-trap 'exit 143' TERM
-
+daily_resource_monitor_set_phase clone
 echo "daily unstable gate: cloning $repository branch $branch"
 if ! git clone --quiet --branch "$branch" --single-branch "$repository" "$checkout"; then
     echo "daily unstable gate: clone failed" >&2
@@ -51,6 +81,7 @@ cd "$checkout"
 # too because its conftest accepts TEST_DB_DSN for explicit developer use.
 unset TEST_DB_DSN
 
+daily_resource_monitor_set_phase flake_update
 echo "daily unstable gate: updating flake.lock"
 if ! nix flake update nixpkgs; then
     echo "daily unstable gate: flake update failed" >&2
@@ -61,10 +92,12 @@ declare -a stage_names=()
 declare -a stage_statuses=()
 
 run_stage() {
-    local name="$1"
-    shift
+    local phase="$1"
+    local name="$2"
+    shift 2
     local status
 
+    daily_resource_monitor_set_phase "$phase"
     echo ""
     echo "=== $name ==="
     if "$@"; then
@@ -74,21 +107,23 @@ run_stage() {
     fi
     stage_names+=("$name")
     stage_statuses+=("$status")
+    daily_resource_monitor_set_phase runner_overhead
 }
 
-run_stage "deterministic full suite" \
+daily_resource_monitor_set_phase runner_overhead
+run_stage deterministic_suite "deterministic full suite" \
     nix-shell --run "bash scripts/run_tests.sh"
-run_stage "stable Nix and Beets-release checks" \
+run_stage stable_nix "stable Nix and Beets-release checks" \
     nix build .#checks.x86_64-linux.beetsStableCandidate --print-build-logs
-run_stage "world-model burst" \
+run_stage world_model "world-model burst" \
     env CRATEDIGGER_WORLD_DATABASE="$world_database" \
     nix-shell --run "bash scripts/world_model_burst.sh"
-run_stage "generated fuzz burst" \
+run_stage generated_fuzz "generated fuzz burst" \
     env HYPOTHESIS_STORAGE_DIRECTORY="$fuzz_database" \
         CRATEDIGGER_FUZZ_OUTPUT_DIR="$fuzz_output_dir" \
         CRATEDIGGER_FUZZ_MAX_EXAMPLES="$overnight_fuzz_max_examples" \
     nix-shell --run "bash scripts/fuzz_burst.sh"
-run_stage "mirror-harness smoke" \
+run_stage mirror_harness "mirror-harness smoke" \
     env CRATEDIGGER_WORLD_DATABASE="$mirror_database" \
         CRATEDIGGER_WORLD_ENGINE="mirror-harness" \
         CRATEDIGGER_WORLD_MIRROR_URL="$mirror_url" \
@@ -96,6 +131,7 @@ run_stage "mirror-harness smoke" \
         CRATEDIGGER_WORLD_STEPS="5" \
     nix-shell --run "bash scripts/world_model_burst.sh"
 
+daily_resource_monitor_set_phase candidate_summary
 echo ""
 echo "=== daily candidate summary ==="
 candidate_failed=0
@@ -113,6 +149,7 @@ if [[ "$candidate_failed" -ne 0 ]]; then
     exit 1
 fi
 
+daily_resource_monitor_set_phase lock_publish
 echo "ALL CANDIDATE GATES GREEN"
 if git diff --quiet -- flake.lock; then
     echo "daily unstable gate: flake.lock already current"

--- a/scripts/daily_resource_monitor.sh
+++ b/scripts/daily_resource_monitor.sh
@@ -1,0 +1,473 @@
+#!/usr/bin/env bash
+# Phase-correlated cgroup and private-scratch receipts for the daily gate.
+
+_daily_resource_invalid() {
+    local reason="$1"
+    _CRATEDIGGER_RESOURCE_TERMINAL_EMITTED=1
+    printf \
+        'CRATEDIGGER_DAILY_RESOURCE_RECEIPT schema=1 status=invalid reason=%s\n' \
+        "$reason"
+    return 1
+}
+
+daily_resource_summarize_samples() {
+    local samples_file="$1"
+    local timestamp_ns phase memory_current memory_peak swap_current swap_peak
+    local anon file_bytes shmem kernel scratch_bytes scratch_byte_limit
+    local scratch_inodes scratch_inode_limit extra value field
+    local sample_count=0 global_memory_peak=-1 global_swap_peak=-1
+    local global_scratch_byte_peak=0 global_scratch_inode_peak=0
+    local global_scratch_byte_limit=-1 global_scratch_inode_limit=-1
+    local memory_peak_owner=""
+    local previous_memory_peak=-1 previous_swap_peak=-1
+    local -a phase_order=()
+    local -A phase_seen=()
+    local -A phase_samples=()
+    local -A phase_memory_current_peak=()
+    local -A phase_memory_peak_start=()
+    local -A phase_memory_peak_end=()
+    local -A phase_swap_current_peak=()
+    local -A phase_swap_peak_start=()
+    local -A phase_swap_peak_end=()
+    local -A phase_anon_at_memory_peak=()
+    local -A phase_file_at_memory_peak=()
+    local -A phase_shmem_at_memory_peak=()
+    local -A phase_kernel_at_memory_peak=()
+    local -A phase_scratch_at_memory_peak=()
+    local -A phase_scratch_inodes_at_memory_peak=()
+    local -A phase_memory_peak_timestamp=()
+    local -A phase_scratch_byte_peak=()
+    local -A phase_scratch_inode_peak=()
+
+    if [[ ! -r "$samples_file" ]]; then
+        _daily_resource_invalid samples_unreadable
+        return
+    fi
+
+    while IFS=$'\t' read -r \
+        timestamp_ns phase memory_current memory_peak swap_current swap_peak \
+        anon file_bytes shmem kernel scratch_bytes scratch_byte_limit \
+        scratch_inodes scratch_inode_limit extra
+    do
+        if [[ -n "${extra:-}" || ! "$phase" =~ ^[a-z][a-z0-9_]*$ ]]; then
+            _daily_resource_invalid sample_shape_invalid
+            return
+        fi
+        for field in \
+            timestamp_ns memory_current memory_peak swap_current swap_peak \
+            anon file_bytes shmem kernel scratch_bytes scratch_byte_limit \
+            scratch_inodes scratch_inode_limit
+        do
+            value="${!field}"
+            if [[ ! "$value" =~ ^[0-9]+$ ]]; then
+                _daily_resource_invalid sample_value_invalid
+                return
+            fi
+        done
+        if ((scratch_byte_limit == 0 || scratch_inode_limit == 0)); then
+            _daily_resource_invalid scratch_limit_invalid
+            return
+        fi
+        if ((scratch_bytes > scratch_byte_limit || scratch_inodes > scratch_inode_limit)); then
+            _daily_resource_invalid scratch_usage_invalid
+            return
+        fi
+        if ((memory_peak < memory_current || swap_peak < swap_current)); then
+            _daily_resource_invalid cgroup_peak_invalid
+            return
+        fi
+        if ((shmem > file_bytes || shmem > memory_current)); then
+            _daily_resource_invalid memory_breakdown_invalid
+            return
+        fi
+        if ((previous_memory_peak >= 0 && memory_peak < previous_memory_peak)); then
+            _daily_resource_invalid memory_peak_regressed
+            return
+        fi
+        if ((previous_swap_peak >= 0 && swap_peak < previous_swap_peak)); then
+            _daily_resource_invalid swap_peak_regressed
+            return
+        fi
+        previous_memory_peak=$memory_peak
+        previous_swap_peak=$swap_peak
+
+        if ((global_scratch_byte_limit < 0)); then
+            global_scratch_byte_limit=$scratch_byte_limit
+            global_scratch_inode_limit=$scratch_inode_limit
+        elif ((
+            scratch_byte_limit != global_scratch_byte_limit
+            || scratch_inode_limit != global_scratch_inode_limit
+        )); then
+            _daily_resource_invalid scratch_limit_changed
+            return
+        fi
+
+        if [[ -z "${phase_seen[$phase]:-}" ]]; then
+            phase_seen[$phase]=1
+            phase_order+=("$phase")
+            phase_samples[$phase]=0
+            phase_memory_current_peak[$phase]=-1
+            phase_memory_peak_start[$phase]=$memory_peak
+            phase_swap_current_peak[$phase]=-1
+            phase_swap_peak_start[$phase]=$swap_peak
+            phase_scratch_byte_peak[$phase]=0
+            phase_scratch_inode_peak[$phase]=0
+        fi
+
+        phase_samples[$phase]=$((phase_samples[$phase] + 1))
+        phase_memory_peak_end[$phase]=$memory_peak
+        phase_swap_peak_end[$phase]=$swap_peak
+        if ((memory_current > phase_memory_current_peak[$phase])); then
+            phase_memory_current_peak[$phase]=$memory_current
+            phase_anon_at_memory_peak[$phase]=$anon
+            phase_file_at_memory_peak[$phase]=$file_bytes
+            phase_shmem_at_memory_peak[$phase]=$shmem
+            phase_kernel_at_memory_peak[$phase]=$kernel
+            phase_scratch_at_memory_peak[$phase]=$scratch_bytes
+            phase_scratch_inodes_at_memory_peak[$phase]=$scratch_inodes
+            phase_memory_peak_timestamp[$phase]=$timestamp_ns
+        fi
+        if ((swap_current > phase_swap_current_peak[$phase])); then
+            phase_swap_current_peak[$phase]=$swap_current
+        fi
+        if ((scratch_bytes > phase_scratch_byte_peak[$phase])); then
+            phase_scratch_byte_peak[$phase]=$scratch_bytes
+        fi
+        if ((scratch_inodes > phase_scratch_inode_peak[$phase])); then
+            phase_scratch_inode_peak[$phase]=$scratch_inodes
+        fi
+
+        if ((memory_peak > global_memory_peak)); then
+            global_memory_peak=$memory_peak
+            memory_peak_owner=$phase
+        fi
+        if ((swap_peak > global_swap_peak)); then
+            global_swap_peak=$swap_peak
+        fi
+        if ((scratch_bytes > global_scratch_byte_peak)); then
+            global_scratch_byte_peak=$scratch_bytes
+        fi
+        if ((scratch_inodes > global_scratch_inode_peak)); then
+            global_scratch_inode_peak=$scratch_inodes
+        fi
+        sample_count=$((sample_count + 1))
+    done < <(sort -n -k1,1 -- "$samples_file")
+
+    if ((sample_count == 0)); then
+        _daily_resource_invalid samples_empty
+        return
+    fi
+
+    for phase in "${phase_order[@]}"; do
+        printf '%s' 'CRATEDIGGER_DAILY_RESOURCE_PHASE schema=1'
+        printf ' phase=%s samples=%d' "$phase" "${phase_samples[$phase]}"
+        printf ' memory_current_peak_bytes=%d' "${phase_memory_current_peak[$phase]}"
+        printf ' memory_peak_start_bytes=%d' "${phase_memory_peak_start[$phase]}"
+        printf ' memory_peak_end_bytes=%d' "${phase_memory_peak_end[$phase]}"
+        printf ' swap_current_peak_bytes=%d' "${phase_swap_current_peak[$phase]}"
+        printf ' swap_peak_start_bytes=%d' "${phase_swap_peak_start[$phase]}"
+        printf ' swap_peak_end_bytes=%d' "${phase_swap_peak_end[$phase]}"
+        printf ' anon_at_memory_current_peak_bytes=%d' "${phase_anon_at_memory_peak[$phase]}"
+        printf ' file_at_memory_current_peak_bytes=%d' "${phase_file_at_memory_peak[$phase]}"
+        printf ' shmem_at_memory_current_peak_bytes=%d' "${phase_shmem_at_memory_peak[$phase]}"
+        printf ' non_shmem_at_memory_current_peak_bytes=%d' "$((
+            phase_memory_current_peak[$phase] - phase_shmem_at_memory_peak[$phase]
+        ))"
+        printf ' kernel_at_memory_current_peak_bytes=%d' "${phase_kernel_at_memory_peak[$phase]}"
+        printf ' scratch_at_memory_current_peak_bytes=%d' "${phase_scratch_at_memory_peak[$phase]}"
+        printf ' scratch_inode_at_memory_current_peak=%d' "${phase_scratch_inodes_at_memory_peak[$phase]}"
+        printf ' scratch_byte_peak=%d' "${phase_scratch_byte_peak[$phase]}"
+        printf ' scratch_inode_peak=%d' "${phase_scratch_inode_peak[$phase]}"
+        printf ' scratch_byte_limit=%d' "$global_scratch_byte_limit"
+        printf ' scratch_inode_limit=%d' "$global_scratch_inode_limit"
+        printf ' memory_current_peak_timestamp_ns=%d\n' "${phase_memory_peak_timestamp[$phase]}"
+    done
+
+    printf '%s' 'CRATEDIGGER_DAILY_RESOURCE_RECEIPT schema=1 status=valid'
+    printf ' samples=%d phases=%d' "$sample_count" "${#phase_order[@]}"
+    printf ' memory_peak_bytes=%d memory_peak_owner=%s' \
+        "$global_memory_peak" "$memory_peak_owner"
+    printf ' swap_peak_bytes=%d' "$global_swap_peak"
+    printf ' scratch_byte_peak=%d scratch_byte_limit=%d' \
+        "$global_scratch_byte_peak" "$global_scratch_byte_limit"
+    printf ' scratch_inode_peak=%d scratch_inode_limit=%d\n' \
+        "$global_scratch_inode_peak" "$global_scratch_inode_limit"
+}
+
+_daily_resource_record_sample_once() {
+    local phase="$1"
+    local memory_current memory_peak swap_current swap_peak
+    local anon="" file_bytes="" shmem="" kernel="" key value
+    local blocks free_blocks block_size total_inodes free_inodes
+    local scratch_bytes scratch_inodes timestamp_ns
+
+    # Capture the ordering witness before reading metrics. Parent boundary
+    # samples and the periodic child may overlap, so terminal aggregation sorts
+    # by this timestamp instead of trusting concurrent append order.
+    timestamp_ns="$(date +%s%N)" || return 1
+    memory_current="$(<"$_CRATEDIGGER_RESOURCE_CGROUP_DIR/memory.current")" || return 1
+    memory_peak="$(<"$_CRATEDIGGER_RESOURCE_CGROUP_DIR/memory.peak")" || return 1
+    swap_current="$(<"$_CRATEDIGGER_RESOURCE_CGROUP_DIR/memory.swap.current")" || return 1
+    swap_peak="$(<"$_CRATEDIGGER_RESOURCE_CGROUP_DIR/memory.swap.peak")" || return 1
+    while read -r key value; do
+        case "$key" in
+            anon) anon="$value" ;;
+            file) file_bytes="$value" ;;
+            shmem) shmem="$value" ;;
+            kernel) kernel="$value" ;;
+        esac
+    done < "$_CRATEDIGGER_RESOURCE_CGROUP_DIR/memory.stat" || return 1
+    if [[ -z "$anon" || -z "$file_bytes" || -z "$shmem" || -z "$kernel" ]]; then
+        return 1
+    fi
+    # memory.current and memory.stat are separate kernel reads. Churn can make
+    # a cross-read breakdown internally impossible; do not publish negative
+    # non-shmem attribution from that transient world.
+    if ((shmem > file_bytes || shmem > memory_current)); then
+        return 1
+    fi
+    read -r blocks free_blocks block_size total_inodes free_inodes < <(
+        stat --file-system --format='%b %f %S %c %d' -- \
+            "$_CRATEDIGGER_RESOURCE_SCRATCH"
+    ) || return 1
+    scratch_bytes=$(((blocks - free_blocks) * block_size))
+    scratch_inodes=$((total_inodes - free_inodes))
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$timestamp_ns" "$phase" "$memory_current" "$memory_peak" \
+        "$swap_current" "$swap_peak" "$anon" "$file_bytes" "$shmem" \
+        "$kernel" "$scratch_bytes" "$((blocks * block_size))" \
+        "$scratch_inodes" "$total_inodes" \
+        >> "$_CRATEDIGGER_RESOURCE_SAMPLES"
+}
+
+_daily_resource_record_sample_unlocked() {
+    local phase="$1" attempts=3
+    while ((attempts > 0)); do
+        if _daily_resource_record_sample_once "$phase"; then
+            return 0
+        fi
+        attempts=$((attempts - 1))
+        sleep 0.01
+    done
+    return 1
+}
+
+_daily_resource_lock() {
+    if [[ "${_CRATEDIGGER_RESOURCE_LOCK_HELD:-0}" == 1 ]]; then
+        return 2
+    fi
+    exec {_CRATEDIGGER_RESOURCE_LOCK_FD}>"$_CRATEDIGGER_RESOURCE_LOCK" \
+        || return 1
+    if ! flock -x -w 2 "$_CRATEDIGGER_RESOURCE_LOCK_FD"; then
+        exec {_CRATEDIGGER_RESOURCE_LOCK_FD}>&-
+        return 1
+    fi
+    _CRATEDIGGER_RESOURCE_LOCK_HELD=1
+}
+
+_daily_resource_unlock() {
+    if [[ "${_CRATEDIGGER_RESOURCE_LOCK_HELD:-0}" != 1 ]]; then
+        return 0
+    fi
+    exec {_CRATEDIGGER_RESOURCE_LOCK_FD}>&- || return 1
+    _CRATEDIGGER_RESOURCE_LOCK_HELD=0
+    unset _CRATEDIGGER_RESOURCE_LOCK_FD
+}
+
+_daily_resource_record_sample_locked() {
+    local phase="$1"
+    local status=0
+    _daily_resource_lock || return 1
+    _daily_resource_record_sample_unlocked "$phase" || status=1
+    _daily_resource_unlock || status=1
+    return "$status"
+}
+
+_daily_resource_record_current_phase_locked() {
+    local phase=""
+    local status=0
+    _daily_resource_lock || return 1
+    phase="$(<"$_CRATEDIGGER_RESOURCE_PHASE")" || status=1
+    if [[ -z "$phase" ]]; then
+        status=1
+    elif ((status == 0)); then
+        _daily_resource_record_sample_unlocked "$phase" || status=1
+    fi
+    _daily_resource_unlock || status=1
+    return "$status"
+}
+
+_daily_resource_write_phase() {
+    local phase="$1"
+    local temporary="$_CRATEDIGGER_RESOURCE_PHASE.next"
+    printf '%s\n' "$phase" > "$temporary" || return 1
+    mv -f -- "$temporary" "$_CRATEDIGGER_RESOURCE_PHASE"
+}
+
+_daily_resource_monitor_loop() {
+    while [[ ! -e "$_CRATEDIGGER_RESOURCE_STOP" ]]; do
+        if ! _daily_resource_record_current_phase_locked; then
+            printf '%s\n' sample_failed > "$_CRATEDIGGER_RESOURCE_FAILURE"
+            return 1
+        fi
+        sleep 0.25
+    done
+}
+
+daily_resource_monitor_start() {
+    local hierarchy controllers relative="" file filesystem
+
+    _CRATEDIGGER_RESOURCE_STARTED=starting
+    _CRATEDIGGER_RESOURCE_TERMINAL_EMITTED=0
+    _CRATEDIGGER_RESOURCE_SCRATCH="${XDG_RUNTIME_DIR:-}"
+    if [[ -z "$_CRATEDIGGER_RESOURCE_SCRATCH" \
+        || ! -d "$_CRATEDIGGER_RESOURCE_SCRATCH" ]]; then
+        _daily_resource_invalid scratch_unavailable
+        return
+    fi
+    filesystem="$(
+        stat --file-system --format='%T' -- "$_CRATEDIGGER_RESOURCE_SCRATCH" \
+            2>/dev/null
+    )" || true
+    if [[ "$filesystem" != tmpfs ]]; then
+        _daily_resource_invalid scratch_not_tmpfs
+        return
+    fi
+
+    while IFS=: read -r hierarchy controllers relative; do
+        if [[ "$hierarchy" == 0 && -z "$controllers" && "$relative" == /* ]]; then
+            break
+        fi
+        relative=""
+    done < /proc/self/cgroup
+    if [[ -z "$relative" ]]; then
+        _daily_resource_invalid cgroup_unavailable
+        return
+    fi
+    _CRATEDIGGER_RESOURCE_CGROUP_DIR="/sys/fs/cgroup$relative"
+    for file in \
+        memory.current memory.peak memory.swap.current memory.swap.peak memory.stat
+    do
+        if [[ ! -r "$_CRATEDIGGER_RESOURCE_CGROUP_DIR/$file" ]]; then
+            _daily_resource_invalid cgroup_metric_unreadable
+            return
+        fi
+    done
+
+    _CRATEDIGGER_RESOURCE_DIR="$(
+        mktemp -d \
+            "$_CRATEDIGGER_RESOURCE_SCRATCH/cratedigger-daily-resource.XXXXXX"
+    )" || {
+        _daily_resource_invalid monitor_state_unavailable
+        return
+    }
+    _CRATEDIGGER_RESOURCE_SAMPLES="$_CRATEDIGGER_RESOURCE_DIR/samples.tsv"
+    _CRATEDIGGER_RESOURCE_PHASE="$_CRATEDIGGER_RESOURCE_DIR/phase"
+    _CRATEDIGGER_RESOURCE_STOP="$_CRATEDIGGER_RESOURCE_DIR/stop"
+    _CRATEDIGGER_RESOURCE_FAILURE="$_CRATEDIGGER_RESOURCE_DIR/failure"
+    _CRATEDIGGER_RESOURCE_LOCK="$_CRATEDIGGER_RESOURCE_DIR/sample.lock"
+    : > "$_CRATEDIGGER_RESOURCE_SAMPLES"
+    : > "$_CRATEDIGGER_RESOURCE_FAILURE"
+    : > "$_CRATEDIGGER_RESOURCE_LOCK"
+    _CRATEDIGGER_RESOURCE_CURRENT_PHASE=bootstrap
+    if ! _daily_resource_write_phase "$_CRATEDIGGER_RESOURCE_CURRENT_PHASE" \
+        || ! _daily_resource_record_sample_unlocked \
+            "$_CRATEDIGGER_RESOURCE_CURRENT_PHASE";
+    then
+        rm -rf -- "$_CRATEDIGGER_RESOURCE_DIR"
+        _daily_resource_invalid initial_sample_failed
+        return
+    fi
+    _daily_resource_monitor_loop &
+    _CRATEDIGGER_RESOURCE_PID=$!
+    _CRATEDIGGER_RESOURCE_STARTED=1
+}
+
+daily_resource_monitor_set_phase() {
+    local phase="$1"
+    local status=0
+    if [[ "${_CRATEDIGGER_RESOURCE_STARTED:-0}" != 1 ]]; then
+        return 1
+    fi
+    if [[ ! "$phase" =~ ^[a-z][a-z0-9_]*$ ]]; then
+        printf '%s\n' phase_invalid > "$_CRATEDIGGER_RESOURCE_FAILURE"
+        return 1
+    fi
+    if ! _daily_resource_lock; then
+        printf '%s\n' phase_transition_failed > "$_CRATEDIGGER_RESOURCE_FAILURE"
+        return 1
+    fi
+    _daily_resource_record_sample_unlocked \
+        "$_CRATEDIGGER_RESOURCE_CURRENT_PHASE" || status=1
+    if ((status == 0)); then
+        _daily_resource_write_phase "$phase" || status=1
+    fi
+    if ((status == 0)); then
+        _CRATEDIGGER_RESOURCE_CURRENT_PHASE="$phase"
+        _daily_resource_record_sample_unlocked \
+            "$_CRATEDIGGER_RESOURCE_CURRENT_PHASE" || status=1
+    fi
+    _daily_resource_unlock || status=1
+    if ((status != 0)); then
+        printf '%s\n' phase_transition_failed > "$_CRATEDIGGER_RESOURCE_FAILURE"
+        return 1
+    fi
+}
+
+daily_resource_monitor_finish() {
+    local monitor_status=0 summary_status=0 reason=""
+    if [[ "${_CRATEDIGGER_RESOURCE_STARTED:-0}" != 1 ]]; then
+        if [[ -n "${_CRATEDIGGER_RESOURCE_PID:-}" ]]; then
+            [[ -n "${_CRATEDIGGER_RESOURCE_STOP:-}" ]] \
+                && : > "$_CRATEDIGGER_RESOURCE_STOP"
+            wait "$_CRATEDIGGER_RESOURCE_PID" 2>/dev/null || true
+        fi
+        if [[ -n "${_CRATEDIGGER_RESOURCE_DIR:-}" \
+            && -d "$_CRATEDIGGER_RESOURCE_DIR" ]]; then
+            rm -rf -- "$_CRATEDIGGER_RESOURCE_DIR"
+        fi
+        if [[ "${_CRATEDIGGER_RESOURCE_TERMINAL_EMITTED:-0}" != 1 ]]; then
+            _daily_resource_invalid monitor_not_started
+        fi
+        return 1
+    fi
+    if ! _daily_resource_record_sample_locked \
+        "$_CRATEDIGGER_RESOURCE_CURRENT_PHASE";
+    then
+        printf '%s\n' final_sample_failed > "$_CRATEDIGGER_RESOURCE_FAILURE"
+    fi
+    : > "$_CRATEDIGGER_RESOURCE_STOP"
+    if ! wait "$_CRATEDIGGER_RESOURCE_PID"; then
+        monitor_status=1
+    fi
+    if [[ -s "$_CRATEDIGGER_RESOURCE_FAILURE" ]]; then
+        reason="$(<"$_CRATEDIGGER_RESOURCE_FAILURE")"
+        _daily_resource_invalid "$reason"
+        summary_status=1
+    elif ((monitor_status != 0)); then
+        _daily_resource_invalid monitor_failed
+        summary_status=1
+    elif ! daily_resource_summarize_samples "$_CRATEDIGGER_RESOURCE_SAMPLES"; then
+        summary_status=1
+    fi
+    rm -rf -- "$_CRATEDIGGER_RESOURCE_DIR"
+    _CRATEDIGGER_RESOURCE_STARTED=0
+    return "$summary_status"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    set -euo pipefail
+    case "${1:-}" in
+        summarize)
+            if [[ "$#" -ne 2 ]]; then
+                _daily_resource_invalid summarize_arguments_invalid
+                exit 1
+            fi
+            daily_resource_summarize_samples "$2"
+            ;;
+        *)
+            _daily_resource_invalid command_invalid
+            exit 1
+            ;;
+    esac
+fi

--- a/tests/test_daily_flake_update.py
+++ b/tests/test_daily_flake_update.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import os
+import signal
+import subprocess
 import tempfile
 import time
 import unittest
@@ -21,6 +24,26 @@ class TestDailyFlakeUpdateScript(unittest.TestCase):
         self.addCleanup(self.tempdir.cleanup)
         self.fake = FakeDailyFlakeUpdateCommands(Path(self.tempdir.name))
 
+    def fake_environment(self) -> dict[str, str]:
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{self.fake.fake_bin}:{env['PATH']}",
+                "DAILY_UPDATE_FAKE_STATE": str(self.fake.state_path),
+                "CRATEDIGGER_AUTOMATION_STATE_DIR": str(
+                    self.fake.automation_state
+                ),
+                "CRATEDIGGER_MIRROR_URL": "http://mirror.example.test/ws/2",
+                "CRATEDIGGER_UPDATE_REPOSITORY": (
+                    "https://github.com/abl030/cratedigger.git"
+                ),
+                "CRATEDIGGER_UPDATE_BRANCH": "main",
+                "TMPDIR": str(self.fake.tmpdir),
+                "TEST_DB_DSN": "postgresql://production-must-not-leak",
+            }
+        )
+        return env
+
     def test_green_candidate_runs_every_gate_and_pushes_only_lock(self) -> None:
         proc = self.fake.run(SCRIPT)
         state = self.fake.state
@@ -39,6 +62,25 @@ class TestDailyFlakeUpdateScript(unittest.TestCase):
         self.assertIn("Refs #498", state["commit_args"])
         self.assertIn("ALL CANDIDATE GATES GREEN", proc.stdout)
         self.assertIn("pushed updated flake.lock", proc.stdout)
+        self.assertEqual(
+            proc.stdout.count("CRATEDIGGER_DAILY_RESOURCE_RECEIPT "), 1
+        )
+        self.assertIn(
+            "CRATEDIGGER_DAILY_RESOURCE_RECEIPT schema=1 status=valid",
+            proc.stdout,
+        )
+        for phase in (
+            "deterministic_suite",
+            "stable_nix",
+            "world_model",
+            "generated_fuzz",
+            "mirror_harness",
+            "cleanup",
+        ):
+            self.assertIn(
+                f"CRATEDIGGER_DAILY_RESOURCE_PHASE schema=1 phase={phase} ",
+                proc.stdout,
+            )
         self.assertEqual(
             state["lock_after_update"]["nodes"]["nixpkgs"]["locked"]["rev"],
             "new-nixpkgs",
@@ -70,6 +112,13 @@ class TestDailyFlakeUpdateScript(unittest.TestCase):
         self.assertIn("FAIL world-model burst", proc.stdout)
         self.assertIn("PASS mirror-harness smoke", proc.stdout)
         self.assertIn("candidate failed; flake.lock was not committed", proc.stderr)
+        self.assertEqual(
+            proc.stdout.count("CRATEDIGGER_DAILY_RESOURCE_RECEIPT "), 1
+        )
+        self.assertIn(
+            "CRATEDIGGER_DAILY_RESOURCE_RECEIPT schema=1 status=valid",
+            proc.stdout,
+        )
 
     def test_unchanged_lock_still_runs_gates_without_commit(self) -> None:
         self.fake.update_state(lock_changed=False)
@@ -154,6 +203,56 @@ class TestDailyFlakeUpdateScript(unittest.TestCase):
         self.assertNotEqual(proc.returncode, 0)
         self.assertIsNone(self.fake.state["clone_path"])
         self.assertIn("CRATEDIGGER_MIRROR_URL", proc.stderr)
+        self.assertEqual(
+            proc.stdout.count("CRATEDIGGER_DAILY_RESOURCE_RECEIPT "), 1
+        )
+        self.assertIn("status=invalid reason=monitor_not_started", proc.stdout)
+
+    def test_invalid_resource_namespace_fails_before_clone_without_zero_metrics(
+        self,
+    ) -> None:
+        proc = self.fake.run(
+            SCRIPT,
+            extra_env={"XDG_RUNTIME_DIR": str(REPO_ROOT)},
+        )
+
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIsNone(self.fake.state["clone_path"])
+        self.assertEqual(
+            proc.stdout.count("CRATEDIGGER_DAILY_RESOURCE_RECEIPT "), 1
+        )
+        self.assertIn("status=invalid reason=scratch_not_tmpfs", proc.stdout)
+        self.assertNotIn("scratch_byte_peak=0", proc.stdout)
+
+    def test_process_group_term_emits_one_terminal_receipt_without_deadlock(
+        self,
+    ) -> None:
+        self.fake.update_state(hold_stage="suite", hold_seconds=30)
+        process = subprocess.Popen(
+            ["bash", str(SCRIPT)],
+            cwd=self.fake.root,
+            env=self.fake_environment(),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            start_new_session=True,
+        )
+        self.addCleanup(lambda: process.poll() is None and process.kill())
+        deadline = time.monotonic() + 5
+        while "suite" not in self.fake.state["stage_started"]:
+            self.assertIsNone(process.poll(), "daily runner exited before suite")
+            self.assertLess(time.monotonic(), deadline, "daily runner never reached suite")
+            time.sleep(0.02)
+
+        os.killpg(process.pid, signal.SIGTERM)
+        stdout, stderr = process.communicate(timeout=5)
+
+        self.assertEqual(process.returncode, 143, stderr)
+        self.assertEqual(
+            stdout.count("CRATEDIGGER_DAILY_RESOURCE_RECEIPT "), 1,
+            stdout,
+        )
+        self.assertRegex(stdout, r"status=(?:valid|invalid) ")
 
     def test_red_tip_canary_cannot_block_green_nixpkgs_candidate(self) -> None:
         # The fake recognises tip-contract as a fault only if a runner invokes

--- a/tests/test_daily_resource_monitor.py
+++ b/tests/test_daily_resource_monitor.py
@@ -1,0 +1,273 @@
+"""Contracts for the daily gate's phase-correlated resource receipt."""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MONITOR = REPO_ROOT / "scripts" / "daily_resource_monitor.sh"
+PHASE_PREFIX = "CRATEDIGGER_DAILY_RESOURCE_PHASE "
+RECEIPT_PREFIX = "CRATEDIGGER_DAILY_RESOURCE_RECEIPT "
+
+
+def sample(
+    timestamp_ns: int,
+    phase: str,
+    *,
+    memory_current: int,
+    memory_peak: int,
+    swap_current: int = 0,
+    swap_peak: int = 0,
+    anon: int = 0,
+    file: int = 0,
+    shmem: int = 0,
+    kernel: int = 0,
+    scratch_bytes: int = 0,
+    scratch_byte_limit: int = 16_000,
+    scratch_inodes: int = 0,
+    scratch_inode_limit: int = 1_000,
+) -> str:
+    return "\t".join(
+        str(value)
+        for value in (
+            timestamp_ns,
+            phase,
+            memory_current,
+            memory_peak,
+            swap_current,
+            swap_peak,
+            anon,
+            file,
+            shmem,
+            kernel,
+            scratch_bytes,
+            scratch_byte_limit,
+            scratch_inodes,
+            scratch_inode_limit,
+        )
+    )
+
+
+def parse_fields(line: str, prefix: str) -> dict[str, str]:
+    if not line.startswith(prefix):
+        raise AssertionError(f"missing prefix {prefix!r}: {line!r}")
+    return dict(field.split("=", 1) for field in line.removeprefix(prefix).split())
+
+
+def summarize_samples(rows: list[str]) -> subprocess.CompletedProcess[str]:
+    with tempfile.TemporaryDirectory() as temporary:
+        samples = Path(temporary) / "samples.tsv"
+        samples.write_text("\n".join(rows) + "\n", encoding="utf-8")
+        return subprocess.run(
+            ["bash", str(MONITOR), "summarize", str(samples)],
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+
+def parsed_valid_summary(
+    completed: subprocess.CompletedProcess[str],
+) -> tuple[dict[str, dict[str, str]], dict[str, str]]:
+    if completed.returncode != 0:
+        raise AssertionError(completed.stderr or completed.stdout)
+    phase_rows: dict[str, dict[str, str]] = {}
+    receipts: list[dict[str, str]] = []
+    for line in completed.stdout.splitlines():
+        if line.startswith(PHASE_PREFIX):
+            fields = parse_fields(line, PHASE_PREFIX)
+            phase_rows[fields["phase"]] = fields
+        elif line.startswith(RECEIPT_PREFIX):
+            receipts.append(parse_fields(line, RECEIPT_PREFIX))
+    if len(receipts) != 1:
+        raise AssertionError(f"expected one terminal receipt, got {len(receipts)}")
+    receipt = receipts[0]
+    if receipt.get("status") != "valid":
+        raise AssertionError(f"resource receipt is not valid: {receipt}")
+    return phase_rows, receipt
+
+
+class TestDailyResourceSummary(unittest.TestCase):
+    def test_phase_transition_serializes_label_and_metric_sampling(self) -> None:
+        harness = r'''
+set -euo pipefail
+source "$1"
+state="$2"
+_CRATEDIGGER_RESOURCE_DIR="$state"
+_CRATEDIGGER_RESOURCE_SAMPLES="$state/samples.tsv"
+_CRATEDIGGER_RESOURCE_PHASE="$state/phase"
+_CRATEDIGGER_RESOURCE_FAILURE="$state/failure"
+_CRATEDIGGER_RESOURCE_LOCK="$state/sample.lock"
+_CRATEDIGGER_RESOURCE_STARTED=1
+_CRATEDIGGER_RESOURCE_CURRENT_PHASE=old_phase
+: > "$_CRATEDIGGER_RESOURCE_SAMPLES"
+: > "$_CRATEDIGGER_RESOURCE_FAILURE"
+: > "$_CRATEDIGGER_RESOURCE_LOCK"
+printf '%s\n' old_phase > "$_CRATEDIGGER_RESOURCE_PHASE"
+printf '%s\n' 100 > "$state/peak"
+
+_daily_resource_record_sample_unlocked() {
+    local phase="$1" peak timestamp
+    timestamp="$(date +%s%N)"
+    if [[ "$phase" == old_phase ]] && mkdir "$state/claim" 2>/dev/null; then
+        : > "$state/entered"
+        while [[ ! -e "$state/release" ]]; do
+            sleep 0.01
+        done
+    fi
+    peak="$(<"$state/peak")"
+    printf '%s\t%s\t%s\t%s\t0\t0\t%s\t0\t0\t0\t0\t1000\t0\t1000\n' \
+        "$timestamp" "$phase" "$peak" "$peak" "$peak" \
+        >> "$_CRATEDIGGER_RESOURCE_SAMPLES"
+}
+
+_daily_resource_record_current_phase_locked &
+background=$!
+while [[ ! -e "$state/entered" ]]; do
+    sleep 0.01
+done
+(sleep 0.2; : > "$state/release") &
+daily_resource_monitor_set_phase new_phase
+printf '%s\n' 200 > "$state/peak"
+_daily_resource_record_sample_locked new_phase
+wait "$background"
+daily_resource_summarize_samples "$_CRATEDIGGER_RESOURCE_SAMPLES"
+'''
+        with tempfile.TemporaryDirectory() as temporary:
+            completed = subprocess.run(
+                ["bash", "-c", harness, "bash", str(MONITOR), temporary],
+                cwd=REPO_ROOT,
+                text=True,
+                capture_output=True,
+                check=False,
+                timeout=5,
+            )
+            samples = Path(temporary, "samples.tsv").read_text(
+                encoding="utf-8"
+            )
+
+        phases, receipt = parsed_valid_summary(completed)
+        old_peaks = [
+            row.split("\t")[3]
+            for row in samples.splitlines()
+            if row.split("\t")[1] == "old_phase"
+        ]
+        self.assertTrue(old_peaks)
+        self.assertEqual(set(old_peaks), {"100"})
+        self.assertEqual(phases["new_phase"]["memory_peak_end_bytes"], "200")
+        self.assertEqual(receipt["memory_peak_owner"], "new_phase")
+
+    def test_phase_peak_retains_its_time_correlated_breakdown(self) -> None:
+        completed = summarize_samples(
+            [
+                sample(
+                    10, "stable_nix", memory_current=800, memory_peak=800,
+                    anon=500, file=240, shmem=40, kernel=60,
+                    scratch_bytes=100, scratch_inodes=10,
+                ),
+                sample(
+                    20, "stable_nix", memory_current=600, memory_peak=800,
+                    anon=300, file=230, shmem=80, kernel=70,
+                    scratch_bytes=300, scratch_inodes=30,
+                ),
+                sample(
+                    30, "generated_fuzz", memory_current=1_700, memory_peak=1_700,
+                    swap_current=20, swap_peak=20,
+                    anon=400, file=1_100, shmem=1_000, kernel=200,
+                    scratch_bytes=1_200, scratch_inodes=120,
+                ),
+                sample(
+                    40, "generated_fuzz", memory_current=1_200, memory_peak=1_700,
+                    swap_current=5, swap_peak=20,
+                    anon=700, file=300, shmem=100, kernel=200,
+                    scratch_bytes=1_500, scratch_inodes=150,
+                ),
+            ]
+        )
+
+        phases, receipt = parsed_valid_summary(completed)
+        fuzz = phases["generated_fuzz"]
+        self.assertEqual(fuzz["memory_current_peak_bytes"], "1700")
+        self.assertEqual(fuzz["anon_at_memory_current_peak_bytes"], "400")
+        self.assertEqual(fuzz["shmem_at_memory_current_peak_bytes"], "1000")
+        self.assertEqual(fuzz["non_shmem_at_memory_current_peak_bytes"], "700")
+        self.assertEqual(fuzz["scratch_at_memory_current_peak_bytes"], "1200")
+        self.assertEqual(fuzz["scratch_byte_peak"], "1500")
+        self.assertEqual(fuzz["scratch_inode_peak"], "150")
+        self.assertEqual(fuzz["memory_peak_start_bytes"], "1700")
+        self.assertEqual(fuzz["memory_peak_end_bytes"], "1700")
+        self.assertEqual(receipt["memory_peak_bytes"], "1700")
+        self.assertEqual(receipt["memory_peak_owner"], "generated_fuzz")
+        self.assertEqual(receipt["swap_peak_bytes"], "20")
+        self.assertEqual(receipt["samples"], "4")
+        self.assertEqual(receipt["phases"], "2")
+
+    def test_zero_scratch_limits_are_invalid_not_empty_evidence(self) -> None:
+        completed = summarize_samples(
+            [
+                sample(
+                    10, "generated_fuzz", memory_current=1, memory_peak=1,
+                    scratch_byte_limit=0, scratch_inode_limit=0,
+                )
+            ]
+        )
+
+        self.assertNotEqual(completed.returncode, 0)
+        receipts = [
+            parse_fields(line, RECEIPT_PREFIX)
+            for line in completed.stdout.splitlines()
+            if line.startswith(RECEIPT_PREFIX)
+        ]
+        self.assertEqual(len(receipts), 1)
+        self.assertEqual(receipts[0]["status"], "invalid")
+        self.assertEqual(receipts[0]["reason"], "scratch_limit_invalid")
+        self.assertNotIn(PHASE_PREFIX, completed.stdout)
+
+    def test_impossible_memory_breakdown_is_invalid_not_negative_evidence(
+        self,
+    ) -> None:
+        completed = summarize_samples(
+            [
+                sample(
+                    10, "generated_fuzz", memory_current=10, memory_peak=20,
+                    file=10, shmem=11,
+                )
+            ]
+        )
+
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("status=invalid", completed.stdout)
+        self.assertIn("reason=memory_breakdown_invalid", completed.stdout)
+        self.assertNotIn("non_shmem_at_memory_current_peak_bytes=-", completed.stdout)
+
+    def test_non_monotonic_kernel_peak_is_rejected(self) -> None:
+        completed = summarize_samples(
+            [
+                sample(10, "stable_nix", memory_current=80, memory_peak=100),
+                sample(20, "stable_nix", memory_current=70, memory_peak=90),
+            ]
+        )
+
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("status=invalid", completed.stdout)
+        self.assertIn("reason=memory_peak_regressed", completed.stdout)
+
+    def test_concurrent_append_order_is_sorted_by_sample_timestamp(self) -> None:
+        completed = summarize_samples(
+            [
+                sample(20, "generated_fuzz", memory_current=200, memory_peak=200),
+                sample(10, "stable_nix", memory_current=100, memory_peak=100),
+            ]
+        )
+
+        phases, receipt = parsed_valid_summary(completed)
+        self.assertEqual(list(phases), ["stable_nix", "generated_fuzz"])
+        self.assertEqual(receipt["memory_peak_owner"], "generated_fuzz")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_daily_resource_monitor_generated.py
+++ b/tests/test_daily_resource_monitor_generated.py
@@ -1,0 +1,281 @@
+"""Generated timeline coverage for the daily resource receipt."""
+
+from __future__ import annotations
+
+import subprocess
+import unittest
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+import tests._hypothesis_profiles  # noqa: F401  (loads the active profile)
+from tests.test_daily_resource_monitor import (
+    PHASE_PREFIX,
+    RECEIPT_PREFIX,
+    parsed_valid_summary,
+    sample,
+    summarize_samples,
+)
+
+
+@st.composite
+def resource_timelines(draw: st.DrawFn) -> list[dict[str, int | str]]:
+    phases = draw(
+        st.lists(
+            st.sampled_from(("stable_nix", "generated_fuzz", "world_model")),
+            min_size=1,
+            max_size=12,
+        )
+    )
+    currents = draw(
+        st.lists(
+            st.integers(min_value=1, max_value=100_000),
+            min_size=len(phases),
+            max_size=len(phases),
+        )
+    )
+    scratch_values = draw(
+        st.lists(
+            st.integers(min_value=0, max_value=50_000),
+            min_size=len(phases),
+            max_size=len(phases),
+        )
+    )
+    inode_values = draw(
+        st.lists(
+            st.integers(min_value=0, max_value=5_000),
+            min_size=len(phases),
+            max_size=len(phases),
+        )
+    )
+    rows: list[dict[str, int | str]] = []
+    memory_peak = 0
+    swap_peak = 0
+    for index, (phase, current, scratch_bytes, scratch_inodes) in enumerate(
+        zip(phases, currents, scratch_values, inode_values, strict=True), start=1
+    ):
+        memory_peak = draw(
+            st.integers(
+                min_value=max(memory_peak, current),
+                max_value=250_000,
+            )
+        )
+        swap_current = draw(st.integers(min_value=0, max_value=2_000))
+        swap_peak = draw(
+            st.integers(
+                min_value=max(swap_peak, swap_current),
+                max_value=5_000,
+            )
+        )
+        shmem = draw(st.integers(min_value=0, max_value=current))
+        remaining = current - shmem
+        anon = draw(st.integers(min_value=0, max_value=remaining))
+        file_bytes = draw(st.integers(min_value=shmem, max_value=shmem + remaining))
+        kernel = max(0, current - anon - file_bytes)
+        rows.append(
+            {
+                "timestamp_ns": index,
+                "phase": phase,
+                "memory_current": current,
+                "memory_peak": memory_peak,
+                "swap_current": swap_current,
+                "swap_peak": swap_peak,
+                "anon": anon,
+                "file": file_bytes,
+                "shmem": shmem,
+                "kernel": kernel,
+                "scratch_bytes": scratch_bytes,
+                "scratch_inodes": scratch_inodes,
+            }
+        )
+    return rows
+
+
+def assert_summary_matches_timeline(
+    rows: list[dict[str, int | str]],
+    phases: dict[str, dict[str, str]],
+    receipt: dict[str, str],
+) -> None:
+    phase_names = list(dict.fromkeys(str(row["phase"]) for row in rows))
+    if set(phases) != set(phase_names):
+        raise AssertionError("phase membership drifted")
+    for phase in phase_names:
+        phase_samples = [row for row in rows if row["phase"] == phase]
+        peak_row = max(
+            phase_samples,
+            key=lambda row: int(row["memory_current"]),
+        )
+        actual = phases[phase]
+        if int(actual["samples"]) != len(phase_samples):
+            raise AssertionError(f"{phase} sample count drifted")
+        if int(actual["memory_current_peak_bytes"]) != int(
+            peak_row["memory_current"]
+        ):
+            raise AssertionError(f"{phase} memory-current peak drifted")
+        for field in ("anon", "file", "shmem", "kernel"):
+            if int(actual[f"{field}_at_memory_current_peak_bytes"]) != int(
+                peak_row[field]
+            ):
+                raise AssertionError(f"{phase} {field} companion sample drifted")
+        if int(actual["non_shmem_at_memory_current_peak_bytes"]) != (
+            int(peak_row["memory_current"]) - int(peak_row["shmem"])
+        ):
+            raise AssertionError(f"{phase} non-shmem companion sample drifted")
+        if int(actual["scratch_at_memory_current_peak_bytes"]) != int(
+            peak_row["scratch_bytes"]
+        ):
+            raise AssertionError(f"{phase} scratch companion sample drifted")
+        if int(actual["scratch_byte_peak"]) != max(
+            int(row["scratch_bytes"]) for row in phase_samples
+        ):
+            raise AssertionError(f"{phase} scratch byte peak drifted")
+        if int(actual["scratch_inode_peak"]) != max(
+            int(row["scratch_inodes"]) for row in phase_samples
+        ):
+            raise AssertionError(f"{phase} scratch inode peak drifted")
+        if int(actual["memory_peak_start_bytes"]) != int(
+            phase_samples[0]["memory_peak"]
+        ):
+            raise AssertionError(f"{phase} memory peak start drifted")
+        if int(actual["memory_peak_end_bytes"]) != int(
+            phase_samples[-1]["memory_peak"]
+        ):
+            raise AssertionError(f"{phase} memory peak end drifted")
+        if int(actual["swap_current_peak_bytes"]) != max(
+            int(row["swap_current"]) for row in phase_samples
+        ):
+            raise AssertionError(f"{phase} swap-current peak drifted")
+        if int(actual["swap_peak_start_bytes"]) != int(
+            phase_samples[0]["swap_peak"]
+        ):
+            raise AssertionError(f"{phase} swap peak start drifted")
+        if int(actual["swap_peak_end_bytes"]) != int(
+            phase_samples[-1]["swap_peak"]
+        ):
+            raise AssertionError(f"{phase} swap peak end drifted")
+
+    final_kernel_peak = max(int(row["memory_peak"]) for row in rows)
+    expected_owner = next(
+        str(row["phase"])
+        for row in rows
+        if int(row["memory_peak"]) == final_kernel_peak
+    )
+    if int(receipt["memory_peak_bytes"]) != final_kernel_peak:
+        raise AssertionError("terminal kernel peak drifted")
+    if receipt["memory_peak_owner"] != expected_owner:
+        raise AssertionError("terminal peak owner drifted")
+
+
+class TestDailyResourceSummaryGenerated(unittest.TestCase):
+    @given(rows=resource_timelines())
+    def test_every_phase_keeps_its_true_maximum_and_companion_sample(
+        self, rows: list[dict[str, int | str]],
+    ) -> None:
+        completed = summarize_samples(
+            [
+                sample(
+                    int(row["timestamp_ns"]),
+                    str(row["phase"]),
+                    memory_current=int(row["memory_current"]),
+                    memory_peak=int(row["memory_peak"]),
+                    swap_current=int(row["swap_current"]),
+                    swap_peak=int(row["swap_peak"]),
+                    anon=int(row["anon"]),
+                    file=int(row["file"]),
+                    shmem=int(row["shmem"]),
+                    kernel=int(row["kernel"]),
+                    scratch_bytes=int(row["scratch_bytes"]),
+                    scratch_inodes=int(row["scratch_inodes"]),
+                    scratch_byte_limit=50_001,
+                    scratch_inode_limit=5_001,
+                )
+                for row in rows
+            ]
+        )
+        phases, receipt = parsed_valid_summary(completed)
+        assert_summary_matches_timeline(rows, phases, receipt)
+
+    @given(
+        memory_current=st.integers(min_value=0, max_value=100_000),
+        excess=st.integers(min_value=1, max_value=100_000),
+    )
+    def test_impossible_shmem_worlds_fail_closed(
+        self, memory_current: int, excess: int,
+    ) -> None:
+        shmem = memory_current + excess
+        completed = summarize_samples(
+            [
+                sample(
+                    1, "generated_fuzz",
+                    memory_current=memory_current,
+                    memory_peak=shmem,
+                    file=shmem,
+                    shmem=shmem,
+                )
+            ]
+        )
+
+        self.assertNotEqual(completed.returncode, 0)
+        self.assertIn("reason=memory_breakdown_invalid", completed.stdout)
+
+    def test_checker_rejects_known_bad_aggregates_and_missing_terminal(self) -> None:
+        rows: list[dict[str, int | str]] = [
+            {
+                "timestamp_ns": 1, "phase": "stable_nix",
+                "memory_current": 100, "memory_peak": 500,
+                "swap_current": 0, "swap_peak": 0,
+                "anon": 40, "file": 50, "shmem": 30, "kernel": 10,
+                "scratch_bytes": 70, "scratch_inodes": 7,
+            },
+            {
+                "timestamp_ns": 2, "phase": "generated_fuzz",
+                "memory_current": 400, "memory_peak": 500,
+                "swap_current": 0, "swap_peak": 0,
+                "anon": 200, "file": 150, "shmem": 100, "kernel": 50,
+                "scratch_bytes": 90, "scratch_inodes": 9,
+            },
+        ]
+        completed = summarize_samples(
+            [
+                sample(
+                    int(row["timestamp_ns"]), str(row["phase"]),
+                    memory_current=int(row["memory_current"]),
+                    memory_peak=int(row["memory_peak"]),
+                    anon=int(row["anon"]), file=int(row["file"]),
+                    shmem=int(row["shmem"]), kernel=int(row["kernel"]),
+                    scratch_bytes=int(row["scratch_bytes"]),
+                    scratch_inodes=int(row["scratch_inodes"]),
+                )
+                for row in rows
+            ]
+        )
+        phases, receipt = parsed_valid_summary(completed)
+
+        bad_last_value = {key: value.copy() for key, value in phases.items()}
+        bad_last_value["generated_fuzz"]["memory_current_peak_bytes"] = "50"
+        with self.assertRaises(AssertionError):
+            assert_summary_matches_timeline(rows, bad_last_value, receipt)
+
+        bad_companion = {key: value.copy() for key, value in phases.items()}
+        bad_companion["generated_fuzz"]["anon_at_memory_current_peak_bytes"] = "20"
+        with self.assertRaises(AssertionError):
+            assert_summary_matches_timeline(rows, bad_companion, receipt)
+
+        bad_owner = receipt.copy()
+        bad_owner["memory_peak_owner"] = "generated_fuzz"
+        with self.assertRaises(AssertionError):
+            assert_summary_matches_timeline(rows, phases, bad_owner)
+
+        without_terminal = "\n".join(
+            line for line in completed.stdout.splitlines()
+            if line.startswith(PHASE_PREFIX) and not line.startswith(RECEIPT_PREFIX)
+        )
+        missing = subprocess.CompletedProcess(
+            args=completed.args, returncode=0, stdout=without_terminal, stderr=""
+        )
+        with self.assertRaises(AssertionError):
+            parsed_valid_summary(missing)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- sample cgroup memory/swap and private scratch usage from inside the daily service namespace
- emit phase-correlated aggregates plus exactly one fail-closed terminal resource receipt
- serialize phase transitions with sampling and retain cleanup/setup/signal evidence
- cover aggregation, malformed kernel snapshots, phase races, and process-group termination with deterministic and generated tests

## Validation

- canonical final gate: pass on `68a64b7c`
- receipt: `/run/user/1000/cratedigger-final-gate.aGCLPlX5`
- depth-100 fuzz burst: 137 modules, 612 targets, 1,628 tests, all green
- independent read-only review: approved with no blockers

Closes #1052
