### PR TITLE
Harden request-union destructive and audit boundaries

### DIFF
--- a/lib/destructive_release_service.py
+++ b/lib/destructive_release_service.py
@@ -47,7 +47,7 @@ from lib.pipeline_db import (
 )
 from lib.quality import resolve_user_requeue_override
 from lib.release_identity import ReleaseIdentity
-from lib.request_identity import resolve_current_for_request
+from lib.request_identity import acceptable_identities, resolve_current_for_request
 
 log = logging.getLogger("cratedigger")
 
@@ -655,11 +655,17 @@ def _delete_confirmations_match(
 ) -> bool:
     if identity is None or not _identity_matches(request.expected_release_id, identity):
         return False
+    if (
+        pipeline_row is not None
+        and identity not in acceptable_identities(pipeline_row)
+    ):
+        return False
     if request.expected_pipeline_id is None:
         return True
-    if pipeline_row is None or int(pipeline_row["id"]) != request.expected_pipeline_id:
-        return False
-    return _request_identity(pipeline_row) == identity
+    return (
+        pipeline_row is not None
+        and int(pipeline_row["id"]) == request.expected_pipeline_id
+    )
 
 
 def _incomplete_delete_detail(
@@ -739,7 +745,11 @@ def _delete_under_release_lock(
     preflight_detail: dict[str, object],
     beets_delete_fn: BeetsDeleteFn,
 ) -> DeleteResult:
-    current_pipeline = pipeline_db.get_request_by_release_id(identity.release_id)
+    current_pipeline = (
+        pipeline_db.get_request(int(pipeline_row["id"]))
+        if pipeline_row is not None
+        else pipeline_db.get_request_by_release_id(identity.release_id)
+    )
     if not _delete_confirmations_match(
         request, identity, current_pipeline,
     ):
@@ -945,8 +955,12 @@ def delete_release_from_library(
         return DeleteAlbumNotFound(request.album_id)
     identity = _album_identity(detail)
     pipeline_row = (
-        pipeline_db.get_request_by_release_id(identity.release_id)
-        if identity is not None else None
+        pipeline_db.get_request(request.expected_pipeline_id)
+        if request.expected_pipeline_id is not None
+        else (
+            pipeline_db.get_request_by_release_id(identity.release_id)
+            if identity is not None else None
+        )
     )
     if not _delete_confirmations_match(request, identity, pipeline_row):
         return _delete_mismatch(request, identity, pipeline_row)
@@ -974,7 +988,6 @@ def delete_release_from_library(
         current_pipeline = pipeline_db.get_request(request_id)
         if (
             current_pipeline is None
-            or _request_identity(current_pipeline) != identity
             or not _delete_confirmations_match(
                 request, identity, current_pipeline,
             )

--- a/lib/disk_coverage_service.py
+++ b/lib/disk_coverage_service.py
@@ -157,6 +157,12 @@ def disk_coverage(
     ids are still flattened across the whole cohort before one batched
     ``check_mbids``, so a merged corpus costs the same single query an
     unmerged one does.
+
+    This is deliberately a presence-only projection, not destructive
+    authority. The #1060 verification measured 0 malformed and 0 conflicting
+    raw identity columns across 8,524 rows, which admits this flattened
+    read; destructive callers must instead retain request identity and use
+    the typed current-resolution boundary.
     """
     rows = pipeline_db.list_non_replaced_requests()
     request_ids: dict[int, set[str]] = {}

--- a/lib/dispatch/core.py
+++ b/lib/dispatch/core.py
@@ -1263,14 +1263,18 @@ def dispatch_import_core(
                             cancellation_token=cancellation_token,
                             owner_session_identity=owner_session_identity,
                         )
-                        _write_album_sidecar_after_import(
-                            db,
-                            request_id=request_id,
-                            mb_release_id=mb_release_id,
-                            cfg=cfg,
-                            beets_library_db_path=effective_beets_library_db_path,
-                            beets_library_root=effective_beets_library_root,
-                        )
+                        if (
+                            post_import_evidence.status == "ready"
+                            and post_import_evidence.evidence is not None
+                        ):
+                            _write_album_sidecar_after_import(
+                                db,
+                                request_id=request_id,
+                                mb_release_id=mb_release_id,
+                                cfg=cfg,
+                                beets_library_db_path=effective_beets_library_db_path,
+                                beets_library_root=effective_beets_library_root,
+                            )
                     except ExecutionCancelled:
                         raise
                     except Exception:

--- a/lib/dispatch/evidence_gate.py
+++ b/lib/dispatch/evidence_gate.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
+from contextlib import AbstractContextManager
 from typing import TYPE_CHECKING, Any
 
 from lib.dispatch.types import (
@@ -52,6 +53,7 @@ from lib.quality_evidence import (
     backfill_current_evidence_from_album_info,
     propagate_candidate_evidence_to_current,
 )
+from lib.request_identity import CurrentBeetsBatchResolver
 
 if TYPE_CHECKING:
     from lib.config import CratediggerConfig
@@ -342,6 +344,7 @@ def _refresh_current_evidence_after_import(
     import_result: ImportResult | None = None,
     beets_library_db_path: str | None = None,
     beets_library_root: str | None = None,
+    beets_factory: Callable[..., AbstractContextManager[CurrentBeetsBatchResolver]] | None = None,
 ) -> EvidenceBuildResult:
     """Persist current evidence for the just-imported Beets album.
 
@@ -383,9 +386,16 @@ def _refresh_current_evidence_after_import(
     # BeetsDB docstring. Both the U10 propagation path and the legacy
     # ``backfill_current_evidence_from_album_info`` path depend on an
     # absolute ``album_info.album_path`` to read the just-imported files.
-    beets_handle = open_beets_db(
-        db_path=beets_library_db_path,
-        library_root=beets_library_root,
+    beets_handle = (
+        beets_factory(
+            db_path=beets_library_db_path,
+            library_root=beets_library_root,
+        )
+        if beets_factory is not None
+        else open_beets_db(
+            db_path=beets_library_db_path,
+            library_root=beets_library_root,
+        )
     )
     identity = release_identity_for_lookup(mb_release_id)
     if identity is None:

--- a/lib/mbid_replace_service.py
+++ b/lib/mbid_replace_service.py
@@ -110,6 +110,7 @@ from lib.util import (
 )
 from lib.wrong_match_delete_service import (
     WrongMatchDeleteDB,
+    WrongMatchDeleteSummary,
     delete_wrong_match_group,
 )
 
@@ -257,6 +258,9 @@ BeetsDBFactory = Callable[[], ReplaceBeetsDB]
 BeetsDeleteFn = Callable[[BeetsDeleteRequest], BeetsDeleteOutcome]
 """Injectable pinned exact-album deletion boundary."""
 
+WrongMatchDeleteFn = Callable[[MbidReplaceDB, int], WrongMatchDeleteSummary]
+"""Injectable post-replace wrong-match cleanup boundary."""
+
 
 def _default_mb_lookup(mbid: str, *, fresh: bool = False) -> dict[str, Any]:
     """Default MB-mirror lookup. Imported lazily so the service module
@@ -298,6 +302,7 @@ class MbidReplaceService:
         discogs_lookup: DiscogsLookup | None = None,
         search_plan_service: SearchPlanService | None = None,
         beets_delete_fn: BeetsDeleteFn | None = None,
+        wrong_match_delete_fn: WrongMatchDeleteFn | None = None,
     ) -> None:
         self.db = db
         self.config = config
@@ -313,6 +318,11 @@ class MbidReplaceService:
         )
         self.beets_delete_fn = (
             beets_delete_fn if beets_delete_fn is not None else run_beets_delete
+        )
+        self.wrong_match_delete_fn = (
+            wrong_match_delete_fn
+            if wrong_match_delete_fn is not None
+            else delete_wrong_match_group
         )
 
     def replace_request_mbid(
@@ -1045,7 +1055,7 @@ class MbidReplaceService:
                     )
 
             try:
-                wm_summary = delete_wrong_match_group(self.db, request_id)
+                wm_summary = self.wrong_match_delete_fn(self.db, request_id)
                 if wm_summary.errors:
                     warnings.append(
                         f"wrong-matches cleanup reported "

--- a/lib/world_audit_service.py
+++ b/lib/world_audit_service.py
@@ -336,10 +336,10 @@ def audit_world(
 
         resolution = resolutions.get(request_id)
         if resolution is None:
-            # The resolver omitted a requested identity. ``resolutions_by_
-            # release_id`` has no entry either, so check_status_membership
-            # reports current_beets_authority_unavailable — an authority
-            # failure, never an absence claim.
+            # The resolver omitted this requested row. Its request-id keyed
+            # entry is absent, so check_status_membership reports
+            # current_beets_authority_unavailable — an authority failure,
+            # never an absence claim.
             continue
         if isinstance(resolution, CurrentBeetsAmbiguous):
             continue

--- a/lib/world_audit_service.py
+++ b/lib/world_audit_service.py
@@ -325,11 +325,6 @@ def audit_world(
         beets_db,
         [row for row, _request_id, _identity in identified_requests],
     )
-    resolutions_by_release_id = {
-        identity.release_id: resolutions[request_id]
-        for _row, request_id, identity in identified_requests
-        if request_id in resolutions
-    }
 
     for row, request_id, identity in identified_requests:
         release_id = identity.release_id
@@ -410,7 +405,7 @@ def audit_world(
     violations.extend(check_library_filesystem(albums))
     violations.extend(check_status_membership(
         memberships,
-        resolutions_by_release_id,
+        resolutions,
     ))
     violations.extend(
         violation

--- a/lib/world_invariants.py
+++ b/lib/world_invariants.py
@@ -239,13 +239,19 @@ def assert_replaced_row_frozen(
 
 def check_status_membership(
     requests: Sequence[RequestMembershipSnapshot],
-    resolutions: Mapping[str, CurrentBeetsResolution],
+    resolutions: Mapping[int, CurrentBeetsResolution],
 ) -> tuple[WorldViolation, ...]:
-    """Require shared typed authority for every installed exact pressing."""
+    """Require shared typed authority for every installed exact pressing.
+
+    ``resolutions`` stays keyed by request id. Release ids are evidence on the
+    membership row, not a join key: active requests may deliberately share an
+    acquisition identity, and one request's union answer must never overwrite
+    another's.
+    """
 
     violations: list[WorldViolation] = []
     for request in requests:
-        resolution = resolutions.get(request.release_id)
+        resolution = resolutions.get(request.request_id)
         if resolution is None:
             violations.append(WorldViolation(
                 code="current_beets_authority_unavailable",

--- a/scripts/targeted_test_selection.py
+++ b/scripts/targeted_test_selection.py
@@ -120,7 +120,7 @@ def _changed_path_neighbours(
     path = PurePosixPath(relative_path)
     neighbours: list[str] = list(EXACT_PATH_NEIGHBOURS.get(relative_path, ()))
     module = _path_module(path)
-    if module is not None and module.startswith("tests."):
+    if module is not None and path.name.startswith("test_"):
         neighbours.append(module)
     for candidate in _direct_test_candidates(path):
         if _existing_module(candidate, repo_root) is not None:

--- a/tests/test_destructive_authority.py
+++ b/tests/test_destructive_authority.py
@@ -1153,7 +1153,12 @@ class TestMergedAlbumIsActuallyRemovable(unittest.TestCase):
     LOSER = "4878ee47-f8b8-45c8-832c-62de3bccfa6e"
     SURVIVOR = "7aabf975-9a06-4b2e-854c-2c700380ebd5"
 
-    def _world_and_db(self, *, canonical: str | None):
+    def _world_and_db(
+        self,
+        *,
+        canonical: str | None,
+        filed_release_id: str | None = None,
+    ):
         from tests.beets_world import BeetsWorld, BeetsWorldRelease
         from tests.fakes import FakePipelineDB
 
@@ -1163,7 +1168,7 @@ class TestMergedAlbumIsActuallyRemovable(unittest.TestCase):
         world = BeetsWorld(repo, subprocess_mirror_url="http://127.0.0.1:9")
         self.addCleanup(world.close)
         album = world.import_release(BeetsWorldRelease(
-            release_id=self.SURVIVOR,
+            release_id=filed_release_id or self.SURVIVOR,
             artist="Merged Artist",
             album="Merged Album",
             year=1996,
@@ -1206,6 +1211,32 @@ class TestMergedAlbumIsActuallyRemovable(unittest.TestCase):
             )
         return result, captured
 
+    def _run_library_delete(self, world, db, request_id, album, filed_release_id):
+        captured: list[BeetsDeleteRequest] = []
+
+        def delete_fn(request: BeetsDeleteRequest):
+            captured.append(request)
+            return run_beets_delete(request)
+
+        with (
+            world.subprocess_environment(),
+            BeetsDB(
+                str(world.library_db), library_root=str(world.library_root),
+            ) as beets,
+        ):
+            result = delete_release_from_library(
+                pipeline_db=db,
+                beets_db=beets,
+                request=DeleteRequest(
+                    album_id=album.album_id,
+                    expected_pipeline_id=request_id,
+                    expected_release_id=filed_release_id,
+                ),
+                beets_delete_fn=delete_fn,
+                notify_fn=lambda _path: (),
+            )
+        return result, captured
+
     def test_bad_rip_removes_an_album_filed_under_the_survivor(self) -> None:
         world, db, request_id, album = self._world_and_db(
             canonical=self.SURVIVOR)
@@ -1239,6 +1270,81 @@ class TestMergedAlbumIsActuallyRemovable(unittest.TestCase):
         self.assertIsInstance(result, BanSourceSuccess)
         assert isinstance(result, BanSourceSuccess)
         self.assertFalse(result.beets_removed)
+
+    def test_library_delete_uses_the_known_request_union_and_filed_identity(self) -> None:
+        """Known-request library deletes reach either physical union side."""
+        for filed_release_id in (self.LOSER, self.SURVIVOR):
+            with self.subTest(filed_release_id=filed_release_id):
+                world, db, request_id, album = self._world_and_db(
+                    canonical=self.SURVIVOR,
+                    filed_release_id=filed_release_id,
+                )
+
+                result, captured = self._run_library_delete(
+                    world, db, request_id, album, filed_release_id,
+                )
+
+                self.assertIsInstance(result, DeleteSuccess)
+                self.assertEqual(
+                    [request.expected_release_id for request in captured],
+                    [filed_release_id],
+                    "the pinned child must receive the Beets-filed identity, "
+                    "not the acquisition id",
+                )
+                self.assertEqual(db.request(request_id)["status"], "imported")
+                with BeetsDB(
+                    str(world.library_db), library_root=str(world.library_root),
+                ) as beets:
+                    self.assertIsNone(beets.get_album_detail(album.album_id))
+
+    def test_library_delete_refuses_a_split_request_union_without_mutation(self) -> None:
+        """Two filed pressings behind one request are never silently picked."""
+        world = BeetsWorld(REPO, subprocess_mirror_url="http://127.0.0.1:9")
+        self.addCleanup(world.close)
+        loser = world.import_release(BeetsWorldRelease(
+            release_id=self.LOSER, artist="Merged Artist", album="Loser", year=1996,
+        ))
+        survivor = world.import_release(BeetsWorldRelease(
+            release_id=self.SURVIVOR, artist="Merged Artist", album="Survivor", year=1996,
+        ))
+        db = FakePipelineDB()
+        request_id = db.add_request(
+            artist_name="Merged Artist", album_title="Loser",
+            source="request", mb_release_id=self.LOSER,
+        )
+        db.update_status(request_id, "imported")
+        from datetime import UTC, datetime
+
+        db.record_canonical_release_id(
+            request_id,
+            canonical_release_id=self.SURVIVOR,
+            resolved_at=datetime(2026, 8, 6, tzinfo=UTC),
+        )
+        captured: list[BeetsDeleteRequest] = []
+
+        with BeetsDB(
+            str(world.library_db), library_root=str(world.library_root),
+        ) as beets:
+            result = delete_release_from_library(
+                pipeline_db=db,
+                beets_db=beets,
+                request=DeleteRequest(
+                    album_id=loser.album_id,
+                    expected_pipeline_id=request_id,
+                    expected_release_id=self.LOSER,
+                ),
+                beets_delete_fn=lambda request: captured.append(request) or run_beets_delete(request),
+                notify_fn=lambda _path: (),
+            )
+
+        self.assertIsInstance(result, DeleteBeetsAmbiguous)
+        self.assertEqual(captured, [])
+        self.assertEqual(db.request(request_id)["status"], "imported")
+        with BeetsDB(
+            str(world.library_db), library_root=str(world.library_root),
+        ) as beets:
+            self.assertIsNotNone(beets.get_album_detail(loser.album_id))
+            self.assertIsNotNone(beets.get_album_detail(survivor.album_id))
 
 
 if __name__ == "__main__":

--- a/tests/test_destructive_authority_generated.py
+++ b/tests/test_destructive_authority_generated.py
@@ -45,6 +45,7 @@ from lib.destructive_release_service import (
 )
 from lib.mbid_replace_service import (
     REPLACE_REASON_CURRENT_BEETS_AMBIGUOUS,
+    REPLACE_REASON_CURRENT_BEETS_UNAVAILABLE,
     REPLACE_REASON_SOURCE_IDENTITY_INVALID,
     RESULT_REPLACED,
     RESULT_WRONG_STATE,
@@ -58,6 +59,14 @@ from lib.pipeline_db import (
 from lib.release_identity import ReleaseIdentity
 from tests.fakes import DenylistEntry, FakeBeetsDB, FakePipelineDB
 from tests.helpers import handoff_automation_owner, make_request_row
+
+
+class _OmittedUnionBeets(FakeBeetsDB):
+    """Collaborator fault: requested union authority is absent from batch."""
+
+    def resolve_current_releases(self, identities: list[ReleaseIdentity]):
+        del identities
+        return {}
 
 
 def assert_fresh_destructive_authority(
@@ -355,7 +364,9 @@ class TestGeneratedDestructiveAuthority(unittest.TestCase):
     @given(
         action=st.sampled_from(("ban", "delete", "replace")),
         source=st.sampled_from(("musicbrainz", "discogs")),
-        authority=st.sampled_from(("unique", "missing", "ambiguous")),
+        authority=st.sampled_from(
+            ("unique", "missing", "ambiguous", "omitted"),
+        ),
         album_id=st.integers(min_value=1, max_value=2_000_000_000),
     )
     def test_each_destructive_caller_requires_fresh_unique_album_authority(
@@ -376,7 +387,11 @@ class TestGeneratedDestructiveAuthority(unittest.TestCase):
             mb_release_id=release_id,
             discogs_release_id=(release_id if source == "discogs" else None),
         ))
-        beets = FakeBeetsDB(library_root="/library")
+        beets = (
+            _OmittedUnionBeets(library_root="/library")
+            if authority == "omitted"
+            else FakeBeetsDB(library_root="/library")
+        )
         beets.set_album_detail(album_id, {
             "id": album_id,
             "album": "Album",
@@ -496,6 +511,13 @@ class TestGeneratedDestructiveAuthority(unittest.TestCase):
                 self.assertEqual(
                     result.reason,
                     REPLACE_REASON_CURRENT_BEETS_AMBIGUOUS,
+                )
+                self.assertEqual(db.request(41), before)
+                self.assertEqual(scans, [])
+            elif authority == "omitted":
+                self.assertEqual(
+                    result.reason,
+                    REPLACE_REASON_CURRENT_BEETS_UNAVAILABLE,
                 )
                 self.assertEqual(db.request(41), before)
                 self.assertEqual(scans, [])

--- a/tests/test_destructive_authority_generated.py
+++ b/tests/test_destructive_authority_generated.py
@@ -1109,6 +1109,91 @@ class TestGeneratedDestructiveAuthority(unittest.TestCase):
                         ),
                     )
 
+    @given(
+        filed_side=st.sampled_from(("acquisition", "survivor")),
+        authority=st.sampled_from(("unique", "split", "ambiguous")),
+    )
+    @example(filed_side="survivor", authority="unique")
+    @example(filed_side="acquisition", authority="unique")
+    @example(filed_side="survivor", authority="split")
+    def test_known_request_library_delete_composes_union_and_filed_identity(
+        self,
+        filed_side: str,
+        authority: str,
+    ) -> None:
+        """Known request ids admit either filed union side, never a split."""
+        acquisition = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        survivor = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+        filed_release_id = (
+            acquisition if filed_side == "acquisition" else survivor
+        )
+        target_album_id = 7 if filed_side == "acquisition" else 8
+        db = FakePipelineDB()
+        request_id = db.add_request(
+            artist_name="Merged Artist",
+            album_title="Merged Album",
+            source="request",
+            mb_release_id=acquisition,
+        )
+        db.request(request_id)["status"] = "imported"
+        db.request(request_id)["canonical_release_id"] = survivor
+        beets = FakeBeetsDB()
+        beets.set_album_detail(target_album_id, {
+            "id": target_album_id,
+            "album": "Merged Album",
+            "artist": "Merged Artist",
+            "mb_albumid": filed_release_id,
+            "discogs_albumid": None,
+            "tracks": [],
+        })
+        if authority == "unique":
+            beets.set_album_ids_for_release(filed_release_id, [target_album_id])
+        elif authority == "split":
+            beets.set_album_ids_for_release(acquisition, [7])
+            beets.set_album_ids_for_release(survivor, [8])
+        else:
+            beets.set_album_ids_for_release(filed_release_id, [target_album_id, 9])
+
+        calls: list[BeetsDeleteRequest] = []
+
+        def exact_delete(request: BeetsDeleteRequest) -> BeetsDeleteCompleted:
+            calls.append(request)
+            beets._album_detail.pop(request.album_id, None)
+            return BeetsDeleteCompleted(
+                album_id=request.album_id,
+                album_name="Merged Album",
+                artist_name="Merged Artist",
+                former_album_path="/library/Merged Artist/Merged Album",
+                deleted_tracks=1,
+                deleted_artifacts=1,
+                preserved_paths=(),
+            )
+
+        result = delete_release_from_library(
+            pipeline_db=db,
+            beets_db=beets,
+            request=DeleteRequest(
+                album_id=target_album_id,
+                expected_pipeline_id=request_id,
+                expected_release_id=filed_release_id,
+            ),
+            beets_delete_fn=exact_delete,
+            notify_fn=lambda _path: (),
+        )
+
+        if authority == "unique":
+            self.assertIsInstance(result, DeleteSuccess)
+            self.assertEqual([call.album_id for call in calls], [target_album_id])
+            self.assertEqual(
+                [call.expected_release_id for call in calls], [filed_release_id],
+            )
+            self.assertIsNone(beets.get_album_detail(target_album_id))
+        else:
+            self.assertIsInstance(result, DeleteBeetsAmbiguous)
+            self.assertEqual(calls, [])
+            self.assertIsNotNone(beets.get_album_detail(target_album_id))
+        self.assertEqual(db.request(request_id)["status"], "imported")
+
     def test_lost_delete_ack_always_requires_manual_recovery(self) -> None:
         # Exhaustive finite lost-ack table. It retains the decisive subprocess
         # track world and protocol/art/orphan world from the former examples.
@@ -1666,10 +1751,10 @@ class TestDestructiveAuthorityCheckerKnownBad(unittest.TestCase):
         class FaultInjectingPipelineDB(FakePipelineDB):
             inject_mutation = False
 
-            def get_request_by_release_id(
-                self, release_id: object | None,
+            def get_request(
+                self, request_id: int,
             ) -> AlbumRequestRow | None:
-                row = super().get_request_by_release_id(release_id)
+                row = super().get_request(request_id)
                 if self.inject_mutation:
                     self.inject_mutation = False
                     self.denylist.append(DenylistEntry(

--- a/tests/test_import_dispatch.py
+++ b/tests/test_import_dispatch.py
@@ -388,6 +388,7 @@ class TestAutomationDispatchExecutionFence(unittest.TestCase):
         token: CancellationToken,
         runner,
         evidence_gate_fn=None,
+        quality_gate_fn=None,
     ):
         from lib.dispatch import dispatch_import_core
 
@@ -413,7 +414,11 @@ class TestAutomationDispatchExecutionFence(unittest.TestCase):
                 scenario="strong_match",
                 files=[],
                 cfg=_full_dispatch_config(),
-                quality_gate_fn=noop_quality_gate,
+                quality_gate_fn=(
+                    quality_gate_fn
+                    if quality_gate_fn is not None
+                    else noop_quality_gate
+                ),
                 candidate_import_job_id=claimed.id,
                 prevalidated_candidate_result=candidate,
                 execution_lease=execution_lease,
@@ -698,6 +703,91 @@ class TestAutomationDispatchExecutionFence(unittest.TestCase):
             sidecar.assert_not_called()
             self.assertFalse(os.path.exists(sidecar_path))
             self.assertEqual(db.get_request_current_evidence_id(42), linked.id)
+
+    def test_stale_refresh_with_evidence_cannot_authorize_sidecar(self) -> None:
+        """Status, not evidence presence, authorizes derived publication."""
+        from lib.dispatch.evidence_gate import _exact_linked_refresh_result
+        from lib.dispatch.quality_gate import _check_quality_gate_core
+        from lib.dispatch.types import ImportOneRun
+        from lib.quality_evidence import EvidenceBuildResult
+        from lib.sidecar import SIDECAR_FILENAME
+        from tests.helpers import finalize_claimed_dispatch
+
+        with tempfile.TemporaryDirectory() as root:
+            db, claimed, candidate, execution_lease = self._world(root)
+            token = CancellationToken()
+            evidence = candidate.evidence
+            assert evidence is not None and evidence.id is not None
+            stale = _exact_linked_refresh_result(
+                db,
+                request_id=42,
+                mb_release_id="test-mbid",
+                result=EvidenceBuildResult(evidence, "ready"),
+            )
+            self.assertEqual(stale.status, "stale_request")
+            # The reducer deliberately clears a stale payload. This outer
+            # boundary receives a concrete persisted row with that real
+            # non-ready status, proving an evidence-only sidecar gate wrong.
+            post_import_evidence = EvidenceBuildResult(
+                evidence,
+                stale.status,
+                stale.reason,
+            )
+            sidecar_path = os.path.join(root, SIDECAR_FILENAME)
+            quality_gate_ids: list[int | None] = []
+
+            def runner(**kwargs):
+                kwargs["on_spawn"](os.getpid())
+                return ImportOneRun(
+                    command=("import_one",),
+                    returncode=0,
+                    stdout="",
+                    stderr="",
+                    import_result=make_import_result(decision="import"),
+                )
+
+            def quality_gate(**kwargs):
+                quality_gate_ids.append(kwargs["expected_current_evidence_id"])
+                return _check_quality_gate_core(**kwargs)
+
+            def sidecar_writer(*_args, **_kwargs):
+                with open(sidecar_path, "wb") as handle:
+                    handle.write(b"sidecar must not be published")
+
+            with patch.object(
+                dispatch_core_module,
+                "_write_quality_evidence_action_file",
+                return_value=None,
+            ), patch.object(
+                dispatch_core_module,
+                "_refresh_current_evidence_after_import",
+                return_value=post_import_evidence,
+            ) as refresh, patch.object(
+                dispatch_core_module,
+                "_write_album_sidecar_after_import",
+                side_effect=sidecar_writer,
+            ) as sidecar, patch_dispatch_externals():
+                outcome = self._dispatch(
+                    root=root,
+                    db=db,
+                    claimed=claimed,
+                    candidate=candidate,
+                    execution_lease=execution_lease,
+                    token=token,
+                    runner=runner,
+                    quality_gate_fn=quality_gate,
+                )
+
+            self.assertTrue(outcome.success)
+            terminal_job = finalize_claimed_dispatch(db, claimed, outcome)
+            assert terminal_job is not None
+            refresh.assert_called_once()
+            sidecar.assert_not_called()
+            self.assertFalse(os.path.exists(sidecar_path))
+            self.assertEqual(quality_gate_ids, [0])
+            self.assertEqual(db.request(42)["status"], "wanted")
+            self.assertIsNone(db.request(42)["active_automation_import_job_id"])
+            self.assertEqual(terminal_job.status, "completed")
 
     def test_completion_capture_conflict_stops_post_beets_effects(
         self,

--- a/tests/test_import_dispatch.py
+++ b/tests/test_import_dispatch.py
@@ -554,9 +554,8 @@ class TestAutomationDispatchExecutionFence(unittest.TestCase):
             def refresh_effect(*_args, **_kwargs):
                 order.append("evidence-refreshed")
                 return EvidenceBuildResult(
-                    evidence=None,
-                    status="failed",
-                    reason="synthetic post-effect fixture",
+                    evidence=candidate.evidence,
+                    status="ready",
                 )
 
             with patch.object(
@@ -602,6 +601,11 @@ class TestAutomationDispatchExecutionFence(unittest.TestCase):
             for effect in ("evidence-refreshed", "sidecar-written"):
                 if effect in order:
                     self.assertGreater(order.index(effect), capture_index)
+            self.assertLess(
+                order.index("evidence-refreshed"),
+                order.index("sidecar-written"),
+                "only a ready post-import refresh authorizes sidecar publication",
+            )
             persisted = db.get_import_job(claimed.id)
             assert persisted is not None and persisted.result is not None
             receipt = persisted.result["automation_completion"]
@@ -609,6 +613,91 @@ class TestAutomationDispatchExecutionFence(unittest.TestCase):
             self.assertEqual(receipt["request_id"], 42)
             self.assertEqual(receipt["canonical_path"], root)
             self.assertEqual(receipt["returncode"], 0)
+
+    def test_failed_refresh_does_not_publish_stale_verified_sidecar(self) -> None:
+        """A failed refresh cannot republish a prior matching evidence row."""
+        from lib.dispatch.types import ImportOneRun
+        from lib.quality_evidence import EvidenceBuildResult
+        from lib.sidecar import SIDECAR_FILENAME
+
+        with tempfile.TemporaryDirectory() as root:
+            db, claimed, candidate, execution_lease = self._world(root)
+            token = CancellationToken()
+            verified = make_album_quality_evidence(
+                mb_release_id="test-mbid",
+                source_path=root,
+                files=snapshot_audio_files(root),
+                measurement=AudioQualityMeasurement(
+                    min_bitrate_kbps=900,
+                    avg_bitrate_kbps=1000,
+                    format="flac",
+                    spectral_grade="genuine",
+                    spectral_subject="source",
+                    spectral_provenance="measured",
+                    was_converted_from="flac",
+                ),
+                storage_format="FLAC",
+                verified_lossless_proof=VerifiedLosslessProof(
+                    provenance="measured",
+                    source="flac",
+                    classifier="spectral",
+                ),
+            )
+            db.upsert_album_quality_evidence(verified)
+            linked = db.find_album_quality_evidence(
+                mb_release_id="test-mbid",
+                snapshot_fingerprint=verified.snapshot_fingerprint,
+            )
+            assert linked is not None and linked.id is not None
+            db.set_request_current_evidence(42, linked.id)
+            sidecar_path = os.path.join(root, SIDECAR_FILENAME)
+
+            def runner(**kwargs):
+                kwargs["on_spawn"](os.getpid())
+                return ImportOneRun(
+                    command=("import_one",),
+                    returncode=0,
+                    stdout="",
+                    stderr="",
+                    import_result=make_import_result(decision="import"),
+                )
+
+            def sidecar_writer(*_args, **_kwargs):
+                with open(sidecar_path, "wb") as handle:
+                    handle.write(b"stale sidecar")
+
+            with patch.object(
+                dispatch_core_module,
+                "_write_quality_evidence_action_file",
+                return_value=None,
+            ), patch.object(
+                dispatch_core_module,
+                "_refresh_current_evidence_after_import",
+                return_value=EvidenceBuildResult(
+                    None,
+                    "failed",
+                    "request-union authority omitted",
+                ),
+            ) as refresh, patch.object(
+                dispatch_core_module,
+                "_write_album_sidecar_after_import",
+                side_effect=sidecar_writer,
+            ) as sidecar, patch_dispatch_externals():
+                outcome = self._dispatch(
+                    root=root,
+                    db=db,
+                    claimed=claimed,
+                    candidate=candidate,
+                    execution_lease=execution_lease,
+                    token=token,
+                    runner=runner,
+                )
+
+            self.assertTrue(outcome.success)
+            refresh.assert_called_once()
+            sidecar.assert_not_called()
+            self.assertFalse(os.path.exists(sidecar_path))
+            self.assertEqual(db.get_request_current_evidence_id(42), linked.id)
 
     def test_completion_capture_conflict_stops_post_beets_effects(
         self,

--- a/tests/test_mbid_replace_service.py
+++ b/tests/test_mbid_replace_service.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import os
 import sys
 import unittest
+from copy import deepcopy
 from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
@@ -35,6 +36,7 @@ from lib.config import CratediggerConfig
 from lib.mbid_replace_service import (
     REPLACE_REASON_CROSS_PATHWAY_TARGET,
     REPLACE_REASON_CURRENT_BEETS_AMBIGUOUS,
+    REPLACE_REASON_CURRENT_BEETS_UNAVAILABLE,
     REPLACE_REASON_SOURCE_IDENTITY_INVALID,
     REPLACE_REASON_SOURCE_NO_RELEASE_GROUP,
     REPLACE_REASON_TARGET_NO_RELEASE_GROUP,
@@ -400,6 +402,85 @@ class TestReplaceOutcomeMatrix(_ServiceCase):
         self.assertEqual(result.reason, REPLACE_REASON_CURRENT_BEETS_AMBIGUOUS)
         self.assertEqual(db.request(42), before)
         self.assertEqual(delete_calls, [])
+
+    def test_omitted_current_beets_union_refuses_before_any_action(self):
+        """A resolver omission is unavailable authority, never absence."""
+        class OmittedUnionBeets(FakeBeetsDB):
+            def resolve_current_releases(self, identities):
+                del identities
+                return {}
+
+        db = FakePipelineDB()
+        self._seed_old(db, status="wanted")
+        def snapshot() -> dict[str, object]:
+            """All persisted/action surfaces a failed Replace could mutate."""
+            keys = (
+                "_requests", "_tracks", "download_logs", "_import_jobs",
+                "_processing_cleanup_journals", "search_logs", "cycle_metrics",
+                "peer_observations", "user_cooldowns", "_search_ledger",
+                "_transfer_ledger", "denylist", "bad_audio_hashes",
+                "persist_import_terminal_outcome_calls",
+                "persist_preview_terminal_outcome_calls",
+                "clear_on_disk_quality_fields_calls", "update_request_fields_calls",
+                "record_artist_probe_calls", "set_unfindable_category_calls",
+                "record_canonical_release_id_calls",
+                "record_consumed_search_attempt_calls",
+                "record_non_consuming_search_attempt_calls",
+                "album_quality_evidence", "_evidence_by_id", "cooldowns_applied",
+                "field_resolutions", "recorded_attempts", "status_history",
+                "update_download_state_calls", "search_plans", "search_plan_items",
+                "plex_added_at_pins", "jellyfin_date_created_pins",
+                "_youtube_album_mappings", "_next_request_id",
+                "_next_download_log_id", "_next_import_job_id",
+                "_next_search_log_id", "_next_evidence_id",
+                "_next_bad_audio_hash_id", "_next_field_resolution_id",
+                "_next_search_plan_id", "_next_search_plan_item_id",
+                "_next_plex_pin_id", "_next_jellyfin_pin_id",
+                "_next_youtube_mapping_id", "_transfer_ledger_next_id",
+            )
+            return {key: deepcopy(getattr(db, key)) for key in keys}
+
+        before = snapshot()
+        beets = OmittedUnionBeets()
+        delete = MagicMock(side_effect=AssertionError("delete reached"))
+        cleanup = MagicMock(side_effect=AssertionError("cleanup reached"))
+        plan = MagicMock()
+        supersede = MagicMock(side_effect=AssertionError("supersede reached"))
+
+        with patch.object(
+            db,
+            "supersede_request_mbid",
+            supersede,
+        ), patch(
+            "lib.mbid_replace_service.trigger_plex_scan",
+        ) as plex, patch(
+            "lib.mbid_replace_service.trigger_jellyfin_scan",
+        ) as jellyfin:
+            result = self._make_service(
+                db,
+                beets_db_factory=lambda: beets,
+                search_plan_service=plan,
+                beets_delete_fn=delete,
+                wrong_match_delete_fn=cleanup,
+            ).replace_request_mbid(
+                42,
+                target_mb_release_id=NEW_MBID,
+            )
+
+        after = snapshot()
+        # Advisory-lock acquisition is the intentional read-only boundary;
+        # every persisted/action surface must remain byte-for-byte unchanged.
+        self.assertEqual(after, before)
+        self.assertEqual(result.outcome, RESULT_WRONG_STATE)
+        self.assertEqual(result.reason, REPLACE_REASON_CURRENT_BEETS_UNAVAILABLE)
+        self.assertEqual(db.request(42)["status"], "wanted")
+        self.assertEqual(beets.close_calls, 1)
+        delete.assert_not_called()
+        cleanup.assert_not_called()
+        plan.generate_for_request.assert_not_called()
+        supersede.assert_not_called()
+        plex.assert_not_called()
+        jellyfin.assert_not_called()
 
     def test_conflicting_source_identities_are_typed_zero_mutation(self):
         db = FakePipelineDB()

--- a/tests/test_mbid_replace_service.py
+++ b/tests/test_mbid_replace_service.py
@@ -27,6 +27,7 @@ from lib.beets_db import BeetsDB, CurrentBeetsMissing
 from lib.beets_delete import (
     BeetsDeleteCompleted,
     BeetsDeleteFailed,
+    BeetsDeleteOutcome,
     BeetsDeleteRequest,
     run_beets_delete,
 )
@@ -233,6 +234,7 @@ class _ServiceCase(unittest.TestCase):
         search_plan_service=None,
         beets_db_factory=None,
         beets_delete_fn=None,
+        wrong_match_delete_fn=None,
         cfg: CratediggerConfig | None = None,
     ) -> MbidReplaceService:
         if mb_lookup is None:
@@ -254,6 +256,7 @@ class _ServiceCase(unittest.TestCase):
             discogs_lookup=discogs_lookup,
             search_plan_service=search_plan_service,
             beets_delete_fn=beets_delete_fn,
+            wrong_match_delete_fn=wrong_match_delete_fn,
         )
 
     def _installed_beets(
@@ -1773,6 +1776,68 @@ class TestReplaceCallOrder(_ServiceCase):
 
 
 class TestReplaceCurrentAuthorityRealBeets(_ServiceCase):
+    def test_survivor_filed_cleanup_sends_the_child_its_filed_identity(self):
+        """A merged request replaces its filed survivor, never its loser id."""
+        survivor = "7aabf975-9a06-4b2e-854c-2c700380ebd5"
+        with BeetsWorld(REPO, subprocess_mirror_url="http://127.0.0.1:9") as world:
+            album = world.import_release(BeetsWorldRelease(
+                release_id=survivor,
+                artist="Merged Artist",
+                album="Merged Source",
+                year=1996,
+            ))
+            db = FakePipelineDB()
+            self._seed_old(db, status="imported")
+            from datetime import UTC, datetime
+
+            db.record_canonical_release_id(
+                42,
+                canonical_release_id=survivor,
+                resolved_at=datetime(2026, 8, 6, tzinfo=UTC),
+            )
+            captured: list[BeetsDeleteRequest] = []
+
+            def delete_fn(request: BeetsDeleteRequest) -> BeetsDeleteOutcome:
+                captured.append(request)
+                return run_beets_delete(request)
+
+            with world.subprocess_environment(), patch(
+                "lib.mbid_replace_service.trigger_plex_scan",
+            ), patch("lib.mbid_replace_service.trigger_jellyfin_scan"):
+                service = self._make_service(
+                    db,
+                    search_plan_service=MagicMock(),
+                    beets_db_factory=lambda: BeetsDB(
+                        str(world.library_db),
+                        library_root=str(world.library_root),
+                    ),
+                    mb_lookup=lambda _rid, *, fresh=False: _fake_target_payload(),
+                    beets_delete_fn=delete_fn,
+                    wrong_match_delete_fn=_empty_wrong_match_summary,
+                )
+                result = service.replace_request_mbid(
+                    42, target_mb_release_id=NEW_MBID,
+                )
+
+            self.assertEqual(result.outcome, RESULT_REPLACED)
+            self.assertEqual([call.album_id for call in captured], [album.album_id])
+            self.assertEqual(
+                [call.expected_release_id for call in captured], [survivor],
+                "the acquisition-id mutant leaves the survivor filed in Beets",
+            )
+            old = db.get_request(42)
+            assert old is not None
+            self.assertEqual(old["status"], "replaced")
+            assert result.new_request_id is not None
+            new = db.get_request(result.new_request_id)
+            assert new is not None
+            self.assertEqual(new["status"], "wanted")
+            self.assertEqual(new["replaces_request_id"], 42)
+            with BeetsDB(
+                str(world.library_db), library_root=str(world.library_root),
+            ) as beets:
+                self.assertIsNone(beets.get_album_detail(album.album_id))
+
     def test_moved_real_album_exact_delete_and_rescans_across_identities(self):
         worlds = (
             ("mb", OLD_MBID, NEW_MBID, RG_ID, False),

--- a/tests/test_request_identity.py
+++ b/tests/test_request_identity.py
@@ -573,14 +573,10 @@ class TestEveryUnionConsumerIsPinnedOverAMergedWorld(unittest.TestCase):
             "under the survivor, or the import leaves no current evidence",
         )
 
-    def test_post_import_refresh_omitted_union_is_unavailable_and_skips_sidecar(self) -> None:
+    def test_post_import_refresh_omitted_union_is_unavailable(self) -> None:
         """A resolver omission is authority loss, never evidence absence."""
-        from lib.dispatch import (
-            _refresh_current_evidence_after_import,
-            _write_album_sidecar_after_import,
-        )
+        from lib.dispatch import _refresh_current_evidence_after_import
         from lib.quality import QualityRankConfig
-        from lib.sidecar_service import OUTCOME_SKIPPED_NO_EVIDENCE
         from tests.fakes import FakeBeetsDB, FakePipelineDB
 
         class OmittedUnionBeets(FakeBeetsDB):
@@ -610,15 +606,6 @@ class TestEveryUnionConsumerIsPinnedOverAMergedWorld(unittest.TestCase):
         self.assertEqual(result.status, "failed")
         self.assertIn("omitted", result.reason or "")
         self.assertIsNone(db.get_request_current_evidence_id(request_id))
-        sidecar = _write_album_sidecar_after_import(
-            db,
-            request_id=request_id,
-            mb_release_id=LOSER,
-            cfg=None,
-            beets_factory=lambda **_kwargs: beets,
-        )
-        self.assertEqual(sidecar.outcome, OUTCOME_SKIPPED_NO_EVIDENCE)
-        self.assertEqual(beets.resolve_current_release_calls, [])
 
     def test_disk_coverage_does_not_call_a_merged_request_off_disk(
         self,

--- a/tests/test_request_identity.py
+++ b/tests/test_request_identity.py
@@ -194,16 +194,6 @@ class TestUnionFold(unittest.TestCase):
         # destructive action would target an id Beets no longer stores.
         self.assertEqual(result.selectors, (f"mb_albumid:{SURVIVOR}",))
 
-    def test_both_sides_naming_one_album_resolves_once(self) -> None:
-        held = _unique(self.canonical, 19345)
-        result = merge_union_resolutions(
-            self.acquisition,
-            [held, _unique(self.acquisition, 19345)],
-        )
-        self.assertIsInstance(result, CurrentBeetsUnique)
-        assert isinstance(result, CurrentBeetsUnique)
-        self.assertEqual(result.album_id, 19345)
-
     def test_neither_side_held_is_missing_under_the_acquisition_id(
         self,
     ) -> None:
@@ -582,6 +572,53 @@ class TestEveryUnionConsumerIsPinnedOverAMergedWorld(unittest.TestCase):
             "the post-import refresh must resolve the album Beets holds "
             "under the survivor, or the import leaves no current evidence",
         )
+
+    def test_post_import_refresh_omitted_union_is_unavailable_and_skips_sidecar(self) -> None:
+        """A resolver omission is authority loss, never evidence absence."""
+        from lib.dispatch import (
+            _refresh_current_evidence_after_import,
+            _write_album_sidecar_after_import,
+        )
+        from lib.quality import QualityRankConfig
+        from lib.sidecar_service import OUTCOME_SKIPPED_NO_EVIDENCE
+        from tests.fakes import FakeBeetsDB, FakePipelineDB
+
+        class OmittedUnionBeets(FakeBeetsDB):
+            def resolve_current_releases(self, identities):
+                del identities
+                return {}
+
+        db = FakePipelineDB()
+        request_id = db.add_request(
+            artist_name="Merged Artist", album_title="Merged Album",
+            source="request", mb_release_id=LOSER,
+        )
+        db.record_canonical_release_id(
+            request_id,
+            canonical_release_id=SURVIVOR,
+            resolved_at=datetime(2026, 8, 6, tzinfo=UTC),
+        )
+        beets = OmittedUnionBeets()
+        result = _refresh_current_evidence_after_import(
+            db,
+            request_id=request_id,
+            mb_release_id=LOSER,
+            quality_ranks=QualityRankConfig.defaults(),
+            beets_factory=lambda **_kwargs: beets,
+        )
+
+        self.assertEqual(result.status, "failed")
+        self.assertIn("omitted", result.reason or "")
+        self.assertIsNone(db.get_request_current_evidence_id(request_id))
+        sidecar = _write_album_sidecar_after_import(
+            db,
+            request_id=request_id,
+            mb_release_id=LOSER,
+            cfg=None,
+            beets_factory=lambda **_kwargs: beets,
+        )
+        self.assertEqual(sidecar.outcome, OUTCOME_SKIPPED_NO_EVIDENCE)
+        self.assertEqual(beets.resolve_current_release_calls, [])
 
     def test_disk_coverage_does_not_call_a_merged_request_off_disk(
         self,

--- a/tests/test_request_identity_generated.py
+++ b/tests/test_request_identity_generated.py
@@ -772,21 +772,37 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
 
     def test_checkers_accept_the_legitimate_worlds(self) -> None:
         """Must-still-work: the real merge passes every checker."""
-        held = _unique(self.acquisition, 19345)
-        check_names_the_acquisition(held, self.acquisition)
+        # The union continues to name the request acquisition, but its only
+        # real Beets filing is the survivor (album 19345). Keep the filing in
+        # the selector rather than fabricating a second identity on that row.
+        survivor_held = _unique(
+            self.acquisition,
+            19345,
+            filed_identity=self.canonical,
+        )
+        acquisition_held = _unique(self.acquisition, 11541)
+        check_names_the_acquisition(survivor_held, self.acquisition)
         check_album_is_acceptable(
-            held, {self.canonical: 19345}, (self.canonical, self.acquisition))
+            survivor_held,
+            {self.canonical: 19345},
+            (self.canonical, self.acquisition),
+        )
         check_split_is_ambiguous(
-            held, {self.canonical: 19345}, (self.canonical, self.acquisition))
-        check_unmerged_is_inert(held, held)
+            survivor_held,
+            {self.canonical: 19345},
+            (self.canonical, self.acquisition),
+        )
+        check_unmerged_is_inert(acquisition_held, acquisition_held)
         check_one_batch(1)
-        check_consumer_state_agrees("a switched consumer", "unique", held)
+        check_consumer_state_agrees(
+            "a switched consumer", "unique", survivor_held,
+        )
         check_consumer_state_agrees(
             "a switched consumer",
             "missing",
             CurrentBeetsMissing(identity=self.acquisition),
         )
-        check_presence_agrees("a presence consumer", True, held)
+        check_presence_agrees("a presence consumer", True, survivor_held)
         check_presence_agrees(
             "a presence consumer",
             False,
@@ -812,13 +828,19 @@ def _identity(release_id: str) -> ReleaseIdentity:
     return identity
 
 
-def _unique(identity: ReleaseIdentity, album_id: int) -> CurrentBeetsUnique:
+def _unique(
+    identity: ReleaseIdentity,
+    album_id: int,
+    *,
+    filed_identity: ReleaseIdentity | None = None,
+) -> CurrentBeetsUnique:
+    filed = filed_identity or identity
     return CurrentBeetsUnique(
         identity=identity,
         album_id=album_id,
         album_path=f"/library/album-{album_id}",
         items=(),
-        selectors=(f"mb_albumid:{identity.release_id}",),
+        selectors=(f"mb_albumid:{filed.release_id}",),
     )
 
 

--- a/tests/test_request_identity_generated.py
+++ b/tests/test_request_identity_generated.py
@@ -46,6 +46,7 @@ import unittest
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
 
 from hypothesis import HealthCheck, example, given, settings
 from hypothesis import strategies as st
@@ -569,6 +570,107 @@ class TestSwitchedConsumersAgreeWithTheUnion(unittest.TestCase):
         off_disk = {off.id for off in (result.off_disk or [])}
         check_presence_agrees(
             "disk coverage", request_id not in off_disk, union)
+
+    @settings(deadline=None, max_examples=25)
+    @given(
+        acquired=st.sampled_from([*HELD, *UNHELD]),
+        canonical=st.one_of(st.none(), st.sampled_from([*HELD, *UNHELD])),
+    )
+    @example(acquired=LOSER, canonical=SURVIVOR)
+    @example(acquired=SURVIVOR, canonical=None)
+    def test_replace_cleanup_uses_the_union_filed_identity(
+        self, acquired: str, canonical: str | None,
+    ) -> None:
+        """Replace delegates deletion only to the union's filed album.
+
+        The shared BeetsWorld has one real album per held identity, so merged
+        pairs can produce unique, missing, and split authority without the
+        producer-impossible shape of two identities on one Beets row.  The
+        child is injected only to keep that immutable property library intact;
+        the public Replace service and real Beets resolver both run.
+        """
+        from lib.beets_delete import BeetsDeleteCompleted, BeetsDeleteRequest
+        from lib.config import CratediggerConfig
+        from lib.mbid_replace_service import (
+            RESULT_REPLACED,
+            RESULT_WRONG_STATE,
+            MbidReplaceService,
+        )
+        from tests.fakes import FakePipelineDB
+
+        if canonical == acquired:
+            canonical = None
+        db = FakePipelineDB()
+        request_id, row = self._merged_request(db, acquired, canonical)
+        db.request(request_id)["status"] = "imported"
+        db.request(request_id)["mb_release_group_id"] = (
+            "11111111-1111-1111-1111-111111111111"
+        )
+        calls: list[BeetsDeleteRequest] = []
+
+        def exact_delete(request: BeetsDeleteRequest) -> BeetsDeleteCompleted:
+            calls.append(request)
+            return BeetsDeleteCompleted(
+                album_id=request.album_id,
+                album_name="Merged Album",
+                artist_name="Merged Artist",
+                former_album_path="/immutable/generated-world",
+                deleted_tracks=1,
+                deleted_artifacts=1,
+                preserved_paths=(),
+            )
+
+        target = {
+            "id": "99999999-9999-9999-9999-999999999999",
+            "title": "Replacement",
+            "artist_name": "Merged Artist",
+            "artist_id": "artist-1",
+            "release_group_id": "11111111-1111-1111-1111-111111111111",
+            "year": 2026,
+            "country": "AU",
+            "tracks": [],
+        }
+        with open_beets_db(
+            db_path=str(self.world.library_db),
+            library_root=str(self.world.library_root),
+        ) as beets:
+            union = resolve_current_for_requests(beets, [row])[request_id]
+
+        with (
+            patch("lib.mbid_replace_service.trigger_plex_scan"),
+            patch("lib.mbid_replace_service.trigger_jellyfin_scan"),
+        ):
+            result = MbidReplaceService(
+                db,
+                CratediggerConfig(),
+                beets_db_factory=lambda: open_beets_db(
+                    db_path=str(self.world.library_db),
+                    library_root=str(self.world.library_root),
+                ),
+                mb_lookup=lambda _rid, *, fresh=False: target,
+                search_plan_service=MagicMock(),
+                beets_delete_fn=exact_delete,
+                wrong_match_delete_fn=lambda _db, _request_id: MagicMock(
+                    errors=0, remaining=0,
+                ),
+            ).replace_request_mbid(
+                request_id,
+                target_mb_release_id=str(target["id"]),
+            )
+
+        if isinstance(union, CurrentBeetsAmbiguous):
+            self.assertEqual(result.outcome, RESULT_WRONG_STATE)
+            self.assertEqual(calls, [])
+        elif isinstance(union, CurrentBeetsMissing):
+            self.assertEqual(result.outcome, RESULT_REPLACED)
+            self.assertEqual(calls, [])
+        else:
+            self.assertEqual(result.outcome, RESULT_REPLACED)
+            self.assertEqual([call.album_id for call in calls], [union.album_id])
+            self.assertEqual(
+                [call.expected_release_id for call in calls],
+                [union.filed_identity.release_id],
+            )
 
 
 class TestInvariantCheckersTripOnViolations(unittest.TestCase):

--- a/tests/test_targeted_test_selection.py
+++ b/tests/test_targeted_test_selection.py
@@ -65,6 +65,15 @@ class TestTargetedTestSelection(unittest.TestCase):
         self.assertNotIn("tests.test_pyright_checks_generated", selected)
         self.assertIn("tests.test_artist_releases", selected)
 
+    def test_changed_test_support_module_is_not_scheduled_as_a_test(self) -> None:
+        selected = expand_test_selection(
+            (),
+            changed_paths=("tests/world_model/support.py",),
+            repo_root=REPO_ROOT,
+        )
+
+        self.assertNotIn("tests.world_model.support", selected)
+
     def test_pipeline_db_change_adds_shared_boundary_contracts(self) -> None:
         selected = expand_test_selection(
             (),

--- a/tests/test_world_audit_service.py
+++ b/tests/test_world_audit_service.py
@@ -538,6 +538,52 @@ class TestWorldAuditService(unittest.TestCase):
             len(codes),
         )
 
+    def test_duplicate_acquisition_ids_keep_request_keyed_union_answers(self) -> None:
+        """One duplicate acquisition cannot overwrite another request's union."""
+        survivor = "dddddddd-dddd-dddd-dddd-dddddddddddd"
+        with tempfile.TemporaryDirectory() as root:
+            album_path = os.path.join(root, "survivor")
+            os.makedirs(album_path)
+            track_path = os.path.join(album_path, "01.flac")
+            with open(track_path, "wb") as handle:
+                handle.write(b"authority")
+
+            db = FakePipelineDB()
+            db.seed_request(make_request_row(
+                id=11,
+                mb_release_id=RELEASE_A,
+                canonical_release_id=survivor,
+                status="imported",
+            ))
+            duplicate = make_request_row(
+                id=12,
+                mb_release_id=RELEASE_A,
+                status="imported",
+            )
+            # The audit is read-only over persisted rows.  Its keying must
+            # remain correct even if an operator import or historical DB
+            # contains duplicate acquisitions; do not change schema policy
+            # merely to make this projection easier to test.
+            db._requests[12] = duplicate
+            beets = FakeBeetsDB(library_root=root)
+            beets.set_album_ids_for_release(survivor, [7])
+            beets.set_item_paths(survivor, [(71, track_path)])
+            beets.set_world_albums([BeetsWorldAlbum(
+                album_id=7,
+                release_ids=(survivor,),
+                album_path=album_path,
+                item_paths=(track_path,),
+            )])
+
+            report = audit_world(db, beets)
+
+        missing_members = [
+            member.request_id
+            for member in report.groups.b.members
+            if member.code == "current_beets_missing"
+        ]
+        self.assertEqual(missing_members, [12])
+
     def test_denylist_audit_includes_frozen_replaced_requests(self) -> None:
         db = FakePipelineDB()
         db.seed_request(make_request_row(

--- a/tests/test_world_audit_service_generated.py
+++ b/tests/test_world_audit_service_generated.py
@@ -11,12 +11,19 @@ from hypothesis import example, given
 from hypothesis import strategies as st
 
 import tests._hypothesis_profiles  # noqa: F401  (loads active profile)
-from lib.beets_db import BeetsWorldAlbum, CurrentBeetsResolution
+from lib.beets_db import (
+    BeetsWorldAlbum,
+    CurrentBeetsMissing,
+    CurrentBeetsResolution,
+)
 from lib.release_identity import ReleaseIdentity
 from lib.world_audit_service import (
+    WorldAuditCounts,
     WorldAuditReport,
+    audit_world,
     audit_world_from_borrowed_factory,
     audit_world_from_factory,
+    build_world_audit_report,
 )
 from tests.fakes import FakeBeetsDB, FakePipelineDB
 from tests.helpers import make_request_row
@@ -256,6 +263,26 @@ def assert_resolver_failure_contract(
         )
 
 
+def assert_duplicate_acquisition_membership(
+    report: WorldAuditReport,
+    *,
+    present_request_id: int,
+    missing_request_id: int,
+) -> None:
+    """Only the request whose own union is missing may report missing."""
+    missing_members = tuple(
+        member.request_id
+        for member in report.groups.b.members
+        if member.code == "current_beets_missing"
+    )
+    if missing_members != (missing_request_id,):
+        raise AssertionError(
+            "duplicate acquisition membership was rekeyed by release id: "
+            f"present={present_request_id}, missing={missing_request_id}, "
+            f"observed={missing_members}"
+        )
+
+
 class TestWorldAuditResolverFailureGenerated(unittest.TestCase):
     @given(world=_resolver_failure_worlds())
     @example(world=_ResolverFailureWorld(
@@ -328,6 +355,92 @@ class TestWorldAuditResolverFailureGenerated(unittest.TestCase):
 
         with self.assertRaisesRegex(AssertionError, "availability failure escaped"):
             assert_resolver_failure_contract(world, known_bad)
+
+
+class TestWorldAuditDuplicateAcquisitionGenerated(unittest.TestCase):
+    """The public audit keeps duplicated acquisition rows distinct by id."""
+
+    @given(
+        request_ids=st.lists(
+            st.integers(min_value=1, max_value=2_000_000_000),
+            min_size=2,
+            max_size=2,
+            unique=True,
+        ),
+        survivor_first=st.booleans(),
+    )
+    @example(request_ids=[11, 12], survivor_first=True)
+    def test_duplicate_acquisition_union_answers_do_not_collide(
+        self,
+        request_ids: list[int],
+        survivor_first: bool,
+    ) -> None:
+        acquisition = _RELEASE_ID
+        survivor = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+        present_request_id, missing_request_id = (
+            (request_ids[0], request_ids[1])
+            if survivor_first else (request_ids[1], request_ids[0])
+        )
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=present_request_id,
+            mb_release_id=acquisition,
+            canonical_release_id=survivor,
+            status="imported",
+        ))
+        db._requests[missing_request_id] = make_request_row(
+            id=missing_request_id,
+            mb_release_id=acquisition,
+            status="imported",
+        )
+        beets = FakeBeetsDB()
+        beets.set_album_ids_for_release(survivor, [77])
+        beets.set_world_albums([BeetsWorldAlbum(
+            album_id=77,
+            release_ids=(survivor,),
+            album_path="",
+            item_paths=(),
+        )])
+
+        report = audit_world(db, beets)
+
+        assert_duplicate_acquisition_membership(
+            report,
+            present_request_id=present_request_id,
+            missing_request_id=missing_request_id,
+        )
+
+    def test_checker_rejects_the_legacy_release_keyed_mutant(self) -> None:
+        from lib.world_invariants import (
+            RequestMembershipSnapshot,
+            check_status_membership,
+        )
+
+        requests = (
+            RequestMembershipSnapshot(11, _RELEASE_ID, "imported"),
+            RequestMembershipSnapshot(12, _RELEASE_ID, "imported"),
+        )
+        legacy_by_release = {
+            _RELEASE_ID: CurrentBeetsMissing(identity=_EXPECTED_IDENTITY),
+        }
+        release_keyed = check_status_membership(
+            requests,
+            {
+                request.request_id: legacy_by_release[request.release_id]
+                for request in requests
+            },
+        )
+        known_bad = build_world_audit_report(
+            counts=WorldAuditCounts(2, 1, 0, 0),
+            violations=release_keyed,
+        )
+
+        with self.assertRaisesRegex(AssertionError, "rekeyed by release id"):
+            assert_duplicate_acquisition_membership(
+                known_bad,
+                present_request_id=11,
+                missing_request_id=12,
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_world_invariants.py
+++ b/tests/test_world_invariants.py
@@ -141,7 +141,10 @@ class TestWorldInvariantPins(unittest.TestCase):
         self.assertEqual(check_folder_exclusivity(albums), ())
         self.assertEqual(check_status_membership(
             requests,
-            {album.release_id: _unique(album) for album in albums},
+            {
+                request.request_id: _unique(album)
+                for request, album in zip(requests, albums, strict=True)
+            },
         ), ())
 
     def test_evidence_proof_policy_and_authority_are_coherent(self) -> None:
@@ -470,7 +473,7 @@ class TestWorldInvariantCheckersTripOnKnownBad(unittest.TestCase):
                 status="imported",
             ),
         ), {
-            "missing-release": CurrentBeetsMissing(
+            10: CurrentBeetsMissing(
                 identity=_identity("missing-release"),
             ),
         })
@@ -481,7 +484,7 @@ class TestWorldInvariantCheckersTripOnKnownBad(unittest.TestCase):
         violations = check_status_membership((
             RequestMembershipSnapshot(10, "release-a", "imported"),
         ), {
-            "release-a": CurrentBeetsAmbiguous(
+            10: CurrentBeetsAmbiguous(
                 identity=_identity("release-a"),
                 album_ids=(1, 2),
                 reason="multiple_matches",

--- a/tests/test_world_invariants_generated.py
+++ b/tests/test_world_invariants_generated.py
@@ -155,7 +155,7 @@ class TestWorldInvariantGenerated(unittest.TestCase):
             check_status_membership(
                 tuple(requests),
                 {
-                    release_id: _unique(release_id, index, os.path.join(
+                    index: _unique(release_id, index, os.path.join(
                         "/library", f"album-{index}",
                     ))
                     for index, release_id in enumerate(release_ids, start=1)
@@ -235,7 +235,7 @@ class TestWorldInvariantGenerated(unittest.TestCase):
                 release_id,
                 "imported",
             ),
-        ), {release_id: CurrentBeetsMissing(identity=identity)})
+        ), {1: CurrentBeetsMissing(identity=identity)})
 
         self.assertIn("current_beets_missing", {v.code for v in violations})
 
@@ -260,7 +260,7 @@ class TestWorldInvariantGenerated(unittest.TestCase):
             release_id=release_id,
             status=status,
         ),), {
-            release_id: CurrentBeetsAmbiguous(
+            request_id: CurrentBeetsAmbiguous(
                 identity=identity,
                 album_ids=tuple(sorted(album_ids)),
                 reason="multiple_matches",

--- a/tests/world_model/support.py
+++ b/tests/world_model/support.py
@@ -2008,8 +2008,8 @@ class LifecycleWorld:
             *check_status_membership(
                 tuple(requests),
                 {
-                    identity.release_id: resolution
-                    for identity, resolution in resolutions.items()
+                    int(row["id"]): resolutions[identity]
+                    for row, identity in identified_rows
                 },
             ),
             *check_evidence_disk_coherence(tuple(evidence)),


### PR DESCRIPTION
## Summary

- prove Replace and known-request Library Delete act on the Beets-filed identity resolved from the request union
- fail closed on omitted current authority before destructive, evidence, or sidecar actions
- authorize post-import sidecars only after a ready evidence refresh with concrete evidence
- keep world-audit membership keyed by request ID so duplicate acquisition IDs cannot overwrite request-specific union results
- remove producer-impossible request-identity test worlds and document disk coverage's measured presence-only boundary

## Evidence

The generated and deterministic suites exercise the public destructive services, real dispatch core, and real world-audit checker boundary. They kill acquisition-ID delete mutants, release-keyed world-audit rekeying, sidecar gating based only on evidence presence, and Replace under omitted authority.

Canonical clean-tree receipt for `580842d9471fd920acec2a8c8754e605de3f8095`:

- receipt: `/run/user/1000/cratedigger-final-gate.zuA7keKC`
- bundle: `/run/user/1000/cratedigger-checks._mx1y0ws`
- all six phases passed; 9,496 Python tests across 429/429 targets

Independent Sol review found no remaining issues on the exact head.

Refs #1065
Refs #1059

#1066's inverse no-pipeline-id association remains deliberately separate and is required before the final deployment. No deployment is part of this PR.
