### PR TITLE
perf(tests): own fake harness wait processes

### DIFF
--- a/tests/test_beets_harness_session.py
+++ b/tests/test_beets_harness_session.py
@@ -99,7 +99,8 @@ VALIDATION_ERROR_VERDICT_PREFIX = (
 #: keeps a large stderr from deadlocking against a parent that only drains
 #: stderr after the stdout loop. The trailing sleep keeps the process alive
 #: so the parent's ``{"action":"skip"}`` writes never hit a closed pipe —
-#: ``beets_validate``'s ``finally`` terminates it immediately afterwards.
+#: ``exec`` makes that wait the exact process ``Popen`` owns, so
+#: ``beets_validate``'s ``finally`` terminates it without orphaning a child.
 _HARNESS_TEMPLATE = """#!/bin/sh
 cat {stdout_file}
 exec 1>&-
@@ -142,7 +143,7 @@ def write_fake_harness(
             stdout_file=_shell_quote(stdout_file),
             stderr_file=_shell_quote(stderr_file),
             terminal_action=(
-                "sleep 20"
+                "exec sleep 20"
                 if process_returncode is None
                 else (
                     f"kill -{-process_returncode} $$"
@@ -153,6 +154,15 @@ def write_fake_harness(
         ))
     os.chmod(harness_path, os.stat(harness_path).st_mode | stat.S_IEXEC)
     return harness_path
+
+
+def assert_fake_harness_wait_is_owned(harness_script: str) -> None:
+    """The terminal wait must replace the shell that ``Popen`` owns."""
+    commands = {line.strip() for line in harness_script.splitlines()}
+    if "sleep 20" in commands or "exec sleep 20" not in commands:
+        raise AssertionError(
+            "fake harness must exec its terminal wait so terminate() owns it"
+        )
 
 
 def run_fake_harness(
@@ -361,6 +371,17 @@ def assert_every_invariant(result: ValidationResult) -> None:
 # ---------------------------------------------------------------------------
 # Pins
 # ---------------------------------------------------------------------------
+
+class TestFakeHarnessProcessLifecycle(unittest.TestCase):
+    def test_terminal_wait_replaces_the_exact_harness_process(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            harness_path = write_fake_harness(
+                tmpdir,
+                stdout_lines=[SESSION_END_LINE],
+            )
+            with open(harness_path, encoding="utf-8") as handle:
+                assert_fake_harness_wait_is_owned(handle.read())
+
 
 class TestSessionsThatOfferedNothing(unittest.TestCase):
     """``no_choose_match``: the run completed and offered no match."""

--- a/tests/test_beets_harness_session_generated.py
+++ b/tests/test_beets_harness_session_generated.py
@@ -21,9 +21,10 @@ docs/generated-testing.md.
 
 from __future__ import annotations
 
+import tempfile
 import unittest
 
-from hypothesis import example, given
+from hypothesis import example, given, settings
 from hypothesis import strategies as st
 
 import tests._hypothesis_profiles  # noqa: F401 - loads the active profile
@@ -47,12 +48,14 @@ from tests.test_beets_harness_session import (
     VALIDATION_ERROR_VERDICT_PREFIX,
     assert_evidence_accompanies_the_name,
     assert_evidence_claims_no_cause,
+    assert_fake_harness_wait_is_owned,
     assert_result_round_trips,
     assert_scenario_is_always_named,
     assert_stays_a_wrong_match_candidate,
     assert_the_name_matches_the_error_state,
     choose_match_line,
     run_fake_harness,
+    write_fake_harness,
 )
 from web.classify import LogEntry, classify_log_entry
 
@@ -296,6 +299,27 @@ def assert_the_row_explains_itself(
 # Properties
 # ---------------------------------------------------------------------------
 
+class TestFakeHarnessProcessLifecycleGenerated(unittest.TestCase):
+    @settings(max_examples=25)
+    @given(
+        lines=st.lists(st.text(max_size=40), max_size=4),
+        stderr_text=st.text(max_size=80),
+    )
+    def test_every_fake_harness_owns_its_terminal_wait(
+        self,
+        lines: list[str],
+        stderr_text: str,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            harness_path = write_fake_harness(
+                tmpdir,
+                stdout_lines=lines,
+                stderr_text=stderr_text,
+            )
+            with open(harness_path, encoding="utf-8") as handle:
+                assert_fake_harness_wait_is_owned(handle.read())
+
+
 class TestNoHarnessTranscriptEverRejectsSilently(unittest.TestCase):
     """The invariant the 276 live rows violated, over the world space."""
 
@@ -463,6 +487,10 @@ class TestADecodableMatchStillDecides(unittest.TestCase):
 
 class TestCheckersTripOnViolations(unittest.TestCase):
     """Known-bad self-tests for the checkers this module owns."""
+
+    def test_unowned_terminal_wait_is_rejected(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "terminate.*owns"):
+            assert_fake_harness_wait_is_owned("#!/bin/sh\nsleep 20\n")
 
     def test_consumed_prefix_stops_only_at_controller_terminal_kinds(
         self,


### PR DESCRIPTION
Follow-up to #1052.

## Summary
- replace the fake Beets harness shell with its terminal wait via `exec sleep 20`
- make `beets_validate` termination reap the exact process it owns instead of orphaning one child per example
- pin the process-ownership contract with deterministic and generated regression coverage

## 20k burst
- all green: 137 modules, 1,639 tests
- service runtime: 23m47.955s
- CPU: 10h48m50.756s, averaging 27.263 cores
- process peak: 13,715 -> 423 (-96.9%)
- surviving `sleep 20` processes: ~11,500 -> 0
- memory peak: 17.79 GiB, zero swap
- scratch peak: 12.39 GiB and 809,601 / 10,000,000 inodes

The matched full burst is 1.7% longer overall because the commit adds eight generated regression shards; core utilization remains above the 25-core target while the pathological tail process cohort is eliminated.

## Validation
- focused deterministic/generated RED -> GREEN
- focused six-phase `scripts/test.sh` bundle: green
- full depth-100 topology: 137 modules, 1,639 tests, green
- definitive depth-20,000 burst: green
- canonical clean-tree final gate: pass on `3e422e628d9f5fd6a7ac0619140d705e993d3f8e`