### PR TITLE
Add explicit canonical identity retirement

### DIFF
--- a/docs/debugging-cli.md
+++ b/docs/debugging-cli.md
@@ -170,6 +170,13 @@ inside socket authorization, never credentials.
 - `pipeline-cli canonical show` — Show one request's frozen acquisition
   release id alongside any stored survivor and when the `301` proving it was
   observed. Exit 2 when the request does not exist.
+- `pipeline-cli canonical retire` — Explicitly retire one stored MusicBrainz
+  merge survivor after independent operator review with `--id N --confirm
+  RETIRE`.
+  It fresh-reads then CAS-clears the survivor and its observation timestamp;
+  it never asks MusicBrainz, so a `200`, `4xx`, outage, or disagreement can
+  never clear a value automatically. Exit 2 for an unknown request and 4 for
+  a replaced, canonical-free, or concurrently changed request.
 - `pipeline-cli library-delete` — Delete one exact server-owned Beets album.
 - `pipeline-cli list` — List album requests.
 - `pipeline-cli long-tail` — Show the wanted long-tail worklist. Exact-authority

--- a/docs/mirrors.md
+++ b/docs/mirrors.md
@@ -46,6 +46,11 @@ The operator runs the official MusicBrainz mirror stack in dedicated CT 100
   Configure the external immutable Beets authority separately with the same
   host:port, plain HTTP, and ratelimit 100 values.
 
+Merge reconciliation reads this same base. A blank base logs that the
+reconciler is inert; no public-MusicBrainz fallback is attempted. Transport
+failures and non-redirect responses leave any stored survivor untouched;
+retiring a proven-stale survivor is the separate confirmed canonical action.
+
 **Endgame note:** the long-term plan is `mb-api` — a sibling Rust project
 reimplementing the observed WS/2 subset (XML for musicbrainzngs/beets,
 JSON for `web/mb.py`) against Discogs-style full-dump re-imports, with

--- a/docs/pipeline-db-schema.md
+++ b/docs/pipeline-db-schema.md
@@ -934,8 +934,12 @@ the survivor depends on whether `mbsync` has retagged those files yet — on the
 live library, both states are present at once. Written only by
 `CanonicalReleaseService` (`pipeline-cli canonical reconcile`,
 `POST /api/canonical/reconcile`, and the daily
-`cratedigger-canonical-reconcile.service`). There is deliberately no clearing
-path.
+`cratedigger-canonical-reconcile.service`). Reconciliation deliberately has
+no clearing path: a `200` without a redirect, any `4xx`, mirror unavailability,
+and disagreement are all non-answers that leave stored state alone. The only
+clear is the explicit operator action `pipeline-cli canonical retire --id N
+--confirm RETIRE` / `POST /api/canonical/retire`; it fresh-reads and
+compare-and-set clears both columns only on a non-`replaced` row.
 
 ### `album_tracks.track_artist` (migration 029, populated at enqueue)
 

--- a/lib/canonical_release_service.py
+++ b/lib/canonical_release_service.py
@@ -25,21 +25,17 @@ ordinary case of an id MusicBrainz still considers current. This service
 never distinguishes them into a write, so a bad mirror day leaves the stored
 survivors exactly as they were.
 
