### PR TITLE
fix(#1081): shared tests/ modules select the tests that exercise them, or fail closed

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -256,8 +256,12 @@ The targeted entrypoint pairs deterministic and generated siblings, selects
 tests adjacent to changed production surfaces, discovers every `test_*_audit`
 module plus explicitly named ratchets, and reuses the canonical JavaScript,
 Pyright, Ruff, and Vulture phases. With no explicit selector, changed paths are
-the target source. This is development feedback; the full suite remains the
-exhaustive pre-review boundary.
+the target source. A changed shared `tests/**.py` module with no mapping in
+`scripts/targeted_test_selection.py::EXACT_PATH_NEIGHBOURS` (or an admitted
+gap in `SHARED_MODULES_WITHOUT_COVERAGE`) fails the whole entrypoint closed
+before any phase runs — silent under-selection there is worse than a loud
+refusal. This is development feedback; the full suite remains the exhaustive
+pre-review boundary.
 
 Always use `nix-shell --run` for Python (`.claude/rules/nix-shell.md`). Direct
 Nix-shell runs are ordinary development feedback; fix their failures in the

--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -256,12 +256,13 @@ The targeted entrypoint pairs deterministic and generated siblings, selects
 tests adjacent to changed production surfaces, discovers every `test_*_audit`
 module plus explicitly named ratchets, and reuses the canonical JavaScript,
 Pyright, Ruff, and Vulture phases. With no explicit selector, changed paths are
-the target source. A changed shared `tests/**.py` module with no mapping in
-`scripts/targeted_test_selection.py::EXACT_PATH_NEIGHBOURS` (or an admitted
-gap in `SHARED_MODULES_WITHOUT_COVERAGE`) fails the whole entrypoint closed
-before any phase runs — silent under-selection there is worse than a loud
-refusal. This is development feedback; the full suite remains the exhaustive
-pre-review boundary.
+the target source. A changed shared `tests/**.py` module resolves via an
+`scripts/targeted_test_selection.py::EXACT_PATH_NEIGHBOURS` entry, one of the
+few remaining directory prefix rules, or an admitted gap in
+`SHARED_MODULES_WITHOUT_COVERAGE`; one with none of those fails the whole
+entrypoint closed (`scripts/test.sh` exit code 2) before any phase runs —
+silent under-selection there is worse than a loud refusal. This is development
+feedback; the full suite remains the exhaustive pre-review boundary.
 
 Always use `nix-shell --run` for Python (`.claude/rules/nix-shell.md`). Direct
 Nix-shell runs are ordinary development feedback; fix their failures in the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,7 +189,11 @@ Use `scripts/test.sh` for normal development validation. It adds the selected
 test's deterministic/generated sibling, tests adjacent to changed production
 surfaces, every repository audit and ratchet, JavaScript checks, both Pyright
 contracts, Ruff, and Vulture to one failure bundle. Use direct `unittest` only
-to debug an isolated failure, not as local convergence evidence.
+to debug an isolated failure, not as local convergence evidence. Exit code 2
+with no phase output at all means a changed shared `tests/**.py` module has no
+mapping in `scripts/targeted_test_selection.py` — map it there (or record it
+in `SHARED_MODULES_WITHOUT_COVERAGE` if it genuinely has no consuming test),
+not a failure in your change.
 
 Direct runs are development feedback; before independent-review handoff, use
 the `check` skill on the converged, clean, committed tree for the one

--- a/README.md
+++ b/README.md
@@ -198,10 +198,11 @@ ratchet. It also runs JavaScript, both Pyright contracts, Ruff, and Vulture in
 the same aggregate failure bundle. With no selector it derives targets from the
 working-tree diff. A changed shared `tests/**.py` module (a fake, helper, or
 other non-`test_*.py` file) with no registered mapping in
-`scripts/targeted_test_selection.py` fails closed before any phase runs, JS and
-Pyright included — see that module's `EXACT_PATH_NEIGHBOURS` /
-`SHARED_MODULES_WITHOUT_COVERAGE` for the mapping and the admitted-gap
-registry. `run_tests.sh` remains the one canonical complete suite.
+`scripts/targeted_test_selection.py` fails closed with exit code 2 before any
+phase runs, JS and Pyright included — see that module's
+`EXACT_PATH_NEIGHBOURS` / `SHARED_MODULES_WITHOUT_COVERAGE` for the mapping
+and the admitted-gap registry. `run_tests.sh` remains the one canonical
+complete suite.
 `run_final_gate.sh` runs that exact suite on a clean commit and adds a receipt;
 it does not select different checks. CI does not enforce this local workflow.
 

--- a/README.md
+++ b/README.md
@@ -196,7 +196,12 @@ nix-shell --run "bash scripts/run_tests.sh"              # complete suite
 deterministic sibling, tests adjacent to every changed path, and every audit and
 ratchet. It also runs JavaScript, both Pyright contracts, Ruff, and Vulture in
 the same aggregate failure bundle. With no selector it derives targets from the
-working-tree diff. `run_tests.sh` remains the one canonical complete suite.
+working-tree diff. A changed shared `tests/**.py` module (a fake, helper, or
+other non-`test_*.py` file) with no registered mapping in
+`scripts/targeted_test_selection.py` fails closed before any phase runs, JS and
+Pyright included — see that module's `EXACT_PATH_NEIGHBOURS` /
+`SHARED_MODULES_WITHOUT_COVERAGE` for the mapping and the admitted-gap
+registry. `run_tests.sh` remains the one canonical complete suite.
 `run_final_gate.sh` runs that exact suite on a clean commit and adds a receipt;
 it does not select different checks. CI does not enforce this local workflow.
 

--- a/scripts/targeted_test_selection.py
+++ b/scripts/targeted_test_selection.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import subprocess
 from collections import Counter
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from pathlib import Path, PurePosixPath
 
 ALWAYS_AMBIENT_TESTS = (
@@ -239,13 +239,16 @@ EXACT_PATH_NEIGHBOURS: dict[str, tuple[str, ...]] = {
 }
 
 #: Shared tests/ modules with NO real consuming test today — an admitted,
-#: named gap, not a silent under-selection. A change to one of these
-#: selects only the ambient gates (_changed_path_neighbours returns early,
-#: before any prefix rule can contribute a lookalike neighbour); the
-#: tree-walking pin in tests/test_targeted_test_selection.py asserts the
-#: absence of a real neighbour explicitly rather than accepting it by
-#: omission. Do not add an entry here to silence the fail-closed check —
-#: only for a module genuinely reviewed and found to have no consumer.
+#: named gap, not a silent under-selection. A change to one of these selects
+#: only the ambient gates (_changed_path_neighbours returns early, before
+#: EXACT_PATH_NEIGHBOURS or any prefix rule can contribute a lookalike
+#: neighbour). _assert_no_double_registration below fails at import time if
+#: a path is ever registered here AND in EXACT_PATH_NEIGHBOURS — the two
+#: registries must stay disjoint, since an early return would otherwise
+#: silently discard a real, hand-authored mapping for the same file. Do not
+#: add an entry here to silence the fail-closed check in
+#: _changed_path_neighbours — only for a module genuinely reviewed and found
+#: to have no consumer.
 SHARED_MODULES_WITHOUT_COVERAGE: dict[str, str] = {
     "tests/ephemeral_slskd.py": (
         "No test drives EphemeralSlskd directly. Its only consumer is the "
@@ -263,6 +266,34 @@ SHARED_MODULES_WITHOUT_COVERAGE: dict[str, str] = {
         "(2026-08 review round, issue #1081)."
     ),
 }
+
+
+def _assert_no_double_registration(
+    exact_path_neighbours: Mapping[str, tuple[str, ...]],
+    shared_modules_without_coverage: Mapping[str, str],
+) -> None:
+    """A path cannot be both a real mapping and an admitted coverage gap.
+
+    _changed_path_neighbours returns early for any path in
+    SHARED_MODULES_WITHOUT_COVERAGE, before EXACT_PATH_NEIGHBOURS or any
+    prefix rule runs — so a path present in BOTH registries would silently
+    discard its real, hand-authored EXACT_PATH_NEIGHBOURS mapping (issue
+    #1081 review round: the tree-walking pin's assertion that a registered
+    path selects nothing was a tautology of the early-return condition and
+    could never have caught this on its own). Fail at import time instead of
+    merely detecting it later — the contradiction becomes impossible to ship.
+    """
+    contradictions = sorted(
+        set(exact_path_neighbours) & set(shared_modules_without_coverage)
+    )
+    if contradictions:
+        raise ValueError(
+            "path(s) registered in both EXACT_PATH_NEIGHBOURS and "
+            f"SHARED_MODULES_WITHOUT_COVERAGE: {', '.join(contradictions)}"
+        )
+
+
+_assert_no_double_registration(EXACT_PATH_NEIGHBOURS, SHARED_MODULES_WITHOUT_COVERAGE)
 
 
 def _module_path(module: str, repo_root: Path) -> Path:

--- a/scripts/targeted_test_selection.py
+++ b/scripts/targeted_test_selection.py
@@ -29,6 +29,12 @@ ROUTE_NEIGHBOURS = (
 # ROUTE_NEIGHBOURS' static audits (test_pydantic_route_audit,
 # test_js_payload_contract_audit): those scan web/routes/*.py, never import
 # _harness, and listing them here would look like coverage without being any.
+# Used as the value for both tests/web/_harness.py and tests/web/__init__.py
+# in EXACT_PATH_NEIGHBOURS below — _harness.py and __init__.py are the only
+# two non-test files under tests/web/, so a prefix rule buys nothing here
+# and would be one more rule that defeats the self-maintaining property (a
+# third non-test file added later should fail closed, not silently inherit
+# this list).
 WEB_TEST_HARNESS_NEIGHBOURS = (
     "tests.web.test_request_security",
     "tests.web.test_route_audit",
@@ -65,7 +71,7 @@ WORLD_MODEL_NEIGHBOURS = (
     "tests.test_parallel_test_runner",
     "tests.test_hypothesis_profile_audit",
     # tests.world_model.state_machine is the ONLY target that actually
-    # imports and drives support.py/state_machine.py/mirror_harness.py — the
+    # imports and drives support.py and (transitively) state_machine.py — the
     # five modules above only assert command strings, test-id strings, or
     # census_seeds in isolation (verified 2026-08 review round). It is
     # deliberately excluded from unittest's own test*.py discovery glob and
@@ -73,7 +79,9 @@ WORLD_MODEL_NEIGHBOURS = (
     # (measured) because it drives real dispatch_import_core/BeetsDB/
     # ban_source rules against a fresh ephemeral PostgreSQL + Beets. That
     # cost is the honest price of actually covering this file — a cheaper
-    # neighbour set would be fake coverage.
+    # neighbour set would be fake coverage. mirror_harness.py is NOT covered
+    # by this list — nothing in the repo imports it (see
+    # SHARED_MODULES_WITHOUT_COVERAGE).
     "tests.world_model.state_machine",
 )
 
@@ -104,10 +112,12 @@ EXACT_PATH_NEIGHBOURS: dict[str, tuple[str, ...]] = {
     ),
     # Shared tests/ infrastructure (issue #1081): none of these are
     # discoverable test modules themselves, so each needs an explicit
-    # mapping to the test(s) that actually exercise it. tests/fakes/,
-    # tests/web/, tests/structural_audits/, and tests/world_model/ are
-    # covered by prefix rules below instead of listed file-by-file here.
-    # Sorted by path (ASCII, so underscore-prefixed entries sort first).
+    # mapping to the test(s) that actually exercise it. tests/structural_audits/
+    # and tests/world_model/ are covered by prefix rules below instead of
+    # listed file-by-file here — tests/fakes/ and tests/web/ are NOT (a
+    # per-file entry here always wins over the tests/fakes/ prefix rule,
+    # which only adds tests.test_fakes on top). Sorted by path (ASCII, so
+    # underscore-prefixed entries sort first).
     "tests/__init__.py": (
         # Sets the ambient BEETSDIR default + writes the suite's minimal
         # config.yaml. tests.test_util's TestBeetsSubprocessEnv exhaustively
@@ -127,14 +137,18 @@ EXACT_PATH_NEIGHBOURS: dict[str, tuple[str, ...]] = {
     "tests/_hypothesis_profiles.py": (
         # test_hypothesis_profile_audit is a pure AST audit (ast, os,
         # unittest, dataclasses only) — it checks that OTHER modules import
-        # this one, never this module's own semantic content (max_examples,
-        # deadline, tier selection). test_parallel_test_runner actually
-        # imports the module and exercises assert_hypothesis_deadlines_disabled
-        # against it; test_import_result_legacy_generated is a real, cheap
-        # @given test that runs under whatever tier this module loads, so a
-        # collapsed max_examples or a re-enabled deadline changes its
-        # observable behavior.
-        "tests.test_hypothesis_profile_audit",
+        # this one and structurally excludes the profile module itself
+        # (PROFILE_MODULE_RELPATH), so it can never exercise this module's
+        # own content and does not belong in this mapping.
+        # test_parallel_test_runner actually imports the module and
+        # exercises assert_hypothesis_deadlines_disabled against it, so a
+        # re-enabled deadline changes its observable behavior.
+        # test_import_result_legacy_generated is a real, cheap @given test
+        # that runs under whatever tier this module loads — a collapsed
+        # max_examples changes how MANY times it runs but is not itself an
+        # observable failure (HypothesisStatsRecorder never fails a run on
+        # example count alone), so it does not by itself prove a max_examples
+        # regression; it is kept for the deadline coverage above.
         "tests.test_parallel_test_runner",
         "tests.test_import_result_legacy_generated",
     ),
@@ -170,6 +184,28 @@ EXACT_PATH_NEIGHBOURS: dict[str, tuple[str, ...]] = {
         "tests.test_parallel_test_runner",
         "tests.test_pipeline_db",
     ),
+    "tests/fakes/beets_contract.py": (
+        "tests.test_beets_config_startup",
+        "tests.test_beets_config_startup_generated",
+        "tests.test_beets_config_contract",
+        "tests.test_beets_config_contract_integration",
+    ),
+    "tests/fakes/daily_flake_update.py": (
+        "tests.test_daily_flake_update",
+        "tests.test_daily_beets_tip_update",
+    ),
+    "tests/fakes/deploy_cycle.py": (
+        "tests.test_deploy_cycle_verifier",
+        "tests.test_deploy_cycle_verifier_generated",
+    ),
+    "tests/fakes/deploy_hold.py": (
+        "tests.test_deploy_hold",
+        "tests.test_deploy_hold_generated",
+    ),
+    "tests/fakes/deploy_pin.py": (
+        "tests.test_deploy_pin_script",
+        "tests.test_deploy_pin_generated",
+    ),
     "tests/finite_domain.py": (
         "tests.test_finite_domain",
     ),
@@ -198,12 +234,14 @@ EXACT_PATH_NEIGHBOURS: dict[str, tuple[str, ...]] = {
     "tests/ruff_lsp_worker.py": (
         "tests.test_ruff_lsp_worker",
     ),
+    "tests/web/__init__.py": WEB_TEST_HARNESS_NEIGHBOURS,
+    "tests/web/_harness.py": WEB_TEST_HARNESS_NEIGHBOURS,
 }
 
 #: Shared tests/ modules with NO real consuming test today — an admitted,
 #: named gap, not a silent under-selection. A change to one of these
-#: selects only the ambient gates; _changed_path_neighbours deliberately
-#: does not fail closed on them (unlike a truly unmapped module), and the
+#: selects only the ambient gates (_changed_path_neighbours returns early,
+#: before any prefix rule can contribute a lookalike neighbour); the
 #: tree-walking pin in tests/test_targeted_test_selection.py asserts the
 #: absence of a real neighbour explicitly rather than accepting it by
 #: omission. Do not add an entry here to silence the fail-closed check —
@@ -214,6 +252,15 @@ SHARED_MODULES_WITHOUT_COVERAGE: dict[str, str] = {
         "dev benchmarking script scripts/bench_parallel_search.py, which "
         "has no dedicated test of its own either (2026-08 review round, "
         "issue #1081)."
+    ),
+    "tests/world_model/mirror_harness.py": (
+        "Nothing imports mirror_harness.py — the only references are the "
+        "module-name string in scripts/run_world_model_burst.py (loaded "
+        "dynamically only for --engine mirror-harness) and the daily-gate "
+        "phase label in tests/test_daily_flake_update.py. The daily mirror-"
+        "harness burst phase is its only real driver, and that is a "
+        "scheduled operational run, not a selectable unittest target "
+        "(2026-08 review round, issue #1081)."
     ),
 }
 
@@ -294,6 +341,14 @@ def _changed_path_neighbours(
     relative_path: str,
     repo_root: Path,
 ) -> tuple[str, ...]:
+    if relative_path in SHARED_MODULES_WITHOUT_COVERAGE:
+        # An admitted gap always selects nothing beyond ambient, regardless
+        # of what a prefix rule below would otherwise contribute — a
+        # registration must not be a lookalike neighbour set (issue #1081
+        # review round: mirror_harness.py was registered but the
+        # tests/world_model/ prefix rule below would still have populated
+        # WORLD_MODEL_NEIGHBOURS for it).
+        return ()
     path = PurePosixPath(relative_path)
     neighbours: list[str] = list(EXACT_PATH_NEIGHBOURS.get(relative_path, ()))
     module = _path_module(path)
@@ -308,8 +363,6 @@ def _changed_path_neighbours(
         neighbours.extend((*PIPELINE_DB_NEIGHBOURS, "tests.test_migrator"))
     if relative_path.startswith("tests/fakes/"):
         neighbours.append("tests.test_fakes")
-    if relative_path.startswith("tests/web/"):
-        neighbours.extend(WEB_TEST_HARNESS_NEIGHBOURS)
     if relative_path.startswith("tests/structural_audits/"):
         neighbours.extend(STRUCTURAL_AUDIT_NEIGHBOURS)
     if relative_path.startswith("tests/world_model/"):
@@ -334,27 +387,21 @@ def _changed_path_neighbours(
                 "tests.test_quality_generated",
             )
         )
-    if (
-        path.suffix == ".py"
-        and path.parts[:1] == ("tests",)
-        and not neighbours
-        and relative_path not in SHARED_MODULES_WITHOUT_COVERAGE
-    ):
+    if path.suffix == ".py" and path.parts[:1] == ("tests",) and not neighbours:
         # A non-test .py file under tests/ with no direct self-selector, no
-        # EXACT_PATH_NEIGHBOURS entry, no matching prefix rule, and no
-        # SHARED_MODULES_WITHOUT_COVERAGE registration is shared test
-        # infrastructure that is neither mapped to a consuming test nor
-        # admitted as uncovered. Silently dropping it under-selects — the
-        # more dangerous failure for a test selector, since the run reports
-        # green having exercised nothing relevant to the change (issue
-        # #1081). Fail closed and name the file so whoever touches it either
-        # adds the mapping or, if truly uncovered, registers it in
-        # SHARED_MODULES_WITHOUT_COVERAGE with a one-line rationale.
+        # EXACT_PATH_NEIGHBOURS entry, and no matching prefix rule is shared
+        # test infrastructure nobody has mapped to a consuming test. Silently
+        # dropping it under-selects — the more dangerous failure for a test
+        # selector, since the run reports green having exercised nothing
+        # relevant to the change (issue #1081). Fail closed and name the
+        # file so whoever touches it adds the mapping — or, if it genuinely
+        # has none, registers it in SHARED_MODULES_WITHOUT_COVERAGE (that
+        # registration is a reviewed admission, not something this error
+        # should advertise as the easy way out).
         raise ValueError(
             f"unmapped shared test module: {relative_path} — add an "
             "EXACT_PATH_NEIGHBOURS entry or a prefix rule for it in "
-            "scripts/targeted_test_selection.py, or register it in "
-            "SHARED_MODULES_WITHOUT_COVERAGE if it genuinely has none"
+            "scripts/targeted_test_selection.py"
         )
     return tuple(neighbours)
 

--- a/scripts/targeted_test_selection.py
+++ b/scripts/targeted_test_selection.py
@@ -23,9 +23,33 @@ ROUTE_NEIGHBOURS = (
     "tests.test_pydantic_route_audit",
     "tests.test_js_payload_contract_audit",
 )
+# Every tests/web/*.py module that actually imports tests/web/_harness.py
+# (verified by grep, 2026-08 review round). tests.web.test_routes_health is
+# the one real exception — it needs no fake DB. Do NOT pad this with
+# ROUTE_NEIGHBOURS' static audits (test_pydantic_route_audit,
+# test_js_payload_contract_audit): those scan web/routes/*.py, never import
+# _harness, and listing them here would look like coverage without being any.
 WEB_TEST_HARNESS_NEIGHBOURS = (
-    *ROUTE_NEIGHBOURS,
+    "tests.web.test_request_security",
+    "tests.web.test_route_audit",
+    "tests.web.test_routes_beets_distance",
+    "tests.web.test_routes_browse",
+    "tests.web.test_routes_imports",
+    "tests.web.test_routes_labels",
+    "tests.web.test_routes_library",
+    "tests.web.test_routes_long_tail",
+    "tests.web.test_routes_pipeline",
+    "tests.web.test_routes_pipeline_dashboard",
+    "tests.web.test_routes_pipeline_mutations",
+    "tests.web.test_routes_release_identity",
+    "tests.web.test_routes_search_plan",
+    "tests.web.test_routes_triage",
+    "tests.web.test_routes_world_audit",
+    "tests.web.test_routes_youtube",
+    "tests.web.test_server_cache",
     "tests.web.test_server_endpoints",
+    "tests.web.test_server_threading",
+    "tests.web.test_static_assets",
 )
 STRUCTURAL_AUDIT_NEIGHBOURS = (
     "tests.test_deploy_pin_script",
@@ -40,6 +64,17 @@ WORLD_MODEL_NEIGHBOURS = (
     "tests.test_world_model_coordinator",
     "tests.test_parallel_test_runner",
     "tests.test_hypothesis_profile_audit",
+    # tests.world_model.state_machine is the ONLY target that actually
+    # imports and drives support.py/state_machine.py/mirror_harness.py — the
+    # five modules above only assert command strings, test-id strings, or
+    # census_seeds in isolation (verified 2026-08 review round). It is
+    # deliberately excluded from unittest's own test*.py discovery glob and
+    # added back by complete_test_modules(); ~18s wall per selection
+    # (measured) because it drives real dispatch_import_core/BeetsDB/
+    # ban_source rules against a fresh ephemeral PostgreSQL + Beets. That
+    # cost is the honest price of actually covering this file — a cheaper
+    # neighbour set would be fake coverage.
+    "tests.world_model.state_machine",
 )
 
 EXACT_PATH_NEIGHBOURS: dict[str, tuple[str, ...]] = {
@@ -72,6 +107,52 @@ EXACT_PATH_NEIGHBOURS: dict[str, tuple[str, ...]] = {
     # mapping to the test(s) that actually exercise it. tests/fakes/,
     # tests/web/, tests/structural_audits/, and tests/world_model/ are
     # covered by prefix rules below instead of listed file-by-file here.
+    # Sorted by path (ASCII, so underscore-prefixed entries sort first).
+    "tests/__init__.py": (
+        # Sets the ambient BEETSDIR default + writes the suite's minimal
+        # config.yaml. tests.test_util's TestBeetsSubprocessEnv exhaustively
+        # patches BEETSDIR itself for every case, so it never exercises this
+        # file's ambient default. These are real callers of
+        # beets_subprocess_env() that rely on the inherited default without
+        # patching it first.
+        "tests.test_beets_validation",
+        "tests.test_dispatch_from_db",
+        "tests.test_beets_retag",
+        "tests.test_run_beets_harness_script",
+        "tests.test_beets_config_startup",
+    ),
+    "tests/_docs_reference_audit.py": (
+        "tests.test_docs_audit",
+    ),
+    "tests/_hypothesis_profiles.py": (
+        # test_hypothesis_profile_audit is a pure AST audit (ast, os,
+        # unittest, dataclasses only) — it checks that OTHER modules import
+        # this one, never this module's own semantic content (max_examples,
+        # deadline, tier selection). test_parallel_test_runner actually
+        # imports the module and exercises assert_hypothesis_deadlines_disabled
+        # against it; test_import_result_legacy_generated is a real, cheap
+        # @given test that runs under whatever tier this module loads, so a
+        # collapsed max_examples or a re-enabled deadline changes its
+        # observable behavior.
+        "tests.test_hypothesis_profile_audit",
+        "tests.test_parallel_test_runner",
+        "tests.test_import_result_legacy_generated",
+    ),
+    "tests/_lambda_audit.py": (
+        "tests.test_lambda_audit",
+    ),
+    "tests/_mock_audit_scanner.py": (
+        "tests.test_mock_audit",
+    ),
+    "tests/_tests_typing_ratchet_baseline.py": (
+        "tests.test_typing_ratchet",
+    ),
+    "tests/_typing_ratchet_baseline.py": (
+        "tests.test_typing_ratchet",
+    ),
+    "tests/_typing_ratchet_scanner.py": (
+        "tests.test_typing_ratchet",
+    ),
     "tests/audio_fixtures.py": (
         "tests.test_conversion_e2e",
         "tests.test_media_readiness",
@@ -88,16 +169,6 @@ EXACT_PATH_NEIGHBOURS: dict[str, tuple[str, ...]] = {
     "tests/conftest.py": (
         "tests.test_parallel_test_runner",
         "tests.test_pipeline_db",
-    ),
-    "tests/_docs_reference_audit.py": (
-        "tests.test_docs_audit",
-    ),
-    "tests/ephemeral_slskd.py": (
-        # No test drives EphemeralSlskd directly today — its only consumer
-        # is the dev benchmarking script scripts/bench_parallel_search.py,
-        # which has no dedicated test of its own either. Nearest existing
-        # benchmarking-tooling test, kept until real coverage exists.
-        "tests.test_bench_artist_cold",
     ),
     "tests/finite_domain.py": (
         "tests.test_finite_domain",
@@ -116,19 +187,6 @@ EXACT_PATH_NEIGHBOURS: dict[str, tuple[str, ...]] = {
         "tests.test_dispatch_core",
         "tests.test_integration_slices",
     ),
-    "tests/_hypothesis_profiles.py": (
-        "tests.test_hypothesis_profile_audit",
-    ),
-    "tests/__init__.py": (
-        "tests.test_util",
-        "tests.test_beets_config_startup",
-    ),
-    "tests/_lambda_audit.py": (
-        "tests.test_lambda_audit",
-    ),
-    "tests/_mock_audit_scanner.py": (
-        "tests.test_mock_audit",
-    ),
     "tests/node_jsonl_worker.py": (
         "tests.test_node_jsonl_worker",
         "tests.test_generated_node_worker_audit",
@@ -140,14 +198,22 @@ EXACT_PATH_NEIGHBOURS: dict[str, tuple[str, ...]] = {
     "tests/ruff_lsp_worker.py": (
         "tests.test_ruff_lsp_worker",
     ),
-    "tests/_tests_typing_ratchet_baseline.py": (
-        "tests.test_typing_ratchet",
-    ),
-    "tests/_typing_ratchet_baseline.py": (
-        "tests.test_typing_ratchet",
-    ),
-    "tests/_typing_ratchet_scanner.py": (
-        "tests.test_typing_ratchet",
+}
+
+#: Shared tests/ modules with NO real consuming test today — an admitted,
+#: named gap, not a silent under-selection. A change to one of these
+#: selects only the ambient gates; _changed_path_neighbours deliberately
+#: does not fail closed on them (unlike a truly unmapped module), and the
+#: tree-walking pin in tests/test_targeted_test_selection.py asserts the
+#: absence of a real neighbour explicitly rather than accepting it by
+#: omission. Do not add an entry here to silence the fail-closed check —
+#: only for a module genuinely reviewed and found to have no consumer.
+SHARED_MODULES_WITHOUT_COVERAGE: dict[str, str] = {
+    "tests/ephemeral_slskd.py": (
+        "No test drives EphemeralSlskd directly. Its only consumer is the "
+        "dev benchmarking script scripts/bench_parallel_search.py, which "
+        "has no dedicated test of its own either (2026-08 review round, "
+        "issue #1081)."
     ),
 }
 
@@ -268,18 +334,27 @@ def _changed_path_neighbours(
                 "tests.test_quality_generated",
             )
         )
-    if path.suffix == ".py" and path.parts[:1] == ("tests",) and not neighbours:
+    if (
+        path.suffix == ".py"
+        and path.parts[:1] == ("tests",)
+        and not neighbours
+        and relative_path not in SHARED_MODULES_WITHOUT_COVERAGE
+    ):
         # A non-test .py file under tests/ with no direct self-selector, no
-        # EXACT_PATH_NEIGHBOURS entry, and no matching prefix rule is shared
-        # test infrastructure nobody has mapped to a consuming test. Silently
-        # dropping it under-selects — the more dangerous failure for a test
-        # selector, since the run reports green having exercised nothing
-        # relevant to the change (issue #1081). Fail closed and name the
-        # file so whoever touches it adds the mapping.
+        # EXACT_PATH_NEIGHBOURS entry, no matching prefix rule, and no
+        # SHARED_MODULES_WITHOUT_COVERAGE registration is shared test
+        # infrastructure that is neither mapped to a consuming test nor
+        # admitted as uncovered. Silently dropping it under-selects — the
+        # more dangerous failure for a test selector, since the run reports
+        # green having exercised nothing relevant to the change (issue
+        # #1081). Fail closed and name the file so whoever touches it either
+        # adds the mapping or, if truly uncovered, registers it in
+        # SHARED_MODULES_WITHOUT_COVERAGE with a one-line rationale.
         raise ValueError(
             f"unmapped shared test module: {relative_path} — add an "
             "EXACT_PATH_NEIGHBOURS entry or a prefix rule for it in "
-            "scripts/targeted_test_selection.py"
+            "scripts/targeted_test_selection.py, or register it in "
+            "SHARED_MODULES_WITHOUT_COVERAGE if it genuinely has none"
         )
     return tuple(neighbours)
 

--- a/scripts/targeted_test_selection.py
+++ b/scripts/targeted_test_selection.py
@@ -23,6 +23,24 @@ ROUTE_NEIGHBOURS = (
     "tests.test_pydantic_route_audit",
     "tests.test_js_payload_contract_audit",
 )
+WEB_TEST_HARNESS_NEIGHBOURS = (
+    *ROUTE_NEIGHBOURS,
+    "tests.web.test_server_endpoints",
+)
+STRUCTURAL_AUDIT_NEIGHBOURS = (
+    "tests.test_deploy_pin_script",
+    "tests.test_ffmpeg_audio_map_audit",
+    "tests.test_js_ast_audits",
+    "tests.test_js_payload_contract_audit",
+    "tests.test_js_window_bindings",
+)
+WORLD_MODEL_NEIGHBOURS = (
+    "tests.test_world_census_seeds",
+    "tests.test_world_model_burst",
+    "tests.test_world_model_coordinator",
+    "tests.test_parallel_test_runner",
+    "tests.test_hypothesis_profile_audit",
+)
 
 EXACT_PATH_NEIGHBOURS: dict[str, tuple[str, ...]] = {
     "pyrightconfig.json": (
@@ -48,6 +66,88 @@ EXACT_PATH_NEIGHBOURS: dict[str, tuple[str, ...]] = {
     ),
     "scripts/test.sh": (
         "tests.test_targeted_test_selection",
+    ),
+    # Shared tests/ infrastructure (issue #1081): none of these are
+    # discoverable test modules themselves, so each needs an explicit
+    # mapping to the test(s) that actually exercise it. tests/fakes/,
+    # tests/web/, tests/structural_audits/, and tests/world_model/ are
+    # covered by prefix rules below instead of listed file-by-file here.
+    "tests/audio_fixtures.py": (
+        "tests.test_conversion_e2e",
+        "tests.test_media_readiness",
+    ),
+    "tests/beets_config_startup_support.py": (
+        "tests.test_beets_config_startup",
+        "tests.test_beets_config_startup_entrypoints",
+    ),
+    "tests/beets_world.py": (
+        "tests.test_beets_world_config",
+        "tests.test_destructive_authority",
+        "tests.test_harness_beets2_contract",
+    ),
+    "tests/conftest.py": (
+        "tests.test_parallel_test_runner",
+        "tests.test_pipeline_db",
+    ),
+    "tests/_docs_reference_audit.py": (
+        "tests.test_docs_audit",
+    ),
+    "tests/ephemeral_slskd.py": (
+        # No test drives EphemeralSlskd directly today — its only consumer
+        # is the dev benchmarking script scripts/bench_parallel_search.py,
+        # which has no dedicated test of its own either. Nearest existing
+        # benchmarking-tooling test, kept until real coverage exists.
+        "tests.test_bench_artist_cold",
+    ),
+    "tests/finite_domain.py": (
+        "tests.test_finite_domain",
+    ),
+    "tests/finite_domain_metadata.py": (
+        "tests.test_finite_domain",
+    ),
+    "tests/fixtures/build_cd_rip_proof_fixture.py": (
+        "tests.test_cd_rip_js_fixture",
+    ),
+    "tests/harness_test_support.py": (
+        "tests.test_harness_test_support",
+    ),
+    "tests/helpers.py": (
+        "tests.test_quality_decisions",
+        "tests.test_dispatch_core",
+        "tests.test_integration_slices",
+    ),
+    "tests/_hypothesis_profiles.py": (
+        "tests.test_hypothesis_profile_audit",
+    ),
+    "tests/__init__.py": (
+        "tests.test_util",
+        "tests.test_beets_config_startup",
+    ),
+    "tests/_lambda_audit.py": (
+        "tests.test_lambda_audit",
+    ),
+    "tests/_mock_audit_scanner.py": (
+        "tests.test_mock_audit",
+    ),
+    "tests/node_jsonl_worker.py": (
+        "tests.test_node_jsonl_worker",
+        "tests.test_generated_node_worker_audit",
+    ),
+    "tests/read_projection_registry.py": (
+        "tests.test_pipeline_db",
+        "tests.test_read_projection_audit",
+    ),
+    "tests/ruff_lsp_worker.py": (
+        "tests.test_ruff_lsp_worker",
+    ),
+    "tests/_tests_typing_ratchet_baseline.py": (
+        "tests.test_typing_ratchet",
+    ),
+    "tests/_typing_ratchet_baseline.py": (
+        "tests.test_typing_ratchet",
+    ),
+    "tests/_typing_ratchet_scanner.py": (
+        "tests.test_typing_ratchet",
     ),
 }
 
@@ -79,7 +179,18 @@ def _paired_module(module: str, repo_root: Path) -> str | None:
 
 
 def _path_module(path: PurePosixPath) -> str | None:
+    """Return the dotted module name, but only for a discoverable test module.
+
+    A shared test-infrastructure file (basename not ``test_*.py``) is not a
+    runnable unittest target — the parallel runner's ``discover_test_modules``
+    only ever finds ``test*.py`` files, so emitting a selector for anything
+    else produces an ``unknown test selector`` crash deep in the runner
+    (issue #1081). Shared infrastructure gets its selectors from
+    ``EXACT_PATH_NEIGHBOURS`` / prefix rules instead.
+    """
     if path.suffix != ".py" or not path.parts:
+        return None
+    if not path.stem.startswith("test"):
         return None
     parts = (*path.parts[:-1], path.stem)
     if any(not part.isidentifier() for part in parts):
@@ -131,6 +242,12 @@ def _changed_path_neighbours(
         neighbours.extend((*PIPELINE_DB_NEIGHBOURS, "tests.test_migrator"))
     if relative_path.startswith("tests/fakes/"):
         neighbours.append("tests.test_fakes")
+    if relative_path.startswith("tests/web/"):
+        neighbours.extend(WEB_TEST_HARNESS_NEIGHBOURS)
+    if relative_path.startswith("tests/structural_audits/"):
+        neighbours.extend(STRUCTURAL_AUDIT_NEIGHBOURS)
+    if relative_path.startswith("tests/world_model/"):
+        neighbours.extend(WORLD_MODEL_NEIGHBOURS)
     if relative_path.startswith("web/routes/"):
         neighbours.extend(ROUTE_NEIGHBOURS)
         route_test = f"tests.web.test_routes_{path.stem}"
@@ -150,6 +267,19 @@ def _changed_path_neighbours(
                 "tests.test_quality_classification",
                 "tests.test_quality_generated",
             )
+        )
+    if path.suffix == ".py" and path.parts[:1] == ("tests",) and not neighbours:
+        # A non-test .py file under tests/ with no direct self-selector, no
+        # EXACT_PATH_NEIGHBOURS entry, and no matching prefix rule is shared
+        # test infrastructure nobody has mapped to a consuming test. Silently
+        # dropping it under-selects — the more dangerous failure for a test
+        # selector, since the run reports green having exercised nothing
+        # relevant to the change (issue #1081). Fail closed and name the
+        # file so whoever touches it adds the mapping.
+        raise ValueError(
+            f"unmapped shared test module: {relative_path} — add an "
+            "EXACT_PATH_NEIGHBOURS entry or a prefix rule for it in "
+            "scripts/targeted_test_selection.py"
         )
     return tuple(neighbours)
 

--- a/tests/test_beets_destructive_configs_generated.py
+++ b/tests/test_beets_destructive_configs_generated.py
@@ -420,9 +420,14 @@ def exercise_real_beets_world(
         # test_real_pinned_beets_common_config_worlds, 2 direct calls in
         # test_invariant_rejects_stdout_prefix_and_false_completion, and 60
         # generated test_common_config_p*_t*_* methods (10 PROFILES x 3
-        # track counts x 2 sources) — and up to 96x120s in a fuzz burst
-        # (scripts/run_fuzz_tests.py discovers @given properties only, so
-        # only the @given test's max_examples=96 counts there).
+        # track counts x 2 sources). A fuzz burst costs proportionally more,
+        # not less: this module is in HOTSPOT_SHARD_POLICIES, so
+        # build_fuzz_targets schedules the @given property AND separate
+        # method-batch pin targets covering every deterministic test above —
+        # each batch is its own process, so exercise_real_beets_world()'s
+        # @cache does not dedupe repeated (profile, track_count, source)
+        # calls across them. No exact multiple is asserted here; see the
+        # commit message for why one keeps turning out wrong.
         child = sp.run(
             [sys.executable, str(REPO / "harness" / "delete_album.py")],
             input=msgspec.json.encode(request),

--- a/tests/test_beets_destructive_configs_generated.py
+++ b/tests/test_beets_destructive_configs_generated.py
@@ -409,8 +409,15 @@ def exercise_real_beets_world(
         child_env = {**os.environ, "BEETSDIR": str(child_config)}
         # This is a hang backstop, not an assertion — under the parallel
         # Hypothesis scheduler it once timed out at 30s (FlakyFailure) then
-        # passed on retry and in isolation (13.7s). 120s gives real headroom
-        # against scheduler contention without being a load-aware cap.
+        # passed on retry and in isolation (13.7s). 120s is not large
+        # headroom: measured worst case under 60-way oversubscription is
+        # ~45s, so 120s is only ~2.6x that, not a generous multiple. There is
+        # no per-target timeout in scripts/run_python_tests.py or
+        # scripts/fuzz_burst.sh, so a genuine hang regression here (not a
+        # scheduler-contention flake) now costs up to 18x120s in the suite
+        # (9 PROFILES x 2 sources) and roughly 96x120s in a fuzz burst before
+        # it is caught — this bound is a real ceiling on that cost, not free
+        # insurance.
         child = sp.run(
             [sys.executable, str(REPO / "harness" / "delete_album.py")],
             input=msgspec.json.encode(request),

--- a/tests/test_beets_destructive_configs_generated.py
+++ b/tests/test_beets_destructive_configs_generated.py
@@ -407,12 +407,16 @@ def exercise_real_beets_world(
             library_root=str(child_root),
         )
         child_env = {**os.environ, "BEETSDIR": str(child_config)}
+        # This is a hang backstop, not an assertion — under the parallel
+        # Hypothesis scheduler it once timed out at 30s (FlakyFailure) then
+        # passed on retry and in isolation (13.7s). 120s gives real headroom
+        # against scheduler contention without being a load-aware cap.
         child = sp.run(
             [sys.executable, str(REPO / "harness" / "delete_album.py")],
             input=msgspec.json.encode(request),
             capture_output=True,
             env=child_env,
-            timeout=30,
+            timeout=120,
             check=False,
         )
         outcome = msgspec.json.decode(child.stdout, type=BeetsDeleteOutcome)

--- a/tests/test_beets_destructive_configs_generated.py
+++ b/tests/test_beets_destructive_configs_generated.py
@@ -409,15 +409,20 @@ def exercise_real_beets_world(
         child_env = {**os.environ, "BEETSDIR": str(child_config)}
         # This is a hang backstop, not an assertion — under the parallel
         # Hypothesis scheduler it once timed out at 30s (FlakyFailure) then
-        # passed on retry and in isolation (13.7s). 120s is not large
-        # headroom: measured worst case under 60-way oversubscription is
-        # ~45s, so 120s is only ~2.6x that, not a generous multiple. There is
-        # no per-target timeout in scripts/run_python_tests.py or
-        # scripts/fuzz_burst.sh, so a genuine hang regression here (not a
-        # scheduler-contention flake) now costs up to 18x120s in the suite
-        # (9 PROFILES x 2 sources) and roughly 96x120s in a fuzz burst before
-        # it is caught — this bound is a real ceiling on that cost, not free
-        # insurance.
+        # passed on retry and in isolation (13.7s); 120s has no verified
+        # safety margin beyond that single observed run, so treat it as a
+        # bound on cost, not a generous cushion. There is no per-target
+        # timeout in scripts/run_python_tests.py or scripts/fuzz_burst.sh, so
+        # a genuine hang in this exact sp.run call (not scheduler contention)
+        # is caught only after up to 83x120s in the deterministic suite —
+        # every call site of exercise_real_beets_world(): 18 @given examples
+        # + 3 pinned @example cases in
+        # test_real_pinned_beets_common_config_worlds, 2 direct calls in
+        # test_invariant_rejects_stdout_prefix_and_false_completion, and 60
+        # generated test_common_config_p*_t*_* methods (10 PROFILES x 3
+        # track counts x 2 sources) — and up to 96x120s in a fuzz burst
+        # (scripts/run_fuzz_tests.py discovers @given properties only, so
+        # only the @given test's max_examples=96 counts there).
         child = sp.run(
             [sys.executable, str(REPO / "harness" / "delete_album.py")],
             input=msgspec.json.encode(request),

--- a/tests/test_targeted_test_selection.py
+++ b/tests/test_targeted_test_selection.py
@@ -2,20 +2,35 @@
 
 from __future__ import annotations
 
+import os
 import subprocess
 import unittest
 from pathlib import Path
 
-from scripts.run_python_tests import discover_test_modules, select_test_targets
+from scripts.run_python_tests import (
+    _parser as _run_python_tests_parser,
+)
+from scripts.run_python_tests import (
+    complete_test_modules,
+    discover_test_modules,
+    select_test_targets,
+)
 from scripts.run_targeted_tests import targeted_phases
 from scripts.targeted_test_selection import (
     ALWAYS_AMBIENT_TESTS,
+    EXACT_PATH_NEIGHBOURS,
+    SHARED_MODULES_WITHOUT_COVERAGE,
+    _changed_path_neighbours,
     ambient_test_modules,
     assert_selection_complete,
     expand_test_selection,
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+#: The runner's own --pattern default (scripts/run_python_tests.py), sourced
+#: rather than duplicated so this pin can never silently drift from what
+#: discover_test_modules actually uses in production.
+_DISCOVERY_PATTERN = _run_python_tests_parser().get_default("pattern")
 
 
 class TestTargetedTestSelection(unittest.TestCase):
@@ -129,27 +144,47 @@ class TestTargetedTestSelection(unittest.TestCase):
 
         Walks tests/ (not hard-listed) so a newly added shared module fails
         this test until scripts/targeted_test_selection.py maps it — the
-        self-maintaining contract issue #1081 requires. Scoped to tests/
-        itself (never REPO_ROOT) so a REPO_ROOT that is itself a
-        `.claude/worktrees/` checkout is never crawled: the filter below
-        checks the path RELATIVE to REPO_ROOT (never the absolute path,
-        which always contains `.claude/worktrees/...` from a worktree
-        session) — see #520/#543 for the prior REPO_ROOT-walk incidents.
+        self-maintaining contract issue #1081 requires. The walk is rooted
+        at REPO_ROOT/"tests" itself (never REPO_ROOT), so `.claude/worktrees/`
+        stale checkouts — siblings of tests/, not descendants — are
+        structurally unreachable; no runtime filter is needed to prove it
+        (see #520/#543 for the prior REPO_ROOT-walk incidents that DID walk
+        from REPO_ROOT and needed one).
+
+        Uses complete_test_modules(), the same set main() resolves against —
+        not discover_test_modules() alone — because
+        tests.world_model.state_machine is deliberately excluded from the
+        test*.py discovery glob and added back only by complete_test_modules().
+        A bare discover_test_modules() set would make this pin reject the one
+        honest neighbour that actually exercises tests/world_model/support.py.
         """
-        modules = discover_test_modules(REPO_ROOT / "tests", REPO_ROOT, "test*.py")
+        modules = complete_test_modules(
+            discover_test_modules(REPO_ROOT / "tests", REPO_ROOT, _DISCOVERY_PATTERN),
+            REPO_ROOT,
+        )
         tests_root = REPO_ROOT / "tests"
         shared_paths = sorted(
-            path
-            for path in tests_root.rglob("*.py")
-            if ".claude" not in path.relative_to(tests_root).parts
-            and "__pycache__" not in path.relative_to(tests_root).parts
-            and not path.name.startswith("test")
+            path for path in tests_root.rglob("*.py") if not path.name.startswith("test")
         )
         self.assertTrue(shared_paths, "expected shared tests/ modules to exist")
 
         for path in shared_paths:
             relative = path.relative_to(REPO_ROOT).as_posix()
             with self.subTest(path=relative):
+                if relative in SHARED_MODULES_WITHOUT_COVERAGE:
+                    # Admitted gap, not silent under-selection: registered by
+                    # name with a rationale (MUST FIX 7, #1081 review round).
+                    # Assert the absence explicitly rather than accepting it
+                    # by omission — a future real mapping added here without
+                    # also removing the registry entry would go unnoticed.
+                    self.assertEqual(
+                        _changed_path_neighbours(relative, REPO_ROOT),
+                        (),
+                        f"{relative} is registered as uncovered but now "
+                        "has a real neighbour — remove it from "
+                        "SHARED_MODULES_WITHOUT_COVERAGE",
+                    )
+                    continue
                 selection = expand_test_selection(
                     (),
                     changed_paths=(relative,),
@@ -162,6 +197,20 @@ class TestTargetedTestSelection(unittest.TestCase):
                 # that needs an expensive discovery-manifest subprocess per
                 # hotspot module, irrelevant here.
                 select_test_targets(modules, selection, hotspot_policies={})
+
+    def test_exact_path_neighbour_keys_still_exist_on_disk(self) -> None:
+        """Reverse direction of the tree-walking pin: no stale mapping keys.
+
+        A file deleted or renamed out from under an EXACT_PATH_NEIGHBOURS /
+        SHARED_MODULES_WITHOUT_COVERAGE entry leaves a dead key that nothing
+        else catches — the forward walk only ever visits real files.
+        """
+        for key in (*EXACT_PATH_NEIGHBOURS, *SHARED_MODULES_WITHOUT_COVERAGE):
+            with self.subTest(key=key):
+                self.assertTrue(
+                    (REPO_ROOT / key).is_file(),
+                    f"mapping key does not exist on disk: {key}",
+                )
 
     def test_unmapped_shared_test_module_fails_closed_with_the_file_name(
         self,
@@ -228,6 +277,25 @@ class TestTargetedSuiteWiring(unittest.TestCase):
         must not die on selector resolution — PR #1075's exact failure mode,
         where js/pyright/ruff/vulture all pass and the python phase exits 1
         before any test runs.
+
+        CRATEDIGGER_TEST_JOBS=1 pins the nested runner to one worker.
+        worker_environment() unconditionally pops TEST_DB_DSN so every
+        persistent worker bootstraps its own ephemeral PostgreSQL — at the
+        default worker count (half the host's CPUs, capped at 12) that is up
+        to 12 nested clusters spun up inside one already-parallel outer suite
+        target: the same class of scheduler-contention flake fixed by
+        widening the sp.run timeout in
+        tests/test_beets_destructive_configs_generated.py elsewhere in this
+        PR. Forcing one worker keeps this a real end-to-end subprocess run
+        of the actual entrypoint without adding a second flake of the same
+        kind.
+
+        A failure here may duplicate an unrelated ambient audit's own
+        failure reported elsewhere in the outer suite — expand_test_selection
+        always appends every ambient audit, so this real subprocess reruns
+        all of them too. That is the accepted cost of driving the real
+        entrypoint rather than a hand-picked subset; the tail-truncated
+        detail below keeps the duplicate report short.
         """
         selectors = expand_test_selection(
             (),
@@ -240,17 +308,15 @@ class TestTargetedSuiteWiring(unittest.TestCase):
         completed = subprocess.run(
             python_phase.command,
             cwd=REPO_ROOT,
+            env={**os.environ, "CRATEDIGGER_TEST_JOBS": "1"},
             capture_output=True,
             text=True,
             timeout=180,
             check=False,
         )
 
-        self.assertEqual(
-            completed.returncode,
-            0,
-            completed.stdout + completed.stderr,
-        )
+        detail = (completed.stdout + completed.stderr)[-4000:]
+        self.assertEqual(completed.returncode, 0, detail)
 
 
 if __name__ == "__main__":

--- a/tests/test_targeted_test_selection.py
+++ b/tests/test_targeted_test_selection.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import subprocess
 import unittest
 from pathlib import Path
 
+from scripts.run_python_tests import discover_test_modules, select_test_targets
 from scripts.run_targeted_tests import targeted_phases
 from scripts.targeted_test_selection import (
     ALWAYS_AMBIENT_TESTS,
@@ -103,6 +105,84 @@ class TestTargetedTestSelection(unittest.TestCase):
                 repo_root=REPO_ROOT,
             )
 
+    def test_changed_shared_infra_module_does_not_self_select_as_a_bad_target(
+        self,
+    ) -> None:
+        """Regression pin for issue #1081 / PR #1075's exact failure.
+
+        ``tests/fakes/pipeline_db.py`` is not a discoverable test module — it
+        must never yield itself (``tests.fakes.pipeline_db``) as a selector.
+        The existing ``tests/fakes/`` prefix rule still rescues the change
+        with the real consumer, ``tests.test_fakes``.
+        """
+        selected = expand_test_selection(
+            (),
+            changed_paths=("tests/fakes/pipeline_db.py",),
+            repo_root=REPO_ROOT,
+        )
+
+        self.assertNotIn("tests.fakes.pipeline_db", selected)
+        self.assertIn("tests.test_fakes", selected)
+
+    def test_every_shared_tests_module_yields_an_accepted_selector(self) -> None:
+        """Tree-walking pin: every non-test module under tests/ must map.
+
+        Walks tests/ (not hard-listed) so a newly added shared module fails
+        this test until scripts/targeted_test_selection.py maps it — the
+        self-maintaining contract issue #1081 requires. Scoped to tests/
+        itself (never REPO_ROOT) so a REPO_ROOT that is itself a
+        `.claude/worktrees/` checkout is never crawled: the filter below
+        checks the path RELATIVE to REPO_ROOT (never the absolute path,
+        which always contains `.claude/worktrees/...` from a worktree
+        session) — see #520/#543 for the prior REPO_ROOT-walk incidents.
+        """
+        modules = discover_test_modules(REPO_ROOT / "tests", REPO_ROOT, "test*.py")
+        tests_root = REPO_ROOT / "tests"
+        shared_paths = sorted(
+            path
+            for path in tests_root.rglob("*.py")
+            if ".claude" not in path.relative_to(tests_root).parts
+            and "__pycache__" not in path.relative_to(tests_root).parts
+            and not path.name.startswith("test")
+        )
+        self.assertTrue(shared_paths, "expected shared tests/ modules to exist")
+
+        for path in shared_paths:
+            relative = path.relative_to(REPO_ROOT).as_posix()
+            with self.subTest(path=relative):
+                selection = expand_test_selection(
+                    (),
+                    changed_paths=(relative,),
+                    repo_root=REPO_ROOT,
+                )
+                # hotspot_policies={}: this pin only proves every selector
+                # resolves to a real discovered module (issue #1081's actual
+                # concern) — hotspot method/class sharding is a separate,
+                # already-covered concern (tests.test_parallel_test_runner)
+                # that needs an expensive discovery-manifest subprocess per
+                # hotspot module, irrelevant here.
+                select_test_targets(modules, selection, hotspot_policies={})
+
+    def test_unmapped_shared_test_module_fails_closed_with_the_file_name(
+        self,
+    ) -> None:
+        """Known-bad self-test: an unmapped shared module must fail loudly.
+
+        Silent dropping under-selects; a raw ``ValueError`` from deep inside
+        ``select_test_targets`` would not name the offending file. The
+        domain-level check in ``_changed_path_neighbours`` must raise before
+        that, naming the exact path.
+        """
+        with self.assertRaisesRegex(
+            ValueError,
+            r"tests/_totally_unmapped_shared_helper\.py",
+        ):
+            expand_test_selection(
+                (),
+                changed_paths=("tests/_totally_unmapped_shared_helper.py",),
+                repo_root=REPO_ROOT,
+            )
+
     def test_selection_checker_names_missing_and_duplicate_targets(self) -> None:
         with self.assertRaisesRegex(AssertionError, "missing.*tests.test_beta"):
             assert_selection_complete(
@@ -142,6 +222,35 @@ class TestTargetedSuiteWiring(unittest.TestCase):
         self.assertIn("scripts/run_targeted_tests.py", source)
         self.assertIn('"$@"', source)
         self.assertNotIn("python3 -m unittest discover", source)
+
+    def test_python_phase_completes_for_a_diff_touching_shared_fakes(self) -> None:
+        """End-to-end pin for issue #1081: a real diff touching tests/fakes/*.py
+        must not die on selector resolution — PR #1075's exact failure mode,
+        where js/pyright/ruff/vulture all pass and the python phase exits 1
+        before any test runs.
+        """
+        selectors = expand_test_selection(
+            (),
+            changed_paths=("tests/fakes/pipeline_db.py",),
+            repo_root=REPO_ROOT,
+        )
+        python_phase = targeted_phases(selectors)[-1]
+        self.assertEqual(python_phase.name, "python")
+
+        completed = subprocess.run(
+            python_phase.command,
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            timeout=180,
+            check=False,
+        )
+
+        self.assertEqual(
+            completed.returncode,
+            0,
+            completed.stdout + completed.stderr,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_targeted_test_selection.py
+++ b/tests/test_targeted_test_selection.py
@@ -20,6 +20,7 @@ from scripts.targeted_test_selection import (
     ALWAYS_AMBIENT_TESTS,
     EXACT_PATH_NEIGHBOURS,
     SHARED_MODULES_WITHOUT_COVERAGE,
+    _assert_no_double_registration,
     _changed_path_neighbours,
     ambient_test_modules,
     assert_selection_complete,
@@ -172,17 +173,20 @@ class TestTargetedTestSelection(unittest.TestCase):
             relative = path.relative_to(REPO_ROOT).as_posix()
             with self.subTest(path=relative):
                 if relative in SHARED_MODULES_WITHOUT_COVERAGE:
-                    # Admitted gap, not silent under-selection: registered by
-                    # name with a rationale (MUST FIX 7, #1081 review round).
-                    # Assert the absence explicitly rather than accepting it
-                    # by omission — a future real mapping added here without
-                    # also removing the registry entry would go unnoticed.
+                    # Pins _changed_path_neighbours's early-return behavior
+                    # for a registered gap: it selects nothing beyond
+                    # ambient. This condition is identical to the
+                    # early-return's own guard, so on its own it cannot
+                    # prove the registry entry lacks a contradicting
+                    # EXACT_PATH_NEIGHBOURS mapping for the same path — a
+                    # prior version of this branch claimed it did (#1081
+                    # review round 3), which was a tautology. That
+                    # contradiction is instead made impossible at import
+                    # time by _assert_no_double_registration, self-tested in
+                    # test_double_registered_path_fails_at_import_time below.
                     self.assertEqual(
                         _changed_path_neighbours(relative, REPO_ROOT),
                         (),
-                        f"{relative} is registered as uncovered but now "
-                        "has a real neighbour — remove it from "
-                        "SHARED_MODULES_WITHOUT_COVERAGE",
                     )
                     continue
                 selection = expand_test_selection(
@@ -231,6 +235,41 @@ class TestTargetedTestSelection(unittest.TestCase):
                     rationale.strip(),
                     f"{path} is registered with an empty rationale",
                 )
+
+    def test_the_two_registries_are_disjoint(self) -> None:
+        """No path claims both a real mapping and an admitted coverage gap.
+
+        Defensive restatement of the guard that already ran at module import
+        (_assert_no_double_registration, called with the real registries at
+        the bottom of scripts/targeted_test_selection.py) — if this were
+        ever violated, the module would already have failed to import before
+        this test file could even load. Named here so the failure mode has a
+        home in the test suite, not only a traceback at collection time.
+        """
+        self.assertEqual(
+            set(EXACT_PATH_NEIGHBOURS) & set(SHARED_MODULES_WITHOUT_COVERAGE),
+            set(),
+        )
+
+    def test_double_registered_path_fails_at_import_time(self) -> None:
+        """Known-bad self-test for _assert_no_double_registration.
+
+        A path present in both registries would silently discard its real
+        EXACT_PATH_NEIGHBOURS mapping — _changed_path_neighbours returns
+        early for any SHARED_MODULES_WITHOUT_COVERAGE path before
+        EXACT_PATH_NEIGHBOURS is even consulted (#1081 review round 3). This
+        proves the checker actually trips on a planted contradiction, using
+        synthetic registries so the test does not depend on (or risk
+        corrupting) the real module-level dicts.
+        """
+        with self.assertRaisesRegex(
+            ValueError,
+            r"tests/_double_registered\.py",
+        ):
+            _assert_no_double_registration(
+                {"tests/_double_registered.py": ("tests.test_something",)},
+                {"tests/_double_registered.py": "claimed as both mapped and a gap"},
+            )
 
     def test_exact_path_neighbour_keys_still_exist_on_disk(self) -> None:
         """Reverse direction of the tree-walking pin: no stale mapping keys.

--- a/tests/test_targeted_test_selection.py
+++ b/tests/test_targeted_test_selection.py
@@ -198,6 +198,40 @@ class TestTargetedTestSelection(unittest.TestCase):
                 # hotspot module, irrelevant here.
                 select_test_targets(modules, selection, hotspot_policies={})
 
+    def test_shared_fakes_map_to_their_real_consumers_not_only_test_fakes(
+        self,
+    ) -> None:
+        """Regression pin for issue #1081 review round 2, MUST FIX 2.
+
+        The tests/fakes/ prefix rule alone maps every fake to
+        tests.test_fakes, but five fakes are neither imported by
+        tests/test_fakes.py nor re-exported by tests/fakes/__init__.py —
+        tests.test_fakes never loads them. tests/fakes/deploy_hold.py is the
+        live instance: another agent was editing it while this regression
+        shipped, and the prefix rule alone would have selected a test that
+        never loads it.
+        """
+        selected = expand_test_selection(
+            (),
+            changed_paths=("tests/fakes/deploy_hold.py",),
+            repo_root=REPO_ROOT,
+        )
+
+        self.assertIn("tests.test_fakes", selected)
+        self.assertIn("tests.test_deploy_hold", selected)
+        self.assertIn("tests.test_deploy_hold_generated", selected)
+
+    def test_registered_coverage_gaps_carry_a_non_empty_rationale(self) -> None:
+        """MUST FIX 6 part 2 (#1081 review round 2): a registration without a
+        reason is indistinguishable from a lazy bypass.
+        """
+        for path, rationale in SHARED_MODULES_WITHOUT_COVERAGE.items():
+            with self.subTest(path=path):
+                self.assertTrue(
+                    rationale.strip(),
+                    f"{path} is registered with an empty rationale",
+                )
+
     def test_exact_path_neighbour_keys_still_exist_on_disk(self) -> None:
         """Reverse direction of the tree-walking pin: no stale mapping keys.
 
@@ -278,7 +312,7 @@ class TestTargetedSuiteWiring(unittest.TestCase):
         where js/pyright/ruff/vulture all pass and the python phase exits 1
         before any test runs.
 
-        CRATEDIGGER_TEST_JOBS=1 pins the nested runner to one worker.
+        CRATEDIGGER_TEST_JOBS=4 caps the nested runner's worker count.
         worker_environment() unconditionally pops TEST_DB_DSN so every
         persistent worker bootstraps its own ephemeral PostgreSQL — at the
         default worker count (half the host's CPUs, capped at 12) that is up
@@ -286,9 +320,14 @@ class TestTargetedSuiteWiring(unittest.TestCase):
         target: the same class of scheduler-contention flake fixed by
         widening the sp.run timeout in
         tests/test_beets_destructive_configs_generated.py elsewhere in this
-        PR. Forcing one worker keeps this a real end-to-end subprocess run
-        of the actual entrypoint without adding a second flake of the same
-        kind.
+        PR. An earlier version of this pin pinned CRATEDIGGER_TEST_JOBS=1,
+        which traded that speculative flake for a measured one: on this host,
+        JOBS=1 measured 123.5s under 2x CPU oversubscription against a 180s
+        bound (~1.45x headroom), while JOBS=4 measured 46.1s (comparable to
+        the unbounded-worker 39.4s). JOBS=4 plus a 300s bound keeps this a
+        real end-to-end subprocess run of the actual entrypoint with real
+        margin in both directions, without the full nested-cluster count of
+        an unbounded run.
 
         A failure here may duplicate an unrelated ambient audit's own
         failure reported elsewhere in the outer suite — expand_test_selection
@@ -308,10 +347,10 @@ class TestTargetedSuiteWiring(unittest.TestCase):
         completed = subprocess.run(
             python_phase.command,
             cwd=REPO_ROOT,
-            env={**os.environ, "CRATEDIGGER_TEST_JOBS": "1"},
+            env={**os.environ, "CRATEDIGGER_TEST_JOBS": "4"},
             capture_output=True,
             text=True,
-            timeout=180,
+            timeout=300,
             check=False,
         )
 


### PR DESCRIPTION
## The defect

`_changed_path_neighbours` mapped a changed `tests/**.py` path to itself as a unittest selector. `select_test_targets` resolves selectors only against discovered `test_*.py` modules, so it raised on anything else — and it raises on the **first** unresolvable name, so a valid neighbour alongside it did not rescue the run.

Measured blast radius: **43 of 43** non-test modules under `tests/` produced an unrunnable selector — every fake, `helpers.py`, `conftest.py`, `web/_harness.py`, the Hypothesis profiles, the Node worker, `world_model/*`, `structural_audits/*`, both typing-ratchet baselines. `tests/helpers.py` yielded nothing runnable at all.

So `bash scripts/test.sh` — the entrypoint `CLAUDE.md` names for normal development validation — failed closed on exactly the changes most likely to need it. Observed on PR #1075: JS, Pyright, Ruff and Vulture all passed and the `python` phase exited 1 on the *selector*.

## The fix

1. `_path_module` emits a selector only for a discoverable test module.
2. Shared infrastructure maps to the tests that genuinely exercise it, via `EXACT_PATH_NEIGHBOURS` and a reduced set of prefix rules.
3. An unmapped non-test module under `tests/` **fails closed naming the file** (exit 2). Silent dropping under-selects, and a green run that exercised nothing relevant is the worse failure.
4. `SHARED_MODULES_WITHOUT_COVERAGE` registers modules with no real consumer as an admitted, named gap — with rationales asserted non-empty, and `_assert_no_double_registration` failing at **import time** if a path is ever in both registries, since the early return would otherwise silently discard a real mapping.

Second commit, separate concern: widens the `harness/delete_album.py` child timeout in `tests/test_beets_destructive_configs_generated.py` from 30s to 120s. It is a hang backstop, not an assertion. Relates to #1086 item 4, non-closing.

## What review changed

Three independent review rounds, each of which found real defects the previous round's fix introduced:

- **Round 1** — `tests/world_model/` mapped `support.py` (2,137 lines) and `state_machine.py` (1,480) to five tests, **none** of which import or execute them, while `support.py` drives `dispatch_import_core`, `dispatch_import_from_db`, `ban_source`, `BeetsDB` and `beets_delete` against real PostgreSQL and real Beets. The tree-walking pin resolved against a module set that made the honest mapping impossible, so it was quietly enforcing the dishonest one. Also: `_hypothesis_profiles.py` mapped to an AST-only audit; `tests/web/_harness.py` mapped to four tests of which two never import it, leaving 18 real consumers unselected.
- **Round 2** — the fix for the above covered two of three modules and added a comment claiming all three were covered; `mirror_harness.py` still has zero consumers. `tests/fakes/` turned out to have the same defect (five fakes absent from the package `__init__`, mapped to a test that never loads them). And `CRATEDIGGER_TEST_JOBS=1` had removed a nested worker pool at the cost of pushing the pin from 39s to 123s under load against a hard 180s timeout — a measured flake traded for a speculative one, in the same PR that widens a timeout for contention.
- **Round 3** — the registry short-circuit made the pin's registered-path assertion a tautology of the production early-return's own condition, reopening the hole from the other side. And the fuzz-burst cost claim was wrong for the third time.

The numeric fuzz claim is now **deleted** rather than corrected a fourth time; the comment states the hazard qualitatively. `scripts/run_fuzz_tests.py` schedules all discovered test ids, not just `@given` properties, and this module's method-batch pin targets run as separate processes so `@cache` gives no dedupe across them.

## Tests

Deterministic only — test infrastructure must not be fed to the generated scheduler, per `.claude/rules/code-quality.md`.

- Tree-walking pin over every non-test module under `tests/`, resolved against `complete_test_modules(...)` — the same set `main()` uses — so a newly added shared module fails until mapped.
- End-to-end pin driving the real `scripts/run_python_tests.py` subprocess for a `tests/fakes/*.py` diff.
- Known-bad self-tests for the fail-closed path and for a double registration.
- Reverse pin that every `EXACT_PATH_NEIGHBOURS` key still exists on disk.

## Known gaps, recorded not fixed

- Non-`.py` files under `tests/` (`tests/fixtures/**`) still select nothing silently. Same class, but outside this issue's `.py`-scoped contract.
- Every mapping claim here is verified by human review, not by an executable check. Three rounds found five false claims, which is the evidence base for **#1095** — whether and how far that verification should be automated. A bounded AST audit was proposed during review and deliberately **not** built here rather than bolting new static-analysis machinery onto a selector bugfix.
- `tests/fakes/beets_contract.py` maps 4 of ~10 module-level consumers. Every named test is honest, and this is strictly better than the prefix rule it replaced, so it is mapping *completeness* rather than *honesty* → #1095.
- Changing a `tests/web/test_*.py` file no longer pulls its 20 siblings — a deliberate side effect of replacing the `tests/web/` prefix rule with exact entries.

Closes #1081

🤖 Generated with [Claude Code](https://claude.com/claude-code)
