### PR TITLE
perf(tests): sustain fuzz concurrency above 25 cores

### DIFF
--- a/docs/generated-testing.md
+++ b/docs/generated-testing.md
@@ -536,28 +536,37 @@ Two independent gates enforce this:
 
 `scripts/fuzz_burst.sh` discovers the exact unittest IDs and effective
 Hypothesis settings in every generated module. Ordinary deterministic pins run
-once as a batch, and fixed per-test `@settings(max_examples=...)` budgets remain
-single-run. Each property using the default fuzz profile divides its generated
-examples exactly across independent entropy shards. The automatic fan-out is
-bounded by both host cores and the effective budget discovered from the loaded
-profile, with at least 250 examples per entropy child. The total budget does not
-grow: on a 30-core host, the ordinary 500-example profile uses two processes of
-250 examples, while the 20,000-example overnight gate keeps eight processes of
-2,500. The child runner loads the owning module and selects the exact discovered
-ID, so dynamically named state-machine tests can be sharded without repeating
+once; modules already audited as deterministic-suite hotspots reuse that
+runner's bounded class/method batches, and those hotspots are admitted before
+ordinary modules so expensive real-tool work cannot become the tail. Every
+randomized, non-finite property may divide its exact discovered budget across
+independent entropy shards, including a fixed per-test
+`@settings(max_examples=...)` budget. Derandomized and independently proved
+finite properties remain one target. The real-Beets destructive matrix is also
+one property target: multiplying its nested Beets startup/migration work causes
+hard subprocess timeouts, so it is frontloaded instead of sharded.
+
+Automatic fan-out is bounded by both host cores and the effective default
+profile budget, with at least 250 examples per entropy child. The total budget
+does not grow: on a 30-core host, the ordinary 500-example profile uses two
+processes of 250 examples, while the 20,000-example overnight gate keeps eight
+processes of 2,500. The child runner loads the owning module, selects the exact
+discovered ID, and applies only that target's divided budget, so dynamically
+named state-machine tests and explicit budgets can be sharded without repeating
 the module's other properties or pins. An exact-budget check rejects any
 schedule that omits a test, repeats a pin, changes a property's combined example
-count, or invents an ID.
+count, exceeds a resource shard limit, or invents an ID.
 