-**There is deliberately no clearing path, and that is a known limitation
-rather than a free one.** A stale survivor — from an upstream un-merge, or a
-mirror that once redirected wrongly — is only harmless while nothing holds
-that id. If some *other* album is filed under it, the union returns that
-album as unique with the identity rewritten to the acquisition id, so no
-consumer's identity check trips and another pressing is silently attributed
-to this request. ``canonical_release_id()`` also collapses "asked, got a
-definitive 200 with no redirect" and "could not ask" into the same ``None``,
-so this service structurally cannot tell a retractable canonical from a
-mirror outage; adding a clear would need that distinction first. Zero live
-instances, and retiring one today means raw SQL. Tracked as #1059 F6.
+**There is no automatic clearing path.** ``canonical_release_id()`` collapses
+"asked, got a definitive 200 with no redirect" and "could not ask" into the
+same ``None``, so reconciliation can never retract a stored survivor. An
+operator may explicitly retire a named survivor when they have independent
+evidence it is stale; that action is a fresh-read compare-and-set and never
+consults the mirror (#1059 F6).
 """
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -47,6 +43,8 @@ from typing import Protocol
 
 from lib.mb_canonical import CanonicalReleaseFn, canonical_release_id
 from lib.release_identity import ReleaseIdentity
+
+logger = logging.getLogger("cratedigger")
 
 #: One row's outcome. Exactly one per branch, mapped to CLI exit codes and
 #: HTTP statuses by the two thin adapters.
@@ -57,6 +55,9 @@ OUTCOME_NOT_MUSICBRAINZ = "not_musicbrainz"
 OUTCOME_INVALID_IDENTITY = "invalid_identity"
 OUTCOME_FROZEN = "frozen"
 OUTCOME_NOT_FOUND = "not_found"
+OUTCOME_RETIRED = "retired"
+OUTCOME_NO_CANONICAL = "no_canonical"
+OUTCOME_STALE = "stale"
 
 #: Outcomes that mean "nothing is wrong, nothing changed". Used by the
 #: sweep summary so an operator reading the journal sees one number for
@@ -81,6 +82,14 @@ class CanonicalReleaseDB(Protocol):
         *,
         canonical_release_id: str,
         resolved_at: datetime,
+    ) -> bool: ...
+
+    def retire_canonical_release_id(
+        self,
+        request_id: int,
+        *,
+        expected_canonical_release_id: str,
+        expected_resolved_at: datetime,
     ) -> bool: ...
 
 
@@ -112,7 +121,20 @@ class CanonicalSweepResult:
         return len(self.resolved)
 
 
-def configure_reconciliation_mirror(mb_api_base: str) -> str:
+@dataclass(frozen=True)
+class CanonicalRetireResult:
+    """One explicit operator retirement outcome."""
+
+    request_id: int
+    outcome: str
+    previous_canonical_release_id: str | None = None
+
+    @property
+    def changed(self) -> bool:
+        return self.outcome == OUTCOME_RETIRED
+
+
+def configure_reconciliation_mirror(mb_api_base: str) -> str | None:
     """Point the resolver at the configured MusicBrainz base.
 
     **Every** surface that reconciles must call this — the daily oneshot,
@@ -129,7 +151,14 @@ def configure_reconciliation_mirror(mb_api_base: str) -> str:
     """
     from lib.mb_canonical import configure_canonical_base
 
-    base = (mb_api_base or "").strip().rstrip("/") + "/ws/2"
+    configured = (mb_api_base or "").strip().rstrip("/")
+    if not configured:
+        logger.warning(
+            "canonical reconciliation is inert: musicbrainz.api_base is blank",
+        )
+        configure_canonical_base(None)
+        return None
+    base = configured + "/ws/2"
     configure_canonical_base(base)
     return base
 
@@ -163,6 +192,41 @@ class CanonicalReleaseService:
         if row is None:
             return CanonicalReconcileResult(request_id, OUTCOME_NOT_FOUND)
         return self.reconcile_row(row)
+
+    def retire_request(self, request_id: int) -> CanonicalRetireResult:
+        """Explicitly retire one stored survivor using a fresh-read CAS.
+
+        This is deliberately separate from reconciliation: a definitive
+        no-redirect answer is indistinguishable from a failed lookup, and
+        neither may clear a survivor. Only this named operator action can.
+        """
+        row = self._db.get_request(request_id)
+        if row is None:
+            return CanonicalRetireResult(request_id, OUTCOME_NOT_FOUND)
+        if row.get("status") == "replaced":
+            return CanonicalRetireResult(request_id, OUTCOME_FROZEN)
+
+        stored = row.get("canonical_release_id")
+        resolved_at = row.get("canonical_resolved_at")
+        if not isinstance(stored, str) or not stored or not isinstance(
+            resolved_at, datetime,
+        ):
+            return CanonicalRetireResult(request_id, OUTCOME_NO_CANONICAL)
+
+        retired = self._db.retire_canonical_release_id(
+            request_id,
+            expected_canonical_release_id=stored,
+            expected_resolved_at=resolved_at,
+        )
+        if not retired:
+            return CanonicalRetireResult(
+                request_id, OUTCOME_STALE,
+                previous_canonical_release_id=stored,
+            )
+        return CanonicalRetireResult(
+            request_id, OUTCOME_RETIRED,
+            previous_canonical_release_id=stored,
+        )
 
     def reconcile_row(
         self, row: Mapping[str, object],
@@ -272,13 +336,17 @@ __all__ = [
     "OUTCOME_INVALID_IDENTITY",
     "OUTCOME_NOT_FOUND",
     "OUTCOME_NOT_MUSICBRAINZ",
+    "OUTCOME_NO_CANONICAL",
     "OUTCOME_NO_REDIRECT",
     "OUTCOME_RESOLVED",
+    "OUTCOME_RETIRED",
+    "OUTCOME_STALE",
     "OUTCOME_UNCHANGED",
     "QUIET_OUTCOMES",
     "CanonicalReconcileResult",
     "CanonicalReleaseDB",
     "CanonicalReleaseService",
+    "CanonicalRetireResult",
     "CanonicalSweepResult",
     "configure_reconciliation_mirror",
 ]

--- a/lib/pipeline_db/requests.py
+++ b/lib/pipeline_db/requests.py
@@ -1908,12 +1908,10 @@ class _RequestsMixin(_PipelineDBBase):
         longer qualifies — it was superseded, or its acquisition id changed
         under the sweep — and the caller reports that rather than retrying.
 
-        There is deliberately **no** clearing counterpart (#1059 invariant 7).
-        A failed or unavailable lookup must leave the stored survivor exactly
-        as it was, and the reconciler cannot violate that if the operation
-        does not exist for it to call. An un-merge upstream is harmless: the
-        stale survivor simply stops resolving to an album and the union falls
-        through to the acquisition id.
+        Reconciliation deliberately never clears a survivor (#1059 invariant
+        7): a failed or unavailable lookup leaves it exactly as it was. The
+        separate explicit operator retirement is a fresh-read CAS and never
+        calls this method.
 
         Guarded on ``status <> 'replaced'``: superseded rows are frozen audit
         records, and the world audit fails the run if one mutates after
@@ -1942,3 +1940,38 @@ class _RequestsMixin(_PipelineDBBase):
         written = cur.fetchone() is not None
         self.conn.commit()
         return written
+
+    def retire_canonical_release_id(
+        self,
+        request_id: int,
+        *,
+        expected_canonical_release_id: str,
+        expected_resolved_at: datetime,
+    ) -> bool:
+        """Clear one explicitly retired survivor with a narrow CAS.
+
+        Reconciliation never calls this: a mirror non-answer cannot prove a
+        survivor is stale. The operator service reads the survivor and its
+        observation timestamp immediately before this write, and a concurrent
+        re-observation makes the update a harmless no-op.
+        """
+        cur = self._execute(
+            """
+            UPDATE album_requests
+            SET canonical_release_id = NULL,
+                canonical_resolved_at = NULL
+            WHERE id = %s
+              AND status != 'replaced'
+              AND canonical_release_id IS NOT DISTINCT FROM %s
+              AND canonical_resolved_at IS NOT DISTINCT FROM %s
+            RETURNING id
+            """,
+            (
+                request_id,
+                expected_canonical_release_id,
+                expected_resolved_at,
+            ),
+        )
+        retired = cur.fetchone() is not None
+        self.conn.commit()
+        return retired

--- a/scripts/pipeline_cli/canonical.py
+++ b/scripts/pipeline_cli/canonical.py
@@ -1,7 +1,8 @@
 """pipeline-cli ``canonical`` commands (#1059).
 
 The operator half of the MusicBrainz merge reconciler. Counterpart of
-``POST /api/canonical/reconcile`` and ``GET /api/canonical/<request_id>``;
+``POST /api/canonical/reconcile``, ``POST /api/canonical/retire``, and
+``GET /api/canonical``;
 both surfaces are thin adapters over ``CanonicalReleaseService``, which is
 the one canonical execution path.
 
@@ -18,10 +19,13 @@ from typing import Protocol
 from lib.canonical_release_service import (
     OUTCOME_FROZEN,
     OUTCOME_INVALID_IDENTITY,
+    OUTCOME_NO_CANONICAL,
     OUTCOME_NOT_FOUND,
+    OUTCOME_STALE,
     CanonicalReconcileResult,
     CanonicalReleaseDB,
     CanonicalReleaseService,
+    CanonicalRetireResult,
     configure_reconciliation_mirror,
 )
 from lib.config import read_runtime_config
@@ -44,6 +48,8 @@ class _CanonicalDB(CanonicalReleaseDB, Protocol):
 _EXIT_CODES = {
     OUTCOME_NOT_FOUND: 2,
     OUTCOME_FROZEN: 4,
+    OUTCOME_NO_CANONICAL: 4,
+    OUTCOME_STALE: 4,
     OUTCOME_INVALID_IDENTITY: 5,
 }
 
@@ -63,8 +69,18 @@ def _result_payload(result: CanonicalReconcileResult) -> dict[str, object]:
     }
 
 
+def _retire_payload(result: CanonicalRetireResult) -> dict[str, object]:
+    return {
+        "request_id": result.request_id,
+        "outcome": result.outcome,
+        "canonical_release_id": None,
+        "previous_canonical_release_id": result.previous_canonical_release_id,
+        "changed": result.changed,
+    }
+
+
 def cmd_canonical(db: _CanonicalDB, args: argparse.Namespace) -> int:
-    """Dispatch ``canonical reconcile`` / ``canonical show``."""
+    """Dispatch ``canonical reconcile`` / ``retire`` / ``show``."""
     if args.canonical_command == "show":
         row = db.get_request(args.id)
         if row is None:
@@ -79,6 +95,11 @@ def cmd_canonical(db: _CanonicalDB, args: argparse.Namespace) -> int:
             "canonical_resolved_at": row.get("canonical_resolved_at"),
         })
         return 0
+
+    if args.canonical_command == "retire":
+        result = CanonicalReleaseService(db).retire_request(args.id)
+        _emit(_retire_payload(result))
+        return _EXIT_CODES.get(result.outcome, 0)
 
     # lib/mb_canonical is inert until a process wires a base. A surface that
     # forgets does not fail loudly — it reports no_redirect for every row and
@@ -143,3 +164,13 @@ def add_canonical_subparser(
         help="Show one request's stored acquisition and survivor ids.",
     )
     show.add_argument("id", type=int, help="Request id.")
+
+    retire = canonical_sub.add_parser(
+        "retire",
+        help="Explicitly retire one stored MusicBrainz merge survivor.",
+    )
+    retire.add_argument("--id", type=int, required=True, help="Request id.")
+    retire.add_argument(
+        "--confirm", choices=("RETIRE",), required=True,
+        help="Required acknowledgement for this explicit identity action.",
+    )

--- a/tests/fakes/pipeline_db.py
+++ b/tests/fakes/pipeline_db.py
@@ -524,6 +524,8 @@ class FakePipelineDB:
             tuple[int, str | None, datetime]] = []
         self.record_canonical_release_id_calls: list[
             tuple[int, str, datetime]] = []
+        self.retire_canonical_release_id_calls: list[
+            tuple[int, str, datetime]] = []
         # Cursor-mutation recorders. The R20 runtime guard asserts
         # these stay empty after a detection run. We instrument both
         # cursor writers and the operator-driven advance.
@@ -5581,6 +5583,32 @@ class FakePipelineDB:
         row["canonical_release_id"] = canonical_release_id
         row["canonical_resolved_at"] = resolved_at
         row["updated_at"] = resolved_at