-The queue uses every host core by default for ordinary targets. Targets whose
-module boots an ephemeral PostgreSQL cluster are capped at two concurrent
-processes, bounding their tmpfs footprint independently of the queue length;
-eligible ordinary work bypasses a PostgreSQL-backed target waiting for that
-resource. Any `ENOSPC`, PostgreSQL `DiskFull`, or unexpected loss of an
-ephemeral database aborts further admission and reports that the property
-verdict is invalid. Set `CRATEDIGGER_FUZZ_JOBS` to cap all concurrent
-processes or `CRATEDIGGER_FUZZ_PROPERTY_SHARDS` to override the automatic
-entropy fan-out. On doc1's 30-core VM on 2026-07-23, the complete 71-module,
+The queue defaults to twice the host's core count because these targets mix
+Python with subprocess and filesystem waits. PostgreSQL-backed targets have a
+separate bounded lane (24 targets on doc1's 30-core host); admission fills that
+lane before ordinary capacity so PostgreSQL work cannot accumulate into a
+low-utilization tail. Any `ENOSPC`, PostgreSQL `DiskFull`, or unexpected loss of
+an ephemeral database aborts further admission and reports that the property
+verdict is invalid. Set `CRATEDIGGER_FUZZ_JOBS` to cap all concurrent processes,
+`CRATEDIGGER_FUZZ_POSTGRES_JOBS` to cap the PostgreSQL lane, or
+`CRATEDIGGER_FUZZ_PROPERTY_SHARDS` to override automatic entropy fan-out. On
+doc1's 30-core VM on 2026-07-23, the complete 71-module,
 769-test overnight burst at 20,000 examples completed in 607.8 seconds. The
 worst subprocess-heavy generated module completed alone in 142.7 seconds; its
 unsharded properties had still not completed after ten minutes.

--- a/scripts/run_fuzz_tests.py
+++ b/scripts/run_fuzz_tests.py
@@ -31,14 +31,17 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from scripts.run_python_tests import (
+    HOTSPOT_SHARD_POLICIES,
     STRATEGY_SPACE_EXHAUSTED,
     ChildTargetResult,
     HypothesisPropertyStats,
+    TestModule,
     _iter_test_cases,
     _test_method,
     assert_hypothesis_deadlines_disabled,
     resolve_hypothesis_settings,
     settings_max_examples,
+    shard_test_ids,
 )
 from tests.finite_domain_metadata import (
     FINITE_DOMAIN_ATTRIBUTE,
@@ -48,8 +51,11 @@ from tests.finite_domain_metadata import (
 TARGET_RUNNER = REPO_ROOT / "scripts" / "run_python_tests.py"
 DEFAULT_PROFILE = "fuzz"
 DEFAULT_DURATIONS = 5
-EPHEMERAL_POSTGRES_TARGET_LIMIT = 2
+EPHEMERAL_POSTGRES_TARGET_LIMIT = 24
 MIN_EXAMPLES_PER_ENTROPY_SHARD = 250
+FUZZ_PROPERTY_SHARD_LIMITS = {
+    "tests.test_beets_destructive_configs_generated": 1,
+}
 _SCHEMA_READY_ENV = "CRATEDIGGER_TEST_SCHEMA_READY"
 _DISCOVERY_DSN = "postgresql:///cratedigger_fuzz_discovery_only"
 
@@ -60,6 +66,14 @@ DEPTH_REPORT_LIMIT = 20
 #: defect: ``assume`` marks a world invalid and Hypothesis refills the budget,
 #: which is exactly why it is the correct way to drop an unanswerable world.
 DISCARD_RATE_THRESHOLD = 0.10
+_DERANDOMIZE_SETTING = "derandomize"
+
+
+def _settings_derandomize(configured: settings) -> bool:
+    value = getattr(configured, _DERANDOMIZE_SETTING)
+    if not isinstance(value, bool):
+        raise TypeError("Hypothesis derandomize setting must be boolean")
+    return value
 
 
 class FuzzPropertyManifest(msgspec.Struct, frozen=True):
@@ -68,6 +82,7 @@ class FuzzPropertyManifest(msgspec.Struct, frozen=True):
     test_id: str
     max_examples: int
     uses_default_settings: bool
+    entropy_shardable: bool = True
     finite_domain_cardinality: int | None = None
 
 
@@ -90,7 +105,7 @@ class FuzzTarget:
     expected_test_ids: tuple[str, ...]
     shard_index: int = 0
     shard_count: int = 1
-    profile_max_examples: int | None = None
+    max_examples_override: int | None = None
     uses_ephemeral_postgres: bool = False
 
 
@@ -159,7 +174,7 @@ class PersistedFuzzTarget(msgspec.Struct, frozen=True):
     expected_test_ids: tuple[str, ...]
     shard_index: int
     shard_count: int
-    profile_max_examples: int | None
+    max_examples_override: int | None
     uses_ephemeral_postgres: bool
 
 
@@ -167,6 +182,55 @@ class PersistedFuzzManifest(msgspec.Struct, frozen=True):
     """Complete target map copied beside retained failure logs."""
 
     targets: tuple[PersistedFuzzTarget, ...]
+
+
+def _build_fuzz_pin_targets(
+    manifest: FuzzModuleManifest,
+    pin_ids: Sequence[str],
+) -> tuple[FuzzTarget, ...]:
+    """Reuse the deterministic runner's audited hotspot sharding for pins."""
+    granularity = HOTSPOT_SHARD_POLICIES.get(manifest.module_name)
+    if granularity is None:
+        return (
+            FuzzTarget(
+                label=f"{manifest.module_name}::pins",
+                module_name=manifest.module_name,
+                load_names=(manifest.module_name,),
+                expected_test_ids=tuple(pin_ids),
+                uses_ephemeral_postgres=manifest.uses_ephemeral_postgres,
+            ),
+        )
+    module = TestModule(
+        name=manifest.module_name,
+        path=Path(),
+        weight=1,
+    )
+    return tuple(
+        FuzzTarget(
+            label=target.test_name,
+            module_name=manifest.module_name,
+            load_names=target.load_names,
+            expected_test_ids=target.expected_test_ids,
+            uses_ephemeral_postgres=manifest.uses_ephemeral_postgres,
+        )
+        for target in shard_test_ids(
+            module,
+            pin_ids,
+            granularity=granularity,
+        )
+    )
+
+
+def _property_shard_count(
+    manifest: FuzzModuleManifest,
+    item: FuzzPropertyManifest,
+) -> int:
+    if item.finite_domain_cardinality is not None or not item.entropy_shardable:
+        return 1
+    return min(
+        item.max_examples,
+        FUZZ_PROPERTY_SHARD_LIMITS.get(manifest.module_name, item.max_examples),
+    )
 
 
 def build_fuzz_targets(
@@ -181,6 +245,7 @@ def build_fuzz_targets(
     ordered_manifests = sorted(
         manifests,
         key=lambda manifest: (
+            manifest.module_name not in HOTSPOT_SHARD_POLICIES,
             -len(manifest.hypothesis_tests),
             -len(manifest.test_ids),
             manifest.module_name,
@@ -206,9 +271,13 @@ def build_fuzz_targets(
         isolate_properties = (
             len(manifest.hypothesis_tests) > 1
             or any(
-                item.uses_default_settings and property_shards > 1
+                min(
+                    property_shards,
+                    _property_shard_count(manifest, item),
+                ) > 1
                 for item in manifest.hypothesis_tests
             )
+            or manifest.module_name in HOTSPOT_SHARD_POLICIES
         )
         if not isolate_properties:
             targets.append(
@@ -230,12 +299,10 @@ def build_fuzz_targets(
                     f"invalid Hypothesis budget for {item.test_id}: "
                     f"{item.max_examples}"
                 )
-            shard_count = 1
-            if (
-                item.finite_domain_cardinality is None
-                and item.uses_default_settings
-            ):
-                shard_count = min(property_shards, item.max_examples)
+            shard_count = min(
+                property_shards,
+                _property_shard_count(manifest, item),
+            )
             quotient, remainder = divmod(item.max_examples, shard_count)
             budgets = tuple(
                 quotient + (1 if index < remainder else 0)
@@ -256,7 +323,7 @@ def build_fuzz_targets(
                         expected_test_ids=(item.test_id,),
                         shard_index=shard_index,
                         shard_count=shard_count,
-                        profile_max_examples=(
+                        max_examples_override=(
                             budget if shard_count > 1 else None
                         ),
                         uses_ephemeral_postgres=(
@@ -270,17 +337,7 @@ def build_fuzz_targets(
             if test_id not in hypothesis_ids
         )
         if pin_ids:
-            targets.append(
-                FuzzTarget(
-                    label=f"{manifest.module_name}::pins",
-                    module_name=manifest.module_name,
-                    load_names=(manifest.module_name,),
-                    expected_test_ids=pin_ids,
-                    uses_ephemeral_postgres=(
-                        manifest.uses_ephemeral_postgres
-                    ),
-                )
-            )
+            targets.extend(_build_fuzz_pin_targets(manifest, pin_ids))
 
     built = tuple(targets)
     assert_exact_fuzz_coverage(manifests, built)
@@ -352,9 +409,9 @@ def assert_exact_fuzz_coverage(
                 )
             if shard_count != 1 or len(scheduled) != 1:
                 raise ValueError(f"finite fuzz property was sharded: {test_id}")
-            if scheduled[0].profile_max_examples is not None:
+            if scheduled[0].max_examples_override is not None:
                 raise ValueError(
-                    f"finite fuzz property received a profile override: {test_id}"
+                    f"finite fuzz property received a budget override: {test_id}"
                 )
             continue
         if shard_count != len(scheduled):
@@ -364,13 +421,20 @@ def assert_exact_fuzz_coverage(
         ):
             raise ValueError(f"invalid fuzz property shard index: {test_id}")
         if shard_count == 1:
-            if scheduled[0].profile_max_examples is not None:
+            if scheduled[0].max_examples_override is not None:
                 raise ValueError(f"unexpected fuzz property budget: {test_id}")
             continue
-        if not item.uses_default_settings:
-            raise ValueError(f"explicit fuzz budget was sharded: {test_id}")
+        resource_limit = FUZZ_PROPERTY_SHARD_LIMITS.get(
+            scheduled[0].module_name,
+        )
+        if resource_limit is not None and shard_count > resource_limit:
+            raise ValueError(
+                f"fuzz property exceeds resource shard limit: {test_id}"
+            )
+        if not item.entropy_shardable:
+            raise ValueError(f"non-randomized fuzz property was sharded: {test_id}")
         shard_budgets = [
-            target.profile_max_examples for target in scheduled
+            target.max_examples_override for target in scheduled
         ]
         if any(budget is None or budget < 1 for budget in shard_budgets):
             raise ValueError(f"invalid fuzz property budget: {test_id}")
@@ -560,11 +624,13 @@ def _discover_module_child(module_name: str, result_path: Path) -> int:
             raise TypeError(f"invalid finite-domain metadata: {test.id()}")
         if raw_finite_spec is not None:
             raw_finite_spec.verify()
+        derandomize = _settings_derandomize(configured)
         hypothesis_tests.append(
             FuzzPropertyManifest(
                 test_id=test.id(),
                 max_examples=configured_max_examples,
                 uses_default_settings=uses_default_settings,
+                entropy_shardable=not derandomize,
                 finite_domain_cardinality=(
                     raw_finite_spec.cardinality
                     if raw_finite_spec is not None
@@ -670,21 +736,20 @@ def _execute_fuzz_target(
     log_path = log_directory / f"{index:04d}.log"
     result_path = log_directory / f"{index:04d}.json"
     child_environment = dict(environment)
-    if target.profile_max_examples is not None:
-        child_environment["CRATEDIGGER_FUZZ_MAX_EXAMPLES"] = str(
-            target.profile_max_examples
-        )
+    command = [
+        sys.executable,
+        str(TARGET_RUNNER),
+        "--_run-target",
+        msgspec.json.encode(target.load_names).decode(),
+        str(DEFAULT_DURATIONS),
+        str(result_path),
+        msgspec.json.encode(target.expected_test_ids).decode(),
+    ]
+    if target.max_examples_override is not None:
+        command.append(str(target.max_examples_override))
     with log_path.open("wb") as raw_output:
         completed = subprocess.run(
-            [
-                sys.executable,
-                str(TARGET_RUNNER),
-                "--_run-target",
-                msgspec.json.encode(target.load_names).decode(),
-                str(DEFAULT_DURATIONS),
-                str(result_path),
-                msgspec.json.encode(target.expected_test_ids).decode(),
-            ],
+            command,
             cwd=REPO_ROOT,
             env=child_environment,
             stdout=raw_output,
@@ -766,6 +831,13 @@ def assert_fuzz_admission(
     )
     if active_postgres + admitted_postgres > postgres_worker_count:
         raise AssertionError("fuzz admission exceeds PostgreSQL capacity")
+    required_postgres = min(
+        postgres_worker_count - active_postgres,
+        worker_count - len(active),
+        sum(target.uses_ephemeral_postgres for target in pending),
+    )
+    if admitted_postgres < required_postgres:
+        raise AssertionError("fuzz admission left PostgreSQL lane idle")
 
     admitted_set = set(admitted_indexes)
     remaining = tuple(
@@ -799,8 +871,17 @@ def select_fuzz_admissions(
     )
     admitted: list[int] = []
     for index, target in enumerate(pending):
+        if postgres_slots < 1 or len(admitted) >= total_slots:
+            break
+        if target.uses_ephemeral_postgres:
+            admitted.append(index)
+            postgres_slots -= 1
+    admitted_set = set(admitted)
+    for index, target in enumerate(pending):
         if len(admitted) >= total_slots:
             break
+        if index in admitted_set:
+            continue
         if target.uses_ephemeral_postgres:
             if postgres_slots < 1:
                 continue
@@ -986,7 +1067,7 @@ def _persist_failure_logs(
                 expected_test_ids=target.expected_test_ids,
                 shard_index=target.shard_index,
                 shard_count=target.shard_count,
-                profile_max_examples=target.profile_max_examples,
+                max_examples_override=target.max_examples_override,
                 uses_ephemeral_postgres=target.uses_ephemeral_postgres,
             )
             for index, target in enumerate(targets)
@@ -1013,11 +1094,41 @@ def _parse_positive_int(value: str) -> int:
     return parsed
 
 
+def recommended_fuzz_jobs(cpu_count: int) -> int:
+    """Keep mixed subprocess/I/O targets runnable at twice host cores."""
+    if cpu_count < 1:
+        raise ValueError("cpu_count must be at least 1")
+    return cpu_count * 2
+
+
+def recommended_postgres_jobs(cpu_count: int, worker_count: int) -> int:
+    """Keep a bounded four-fifths-host PG lane busy through target turnover."""
+    if cpu_count < 1:
+        raise ValueError("cpu_count must be at least 1")
+    if worker_count < 1:
+        raise ValueError("worker_count must be at least 1")
+    return min(
+        worker_count,
+        EPHEMERAL_POSTGRES_TARGET_LIMIT,
+        max(1, (cpu_count * 4 + 4) // 5),
+    )
+
+
 def _default_jobs() -> int:
     configured = os.environ.get("CRATEDIGGER_FUZZ_JOBS")
     if configured is not None:
         return _parse_positive_int(configured)
-    return os.cpu_count() or 1
+    return recommended_fuzz_jobs(os.cpu_count() or 1)
+
+
+def _default_postgres_jobs() -> int:
+    configured = os.environ.get("CRATEDIGGER_FUZZ_POSTGRES_JOBS")
+    if configured is not None:
+        return _parse_positive_int(configured)
+    return recommended_postgres_jobs(
+        os.cpu_count() or 1,
+        _default_jobs(),
+    )
 
 
 def property_profile_max_examples(
@@ -1075,6 +1186,11 @@ def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("modules", nargs="*")
     parser.add_argument("--jobs", type=_parse_positive_int, default=_default_jobs())
+    parser.add_argument(
+        "--postgres-jobs",
+        type=_parse_positive_int,
+        default=_default_postgres_jobs(),
+    )
     parser.add_argument(
         "--property-shards",
         type=_parse_positive_int,
@@ -1163,7 +1279,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             f"{len(targets)} targets ({property_targets} property targets, "
             f"up to {property_shards} entropy shards), "
             f"up to {worker_count} parallel, "
-            f"up to {min(EPHEMERAL_POSTGRES_TARGET_LIMIT, worker_count)} "
+            f"up to {min(args.postgres_jobs, worker_count)} "
             "PostgreSQL-backed "
             f"({os.cpu_count() or 1} host cores), profile={args.profile}",
             flush=True,
@@ -1173,7 +1289,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             targets,
             worker_count=worker_count,
             postgres_worker_count=min(
-                EPHEMERAL_POSTGRES_TARGET_LIMIT,
+                args.postgres_jobs,
                 worker_count,
             ),
             environment=child_environment,

--- a/scripts/run_python_tests.py
+++ b/scripts/run_python_tests.py
@@ -842,6 +842,45 @@ def hypothesis_example_budgets(suite: unittest.TestSuite) -> dict[str, int]:
     return budgets
 
 
+def override_hypothesis_max_examples(
+    suite: unittest.TestSuite,
+    max_examples: int,
+) -> None:
+    """Set one isolated target's budget without changing its other settings."""
+    if max_examples < 1:
+        raise ValueError("Hypothesis target max_examples must be at least 1")
+    properties = tuple(
+        (test, resolved)
+        for test in _iter_test_cases(suite)
+        if (resolved := resolve_hypothesis_settings(test)) is not None
+    )
+    if len(properties) != 1:
+        raise ValueError(
+            "Hypothesis target budget override requires exactly one property, "
+            f"found {len(properties)}"
+        )
+    test, resolved = properties[0]
+    overridden = settings(
+        parent=resolved.configured,
+        max_examples=max_examples,
+    )
+    if resolved.from_state_machine_class:
+        setattr(  # noqa: B010 - Hypothesis stores state-machine settings here
+            type(test),
+            "settings",
+            overridden,
+        )
+        return
+    method = _test_method(test)
+    if method is None:
+        raise ValueError(f"could not resolve Hypothesis target: {test.id()}")
+    setattr(  # noqa: B010 - Hypothesis stores effective settings on the method
+        method,
+        "_hypothesis_internal_use_settings",
+        overridden,
+    )
+
+
 def assert_hypothesis_deadlines_disabled(suite: unittest.TestSuite) -> None:
     """Every Hypothesis test in this suite must resolve ``deadline=None``.
 
@@ -925,6 +964,7 @@ def _run_test_target_child(
     durations: int,
     result_path: Path,
     selected_test_ids: tuple[str, ...] | None = None,
+    max_examples_override: int | None = None,
 ) -> int:
     """Run one target in a fresh interpreter and persist its complete result."""
     stream = io.StringIO()
@@ -948,6 +988,8 @@ def _run_test_target_child(
         suite = unittest.TestSuite(
             discovered_by_id[test_id] for test_id in selected_test_ids
         )
+    if max_examples_override is not None:
+        override_hypothesis_max_examples(suite, max_examples_override)
     assert_hypothesis_deadlines_disabled(suite)
     recorder = HypothesisStatsRecorder(hypothesis_example_budgets(suite))
 
@@ -1321,7 +1363,7 @@ if __name__ == "__main__":
                 Path(sys.argv[3]),
             )
         )
-    if len(sys.argv) in {5, 6} and sys.argv[1] == "--_run-target":
+    if len(sys.argv) in {5, 6, 7} and sys.argv[1] == "--_run-target":
         raise SystemExit(
             _run_test_target_child(
                 msgspec.json.decode(sys.argv[2], type=tuple[str, ...]),
@@ -1329,9 +1371,10 @@ if __name__ == "__main__":
                 Path(sys.argv[4]),
                 (
                     msgspec.json.decode(sys.argv[5], type=tuple[str, ...])
-                    if len(sys.argv) == 6
+                    if len(sys.argv) >= 6
                     else None
                 ),
+                int(sys.argv[6]) if len(sys.argv) == 7 else None,
             )
         )
     raise SystemExit(main())

--- a/tests/test_fuzz_burst.py
+++ b/tests/test_fuzz_burst.py
@@ -25,6 +25,8 @@ from scripts.run_fuzz_tests import (
     format_depth_report,
     is_structurally_shallow,
     property_profile_max_examples,
+    recommended_fuzz_jobs,
+    recommended_postgres_jobs,
     recommended_property_shards,
     select_fuzz_admissions,
 )
@@ -93,6 +95,43 @@ class TestFuzzTargetPlanning(unittest.TestCase):
             ),
         )
 
+    def test_audited_method_hotspot_splits_fixed_tests_into_twelve_batches(
+        self,
+    ) -> None:
+        module_name = "tests.test_beets_destructive_configs_generated"
+        property_ids = tuple(
+            f"{module_name}.TestWorld.test_property_{index}"
+            for index in range(2)
+        )
+        pin_ids = tuple(
+            f"{module_name}.TestMatrix.test_cell_{index:02d}"
+            for index in range(60)
+        )
+        manifest = FuzzModuleManifest(
+            module_name=module_name,
+            test_ids=property_ids + pin_ids,
+            hypothesis_tests=tuple(
+                self.property(property_id) for property_id in property_ids
+            ),
+        )
+
+        targets = build_fuzz_targets((manifest,))
+
+        assert_exact_fuzz_coverage((manifest,), targets)
+        pin_targets = tuple(
+            target
+            for target in targets
+            if set(target.expected_test_ids).intersection(pin_ids)
+        )
+        self.assertEqual(len(pin_targets), 12)
+        self.assertEqual(
+            {len(target.expected_test_ids) for target in pin_targets},
+            {5},
+        )
+        self.assertTrue(
+            all(target.load_names == target.expected_test_ids for target in pin_targets)
+        )
+
     def test_single_property_module_keeps_one_process(self) -> None:
         property_id = "tests.test_example_generated.TestWorld.test_property"
         manifest = FuzzModuleManifest(
@@ -145,7 +184,7 @@ class TestFuzzTargetPlanning(unittest.TestCase):
             ]
             self.assertEqual(len(shards), 4)
             self.assertEqual(
-                sum(target.profile_max_examples or 0 for target in shards),
+            sum(target.max_examples_override or 0 for target in shards),
                 20_003,
             )
             self.assertEqual(
@@ -159,7 +198,7 @@ class TestFuzzTargetPlanning(unittest.TestCase):
                 )
             )
 
-    def test_explicit_property_budget_is_not_multiplied(self) -> None:
+    def test_explicit_property_budget_is_split_without_multiplication(self) -> None:
         property_id = "tests.test_example_generated.TestWorld.test_property"
         manifest = FuzzModuleManifest(
             module_name="tests.test_example_generated",
@@ -176,8 +215,58 @@ class TestFuzzTargetPlanning(unittest.TestCase):
         targets = build_fuzz_targets((manifest,), property_shards=8)
 
         assert_exact_fuzz_coverage((manifest,), targets)
+        self.assertEqual(len(targets), 8)
+        self.assertEqual(
+            sum(target.max_examples_override or 0 for target in targets),
+            30,
+        )
+        self.assertEqual(
+            {target.shard_index for target in targets},
+            set(range(8)),
+        )
+
+    def test_derandomized_explicit_property_remains_one_target(self) -> None:
+        property_id = "tests.test_example_generated.TestWorld.test_property"
+        manifest = FuzzModuleManifest(
+            module_name="tests.test_example_generated",
+            test_ids=(property_id,),
+            hypothesis_tests=(
+                FuzzPropertyManifest(
+                    test_id=property_id,
+                    max_examples=30,
+                    uses_default_settings=False,
+                    entropy_shardable=False,
+                ),
+            ),
+        )
+
+        targets = build_fuzz_targets((manifest,), property_shards=8)
+
+        assert_exact_fuzz_coverage((manifest,), targets)
         self.assertEqual(len(targets), 1)
-        self.assertIsNone(targets[0].profile_max_examples)
+        self.assertIsNone(targets[0].max_examples_override)
+
+    def test_real_beets_property_remains_one_frontloaded_target(self) -> None:
+        module_name = "tests.test_beets_destructive_configs_generated"
+        property_id = f"{module_name}.TestWorld.test_property"
+        manifest = FuzzModuleManifest(
+            module_name=module_name,
+            test_ids=(property_id,),
+            hypothesis_tests=(
+                FuzzPropertyManifest(
+                    test_id=property_id,
+                    max_examples=96,
+                    uses_default_settings=False,
+                ),
+            ),
+        )
+
+        targets = build_fuzz_targets((manifest,), property_shards=8)
+
+        assert_exact_fuzz_coverage((manifest,), targets)
+        self.assertEqual(len(targets), 1)
+        self.assertEqual(targets[0].module_name, module_name)
+        self.assertIsNone(targets[0].max_examples_override)
 
     def test_property_dense_modules_are_frontloaded(self) -> None:
         light = FuzzModuleManifest(
@@ -216,6 +305,43 @@ class TestFuzzTargetPlanning(unittest.TestCase):
             all(
                 target.module_name == dense.module_name
                 for target in targets[:4]
+            )
+        )
+
+    def test_audited_hotspot_precedes_an_ordinary_property_dense_module(
+        self,
+    ) -> None:
+        hotspot_name = "tests.test_beets_destructive_configs_generated"
+        hotspot_property = f"{hotspot_name}.TestWorld.test_property"
+        hotspot = FuzzModuleManifest(
+            module_name=hotspot_name,
+            test_ids=(
+                hotspot_property,
+                f"{hotspot_name}.TestWorld.test_pin",
+            ),
+            hypothesis_tests=(self.property(hotspot_property),),
+        )
+        ordinary_name = "tests.test_dense_generated"
+        ordinary_ids = tuple(
+            f"{ordinary_name}.TestWorld.test_property_{index}"
+            for index in range(8)
+        )
+        ordinary = FuzzModuleManifest(
+            module_name=ordinary_name,
+            test_ids=ordinary_ids,
+            hypothesis_tests=tuple(
+                self.property(test_id) for test_id in ordinary_ids
+            ),
+        )
+
+        targets = build_fuzz_targets((ordinary, hotspot))
+
+        self.assertEqual(targets[0].module_name, hotspot_name)
+        self.assertTrue(
+            all(
+                target.module_name == hotspot_name
+                for target in targets
+                if target.module_name == hotspot_name
             )
         )
 
@@ -288,13 +414,76 @@ class TestFuzzTargetPlanning(unittest.TestCase):
             postgres_worker_count=1,
         )
         self.assertEqual(admitted, (2,))
-        self.assertEqual(EPHEMERAL_POSTGRES_TARGET_LIMIT, 2)
+        self.assertEqual(EPHEMERAL_POSTGRES_TARGET_LIMIT, 24)
+
+    def test_idle_postgres_lane_is_filled_before_ordinary_capacity(self) -> None:
+        pending = tuple(
+            FuzzTarget(
+                label=f"ordinary-{index}",
+                module_name=f"ordinary-{index}",
+                load_names=(f"ordinary-{index}",),
+                expected_test_ids=(f"ordinary-{index}.test",),
+            )
+            for index in range(3)
+        ) + (
+            FuzzTarget(
+                label="postgres",
+                module_name="postgres",
+                load_names=("postgres",),
+                expected_test_ids=("postgres.test",),
+                uses_ephemeral_postgres=True,
+            ),
+        )
+
+        admitted = select_fuzz_admissions(
+            pending,
+            (),
+            worker_count=3,
+            postgres_worker_count=1,
+        )
+
+        self.assertEqual(len(admitted), 3)
+        self.assertIn(3, admitted)
+
+    def test_admission_checker_rejects_an_idle_postgres_lane(self) -> None:
+        pending = tuple(
+            FuzzTarget(
+                label=f"ordinary-{index}",
+                module_name=f"ordinary-{index}",
+                load_names=(f"ordinary-{index}",),
+                expected_test_ids=(f"ordinary-{index}.test",),
+            )
+            for index in range(2)
+        ) + (
+            FuzzTarget(
+                label="postgres",
+                module_name="postgres",
+                load_names=("postgres",),
+                expected_test_ids=("postgres.test",),
+                uses_ephemeral_postgres=True,
+            ),
+        )
+
+        with self.assertRaisesRegex(AssertionError, "PostgreSQL lane idle"):
+            assert_fuzz_admission(
+                pending,
+                (),
+                (0, 1),
+                worker_count=2,
+                postgres_worker_count=1,
+            )
 
     def test_30_core_500_example_profile_uses_two_entropy_shards(self) -> None:
         self.assertEqual(recommended_property_shards(30, 500), 2)
 
     def test_30_core_overnight_profile_keeps_eight_entropy_shards(self) -> None:
         self.assertEqual(recommended_property_shards(30, 20_000), 8)
+
+    def test_30_core_host_defaults_to_60_by_24_concurrency(self) -> None:
+        workers = recommended_fuzz_jobs(30)
+
+        self.assertEqual(workers, 60)
+        self.assertEqual(recommended_postgres_jobs(30, workers), 24)
 
     def test_discovered_profile_budget_ignores_explicit_properties(self) -> None:
         manifest = FuzzModuleManifest(
@@ -638,10 +827,16 @@ class TestFuzzRunnerProcess(unittest.TestCase):
             "    @settings(max_examples=3, deadline=None)\n"
             "    @given(value=st.integers())\n"
             "    def test_property_one(self, value):\n"
+            "        count_dir = Path(os.environ['FUZZ_COUNT_DIR'])\n"
+            "        with (count_dir / 'property-one-count').open('ab') as stream:\n"
+            "            stream.write(b'x')\n"
             "        self.assertEqual(value, value)\n\n"
             "    @settings(max_examples=3, deadline=None)\n"
             "    @given(value=st.text(max_size=3))\n"
             "    def test_property_two(self, value):\n"
+            "        count_dir = Path(os.environ['FUZZ_COUNT_DIR'])\n"
+            "        with (count_dir / 'property-two-count').open('ab') as stream:\n"
+            "            stream.write(b'x')\n"
             "        self.assertEqual(value, value)\n\n"
             "    def test_pin(self):\n"
             "        database = Path(os.environ['HYPOTHESIS_STORAGE_DIRECTORY'])\n"
@@ -769,6 +964,7 @@ class TestFuzzRunnerProcess(unittest.TestCase):
             "HYPOTHESIS_STORAGE_DIRECTORY": str(self.database),
             "CRATEDIGGER_FUZZ_OUTPUT_DIR": str(self.output_dir),
             "FUZZ_FIXTURE_FAIL": "1" if failing else "0",
+            "FUZZ_COUNT_DIR": str(self.root),
         }
         return subprocess.run(
             [
@@ -911,6 +1107,43 @@ class TestFuzzRunnerProcess(unittest.TestCase):
         self.assertIn("4 targets", completed.stdout)
         self.assertIn("1 tests", completed.stdout)
         self.assertIn("ALL GREEN", completed.stdout)
+
+    def test_explicit_property_shards_run_their_divided_budget(self) -> None:
+        env = {
+            **os.environ,
+            "PYTHONPATH": os.pathsep.join(
+                (str(self.root), str(REPO_ROOT), os.environ.get("PYTHONPATH", ""))
+            ),
+            "HYPOTHESIS_STORAGE_DIRECTORY": str(self.database),
+            "CRATEDIGGER_FUZZ_MAX_EXAMPLES": "100",
+            "FUZZ_COUNT_DIR": str(self.root),
+        }
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(RUNNER),
+                "--jobs",
+                "3",
+                "--profile",
+                "fuzz",
+                "--property-shards",
+                "3",
+                self.module,
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(completed.returncode, 0, completed.stdout + completed.stderr)
+        self.assertIn("7 targets (6 property targets", completed.stdout)
+        self.assertIn("DEPTH 2 properties measured", completed.stdout)
+        self.assertIn("ALL GREEN", completed.stdout)
+        self.assertEqual((self.root / "property-one-count").read_bytes(), b"xxx")
+        self.assertEqual((self.root / "property-two-count").read_bytes(), b"xxx")
 
     def test_burst_discloses_a_structurally_shallow_property(self) -> None:
         """End-to-end: real runner, real child, real Hypothesis statistics."""

--- a/tests/test_fuzz_runner_generated.py
+++ b/tests/test_fuzz_runner_generated.py
@@ -31,11 +31,14 @@ from scripts.run_fuzz_tests import (
     discover_fuzz_manifests,
     format_depth_report,
     is_structurally_shallow,
+    recommended_fuzz_jobs,
+    recommended_postgres_jobs,
     recommended_property_shards,
     select_fuzz_admissions,
 )
 from scripts.run_python_tests import (
     _MIN_VALID_TEMP_HEADROOM_BYTES,
+    HOTSPOT_METHOD_BATCHES,
     STRATEGY_SPACE_EXHAUSTED,
     HypothesisPropertyStats,
     RecordingTextTestResult,
@@ -50,6 +53,63 @@ STOPPED_BECAUSE = (
     "settings.max_examples=2500, but < 1% of examples satisfied assumptions",
     "",
 )
+
+
+def assert_method_batched_fuzz_pins(
+    targets: Sequence[FuzzTarget],
+    pin_ids: Sequence[str],
+) -> None:
+    """Audited method hotspots spread every fixed test across bounded targets."""
+    expected = set(pin_ids)
+    pin_targets = tuple(
+        target
+        for target in targets
+        if expected.intersection(target.expected_test_ids)
+    )
+    scheduled = tuple(
+        test_id
+        for target in pin_targets
+        for test_id in target.expected_test_ids
+        if test_id in expected
+    )
+    if len(scheduled) != len(set(scheduled)) or set(scheduled) != expected:
+        raise AssertionError("method-batched fuzz pins do not have exact coverage")
+    batch_count = min(HOTSPOT_METHOD_BATCHES, len(pin_ids))
+    if len(pin_targets) != batch_count:
+        raise AssertionError(
+            f"method-batched fuzz pins use {len(pin_targets)} batches, "
+            f"expected {batch_count}"
+        )
+    widths = tuple(
+        sum(test_id in expected for test_id in target.expected_test_ids)
+        for target in pin_targets
+    )
+    if widths and max(widths) - min(widths) > 1:
+        raise AssertionError(f"method-batched fuzz pins are imbalanced: {widths}")
+
+
+def assert_fuzz_hotspots_frontloaded(
+    targets: Sequence[FuzzTarget],
+    hotspot_modules: set[str],
+) -> None:
+    """No ordinary target may precede an audited hotspot target."""
+    first_ordinary = next(
+        (
+            index
+            for index, target in enumerate(targets)
+            if target.module_name not in hotspot_modules
+        ),
+        len(targets),
+    )
+    late_hotspots = tuple(
+        target.label
+        for target in targets[first_ordinary:]
+        if target.module_name in hotspot_modules
+    )
+    if late_hotspots:
+        raise AssertionError(
+            f"fuzz hotspots were scheduled after ordinary work: {late_hotspots}"
+        )
 
 
 def property_stats(id_count: int, max_size: int) -> st.SearchStrategy[
@@ -262,6 +322,21 @@ def assert_report_names_exactly_the_discarding_properties(
 
 
 class TestGeneratedFuzzTargetPlanning(unittest.TestCase):
+    @given(cpu_count=st.integers(min_value=1, max_value=256))
+    def test_default_concurrency_keeps_bounded_headroom_above_host_cores(
+        self,
+        cpu_count: int,
+    ) -> None:
+        workers = recommended_fuzz_jobs(cpu_count)
+        postgres_workers = recommended_postgres_jobs(cpu_count, workers)
+
+        self.assertGreaterEqual(workers, cpu_count)
+        self.assertLessEqual(workers, cpu_count * 2)
+        self.assertGreaterEqual(postgres_workers, 1)
+        self.assertLessEqual(postgres_workers, min(workers, 24))
+        if cpu_count >= 29:
+            self.assertEqual(postgres_workers, 24)
+
     @given(
         cpu_count=st.integers(min_value=1, max_value=256),
         max_examples=st.integers(min_value=1, max_value=100_000),
@@ -330,11 +405,11 @@ class TestGeneratedFuzzTargetPlanning(unittest.TestCase):
             ]
             self.assertEqual(len(shards), property_shards)
             if property_shards == 1:
-                self.assertIsNone(shards[0].profile_max_examples)
+                self.assertIsNone(shards[0].max_examples_override)
             else:
                 self.assertEqual(
                     sum(
-                        target.profile_max_examples or 0
+                        target.max_examples_override or 0
                         for target in shards
                     ),
                     max_examples,
@@ -344,6 +419,163 @@ class TestGeneratedFuzzTargetPlanning(unittest.TestCase):
                 sum(pin_id in target.expected_test_ids for target in targets),
                 1,
             )
+
+    @given(
+        max_examples=st.integers(min_value=1, max_value=200),
+        property_shards=st.integers(min_value=1, max_value=12),
+        entropy_shardable=st.booleans(),
+    )
+    def test_randomized_explicit_budgets_are_conserved_across_shards(
+        self,
+        max_examples: int,
+        property_shards: int,
+        entropy_shardable: bool,
+    ) -> None:
+        property_id = "tests.test_generated_world.TestWorld.test_explicit"
+        manifest = FuzzModuleManifest(
+            module_name="tests.test_generated_world",
+            test_ids=(property_id,),
+            hypothesis_tests=(
+                FuzzPropertyManifest(
+                    test_id=property_id,
+                    max_examples=max_examples,
+                    uses_default_settings=False,
+                    entropy_shardable=entropy_shardable,
+                ),
+            ),
+        )
+
+        targets = build_fuzz_targets(
+            (manifest,),
+            property_shards=property_shards,
+        )
+
+        assert_exact_fuzz_coverage((manifest,), targets)
+        expected_shards = (
+            min(property_shards, max_examples)
+            if entropy_shardable
+            else 1
+        )
+        self.assertEqual(len(targets), expected_shards)
+        if expected_shards == 1:
+            self.assertIsNone(targets[0].max_examples_override)
+        else:
+            self.assertEqual(
+                sum(target.max_examples_override or 0 for target in targets),
+                max_examples,
+            )
+
+    @example(pin_count=60)
+    @given(pin_count=st.integers(min_value=1, max_value=100))
+    def test_audited_method_hotspots_balance_every_fixed_test(
+        self,
+        pin_count: int,
+    ) -> None:
+        module_name = "tests.test_beets_destructive_configs_generated"
+        property_ids = tuple(
+            f"{module_name}.TestWorld.test_property_{index}"
+            for index in range(2)
+        )
+        pin_ids = tuple(
+            f"{module_name}.TestMatrix.test_cell_{index:03d}"
+            for index in range(pin_count)
+        )
+        manifest = FuzzModuleManifest(
+            module_name=module_name,
+            test_ids=property_ids + pin_ids,
+            hypothesis_tests=tuple(
+                FuzzPropertyManifest(
+                    test_id=test_id,
+                    max_examples=500,
+                    uses_default_settings=True,
+                )
+                for test_id in property_ids
+            ),
+        )
+
+        targets = build_fuzz_targets((manifest,))
+
+        assert_exact_fuzz_coverage((manifest,), targets)
+        assert_method_batched_fuzz_pins(targets, pin_ids)
+
+    @given(
+        ordinary_properties=st.integers(min_value=2, max_value=30),
+        hotspot_pins=st.integers(min_value=1, max_value=40),
+    )
+    def test_audited_hotspots_never_wait_behind_ordinary_modules(
+        self,
+        ordinary_properties: int,
+        hotspot_pins: int,
+    ) -> None:
+        hotspot_name = "tests.test_beets_destructive_configs_generated"
+        hotspot_property = f"{hotspot_name}.TestWorld.test_property"
+        hotspot = FuzzModuleManifest(
+            module_name=hotspot_name,
+            test_ids=(hotspot_property,) + tuple(
+                f"{hotspot_name}.TestWorld.test_pin_{index}"
+                for index in range(hotspot_pins)
+            ),
+            hypothesis_tests=(
+                FuzzPropertyManifest(
+                    test_id=hotspot_property,
+                    max_examples=500,
+                    uses_default_settings=True,
+                ),
+            ),
+        )
+        ordinary_name = "tests.test_ordinary_generated"
+        ordinary_ids = tuple(
+            f"{ordinary_name}.TestWorld.test_property_{index}"
+            for index in range(ordinary_properties)
+        )
+        ordinary = FuzzModuleManifest(
+            module_name=ordinary_name,
+            test_ids=ordinary_ids,
+            hypothesis_tests=tuple(
+                FuzzPropertyManifest(
+                    test_id=test_id,
+                    max_examples=500,
+                    uses_default_settings=True,
+                )
+                for test_id in ordinary_ids
+            ),
+        )
+
+        targets = build_fuzz_targets((ordinary, hotspot))
+
+        assert_fuzz_hotspots_frontloaded(targets, {hotspot_name})
+
+    @given(
+        max_examples=st.integers(min_value=1, max_value=200),
+        property_shards=st.integers(min_value=1, max_value=12),
+    )
+    def test_real_beets_property_never_multiplies_nested_beets_startup(
+        self,
+        max_examples: int,
+        property_shards: int,
+    ) -> None:
+        module_name = "tests.test_beets_destructive_configs_generated"
+        property_id = f"{module_name}.TestWorld.test_property"
+        manifest = FuzzModuleManifest(
+            module_name=module_name,
+            test_ids=(property_id,),
+            hypothesis_tests=(
+                FuzzPropertyManifest(
+                    test_id=property_id,
+                    max_examples=max_examples,
+                    uses_default_settings=False,
+                ),
+            ),
+        )
+
+        targets = build_fuzz_targets(
+            (manifest,),
+            property_shards=property_shards,
+        )
+
+        assert_exact_fuzz_coverage((manifest,), targets)
+        self.assertEqual(len(targets), 1)
+        self.assertIsNone(targets[0].max_examples_override)
 
     @given(
         active_pg=st.integers(min_value=0, max_value=4),
@@ -388,6 +620,15 @@ class TestGeneratedFuzzTargetPlanning(unittest.TestCase):
             worker_count=worker_count,
             postgres_worker_count=postgres_worker_count,
         )
+        admitted_postgres = sum(
+            queued[index].uses_ephemeral_postgres for index in admitted
+        )
+        expected_postgres = min(
+            postgres_worker_count - active_pg,
+            worker_count - len(active),
+            sum(queued_target.uses_ephemeral_postgres for queued_target in queued),
+        )
+        self.assertEqual(admitted_postgres, expected_postgres)
 
     @given(
         postgres=st.booleans(),
@@ -705,14 +946,43 @@ class TestFuzzCoverageCheckerKnownBad(unittest.TestCase):
             ),
         )
         targets = list(build_fuzz_targets((manifest,), property_shards=4))
-        assert targets[0].profile_max_examples is not None
+        assert targets[0].max_examples_override is not None
         targets[0] = replace(
             targets[0],
-            profile_max_examples=targets[0].profile_max_examples + 1,
+            max_examples_override=targets[0].max_examples_override + 1,
         )
 
         with self.assertRaisesRegex(ValueError, "changed fuzz property budget"):
             assert_exact_fuzz_coverage((manifest,), targets)
+
+    def test_checker_rejects_a_multiplied_explicit_budget(self) -> None:
+        property_id = "tests.test_generated_world.TestWorld.test_explicit"
+        manifest = FuzzModuleManifest(
+            module_name="tests.test_generated_world",
+            test_ids=(property_id,),
+            hypothesis_tests=(
+                FuzzPropertyManifest(
+                    test_id=property_id,
+                    max_examples=30,
+                    uses_default_settings=False,
+                ),
+            ),
+        )
+        multiplied = tuple(
+            FuzzTarget(
+                label=f"{property_id}::{index}",
+                module_name=manifest.module_name,
+                load_names=(manifest.module_name,),
+                expected_test_ids=(property_id,),
+                shard_index=index,
+                shard_count=3,
+                max_examples_override=30,
+            )
+            for index in range(3)
+        )
+
+        with self.assertRaisesRegex(ValueError, "changed fuzz property budget"):
+            assert_exact_fuzz_coverage((manifest,), multiplied)
 
     def test_admission_checker_rejects_too_many_pg_targets(self) -> None:
         pending = (fuzz_target(0, True), fuzz_target(1, True))
@@ -725,6 +995,70 @@ class TestFuzzCoverageCheckerKnownBad(unittest.TestCase):
                 worker_count=2,
                 postgres_worker_count=1,
             )
+
+    def test_method_batch_checker_rejects_the_historical_single_pin_target(
+        self,
+    ) -> None:
+        module_name = "tests.test_beets_destructive_configs_generated"
+        pin_ids = tuple(
+            f"{module_name}.TestMatrix.test_cell_{index}" for index in range(2)
+        )
+        unsplit = (
+            FuzzTarget(
+                label=f"{module_name}::pins",
+                module_name=module_name,
+                load_names=(module_name,),
+                expected_test_ids=pin_ids,
+            ),
+        )
+
+        with self.assertRaisesRegex(AssertionError, "use 1 batches"):
+            assert_method_batched_fuzz_pins(unsplit, pin_ids)
+
+    def test_hotspot_order_checker_rejects_the_historical_late_target(
+        self,
+    ) -> None:
+        ordinary = fuzz_target(0, False)
+        hotspot = replace(
+            fuzz_target(1, False),
+            module_name="tests.test_beets_destructive_configs_generated",
+        )
+
+        with self.assertRaisesRegex(AssertionError, "after ordinary work"):
+            assert_fuzz_hotspots_frontloaded(
+                (ordinary, hotspot),
+                {hotspot.module_name},
+            )
+
+    def test_coverage_checker_rejects_sharded_real_beets_property(self) -> None:
+        module_name = "tests.test_beets_destructive_configs_generated"
+        property_id = f"{module_name}.TestWorld.test_property"
+        manifest = FuzzModuleManifest(
+            module_name=module_name,
+            test_ids=(property_id,),
+            hypothesis_tests=(
+                FuzzPropertyManifest(
+                    test_id=property_id,
+                    max_examples=4,
+                    uses_default_settings=False,
+                ),
+            ),
+        )
+        sharded = tuple(
+            FuzzTarget(
+                label=f"{property_id}::{index}",
+                module_name=module_name,
+                load_names=(module_name,),
+                expected_test_ids=(property_id,),
+                shard_index=index,
+                shard_count=2,
+                max_examples_override=2,
+            )
+            for index in range(2)
+        )
+
+        with self.assertRaisesRegex(ValueError, "resource shard limit"):
+            assert_exact_fuzz_coverage((manifest,), sharded)
 
     def test_capacity_checker_rejects_an_unrelated_io_error(self) -> None:
         with self.assertRaisesRegex(
@@ -774,7 +1108,7 @@ class TestFuzzDiscoverySettingsContract(unittest.TestCase):
         )
         self.assertEqual(len(matching), 1)
         self.assertEqual(matching[0].shard_count, 1)
-        self.assertIsNone(matching[0].profile_max_examples)
+        self.assertIsNone(matching[0].max_examples_override)
 
     def test_finite_metadata_prevents_sharding_even_if_default_flag_drifts(self) -> None:
         property_id = "tests.test_generated_world.TestWorld.test_finite"
@@ -795,7 +1129,7 @@ class TestFuzzDiscoverySettingsContract(unittest.TestCase):
 
         self.assertEqual(len(targets), 1)
         self.assertEqual(targets[0].shard_count, 1)
-        self.assertIsNone(targets[0].profile_max_examples)
+        self.assertIsNone(targets[0].max_examples_override)
 
     def test_finite_metadata_rejects_a_budget_cardinality_mismatch(self) -> None:
         property_id = "tests.test_generated_world.TestWorld.test_finite"
@@ -837,7 +1171,7 @@ class TestFuzzDiscoverySettingsContract(unittest.TestCase):
                 expected_test_ids=(property_id,),
                 shard_index=index,
                 shard_count=2,
-                profile_max_examples=2,
+                max_examples_override=2,
             )
             for index in range(2)
         )


### PR DESCRIPTION
## Summary

- keep the PostgreSQL lane work-conserving and raise doc1 defaults to 60 total workers / 24 PostgreSQL-backed targets
- split every randomized non-finite property by its exact discovered budget, while retaining audited resource limits for the real-Beets matrix
- reuse deterministic hotspot pin batches and front-load expensive targets so they do not become the tail
- pass per-target Hypothesis budgets through the isolated child runner without changing any other settings
- preserve exact coverage, exact total example budgets, fail-closed infrastructure handling, and depth reporting

## Validation

- receipt-backed canonical gate: `pass` on `e9dac1fc8cbe2d751e7b5a06e5f027e32cc1af73`
- targeted six-phase gate: PASS
- final production-shaped 20,000-example burst: ALL GREEN, 137 modules, 4,395 targets, 1,637 tests
- service runtime: 1,404.146s; CPU: 38,358.660s; average utilization: **27.32 cores** (goal: >25)
- valid resource receipt: 19,198,099,456-byte memory peak, zero cgroup swap, 13,189,857,280-byte scratch peak, 854,013 inode peak

## Measured comparison

The existing baseline was 14.20 average cores over 35m44.668s. This candidate sustains 27.32 average cores and completes in 23m24.146s, while retaining the full 20,000-example workload and exact-coverage checks.