+        return True
+
+    def retire_canonical_release_id(
+        self,
+        request_id: int,
+        *,
+        expected_canonical_release_id: str,
+        expected_resolved_at: datetime,
+    ) -> bool:
+        """Mirror PipelineDB.retire_canonical_release_id's CAS guards."""
+        self.retire_canonical_release_id_calls.append(
+            (
+                request_id,
+                expected_canonical_release_id,
+                expected_resolved_at,
+            ),
+        )
+        row = self._requests.get(request_id)
+        if row is None or row.get("status") == "replaced":
+            return False
+        if row.get("canonical_release_id") != expected_canonical_release_id:
+            return False
+        if row.get("canonical_resolved_at") != expected_resolved_at:
+            return False
+        row["canonical_release_id"] = None
+        row["canonical_resolved_at"] = None
         return True
 
     def get_unfindable_search_log_signal(

--- a/tests/test_canonical_mirror_guard.py
+++ b/tests/test_canonical_mirror_guard.py
@@ -68,6 +68,15 @@ class TestConfigureReconciliationMirror(_WiringCase):
         self.assertEqual(
             mb_canonical.configured_canonical_base(), f"{MIRROR}/ws/2")
 
+    def test_blank_base_warns_once_and_leaves_the_resolver_inert(self) -> None:
+        with self.assertLogs("cratedigger", level="WARNING") as logs:
+            base = configure_reconciliation_mirror("")
+
+        self.assertIsNone(base)
+        self.assertIsNone(mb_canonical.configured_canonical_base())
+        self.assertEqual(len(logs.output), 1)
+        self.assertIn("musicbrainz.api_base is blank", logs.output[0])
+
 
 class TestEverySurfaceWiresBeforeSweeping(_WiringCase):
     """One test per surface. Removing the wiring call from any of them
@@ -158,6 +167,35 @@ class TestCliReconcileOutcomes(_WiringCase):
 
         self.assertEqual(self._run(args, db, None), 0)
         self.assertIsNone(db.request(request_id)["canonical_release_id"])
+
+
+class TestCliRetireOutcomes(unittest.TestCase):
+    def test_retire_uses_the_service_and_matches_state_exit_codes(self) -> None:
+        from datetime import UTC, datetime
+
+        from scripts.pipeline_cli.canonical import cmd_canonical
+
+        db = FakePipelineDB()
+        request_id = db.add_request(
+            artist_name="Merged", album_title="Release", source="request",
+            mb_release_id=LOSER,
+        )
+        db.record_canonical_release_id(
+            request_id,
+            canonical_release_id=SURVIVOR,
+            resolved_at=datetime(2026, 8, 7, tzinfo=UTC),
+        )
+        args = argparse.Namespace(
+            canonical_command="retire", id=request_id, confirm="RETIRE",
+        )
+        self.assertEqual(cmd_canonical(db, args), 0)
+        self.assertIsNone(db.request(request_id)["canonical_release_id"])
+
+        self.assertEqual(cmd_canonical(db, args), 4)
+        missing = argparse.Namespace(
+            canonical_command="retire", id=999_999, confirm="RETIRE",
+        )
+        self.assertEqual(cmd_canonical(db, missing), 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_canonical_release_service.py
+++ b/tests/test_canonical_release_service.py
@@ -24,10 +24,13 @@ from datetime import UTC, datetime
 from lib.canonical_release_service import (
     OUTCOME_FROZEN,
     OUTCOME_INVALID_IDENTITY,
+    OUTCOME_NO_CANONICAL,
     OUTCOME_NO_REDIRECT,
     OUTCOME_NOT_FOUND,
     OUTCOME_NOT_MUSICBRAINZ,
     OUTCOME_RESOLVED,
+    OUTCOME_RETIRED,
+    OUTCOME_STALE,
     OUTCOME_UNCHANGED,
     CanonicalReleaseService,
 )
@@ -128,12 +131,8 @@ class TestReconcileRequest(unittest.TestCase):
         self.assertEqual(
             self.db.request(rid)["canonical_release_id"], SURVIVOR)
 
-    def test_the_service_has_no_way_to_clear_a_survivor(self) -> None:
-        """I7 by construction, not by discipline.
-
-        A clearing path is the only way this service could violate the
-        invariant, so it must not exist on the DB surface it can reach.
-        """
+    def test_only_explicit_retirement_can_clear_a_survivor(self) -> None:
+        """I7: reconciliation itself has no clearing capability."""
         from lib.canonical_release_service import CanonicalReleaseDB
 
         surface = {
@@ -146,7 +145,103 @@ class TestReconcileRequest(unittest.TestCase):
                 "get_request",
                 "list_non_replaced_requests",
                 "record_canonical_release_id",
+                "retire_canonical_release_id",
             },
+        )
+
+
+class TestRetireRequest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.db = FakePipelineDB()
+        self.request_id = self.db.add_request(
+            artist_name="Merged", album_title="Release", source="request",
+            mb_release_id=LOSER,
+        )
+        self.db.record_canonical_release_id(
+            self.request_id, canonical_release_id=SURVIVOR, resolved_at=NOW,
+        )
+
+    def test_explicit_retirement_clears_only_canonical_fields(self) -> None:
+        before = dict(self.db.request(self.request_id))
+        result = CanonicalReleaseService(
+            self.db, now_fn=lambda: NOW.replace(hour=13),
+        ).retire_request(self.request_id)
+
+        self.assertEqual(result.outcome, OUTCOME_RETIRED)
+        self.assertTrue(result.changed)
+        self.assertEqual(result.previous_canonical_release_id, SURVIVOR)
+        after = self.db.request(self.request_id)
+        self.assertIsNone(after["canonical_release_id"])
+        self.assertIsNone(after["canonical_resolved_at"])
+        self.assertEqual(
+            {
+                field for field in before if before[field] != after[field]
+            },
+            {"canonical_release_id", "canonical_resolved_at"},
+        )
+
+    def test_missing_no_canonical_and_replaced_are_noops(self) -> None:
+        service = CanonicalReleaseService(self.db, now_fn=lambda: NOW)
+        self.assertEqual(
+            service.retire_request(999_999).outcome, OUTCOME_NOT_FOUND)
+
+        no_canonical = self.db.add_request(
+            artist_name="Plain", album_title="Release", source="request",
+            mb_release_id=SECOND_SURVIVOR,
+        )
+        before = dict(self.db.request(no_canonical))
+        self.assertEqual(
+            service.retire_request(no_canonical).outcome, OUTCOME_NO_CANONICAL)
+        self.assertEqual(self.db.request(no_canonical), before)
+
+        self.db.supersede_request_mbid(
+            self.request_id,
+            new_mb_release_id="bce7d8c3-815b-449c-8e18-df806398986c",
+            new_mb_release_group_id=None,
+            new_mb_artist_id=None,
+            new_artist_name="Merged",
+            new_album_title="Release",
+            new_year=None,
+            new_country=None,
+            new_tracks=[],
+        )
+        frozen = dict(self.db.request(self.request_id))
+        self.assertEqual(
+            service.retire_request(self.request_id).outcome, OUTCOME_FROZEN)
+        self.assertEqual(self.db.request(self.request_id), frozen)
+
+    def test_a_newer_observation_wins_the_retirement_race(self) -> None:
+        class RacingDB(FakePipelineDB):
+            def retire_canonical_release_id(self, request_id, **kwargs):
+                return False
+
+        db = RacingDB()
+        request_id = db.add_request(
+            artist_name="Merged", album_title="Release", source="request",
+            mb_release_id=LOSER,
+        )
+        db.record_canonical_release_id(
+            request_id, canonical_release_id=SURVIVOR, resolved_at=NOW,
+        )
+        before = dict(db.request(request_id))
+        result = CanonicalReleaseService(db, now_fn=lambda: NOW).retire_request(
+            request_id,
+        )
+
+        self.assertEqual(result.outcome, OUTCOME_STALE)
+        self.assertEqual(db.request(request_id), before)
+
+
+class TestReconcileRequestOutcomes(unittest.TestCase):
+    def setUp(self) -> None:
+        self.db = FakePipelineDB()
+
+    def _seed(
+        self, *, mb: str | None = LOSER, discogs: str | None = None,
+    ) -> int:
+        return self.db.add_request(
+            artist_name="Merged", album_title="Release", source="request",
+            mb_release_id=mb, discogs_release_id=discogs,
         )
 
     def test_discogs_request_never_asks_musicbrainz(self) -> None:

--- a/tests/test_canonical_release_service_generated.py
+++ b/tests/test_canonical_release_service_generated.py
@@ -1,0 +1,116 @@
+"""Generated state properties for explicit canonical retirement (#1059 F6)."""
+
+from __future__ import annotations
+
+import unittest
+from datetime import UTC, datetime
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+import tests._hypothesis_profiles  # noqa: F401
+from lib.canonical_release_service import (
+    OUTCOME_RETIRED,
+    CanonicalReleaseService,
+)
+from tests.fakes import FakePipelineDB
+
+LOSER = "4878ee47-f8b8-45c8-832c-62de3bccfa6e"
+SURVIVOR = "7aabf975-9a06-4b2e-854c-2c700380ebd5"
+SECOND = "abe18a1c-ad01-423c-b6ca-63cfa8a9daf1"
+OBSERVED = datetime(2026, 8, 6, tzinfo=UTC)
+
+
+def check_retirement_preserves_request(
+    before: dict[str, object], after: dict[str, object], *, changed: bool,
+) -> None:
+    """A retirement changes precisely its two canonical fields."""
+    if changed:
+        if after["canonical_release_id"] is not None:
+            raise AssertionError("retired request retained its survivor")
+        if after["canonical_resolved_at"] is not None:
+            raise AssertionError("retired request retained its observation")
+        changed_fields = {
+            field for field in before if before[field] != after[field]
+        }
+        if changed_fields != {"canonical_release_id", "canonical_resolved_at"}:
+            raise AssertionError(
+                f"retirement changed fields beyond canonical state: {changed_fields}")
+    elif after != before:
+        raise AssertionError("a no-op retirement changed the request")
+
+
+def check_lookup_non_answer_preserves_canonical(
+    before: str | None, after: str | None,
+) -> None:
+    """A mirror non-answer never authorizes a clear."""
+    if after != before:
+        raise AssertionError("lookup non-answer changed canonical state")
+
+
+class TestCanonicalRetirementGenerated(unittest.TestCase):
+    @given(st.sampled_from(("canonical", "none", "replaced", "stale")))
+    def test_retirement_is_explicit_and_compare_and_set(self, state: str) -> None:
+        class RaceDB(FakePipelineDB):
+            def retire_canonical_release_id(self, request_id, **kwargs):
+                if state == "stale":
+                    return False
+                return super().retire_canonical_release_id(request_id, **kwargs)
+
+        db = RaceDB()
+        request_id = db.add_request(
+            artist_name="Merged", album_title="Release", source="request",
+            mb_release_id=LOSER,
+        )
+        if state != "none":
+            db.record_canonical_release_id(
+                request_id, canonical_release_id=SURVIVOR, resolved_at=OBSERVED,
+            )
+        if state == "replaced":
+            db.supersede_request_mbid(
+                request_id, new_mb_release_id=SECOND,
+                new_mb_release_group_id=None, new_mb_artist_id=None,
+                new_artist_name="Merged", new_album_title="Release",
+                new_year=None, new_country=None, new_tracks=[],
+            )
+        before = dict(db.request(request_id))
+        result = CanonicalReleaseService(
+            db, now_fn=lambda: OBSERVED.replace(hour=2),
+        ).retire_request(request_id)
+        after = db.request(request_id)
+
+        check_retirement_preserves_request(
+            before, after, changed=result.outcome == OUTCOME_RETIRED,
+        )
+
+    @given(st.sampled_from((SURVIVOR, SECOND)))
+    def test_lookup_non_answers_cannot_clear(self, survivor: str) -> None:
+        db = FakePipelineDB()
+        request_id = db.add_request(
+            artist_name="Merged", album_title="Release", source="request",
+            mb_release_id=LOSER,
+        )
+        db.record_canonical_release_id(
+            request_id, canonical_release_id=survivor, resolved_at=OBSERVED,
+        )
+        before = db.request(request_id)["canonical_release_id"]
+        CanonicalReleaseService(
+            db, canonical_fn=lambda _id: None, now_fn=lambda: OBSERVED,
+        ).reconcile_request(request_id)
+        check_lookup_non_answer_preserves_canonical(
+            before, db.request(request_id)["canonical_release_id"],
+        )
+
+    def test_known_bad_unconditional_clear_dies(self) -> None:
+        with self.assertRaises(AssertionError):
+            check_retirement_preserves_request(
+                {"mb_release_id": LOSER, "status": "wanted", "current_evidence_id": None,
+                 "canonical_release_id": SURVIVOR, "canonical_resolved_at": OBSERVED},
+                {"mb_release_id": LOSER, "status": "wanted", "current_evidence_id": None,
+                 "canonical_release_id": None, "canonical_resolved_at": None},
+                changed=False,
+            )
+
+    def test_known_bad_lookup_clear_dies(self) -> None:
+        with self.assertRaises(AssertionError):
+            check_lookup_non_answer_preserves_canonical(SURVIVOR, None)

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -16692,6 +16692,91 @@ class TestCanonicalReleaseId(unittest.TestCase):
         finally:
             db.close()
 
+    def test_retire_canonical_release_id_round_trip_is_a_narrow_cas(self):
+        db = make_db()
+        try:
+            request_id = self._seed(db)
+            observed_at = datetime(2026, 8, 6, 12, tzinfo=UTC)
+            self.assertTrue(db.record_canonical_release_id(
+                request_id,
+                canonical_release_id=self.SURVIVOR,
+                resolved_at=observed_at,
+            ))
+            before = db.get_request(request_id)
+            assert before is not None
+
+            self.assertTrue(db.retire_canonical_release_id(
+                request_id,
+                expected_canonical_release_id=self.SURVIVOR,
+                expected_resolved_at=observed_at,
+            ))
+            after = db.get_request(request_id)
+            assert after is not None
+            self.assertIsNone(after["canonical_release_id"])
+            self.assertIsNone(after["canonical_resolved_at"])
+            self.assertEqual(
+                {
+                    field for field in before if before[field] != after[field]
+                },
+                {"canonical_release_id", "canonical_resolved_at"},
+            )
+
+            stored = db._execute(
+                "SELECT canonical_release_id, canonical_resolved_at "
+                "FROM album_requests WHERE id = %s",
+                (request_id,),
+            ).fetchone()
+            self.assertIsNone(stored["canonical_release_id"])
+            self.assertIsNone(stored["canonical_resolved_at"])
+        finally:
+            db.close()
+
+    def test_retire_cas_refuses_newer_or_replaced_rows_without_mutation(self):
+        db = make_db()
+        try:
+            request_id = self._seed(db)
+            first = datetime(2026, 8, 6, tzinfo=UTC)
+            second = datetime(2026, 8, 7, tzinfo=UTC)
+            self.assertTrue(db.record_canonical_release_id(
+                request_id, canonical_release_id=self.SURVIVOR,
+                resolved_at=first,
+            ))
+            self.assertTrue(db.record_canonical_release_id(
+                request_id, canonical_release_id="abe18a1c-ad01-423c-b6ca-63cfa8a9daf1",
+                resolved_at=second,
+            ))
+            before = db.get_request(request_id)
+            assert before is not None
+            self.assertFalse(db.retire_canonical_release_id(
+                request_id,
+                expected_canonical_release_id=self.SURVIVOR,
+                expected_resolved_at=first,
+            ))
+            self.assertEqual(db.get_request(request_id), before)
+
+            replacement = db.supersede_request_mbid(
+                request_id,
+                new_mb_release_id="bce7d8c3-815b-449c-8e18-df806398986c",
+                new_mb_release_group_id=None,
+                new_mb_artist_id=None,
+                new_artist_name="Merged",
+                new_album_title="Release",
+                new_year=None,
+                new_country=None,
+                new_tracks=[],
+            )
+            frozen = db.get_request(request_id)
+            assert frozen is not None
+            self.assertFalse(db.retire_canonical_release_id(
+                request_id,
+                expected_canonical_release_id="abe18a1c-ad01-423c-b6ca-63cfa8a9daf1",
+                expected_resolved_at=second,
+            ))
+            self.assertEqual(db.get_request(request_id), frozen)
+            self.assertIsNotNone(replacement)
+        finally:
+            db.close()
+
     def test_check_constraints_reject_the_shapes_the_guard_prevents(self):
         """Known-bad: bypass the method and the schema still fails closed."""
         import psycopg2.errors

--- a/tests/web/test_routes_canonical.py
+++ b/tests/web/test_routes_canonical.py
@@ -12,6 +12,7 @@ import os
 import sys
 import tempfile
 import unittest
+from datetime import UTC, datetime
 from typing import ClassVar
 from unittest.mock import patch
 
@@ -50,6 +51,13 @@ class TestCanonicalRouteContracts(_FakeDbWebServerCase):
         "previous_canonical_release_id",
         "changed",
     }
+    RETIRE_REQUIRED_FIELDS: ClassVar[set[str]] = {
+        "request_id",
+        "outcome",
+        "canonical_release_id",
+        "previous_canonical_release_id",
+        "changed",
+    }
     SWEEP_REQUIRED_FIELDS: ClassVar[set[str]] = {
         "scanned",
         "changed",
@@ -59,9 +67,8 @@ class TestCanonicalRouteContracts(_FakeDbWebServerCase):
 
     def setUp(self) -> None:
         super().setUp()
-        # The route refuses to reconcile without a LOCAL mirror configured.
-        # Drive the real guard with a real runtime config rather than
-        # patching it out, so a regression in the guard is visible here.
+        # Reconciliation wires the configured mirror before the real resolver
+        # runs. Drive that configuration rather than patching it out.
         config_dir = tempfile.TemporaryDirectory()
         self.addCleanup(config_dir.cleanup)
         config_path = os.path.join(config_dir.name, "config.ini")
@@ -125,6 +132,45 @@ class TestCanonicalRouteContracts(_FakeDbWebServerCase):
         self.assertEqual(
             self.db.request(request_id)["canonical_release_id"], SURVIVOR)
 
+    def test_reconcile_route_wires_the_real_resolver_before_network(self) -> None:
+        """E15: only urllib is replaced; the route/service stay real."""
+        from lib import mb_canonical
+
+        request_id = self._seed()
+        mb_canonical.configure_canonical_base(None)
+        requested_urls: list[str] = []
+
+        class Response:
+            url = (
+                "http://mirror.test/ws/2/release/"
+                f"{SURVIVOR}?fmt=json"
+            )
+
+            def read(self, _limit: int) -> bytes:
+                return ('{"id": "' + SURVIVOR + '"}').encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+        def urlopen(request, *, timeout):
+            requested_urls.append(request.full_url)
+            self.assertEqual(timeout, 15)
+            return Response()
+
+        with patch("urllib.request.urlopen", urlopen):
+            status, payload = self._post(
+                "/api/canonical/reconcile", {"request_id": request_id})
+
+        self.assertEqual(status, 200)
+        self.assertEqual(payload["outcome"], "resolved")
+        self.assertEqual(
+            requested_urls,
+            [f"http://mirror.test/ws/2/release/{LOSER}?fmt=json"],
+        )
+
     def test_reconcile_unknown_request_is_404(self) -> None:
         with patch(
             "web.routes.canonical.canonical_release_fn",
@@ -184,6 +230,62 @@ class TestCanonicalRouteContracts(_FakeDbWebServerCase):
         self.assertEqual(payload["scanned"], 2)
         self.assertEqual(payload["changed"], 1)
         self.assertEqual(payload["resolved"][0]["request_id"], merged)
+
+    def test_retire_matches_cli_service_outcomes(self) -> None:
+        request_id = self._seed()
+        self.db.record_canonical_release_id(
+            request_id,
+            canonical_release_id=SURVIVOR,
+            resolved_at=datetime.now(UTC),
+        )
+        status, payload = self._post(
+            "/api/canonical/retire",
+            {"request_id": request_id, "confirm": "RETIRE"},
+        )
+        self.assertEqual(status, 200)
+        _assert_required_fields(
+            self, payload, self.RETIRE_REQUIRED_FIELDS,
+            "POST /api/canonical/retire")
+        self.assertEqual(payload["outcome"], "retired")
+        self.assertTrue(payload["changed"])
+        self.assertIsNone(self.db.request(request_id)["canonical_release_id"])
+
+    def test_retire_rejects_bad_confirmation_and_reports_state(self) -> None:
+        status, _payload = self._post(
+            "/api/canonical/retire", {"request_id": 1, "confirm": "NO"})
+        self.assertEqual(status, 400)
+
+        request_id = self._seed()
+        status, payload = self._post(
+            "/api/canonical/retire",
+            {"request_id": request_id, "confirm": "RETIRE"},
+        )
+        self.assertEqual(status, 409)
+        self.assertEqual(payload["outcome"], "no_canonical")
+
+        status, payload = self._post(
+            "/api/canonical/retire",
+            {"request_id": 999_999, "confirm": "RETIRE"},
+        )
+        self.assertEqual(status, 404)
+        self.assertEqual(payload["outcome"], "not_found")
+
+    def test_retire_requires_a_strict_positive_integer_id(self) -> None:
+        request_id = self._seed()
+        self.db.record_canonical_release_id(
+            request_id,
+            canonical_release_id=SURVIVOR,
+            resolved_at=datetime.now(UTC),
+        )
+        for invalid_id in (True, "1", 1.0, 0):
+            with self.subTest(request_id=invalid_id):
+                before = dict(self.db.request(request_id))
+                status, _payload = self._post(
+                    "/api/canonical/retire",
+                    {"request_id": invalid_id, "confirm": "RETIRE"},
+                )
+                self.assertEqual(status, 400)
+                self.assertEqual(self.db.request(request_id), before)
 
 if __name__ == "__main__":
     unittest.main()

--- a/web/routes/canonical.py
+++ b/web/routes/canonical.py
@@ -7,15 +7,19 @@ outcome→exit-code mapping exactly.
 """
 
 import logging
+from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from lib.canonical_release_service import (
     OUTCOME_FROZEN,
     OUTCOME_INVALID_IDENTITY,
+    OUTCOME_NO_CANONICAL,
     OUTCOME_NOT_FOUND,
+    OUTCOME_STALE,
     CanonicalReconcileResult,
     CanonicalReleaseService,
+    CanonicalRetireResult,
     configure_reconciliation_mirror,
 )
 from lib.config import read_runtime_config
@@ -37,6 +41,8 @@ canonical_release_fn = canonical_release_id
 _STATUS = {
     OUTCOME_NOT_FOUND: 404,
     OUTCOME_FROZEN: 409,
+    OUTCOME_NO_CANONICAL: 409,
+    OUTCOME_STALE: 409,
     OUTCOME_INVALID_IDENTITY: 422,
 }
 
@@ -47,6 +53,16 @@ def _payload(result: CanonicalReconcileResult) -> dict[str, object]:
         "outcome": result.outcome,
         "acquisition_release_id": result.acquisition_release_id,
         "canonical_release_id": result.canonical_release_id,
+        "previous_canonical_release_id": result.previous_canonical_release_id,
+        "changed": result.changed,
+    }
+
+
+def _retire_payload(result: CanonicalRetireResult) -> dict[str, object]:
+    return {
+        "request_id": result.request_id,
+        "outcome": result.outcome,
+        "canonical_release_id": None,
         "previous_canonical_release_id": result.previous_canonical_release_id,
         "changed": result.changed,
     }
@@ -91,6 +107,13 @@ class CanonicalReconcileRequest(BaseModel):
     request_id: int | None = None
 
 
+class CanonicalRetireRequest(BaseModel):
+    """Body for ``POST /api/canonical/retire``."""
+
+    request_id: int = Field(gt=0, strict=True)
+    confirm: Literal["RETIRE"]
+
+
 def post_canonical_reconcile(h: RouteHandler, body: bytes) -> None:
     """``POST /api/canonical/reconcile`` — ask MusicBrainz, store the answer.
 
@@ -125,6 +148,17 @@ def post_canonical_reconcile(h: RouteHandler, body: bytes) -> None:
     })
 
 
+def post_canonical_retire(h: RouteHandler, body: bytes) -> None:
+    """``POST /api/canonical/retire`` — explicitly clear one survivor."""
+    parsed = parse_body(h, body, CanonicalRetireRequest)
+    if parsed is None:
+        return
+    result = CanonicalReleaseService(_server()._db()).retire_request(
+        parsed.request_id,
+    )
+    h._json(_retire_payload(result), status=_STATUS.get(result.outcome, 200))
+
+
 ROUTES: list[RouteRegistration] = [
     route(
         "GET", "/api/canonical", get_canonical_request,
@@ -139,6 +173,13 @@ ROUTES: list[RouteRegistration] = [
         "With request_id reconciles one row; without it sweeps every "
         "non-replaced request. Wraps CanonicalReleaseService, the same "
         "service pipeline-cli canonical wraps.",
+        classified=True,
+    ),
+    route(
+        "POST", "/api/canonical/retire", post_canonical_retire,
+        "Explicitly retire one stored MusicBrainz merge survivor after the "
+        "caller confirms RETIRE. The service fresh-reads and CAS-clears the "
+        "survivor plus its observation; it never consults the mirror.",
         classified=True,
     ),
 ]


### PR DESCRIPTION
## Summary

- add one compare-and-set canonical retirement service that clears only `canonical_release_id` and `canonical_resolved_at`
- expose the action symmetrically as `pipeline-cli canonical retire --id N --confirm RETIRE` and `POST /api/canonical/retire`
- keep acquisition identity, lifecycle timestamps/status, evidence, and unrelated request fields unchanged
- distinguish missing, no-canonical, replaced, and stale-CAS zero-mutation outcomes
- behaviorally pin canonical reconcile route mirror configuration and warn on an empty inert mirror base

## Safety and evidence

No automatic lookup path can retire a canonical. The DB update is a non-replaced expected-value CAS, and full-row tests prove successful retirement changes exactly two fields. API targets require strict positive integers; coercive bool/string/float inputs fail without mutation.

Canonical clean-tree receipt for `2f1ae4d64d7df8e92dab4459ca040c01496b7603`:

- receipt: `/run/user/1000/cratedigger-final-gate.YdUx3Q5x`
- bundle: `/run/user/1000/cratedigger-checks.0luxatyx`
- all six phases passed; 9,511 Python tests

Independent Sol review and exact-head re-review found no remaining issues.

Refs #1065
Refs #1059

No deployment is part of this PR; the batch deploys once after every required PR is merged.
