### PR TITLE
test(#1094): per-clause proof for the quality-decision core

### DIFF
--- a/docs/generated-testing.md
+++ b/docs/generated-testing.md
@@ -836,6 +836,37 @@ defect and caught it in review: a widened `pg_partial` arm ran 9 times in
 production fail-open mutant alive through the full suite and the final gate
 until an `@example` pinned it.
 
+**Editing a property body reshuffles its worlds — re-measure afterwards.**
+`derandomize=True` seeds from the test function's own digest, so *any* edit
+to a property's body changes the entire example sequence it draws. This is
+not limited to widening a strategy: adding an assertion, renaming a local,
+or reordering two statements can silently drop a decisive world out of the
+gating tier. Measured during the #1094 second pass: a `tier4_only` world ran
+**4 / 150** before the audit touched that property and **0 / 150** after,
+removing a real ladder branch from every gating run — the round-one defect
+arriving through a door nobody was watching. So after editing a property,
+count how often each decisive arm actually executes under the default
+profile, and pin any arm that reaches zero. Instrument by wrapping the
+checker at the module attribute in a throwaway script; do not commit it.
+
+**Clause ordering masks across checkers, not just within one.** A property
+that calls checker A then checker B hides every clause of B that A also
+rejects. In the same pass, `check_reserved_ceiling_tiers_unused` could never
+fire: `check_tier_follows_fired_legs` ran first and re-derived the ladder,
+so both reserved-tier mutants died on the *earlier checker's* message. The
+fix is to order independent checker calls so each clause is attributed to
+the checker that legislates it — which is a different operation from
+reordering clauses inside one checker, and unlike that one it is legitimate.
+
+**Count clauses by hand, not by one grep.** `grep -c "raise AssertionError"`
+is a starting point, not an inventory: clauses are also written as bare
+`assert cond, "message"`, and accumulating checkers append to a list instead
+of raising. The #1094 second pass found a module whose real clause count was
+34 against a grepped 26 — nine `assert x, msg` clauses and one `raise` that
+belonged to an in-world stub rather than a checker. Derive the inventory from
+the checker functions themselves and say so when your count disagrees with
+the brief.
+
 **A survivor is not a licence to delete.** The default remedy is to widen
 the strategy until the world is producible. A guard over a shared namespace
 legislates for every *other* writer of that namespace, present and future

--- a/tests/test_dispatch_outcomes_generated.py
+++ b/tests/test_dispatch_outcomes_generated.py
@@ -54,6 +54,7 @@ Full usage guide: docs/generated-testing.md.
 import configparser
 import json
 import os
+import re
 import shutil
 import sys
 import tempfile
@@ -688,8 +689,15 @@ def _run_have_analysis_abort(
     search_override: str | None,
     username: str | None,
     cooldown_verdict: bool,
+    attach_import_job: bool = True,
 ) -> FakePipelineDB:
-    """Drive the real current-evidence gate through its terminal DB bundle."""
+    """Drive the real current-evidence gate through its terminal DB bundle.
+
+    ``attach_import_job=False`` is the queue-less production shape (no
+    ``candidate_import_job_id``), which makes ``_record_have_analysis_error``
+    write directly and return a row id instead of a terminal bundle. It is the
+    Q1 world for this harness's own bundle guard below.
+    """
 
     from lib.dispatch import dispatch_import_core
     from lib.import_evidence import (
@@ -830,7 +838,7 @@ def _run_have_analysis_abort(
                     processing_dir=processing_dir,
                 ),
                 requeue_on_failure=mode == "auto",
-                candidate_import_job_id=job.id,
+                candidate_import_job_id=job.id if attach_import_job else None,
                 prevalidated_candidate_result=candidate_result,
                 quality_gate_fn=noop_quality_gate,
                 current_evidence_loader=(
@@ -1682,7 +1690,14 @@ class TestGeneratedArchivalQuarantineIsolation(unittest.TestCase):
 # ===========================================================================
 
 class TestInvariantCheckersTripOnViolations(unittest.TestCase):
-    """Known-bad self-tests: prove the harness detects what it claims to."""
+    """Known-bad self-tests: prove the harness detects what it claims to.
+
+    Per-clause proof (#1094): every ``raise AssertionError`` above owns a
+    world here that makes THAT clause's condition true while every earlier
+    clause in the same function passes, and asserts that clause's own
+    message. A bare ``assertRaises`` would let a short-circuiting checker
+    claim a clause it never evaluated.
+    """
 
     def _ambiguous_world(self) -> DispatchWorld:
         return DispatchWorld(
@@ -1702,6 +1717,108 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
         runtime.start()
         self.addCleanup(runtime.stop)
         return beets
+
+    def _planted_terminal_world(
+        self,
+        *,
+        automation: bool = True,
+        job_status: str = "failed",
+        request_status: str = "wanted",
+        owner_attached: bool = False,
+        active_download_state: dict[str, object] | None = None,
+        job_message: str | None = "generated terminal message",
+        job_error: str | None = "generated terminal error",
+    ) -> FakePipelineDB:
+        """One finalized world, planted directly, violating one clause.
+
+        Real dispatch cannot build most of these — the terminal command
+        refuses them (see the module docstring's per-clause notes) — which
+        is exactly why the Q1 worlds are planted rather than dispatched.
+        """
+        from lib.import_queue import IMPORT_JOB_FORCE
+
+        state = {
+            "files": [],
+            "filetype": "mp3",
+            "enqueued_at": "2026-07-29T00:00:00+00:00",
+            "current_path": "/processing/albums/request-42",
+        }
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42, status="wanted", mb_release_id="mbid-generated"))
+        if automation:
+            job = handoff_automation_owner(
+                db,
+                42,
+                state=state,
+                canonical_path="/processing/albums/request-42",
+            )
+        else:
+            job = db.enqueue_import_job(
+                IMPORT_JOB_FORCE,
+                request_id=42,
+                payload={
+                    "download_log_id": 1,
+                    "failed_path": "/processing/albums/wrong_matches/album",
+                },
+            )
+        assert job.id == _GENERATED_JOB_ID
+        row = next(r for r in db._import_jobs if r["id"] == job.id)
+        row["status"] = job_status
+        row["message"] = job_message
+        row["error"] = job_error
+        request = db.request(42)
+        request["status"] = request_status
+        request["active_automation_import_job_id"] = (
+            job.id if owner_attached else None
+        )
+        request["active_download_state"] = active_download_state
+        return db
+
+    def _routing_db(
+        self,
+        *,
+        status: str,
+        log_outcome: str,
+        **row_overrides: object,
+    ) -> FakePipelineDB:
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42, status=status, **row_overrides))
+        db.log_download(request_id=42, outcome=log_outcome)
+        return db
+
+    def _routing_world(
+        self, decision: str, *, requeue_on_failure: bool = True,
+    ) -> DispatchWorld:
+        return DispatchWorld(
+            mode="decision", decision=decision, new_min_bitrate=245,
+            prev_min_bitrate=None, spectral_grade="genuine",
+            spectral_bitrate=None, was_converted=False,
+            requeue_on_failure=requeue_on_failure, source_username="user1")
+
+    def test_rejection_writer_harness_refuses_an_unknown_writer(self):
+        """Adding a writer name without a branch fails loudly, not silently."""
+        with self.assertRaisesRegex(
+            AssertionError, r"^unknown rejection writer 'phantom_writer'$",
+        ):
+            _run_rejection_writer(
+                writer="phantom_writer", distance=None, scenario=None)
+
+    def test_have_analysis_harness_requires_a_terminal_bundle(self):
+        """The queue-less shape produces no bundle; the harness says so."""
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"^HAVE-analysis abort did not build a terminal outcome$",
+        ):
+            _run_have_analysis_abort(
+                mode="force",
+                raw_error=_HAVE_ANALYSIS_FAILURES[0],
+                search_override=None,
+                username="user1",
+                cooldown_verdict=False,
+                attach_import_job=False,
+            )
 
     def test_never_parked_checker_trips_on_parked_recovery_required_job(self):
         """The removed policy IS the planted bug now.
@@ -1729,7 +1846,7 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
                 self._ambiguous_world(), db, outcome["result"])
 
     def test_never_parked_checker_trips_on_retained_processing_owner(self):
-        """An owner pointer left attached is a request nothing selects again."""
+        """An unterminalized dispatch leaves the real handoff world behind."""
         db = FakePipelineDB()
         db.seed_request(make_request_row(
             id=42, status="wanted", mb_release_id="mbid-generated"))
@@ -1746,10 +1863,160 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
         )
         # Planted mutant: dispatch returned without terminalizing, so the real
         # handoff writer's ``processing`` + owner pointer are still in place.
+        # The QUEUE clause is the one that fires here — ``queued`` is an
+        # active status — so this world proves that clause, not the owner or
+        # ``processing`` clauses below.
         self.assertEqual(job.id, _GENERATED_JOB_ID)
         self.assertEqual(db.request(42)["status"], "processing")
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"automation_import job 1 rested in non-terminal status 'queued'",
+        ):
             assert_request_never_parked(db)
+
+    def test_never_parked_checker_names_every_clause_it_trips_on(self):
+        """Per-clause Q1: one planted world per raise site, own message.
+
+        Three of these are fail-closed legislation rather than worlds a
+        production mutant can still reach (#1094 Q2): nothing deletes an
+        ``import_jobs`` row, the automation terminal command refuses any
+        request edge outside ``wanted``/``imported``, and ``downloading ->
+        unsearchable`` is not in ``transitions.VALID_TRANSITIONS`` (a
+        planted force-reject transition to ``unsearchable`` raises
+        ``RequestTransitionConflict`` instead of landing). They stay so a
+        future writer that bypasses those boundaries fails loudly.
+        """
+        state = {
+            "files": [],
+            "filetype": "mp3",
+            "enqueued_at": "2026-07-29T00:00:00+00:00",
+            "current_path": "/processing/albums/request-42",
+        }
+        no_job = FakePipelineDB()
+        no_job.seed_request(make_request_row(id=42, status="wanted"))
+        cases = [
+            (
+                "no import job row",
+                no_job,
+                r"^dispatch finalized with no import job row to read$",
+            ),
+            (
+                "owner pointer still attached",
+                self._planted_terminal_world(owner_attached=True),
+                (
+                    r"terminal dispatch left active_automation_import_job_id=1 "
+                    r"attached"
+                ),
+            ),
+            (
+                "request left processing behind an inactive job",
+                self._planted_terminal_world(request_status="processing"),
+                (
+                    r"terminal dispatch left the request in 'processing' behind "
+                    r"an inactive job"
+                ),
+            ),
+            (
+                "automation landed off the runnable set",
+                self._planted_terminal_world(request_status="unsearchable"),
+                r"automation terminal left status='unsearchable', want one of "
+                + re.escape("['imported', 'wanted']"),
+            ),
+            (
+                "automation kept its owned download state",
+                self._planted_terminal_world(active_download_state=state),
+                r"^automation terminal left owned download state attached$",
+            ),
+            (
+                "caller-retained landed off the operator's status",
+                self._planted_terminal_world(
+                    automation=False, request_status="unsearchable"),
+                (
+                    r"caller-retained terminal left status='unsearchable', want "
+                    r"the operator's 'downloading'"
+                ),
+            ),
+        ]
+        for clause, db, pattern in cases:
+            with self.subTest(clause=clause), self.assertRaisesRegex(
+                AssertionError, pattern,
+            ):
+                assert_request_never_parked(db)
+
+    def test_operator_visible_checker_names_every_clause_it_trips_on(self):
+        """Per-clause Q1 for the bundle-less and audit-count clauses.
+
+        The "no readable message or error" clause is fail-closed
+        legislation: ``non_automation_failure_terminal_outcome`` raises
+        ``non-automation failure requires a diagnostic`` before an empty
+        one can be persisted (#1094 Q2), so only a writer that bypasses
+        that builder could produce the world it names.
+        """
+        failure = DispatchOutcome(success=False, message="generated failure")
+        no_job = FakePipelineDB()
+        no_job.seed_request(make_request_row(id=42, status="wanted"))
+
+        with self.subTest(clause="no import job row"), self.assertRaisesRegex(
+                AssertionError,
+                r"^dispatch finalized with no import job row to read$",
+            ):
+            assert_outcome_is_operator_visible(no_job, failure)
+
+        with self.subTest(clause="bundle-less force job is not failed"):
+            db = self._planted_terminal_world(
+                automation=False, job_status="completed")
+            with self.assertRaisesRegex(
+                AssertionError,
+                r"bundle-less caller-retained outcome left job "
+                r"status='completed', want 'failed'",
+            ):
+                assert_outcome_is_operator_visible(db, failure)
+
+        with self.subTest(clause="bundle-less force failure says nothing"):
+            db = self._planted_terminal_world(
+                automation=False, job_message=None, job_error=None)
+            with self.assertRaisesRegex(
+                AssertionError,
+                r"bundle-less caller-retained failure recorded no readable "
+                r"message or error",
+            ):
+                assert_outcome_is_operator_visible(db, failure)
+
+        with self.subTest(clause="two audit rows for one outcome"):
+            db = self._planted_terminal_world()
+            db.log_download(request_id=42, outcome="rejected")
+            db.log_download(request_id=42, outcome="rejected")
+            with self.assertRaisesRegex(
+                AssertionError, r"one dispatch wrote 2 audit rows",
+            ):
+                assert_outcome_is_operator_visible(db, failure)
+
+    def test_self_heal_checker_trips_when_ambiguity_is_recorded_as_acquired(
+        self,
+    ):
+        """A world failure recorded as an acquisition never re-searches.
+
+        Fail-closed legislation (#1094 Q2): planting the same world in
+        production — ``_self_heal_automation_world_failure`` transitioning
+        to ``imported`` — is refused by
+        ``validate_automation_terminal_authority`` ("automation
+        world-failure self-heal must fail the job, record a failed audit,
+        and return the request to wanted") before it can commit.
+        """
+        from scripts.importer import _WORLD_FAILURE_AUDIT_PREFIX
+
+        db = self._planted_terminal_world(request_status="imported")
+        db.log_download(
+            request_id=42,
+            outcome="rejected",
+            beets_detail=f"{_WORLD_FAILURE_AUDIT_PREFIX}: generated ambiguity",
+        )
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"automation world failure left status='imported', want 'wanted'",
+        ):
+            assert_world_failure_self_heals(
+                db, DispatchOutcome(success=False, message="ambiguous"))
 
     def test_audit_checker_trips_on_silent_and_invisible_world_failures(self):
         """A self-heal the operator cannot read is still a silent stop."""
@@ -1797,36 +2064,106 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
 
     def test_log_row_checker_trips_on_empty_db(self):
         db = FakePipelineDB()
-        with self.assertRaises(AssertionError):
-            assert_download_log_row_created(db)
-
-    def test_archival_checker_trips_on_wrong_match_cleanup(self):
         with self.assertRaisesRegex(
             AssertionError,
-            "reached Wrong Matches cleanup",
+            r"^expected >= 1 download_log row\(s\), got 0$",
         ):
-            assert_archival_quarantine_isolated(
-                cleanup_call_count=1,
-                terminal_log=DownloadLogRow(
-                    request_id=835,
-                    outcome="rejected",
-                    candidate_evidence_id=7,
-                    validation_result=json.dumps({
-                        "scenario": "audio_corrupt",
-                    }),
-                ),
-                expected_candidate_evidence_id=7,
-            )
+            assert_download_log_row_created(db)
 
-    def test_verified_lossless_lock_checker_trips_on_reopened_request(self):
-        db = FakePipelineDB()
-        db.seed_request(make_request_row(
-            id=42,
-            status="wanted",
-            search_filetype_override="lossless",
-        ))
-        with self.assertRaises(AssertionError):
-            assert_verified_lossless_lock_preserves_imported(db)
+    def test_archival_checker_names_every_clause_it_trips_on(self):
+        """Per-clause Q1 for the archival-quarantine isolation checker.
+
+        The deletion-triage clause is the persisted-row witness of the same
+        fail-open the cleanup-call clause catches: the destructive reducer
+        is injected as a recorder at that boundary, so only a writer that
+        stamps triage onto an archival audit row can produce it.
+        """
+        def planted(**overrides: object) -> DownloadLogRow:
+            kwargs: dict[str, object] = {
+                "request_id": 835,
+                "outcome": "rejected",
+                "candidate_evidence_id": 7,
+                "validation_result": json.dumps({"scenario": "audio_corrupt"}),
+            }
+            kwargs.update(overrides)
+            return DownloadLogRow(**kwargs)  # pyright: ignore[reportArgumentType]
+
+        cases = [
+            (
+                "destructive reducer reached",
+                1,
+                planted(),
+                r"^archival quarantine reached Wrong Matches cleanup$",
+            ),
+            (
+                "candidate evidence dropped",
+                0,
+                planted(candidate_evidence_id=None),
+                r"^archival terminal audit lost candidate evidence$",
+            ),
+            (
+                "deletion triage attached",
+                0,
+                planted(validation_result=json.dumps({
+                    "scenario": "audio_corrupt",
+                    "wrong_match_triage": {"decision": "delete"},
+                })),
+                r"^archival terminal audit gained deletion triage$",
+            ),
+        ]
+        for clause, cleanup_calls, terminal_log, pattern in cases:
+            with self.subTest(clause=clause), self.assertRaisesRegex(
+                AssertionError, pattern,
+            ):
+                assert_archival_quarantine_isolated(
+                    cleanup_call_count=cleanup_calls,
+                    terminal_log=terminal_log,
+                    expected_candidate_evidence_id=7,
+                )
+
+    def test_verified_lossless_lock_checker_names_every_clause(self):
+        """Per-clause Q1 for the non-punitive proof lock."""
+        from tests.fakes import DenylistEntry
+
+        cases = [
+            (
+                "acquisition reopened",
+                "wanted",
+                None,
+                False,
+                (
+                    r"^verified lossless lock left status='wanted', "
+                    r"want 'imported'$"
+                ),
+            ),
+            (
+                "search policy narrowed",
+                "imported",
+                "lossless",
+                False,
+                r"^verified lossless lock narrowed search policy$",
+            ),
+            (
+                "source blamed",
+                "imported",
+                None,
+                True,
+                r"^verified lossless lock denylisted the source$",
+            ),
+        ]
+        for clause, status, override, denylisted, pattern in cases:
+            with self.subTest(clause=clause):
+                db = FakePipelineDB()
+                db.seed_request(make_request_row(
+                    id=42,
+                    status=status,
+                    search_filetype_override=override,
+                ))
+                if denylisted:
+                    db.denylist.append(
+                        DenylistEntry(42, "user1", "planted mutant"))
+                with self.assertRaisesRegex(AssertionError, pattern):
+                    assert_verified_lossless_lock_preserves_imported(db)
 
     def test_log_row_checker_trips_on_blank_outcome(self):
         db = FakePipelineDB()
@@ -1834,24 +2171,118 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
         # Bypass log_download's outcome-taxonomy check to plant a row a
         # real writer could never produce — proves the checker itself
         # (not just the CHECK constraint mirror) catches an empty outcome.
+        # Fail-closed legislation (#1094 Q2): a production writer that
+        # emits outcome='' raises download_log_outcome_check instead, and
+        # the request self-heals; the clause guards a writer that ever
+        # reaches the row without going through log_download.
         db.download_logs.append(DownloadLogRow(request_id=42, outcome=None))
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+            AssertionError, r"^download_log row has empty/None outcome:",
+        ):
             assert_download_log_row_created(db)
 
-    def test_routing_checker_trips_when_import_status_wrong(self):
-        db = FakePipelineDB()
-        db.seed_request(make_request_row(id=42, status="downloading"))
-        db.log_download(request_id=42, outcome="success")
-        # Planted bug: an ordinary "import" decision
-        # that never actually flipped the request to 'imported'.
-        world = DispatchWorld(
-            mode="decision", decision="import", new_min_bitrate=245,
-            prev_min_bitrate=None, spectral_grade="genuine",
-            spectral_bitrate=None, was_converted=False,
-            requeue_on_failure=True, source_username="user1")
-        outcome = DispatchOutcome(success=True, message="ok")
-        with self.assertRaises(AssertionError):
-            assert_dispatch_outcome_matches_routing(world, db, outcome)
+    def test_routing_checker_names_every_clause_it_trips_on(self):
+        """Per-clause Q1 for the routing oracle's eight mismatch clauses."""
+        from tests.fakes import DenylistEntry
+
+        denylisted = self._routing_db(status="imported", log_outcome="success")
+        denylisted.denylist.append(DenylistEntry(42, "user1", "planted"))
+        cases = [
+            (
+                "mark_done logged as a rejection",
+                self._routing_db(status="imported", log_outcome="rejected"),
+                self._routing_world("import"),
+                DispatchOutcome(success=True, message="ok"),
+                (
+                    r"decision='import' mark_done=True but logged "
+                    r"outcome='rejected', want 'success'"
+                ),
+            ),
+            (
+                "mark_done reported failure",
+                self._routing_db(status="imported", log_outcome="success"),
+                self._routing_world("import"),
+                DispatchOutcome(success=False, message="ok"),
+                r"decision='import' mark_done=True but result.success=False",
+            ),
+            (
+                "mark_done never flipped the request",
+                self._routing_db(status="downloading", log_outcome="success"),
+                self._routing_world("import"),
+                DispatchOutcome(success=True, message="ok"),
+                (
+                    r"decision='import' mark_done=True left status='downloading', "
+                    r"want 'imported'"
+                ),
+            ),
+            (
+                "mark_done narrowed the search policy",
+                self._routing_db(
+                    status="imported",
+                    log_outcome="success",
+                    search_filetype_override="lossless",
+                ),
+                self._routing_world("import"),
+                DispatchOutcome(success=True, message="ok"),
+                (
+                    r"decision='import' mark_done=True left override='lossless', "
+                    r"want None"
+                ),
+            ),
+            (
+                "mark_done denylisted the source",
+                denylisted,
+                self._routing_world("import"),
+                DispatchOutcome(success=True, message="ok"),
+                r"decision='import' mark_done=True denylist=True, want False",
+            ),
+            (
+                "rejection logged as a success",
+                self._routing_db(status="wanted", log_outcome="success"),
+                self._routing_world("downgrade"),
+                DispatchOutcome(success=False, message="rejected"),
+                (
+                    r"decision='downgrade' record_rejection=True but logged "
+                    r"outcome='success', want 'rejected'"
+                ),
+            ),
+            (
+                "rejection reported success",
+                self._routing_db(status="wanted", log_outcome="rejected"),
+                self._routing_world("downgrade"),
+                DispatchOutcome(success=True, message="rejected"),
+                r"decision='downgrade' reject reported success=True",
+            ),
+            (
+                "rejection ignored the caller's requeue flag",
+                self._routing_db(status="downloading", log_outcome="rejected"),
+                self._routing_world("downgrade"),
+                DispatchOutcome(success=False, message="rejected"),
+                (
+                    r"decision='downgrade' requeue_on_failure=True left "
+                    r"status='downloading', want 'wanted'"
+                ),
+            ),
+        ]
+        for clause, db, world, outcome, pattern in cases:
+            with self.subTest(clause=clause), self.assertRaisesRegex(
+                AssertionError, pattern,
+            ):
+                assert_dispatch_outcome_matches_routing(world, db, outcome)
+
+    def test_routing_checker_has_no_unroutable_decision_world(self):
+        """The unroutable-decision clause is fail-closed legislation.
+
+        ``dispatch_action``'s final ``else`` returns ``record_rejection``,
+        so no decision string — known, generated, or unknown — can reach
+        the checker's last ``raise``. It stays so a future
+        ``DispatchAction`` that sets neither flag fails loudly instead of
+        passing every routing assertion silently.
+        """
+        for decision in (*_KNOWN_DECISIONS, "a decision nobody wrote yet"):
+            with self.subTest(decision=decision):
+                action = dispatch_action(decision)
+                self.assertTrue(action.mark_done or action.record_rejection)
 
     def test_routing_checker_trips_on_ambiguity_reporting_success(self):
         db = FakePipelineDB()
@@ -1867,7 +2298,11 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
     def test_preimport_caller_flag_checker_trips_when_flag_ignored(self):
         db = FakePipelineDB()
         db.seed_request(make_request_row(id=42, status="wanted"))
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"^preimport-fact reject 'audio_corrupt' left status='wanted', "
+            r"want 'downloading' for requeue_on_failure=False$",
+        ):
             assert_preimport_fact_honors_caller_flag(
                 "audio_corrupt", False, db)
 
@@ -1876,34 +2311,92 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
         # Planted bug: status is 'wanted' even though requeue_on_failure
         # was False — the caller's flag was ignored.
         db.seed_request(make_request_row(id=42, status="wanted"))
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"^quality-side reject 'downgrade' requeue_on_failure=False left "
+            r"status='wanted', want 'downloading'$",
+        ):
             assert_quality_side_reject_honors_caller_flag(
                 "downgrade", False, db)
 
-    def test_have_analysis_checker_trips_on_quality_consequences(self):
+    def _have_analysis_db(self, **row_overrides: object) -> FakePipelineDB:
+        """A HAVE-analysis abort world that satisfies every clause."""
+        row: dict[str, object] = {
+            "id": 42,
+            "status": "wanted",
+            "validation_attempts": 1,
+            "next_retry_after": "planted-backoff",
+            "search_filetype_override": None,
+        }
+        row.update(row_overrides)
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(**row))
+        db.log_download(request_id=42, outcome="have_analysis_error")
+        return db
+
+    def test_have_analysis_checker_names_every_clause_it_trips_on(self):
+        """Per-clause Q1 for the non-quality abort checker."""
         from tests.fakes import DenylistEntry
 
-        db = FakePipelineDB()
-        db.seed_request(make_request_row(
-            id=42,
-            status="wanted",
-            validation_attempts=1,
-            next_retry_after="planted-backoff",
-            search_filetype_override="lossless",
-        ))
-        db.log_download(request_id=42, outcome="have_analysis_error")
-        db.denylist.append(DenylistEntry(42, "bad-user", "planted mutant"))
-        with self.assertRaises(AssertionError):
-            assert_have_analysis_abort_is_non_quality(
-                db,
-                mode="auto",
-                expected_search_override=None,
-            )
+        denylisted = self._have_analysis_db()
+        denylisted.denylist.append(
+            DenylistEntry(42, "bad-user", "planted mutant"))
+        wrong_outcome = self._have_analysis_db()
+        wrong_outcome.log_download(request_id=42, outcome="rejected")
+        cases = [
+            (
+                "caller lifecycle moved",
+                self._have_analysis_db(status="unsearchable"),
+                (
+                    r"^HAVE-analysis abort left status='unsearchable', "
+                    r"want 'wanted' for auto$"
+                ),
+            ),
+            (
+                "search policy narrowed",
+                self._have_analysis_db(search_filetype_override="lossless"),
+                (
+                    r"HAVE-analysis abort changed search_filetype_override from "
+                    r"None to 'lossless'"
+                ),
+            ),
+            (
+                "source blamed",
+                denylisted,
+                r"^HAVE-analysis abort wrote quality denylist entries:",
+            ),
+            (
+                "audit taxonomy lost",
+                wrong_outcome,
+                (
+                    r"^HAVE-analysis abort did not persist "
+                    r"outcome='have_analysis_error'$"
+                ),
+            ),
+            (
+                "retry bookkeeping dropped",
+                self._have_analysis_db(
+                    validation_attempts=0, next_retry_after=None),
+                r"^HAVE-analysis abort applied the wrong retry bookkeeping$",
+            ),
+        ]
+        for clause, db, pattern in cases:
+            with self.subTest(clause=clause), self.assertRaisesRegex(
+                AssertionError, pattern,
+            ):
+                assert_have_analysis_abort_is_non_quality(
+                    db,
+                    mode="auto",
+                    expected_search_override=None,
+                )
 
     def test_have_analysis_cooldown_checker_trips_on_double_evaluation(self):
         db = FakePipelineDB()
         db.cooldowns_applied.extend(("peer", "peer"))
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"^HAVE-analysis cooldown evaluations drifted: ",
+        ):
             assert_have_analysis_abort_cooldown_policy(
                 db,
                 username="peer",
@@ -1913,7 +2406,10 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
     def test_have_analysis_cooldown_checker_trips_on_missing_write(self):
         db = FakePipelineDB()
         db.cooldowns_applied.append("peer")
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"^HAVE-analysis cooldown persistence drifted: ",
+        ):
             assert_have_analysis_abort_cooldown_policy(
                 db,
                 username="peer",
@@ -1927,7 +2423,10 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
             datetime.now(UTC) + timedelta(days=1),
             "planted mutant",
         )
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"^HAVE-analysis cooldown persistence drifted: ",
+        ):
             assert_have_analysis_abort_cooldown_policy(
                 db,
                 username=None,
@@ -1942,26 +2441,51 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
             datetime.now(UTC) + timedelta(days=1),
             "planted mutant",
         )
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"^HAVE-analysis cooldown persistence drifted: ",
+        ):
             assert_have_analysis_abort_cooldown_policy(
                 db,
                 username="peer",
                 cooldown_verdict=False,
             )
 
-    def test_operator_retained_checker_trips_when_stop_is_cleared(self):
-        db = FakePipelineDB()
-        db.seed_request(make_request_row(
-            id=42,
-            status="wanted",
-            search_filetype_override="lossless",
-        ))
-        with self.assertRaises(AssertionError):
-            assert_operator_retained_lifecycle(
-                db,
-                initial_status="unsearchable",
-                expected_override="lossless",
-            )
+    def test_operator_retained_checker_names_every_clause(self):
+        """Per-clause Q1 for the retained force-import lifecycle checker."""
+        cleared = FakePipelineDB()
+        cleared.seed_request(make_request_row(
+            id=42, status="wanted", search_filetype_override="lossless"))
+        unrecorded = FakePipelineDB()
+        unrecorded.seed_request(make_request_row(
+            id=42, status="unsearchable", search_filetype_override=None))
+        cases = [
+            (
+                "operator search stop cleared",
+                cleared,
+                (
+                    r"^retained force import changed lifecycle from "
+                    r"'unsearchable' to 'wanted'$"
+                ),
+            ),
+            (
+                "canonical search policy not recorded",
+                unrecorded,
+                (
+                    r"^retained force import failed to record canonical search "
+                    r"policy$"
+                ),
+            ),
+        ]
+        for clause, db, pattern in cases:
+            with self.subTest(clause=clause), self.assertRaisesRegex(
+                AssertionError, pattern,
+            ):
+                assert_operator_retained_lifecycle(
+                    db,
+                    initial_status="unsearchable",
+                    expected_override="lossless",
+                )
 
     def test_distance_checker_trips_when_null_gets_fabricated_as_zero(self):
         db = FakePipelineDB()
@@ -1970,7 +2494,10 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
         # but the writer fabricated a 0.0 "perfect match" — exactly the
         # #550 defect #4 regression this property exists to catch.
         db.log_download(request_id=42, outcome="rejected", beets_distance=0.0)
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"^expected persisted beets_distance=None, got 0\.0",
+        ):
             assert_beets_distance_round_trips(db, None)
 
     def test_distance_checker_trips_when_measured_value_gets_nulled(self):
@@ -1979,25 +2506,63 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
         # Planted bug: a genuinely measured distance (0.07) was dropped
         # to NULL instead of being persisted as-is.
         db.log_download(request_id=42, outcome="rejected", beets_distance=None)
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"^expected persisted beets_distance=0\.07, got None",
+        ):
             assert_beets_distance_round_trips(db, 0.07)
 
-    def test_validation_projection_checker_trips_on_dual_sink_drift(self):
+    def test_validation_projection_checker_names_every_clause(self):
+        """Per-clause Q1 for the envelope/query-column projection checker."""
         from lib.quality import ValidationResult
 
-        db = FakePipelineDB()
-        db.download_logs.append(DownloadLogRow(
-            request_id=42,
-            outcome="rejected",
-            beets_distance=0.99,
-            beets_scenario="wrong_scenario",
-            validation_result=ValidationResult(
-                distance=0.07,
-                scenario="high_distance",
-            ).to_json(),
-        ))
-        with self.assertRaises(AssertionError):
-            assert_validation_projection_matches_payload(db)
+        envelope = ValidationResult(
+            distance=0.07, scenario="high_distance").to_json()
+        cases = [
+            (
+                "no object envelope persisted",
+                DownloadLogRow(
+                    request_id=42,
+                    outcome="rejected",
+                    validation_result=None,
+                ),
+                r"^rejection writer did not persist an object envelope$",
+            ),
+            (
+                "distance drifted from its envelope",
+                DownloadLogRow(
+                    request_id=42,
+                    outcome="rejected",
+                    beets_distance=0.99,
+                    beets_scenario="high_distance",
+                    validation_result=envelope,
+                ),
+                (
+                    r"^validation distance=0\.07 drifted from "
+                    r"beets_distance=0\.99$"
+                ),
+            ),
+            (
+                "scenario drifted from its envelope",
+                DownloadLogRow(
+                    request_id=42,
+                    outcome="rejected",
+                    beets_distance=0.07,
+                    beets_scenario="wrong_scenario",
+                    validation_result=envelope,
+                ),
+                (
+                    r"^validation scenario='high_distance' drifted from "
+                    r"beets_scenario='wrong_scenario'$"
+                ),
+            ),
+        ]
+        for clause, row, pattern in cases:
+            with self.subTest(clause=clause):
+                db = FakePipelineDB()
+                db.download_logs.append(row)
+                with self.assertRaisesRegex(AssertionError, pattern):
+                    assert_validation_projection_matches_payload(db)
 
     def test_hypothesis_harness_detects_planted_bad_router(self):
         """End-to-end RED proof: strategies + checker + Hypothesis catch a

--- a/tests/test_dispatch_outcomes_generated.py
+++ b/tests/test_dispatch_outcomes_generated.py
@@ -1837,11 +1837,14 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
         assert parked is not None
         self.assertEqual(parked.status, "recovery_required")
         self.assertEqual(db.request(42)["status"], "processing")
-        with self.assertRaisesRegex(AssertionError, "non-terminal status"):
+        parked_clause = (
+            r"^automation_import job 1 rested in non-terminal status "
+            r"'recovery_required';")
+        with self.assertRaisesRegex(AssertionError, parked_clause):
             assert_request_never_parked(db)
-        with self.assertRaisesRegex(AssertionError, "non-terminal status"):
+        with self.assertRaisesRegex(AssertionError, parked_clause):
             assert_world_failure_self_heals(db, outcome["result"])
-        with self.assertRaisesRegex(AssertionError, "non-terminal status"):
+        with self.assertRaisesRegex(AssertionError, parked_clause):
             assert_dispatch_outcome_matches_routing(
                 self._ambiguous_world(), db, outcome["result"])
 
@@ -2031,9 +2034,13 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
 
         with self.subTest(plant="no audit row at all"):
             db.download_logs.clear()
-            with self.assertRaisesRegex(AssertionError, "download_log row"):
+            with self.assertRaisesRegex(
+                AssertionError, r"^expected >= 1 download_log row\(s\), got 0$",
+            ):
                 assert_outcome_is_operator_visible(db, result)
-            with self.assertRaisesRegex(AssertionError, "download_log row"):
+            with self.assertRaisesRegex(
+                AssertionError, r"^expected >= 1 download_log row\(s\), got 0$",
+            ):
                 assert_world_failure_self_heals(db, result)
         db.download_logs.append(audit)
 
@@ -2292,7 +2299,10 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
         db.log_download(request_id=42, outcome="success")
         world = self._ambiguous_world()
         outcome = DispatchOutcome(success=True, message="")
-        with self.assertRaisesRegex(AssertionError, "reported success=True"):
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"^ambiguous acknowledgement reported success=True$",
+        ):
             assert_dispatch_outcome_matches_routing(world, db, outcome)
 
     def test_preimport_caller_flag_checker_trips_when_flag_ignored(self):

--- a/tests/test_dispatch_outcomes_generated.py
+++ b/tests/test_dispatch_outcomes_generated.py
@@ -1692,7 +1692,7 @@ class TestGeneratedArchivalQuarantineIsolation(unittest.TestCase):
 class TestInvariantCheckersTripOnViolations(unittest.TestCase):
     """Known-bad self-tests: prove the harness detects what it claims to.
 
-    Per-clause proof (#1094): every ``raise AssertionError`` above owns a
+    Per-clause proof (#1094): every checker raise site above owns a
     world here that makes THAT clause's condition true while every earlier
     clause in the same function passes, and asserts that clause's own
     message. A bare ``assertRaises`` would let a short-circuiting checker

--- a/tests/test_evidence_generated.py
+++ b/tests/test_evidence_generated.py
@@ -18,10 +18,19 @@ Profiles and promotion policy: tests/_hypothesis_profiles.py and
 docs/generated-testing.md. The exact minimized cases from the original
 RED run are committed in tests/test_import_evidence.py; the ``@example``
 pin below keeps the original failing shape replaying here forever.
+
+Every clause of every checker here carries a known-bad world that names
+that clause's own message (issue #1094, docs/generated-testing.md
+§ "Per-clause proof"). Two checkers accumulate their violations instead of
+raising on the first — the two-axis carry checker and the integrity
+precedence checker — because the audit found clauses whose only reachable
+world already trips an earlier one, which under a raise chain left them
+unfalsifiable rather than satisfied.
 """
 
 import configparser
 import os
+import re
 import shutil
 import sys
 import tempfile
@@ -33,6 +42,7 @@ from unittest.mock import patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
+import msgspec
 from hypothesis import example, given
 from hypothesis import strategies as st
 
@@ -50,6 +60,7 @@ from lib.quality import (
     AlbumQualityEvidence,
     AlbumQualityV0Metric,
     AudioQualityMeasurement,
+    EvidenceProvenance,
     EvidenceSubject,
     SpectralAnalysisDetail,
     VerifiedLosslessProof,
@@ -570,6 +581,20 @@ _BLANK_LOSSLESS_NO_SCALAR_WORLD = BlankPathWorld(
     request_has_v0_scalar=False,
 )
 
+# The must-still-work arm, pinned by the issue #1094 per-clause audit: a
+# complete real-path row that is not converted-from-lossless is the only
+# world in which "must load as authoritative" can fire. It ran 21 times in
+# the 152-example suite tier; the pin keeps that decisive world reachable
+# no matter how the strategy is later reshaped.
+_REAL_PATH_COMPLETE_WORLD = BlankPathWorld(
+    source_path_kind="real",
+    spectral_grade=None,
+    min_bitrate=186,
+    avg_bitrate=194,
+    was_converted_from=None,
+    request_has_v0_scalar=False,
+)
+
 
 class TestGeneratedBlankSourcePath(unittest.TestCase):
     """Action-loader invariants over generated source_path worlds."""
@@ -577,6 +602,7 @@ class TestGeneratedBlankSourcePath(unittest.TestCase):
     @given(world=blank_path_worlds())
     @example(world=_FRENCH_QUARTER_WORLD)
     @example(world=_BLANK_LOSSLESS_NO_SCALAR_WORLD)
+    @example(world=_REAL_PATH_COMPLETE_WORLD)
     def test_blank_source_path_is_never_authoritative(self, world):
         current_status, available, result_source_path = (
             _run_blank_path_world(world)
@@ -591,42 +617,72 @@ class TestGeneratedBlankSourcePath(unittest.TestCase):
 
 
 class TestBlankPathCheckerTripsOnViolations(unittest.TestCase):
-    """Known-bad self-tests for the blank-path invariant checker."""
+    """Per-clause known-bad worlds for the blank-path checker (issue #1094).
 
-    def test_trips_on_loaded_blank_path(self):
-        with self.assertRaises(AssertionError):
-            assert_blank_path_outcome(
-                source_path_kind="blank", requires_lossless_v0=False,
-                current_status="loaded",
-                available=True, result_source_path="")
+    Each world makes exactly one clause's condition true while every earlier
+    clause passes, and names that clause's own message.
+    """
 
-    def test_trips_on_fail_closed_instead_of_rebuild(self):
-        with self.assertRaises(AssertionError):
-            assert_blank_path_outcome(
-                source_path_kind="blank", requires_lossless_v0=False,
-                current_status="failed",
-                available=False, result_source_path=None)
+    # (description, source_path_kind, requires_lossless_v0, current_status,
+    #  available, result_source_path, message)
+    CASES: tuple[
+        tuple[str, str, bool, str, bool, str | None, str], ...
+    ] = (
+        (
+            "real path that did not load",
+            "real", False, "backfilled", True, "/library/album",
+            ("complete current evidence with a real source_path must load as "
+             "authoritative (got backfilled)"),
+        ),
+        (
+            "blank path loaded as authority",
+            "blank", False, "loaded", False, "/library/album",
+            "blank-source_path current evidence was loaded as authoritative",
+        ),
+        (
+            "lossless-source row became available",
+            "blank", True, "backfilled", True, "/library/album",
+            ("lossless-source row without a V0 backfill source must fail "
+             "closed, not become available"),
+        ),
+        (
+            "blank path failed closed instead of rebuilding",
+            "blank", False, "failed", False, None,
+            ("blank-source_path row must rebuild from album_info, not fail "
+             "closed"),
+        ),
+        (
+            "rebuilt row still carries a blank path",
+            "whitespace", False, "backfilled", True, "   ",
+            "rebuilt action evidence still carries a blank source_path",
+        ),
+    )
 
-    def test_trips_on_rebuilt_row_still_blank(self):
-        with self.assertRaises(AssertionError):
-            assert_blank_path_outcome(
-                source_path_kind="whitespace", requires_lossless_v0=False,
-                current_status="backfilled",
-                available=True, result_source_path="   ")
+    def test_every_clause_trips_with_its_own_message(self):
+        for (
+            description, kind, requires_v0, status, available, path, message,
+        ) in self.CASES:
+            with self.subTest(description=description), self.assertRaisesRegex(
+                AssertionError, re.escape(message),
+            ):
+                assert_blank_path_outcome(
+                    source_path_kind=kind,
+                    requires_lossless_v0=requires_v0,
+                    current_status=status,
+                    available=available,
+                    result_source_path=path,
+                )
 
-    def test_trips_on_real_path_not_loading(self):
-        with self.assertRaises(AssertionError):
-            assert_blank_path_outcome(
-                source_path_kind="real", requires_lossless_v0=False,
-                current_status="backfilled",
-                available=True, result_source_path="/library/album")
-
-    def test_trips_on_lossless_no_scalar_becoming_available(self):
-        with self.assertRaises(AssertionError):
-            assert_blank_path_outcome(
-                source_path_kind="blank", requires_lossless_v0=True,
-                current_status="backfilled",
-                available=True, result_source_path="/library/album")
+    def test_complete_real_path_world_is_accepted(self):
+        """The must-still-work control: no clause fires on a legal world."""
+        assert_blank_path_outcome(
+            source_path_kind="real", requires_lossless_v0=False,
+            current_status="loaded", available=True,
+            result_source_path="/library/album")
+        assert_blank_path_outcome(
+            source_path_kind="blank", requires_lossless_v0=False,
+            current_status="backfilled", available=True,
+            result_source_path="/library/album")
 
 
 LosslessSpectralFailureKind = Literal[
@@ -661,6 +717,34 @@ def assert_lossless_spectral_failure_lifecycle(
         raise AssertionError("harness ran without usable lossless spectral evidence")
 
 
+def integrity_precedence_violations(
+    *,
+    job_status: str,
+    preview_status: str | None,
+    decision: str | None,
+    harness_calls: int,
+    candidate_evidence_id: int | None,
+) -> list[str]:
+    """Accumulate every integrity-precedence violation of one preview run.
+
+    Accumulating rather than raising (issue #1094 per-clause audit): leaving
+    the measurement-only path is the only way production can reach the
+    harness, and doing so also moves the decision and the job status — so
+    under a raise chain the harness and link clauses could never witness
+    anything the first clause had not already caught.
+    """
+    violations: list[str] = []
+    if job_status != "queued" or preview_status != "evidence_ready":
+        violations.append("audio corruption was demoted to measurement failure")
+    if decision != "audio_corrupt":
+        violations.append("audio corruption did not win decision precedence")
+    if harness_calls:
+        violations.append("harness ran after completed audio-corrupt evidence")
+    if candidate_evidence_id is None:
+        violations.append("audio-corrupt candidate evidence was not linked")
+    return violations
+
+
 def assert_integrity_fact_precedes_spectral_failure(
     *,
     job_status: str,
@@ -671,14 +755,15 @@ def assert_integrity_fact_precedes_spectral_failure(
 ) -> None:
     """Completed corruption evidence must not become measurement_failed."""
 
-    if job_status != "queued" or preview_status != "evidence_ready":
-        raise AssertionError("audio corruption was demoted to measurement failure")
-    if decision != "audio_corrupt":
-        raise AssertionError("audio corruption did not win decision precedence")
-    if harness_calls:
-        raise AssertionError("harness ran after completed audio-corrupt evidence")
-    if candidate_evidence_id is None:
-        raise AssertionError("audio-corrupt candidate evidence was not linked")
+    violations = integrity_precedence_violations(
+        job_status=job_status,
+        preview_status=preview_status,
+        decision=decision,
+        harness_calls=harness_calls,
+        candidate_evidence_id=candidate_evidence_id,
+    )
+    if violations:
+        raise AssertionError("; ".join(violations))
 
 
 def _lossless_spectral_detail(
@@ -907,53 +992,210 @@ class TestGeneratedLosslessSpectralFailureLifecycle(unittest.TestCase):
 
 
 class TestLosslessSpectralFailureCheckerTripsOnViolations(unittest.TestCase):
-    def test_trips_when_failed_preview_changes_force_request_status(self):
-        with self.assertRaises(AssertionError):
-            assert_lossless_spectral_failure_lifecycle(
-                request_status="imported",
-                expected_request_status="downloading",
-                job_status="failed",
-                preview_status="measurement_failed",
-                harness_calls=0,
-            )
+    """Per-clause known-bad worlds for both preview checkers (issue #1094)."""
 
-    def test_trips_when_harness_runs(self):
-        with self.assertRaises(AssertionError):
-            assert_lossless_spectral_failure_lifecycle(
-                request_status="wanted",
-                expected_request_status="wanted",
-                job_status="failed",
-                preview_status="measurement_failed",
-                harness_calls=1,
-            )
+    # (description, request_status, expected_request_status, job_status,
+    #  preview_status, harness_calls, message)
+    LIFECYCLE_CASES: tuple[
+        tuple[str, str, str, str, str | None, int, str], ...
+    ] = (
+        (
+            "failed preview moved the force request",
+            "imported", "downloading", "failed", "measurement_failed", 0,
+            ("lossless spectral failure changed the force-import request from "
+             "'downloading' to 'imported'"),
+        ),
+        (
+            "job did not fail",
+            "downloading", "downloading", "queued", "measurement_failed", 0,
+            "lossless spectral failure did not terminate the preview job",
+        ),
+        (
+            "preview did not record measurement_failed",
+            "downloading", "downloading", "failed", "evidence_ready", 0,
+            "lossless spectral failure did not terminate the preview job",
+        ),
+        (
+            "harness ran anyway",
+            "downloading", "downloading", "failed", "measurement_failed", 1,
+            "harness ran without usable lossless spectral evidence",
+        ),
+    )
 
-    def test_integrity_checker_trips_on_measurement_failure(self):
-        with self.assertRaisesRegex(AssertionError, "demoted"):
-            assert_integrity_fact_precedes_spectral_failure(
-                job_status="failed",
-                preview_status="measurement_failed",
-                decision="spectral_analysis_failed",
-                harness_calls=0,
-                candidate_evidence_id=None,
-            )
+    # (description, job_status, preview_status, decision, harness_calls,
+    #  candidate_evidence_id, message)
+    INTEGRITY_CASES: tuple[
+        tuple[str, str, str | None, str | None, int, int | None, str], ...
+    ] = (
+        (
+            "corruption demoted to a failed job",
+            "failed", "measurement_failed", "audio_corrupt", 0, 7,
+            "audio corruption was demoted to measurement failure",
+        ),
+        (
+            "corruption demoted to a non-ready preview status",
+            "queued", "measurement_failed", "audio_corrupt", 0, 7,
+            "audio corruption was demoted to measurement failure",
+        ),
+        (
+            "another fact won decision precedence",
+            "queued", "evidence_ready", "bad_audio_hash", 0, 7,
+            "audio corruption did not win decision precedence",
+        ),
+        (
+            "harness ran on completed corruption evidence",
+            "queued", "evidence_ready", "audio_corrupt", 1, 7,
+            "harness ran after completed audio-corrupt evidence",
+        ),
+        (
+            "candidate evidence was not linked to the job",
+            "queued", "evidence_ready", "audio_corrupt", 0, None,
+            "audio-corrupt candidate evidence was not linked",
+        ),
+    )
+
+    def test_every_lifecycle_clause_trips_with_its_own_message(self):
+        for (
+            description, request_status, expected_status, job_status,
+            preview_status, harness_calls, message,
+        ) in self.LIFECYCLE_CASES:
+            with self.subTest(description=description), self.assertRaisesRegex(
+                AssertionError, re.escape(message),
+            ):
+                assert_lossless_spectral_failure_lifecycle(
+                    request_status=request_status,
+                    expected_request_status=expected_status,
+                    job_status=job_status,
+                    preview_status=preview_status,
+                    harness_calls=harness_calls,
+                )
+
+    def test_every_integrity_clause_trips_with_its_own_message(self):
+        for (
+            description, job_status, preview_status, decision, harness_calls,
+            candidate_evidence_id, message,
+        ) in self.INTEGRITY_CASES:
+            with self.subTest(description=description), self.assertRaisesRegex(
+                AssertionError, re.escape(message),
+            ):
+                assert_integrity_fact_precedes_spectral_failure(
+                    job_status=job_status,
+                    preview_status=preview_status,
+                    decision=decision,
+                    harness_calls=harness_calls,
+                    candidate_evidence_id=candidate_evidence_id,
+                )
+
+    def test_legal_worlds_are_accepted(self):
+        """The must-still-work control for both preview checkers."""
+        assert_lossless_spectral_failure_lifecycle(
+            request_status="downloading",
+            expected_request_status="downloading",
+            job_status="failed",
+            preview_status="measurement_failed",
+            harness_calls=0,
+        )
+        assert_integrity_fact_precedes_spectral_failure(
+            job_status="queued",
+            preview_status="evidence_ready",
+            decision="audio_corrupt",
+            harness_calls=0,
+            candidate_evidence_id=7,
+        )
 
 class TestLifecycleCheckerTripsOnViolations(unittest.TestCase):
-    """Known-bad self-tests for the lifecycle invariant checker."""
+    """Per-clause known-bad worlds for the lifecycle checker (issue #1094)."""
 
-    def test_trips_on_loaded_without_v0(self):
-        with self.assertRaises(AssertionError):
-            assert_lifecycle_outcome(
-                current_status="loaded", available=True, result_v0_avg=171)
+    # (description, current_status, available, result_v0_avg, message)
+    CASES: tuple[tuple[str, str, bool, int | None, str], ...] = (
+        (
+            "loaded without the linked V0 metric",
+            "loaded", False, None,
+            ("lossless-source transcode current evidence loaded without V0 "
+             "metric"),
+        ),
+        (
+            "available despite the missing linked fact",
+            "rebuilt", True, None,
+            "request stamps resurrected a missing linked V0 fact",
+        ),
+        (
+            "request scalar resurrected as an evidence V0 average",
+            "rebuilt", False, 171,
+            "request stamps resurrected a missing linked V0 fact",
+        ),
+    )
 
-    def test_trips_when_scalar_fact_is_resurrected(self):
-        with self.assertRaises(AssertionError):
-            assert_lifecycle_outcome(
-                current_status="rebuilt", available=False, result_v0_avg=171)
+    def test_every_clause_trips_with_its_own_message(self):
+        for description, status, available, v0_avg, message in self.CASES:
+            with self.subTest(description=description), self.assertRaisesRegex(
+                AssertionError, re.escape(message),
+            ):
+                assert_lifecycle_outcome(
+                    current_status=status,
+                    available=available,
+                    result_v0_avg=v0_avg,
+                )
 
-    def test_trips_on_not_failing_closed(self):
-        with self.assertRaises(AssertionError):
-            assert_lifecycle_outcome(
-                current_status="rebuilt", available=True, result_v0_avg=None)
+    def test_fail_closed_world_is_accepted(self):
+        """The must-still-work control: the legal fail-closed outcome passes."""
+        assert_lifecycle_outcome(
+            current_status="failed", available=False, result_v0_avg=None)
+
+
+def fingerprint_flip_two_axis_violations(
+    *,
+    original_subject: str,
+    evidence: AlbumQualityEvidence,
+) -> list[str]:
+    """Accumulate every two-axis carry violation of one rebuilt row.
+
+    Accumulating rather than raising (issue #1094 per-clause audit): under
+    the original raise chain the two cross-product clauses had no world of
+    their own. ``installed V0 fact cannot be carried`` could only arrive
+    behind ``installed V0 fact crossed fingerprints`` or
+    ``source V0 fact was not marked carried``, both of which raised first,
+    so the clause was unfalsifiable rather than satisfied.
+    """
+    violations: list[str] = []
+    measurement = evidence.measurement
+    if original_subject == "source":
+        if measurement.spectral_grade is None:
+            violations.append("source spectral fact was dropped")
+        elif (
+            measurement.spectral_subject,
+            measurement.spectral_provenance,
+        ) != ("source", "carried"):
+            violations.append("source spectral fact was not marked carried")
+        if evidence.v0_metric is None:
+            violations.append("source V0 fact was dropped")
+        elif (
+            evidence.v0_metric.subject,
+            evidence.v0_metric.provenance,
+        ) != ("source", "carried"):
+            violations.append("source V0 fact was not marked carried")
+    else:
+        if measurement.spectral_grade is not None:
+            violations.append("installed spectral fact crossed fingerprints")
+        if evidence.v0_metric is not None:
+            violations.append("installed V0 fact crossed fingerprints")
+
+    if (
+        measurement.spectral_subject == "installed"
+        and measurement.spectral_provenance == "carried"
+    ):
+        violations.append("installed spectral fact cannot be carried")
+    if (
+        evidence.v0_metric is not None
+        and evidence.v0_metric.subject == "installed"
+        and evidence.v0_metric.provenance == "carried"
+    ):
+        violations.append("installed V0 fact cannot be carried")
+    if evidence.verified_lossless_proof is None:
+        violations.append("verified-lossless proof was dropped")
+    elif evidence.verified_lossless_proof.provenance != "carried":
+        violations.append("verified-lossless proof was not marked carried")
+    return violations
 
 
 def assert_fingerprint_flip_two_axis_carry(
@@ -967,43 +1209,12 @@ def assert_fingerprint_flip_two_axis_carry(
     facts remain meaningful but become carried; installed facts must be
     measured again from the new files rather than copied from the old row.
     """
-    measurement = evidence.measurement
-    if original_subject == "source":
-        if measurement.spectral_grade is None:
-            raise AssertionError("source spectral fact was dropped")
-        if (
-            measurement.spectral_subject,
-            measurement.spectral_provenance,
-        ) != ("source", "carried"):
-            raise AssertionError("source spectral fact was not marked carried")
-        if evidence.v0_metric is None:
-            raise AssertionError("source V0 fact was dropped")
-        if (
-            evidence.v0_metric.subject,
-            evidence.v0_metric.provenance,
-        ) != ("source", "carried"):
-            raise AssertionError("source V0 fact was not marked carried")
-    else:
-        if measurement.spectral_grade is not None:
-            raise AssertionError("installed spectral fact crossed fingerprints")
-        if evidence.v0_metric is not None:
-            raise AssertionError("installed V0 fact crossed fingerprints")
-
-    if (
-        measurement.spectral_subject == "installed"
-        and measurement.spectral_provenance == "carried"
-    ):
-        raise AssertionError("installed spectral fact cannot be carried")
-    if (
-        evidence.v0_metric is not None
-        and evidence.v0_metric.subject == "installed"
-        and evidence.v0_metric.provenance == "carried"
-    ):
-        raise AssertionError("installed V0 fact cannot be carried")
-    if evidence.verified_lossless_proof is None:
-        raise AssertionError("verified-lossless proof was dropped")
-    if evidence.verified_lossless_proof.provenance != "carried":
-        raise AssertionError("verified-lossless proof was not marked carried")
+    violations = fingerprint_flip_two_axis_violations(
+        original_subject=original_subject,
+        evidence=evidence,
+    )
+    if violations:
+        raise AssertionError("; ".join(violations))
 
 
 def _run_fingerprint_flip_world(
@@ -1087,58 +1298,189 @@ class TestGeneratedTwoAxisFingerprintCarry(unittest.TestCase):
                 )
 
 
+def _carried_proof(
+    provenance: EvidenceProvenance = "carried",
+) -> VerifiedLosslessProof:
+    return VerifiedLosslessProof(
+        provenance=provenance,
+        source="flac",
+        classifier="spectral_verified_lossless",
+    )
+
+
+def _two_axis_evidence(
+    *,
+    spectral_grade: str | None = "genuine",
+    spectral_subject: EvidenceSubject | None = "source",
+    spectral_provenance: EvidenceProvenance | None = "carried",
+    v0_metric: AlbumQualityV0Metric | None = None,
+    proof_provenance: EvidenceProvenance | None = "carried",
+) -> AlbumQualityEvidence:
+    """A rebuilt row with exactly the two-axis facts a known-bad world needs.
+
+    ``proof_provenance=None`` drops the verified-lossless proof entirely.
+    """
+    evidence = make_album_quality_evidence(
+        lineage_version=3,
+        measurement=AudioQualityMeasurement(
+            spectral_grade=spectral_grade,
+            spectral_subject=spectral_subject,
+            spectral_provenance=spectral_provenance,
+        ),
+        v0_metric=v0_metric,
+        verified_lossless_proof=(
+            _carried_proof(proof_provenance)
+            if proof_provenance is not None
+            else None
+        ),
+    )
+    # The builder normalises a grade with no subject; these worlds need the
+    # exact stored tuple, including shapes production's own validator refuses.
+    return msgspec.structs.replace(
+        evidence,
+        measurement=msgspec.structs.replace(
+            evidence.measurement,
+            spectral_grade=spectral_grade,
+            spectral_subject=spectral_subject,
+            spectral_provenance=spectral_provenance,
+        ),
+    )
+
+
 class TestTwoAxisCarryCheckerTripsOnViolations(unittest.TestCase):
-    """Known-bad self-tests prove the generated checker has teeth."""
+    """Per-clause known-bad worlds for the two-axis checker (issue #1094).
 
-    def test_trips_when_installed_facts_cross_fingerprints(self):
-        known_bad = make_album_quality_evidence(
-            lineage_version=3,
-            measurement=AudioQualityMeasurement(
-                spectral_grade="genuine",
-                spectral_subject="installed",
-                spectral_provenance="carried",
+    Two clauses — the installed/carried cross-product pair — can only ever
+    arrive alongside another violation, which is why the checker accumulates
+    rather than raising on the first hit. Their worlds name their own message
+    out of the accumulated report.
+    """
+
+    SOURCE_V0 = AlbumQualityV0Metric(
+        subject="source", provenance="carried", avg_bitrate_kbps=245,
+    )
+
+    def _cases(self) -> tuple[tuple[str, str, AlbumQualityEvidence, str], ...]:
+        return (
+            (
+                "source spectral grade dropped",
+                "source",
+                _two_axis_evidence(
+                    spectral_grade=None, spectral_subject=None,
+                    spectral_provenance=None, v0_metric=self.SOURCE_V0,
+                ),
+                "source spectral fact was dropped",
             ),
-            v0_metric=AlbumQualityV0Metric(
-                subject="installed",
-                provenance="carried",
-                avg_bitrate_kbps=245,
+            (
+                "source spectral still marked measured",
+                "source",
+                _two_axis_evidence(
+                    spectral_provenance="measured", v0_metric=self.SOURCE_V0,
+                ),
+                "source spectral fact was not marked carried",
             ),
-            verified_lossless_proof=VerifiedLosslessProof(
-                provenance="carried",
-                source="flac",
-                classifier="spectral_verified_lossless",
+            (
+                "source V0 dropped",
+                "source",
+                _two_axis_evidence(v0_metric=None),
+                "source V0 fact was dropped",
+            ),
+            (
+                "source V0 still marked measured",
+                "source",
+                _two_axis_evidence(
+                    v0_metric=AlbumQualityV0Metric(
+                        subject="source", provenance="measured",
+                        avg_bitrate_kbps=245,
+                    ),
+                ),
+                "source V0 fact was not marked carried",
+            ),
+            (
+                "installed spectral survived the flip",
+                "installed",
+                _two_axis_evidence(
+                    spectral_subject="installed",
+                    spectral_provenance="measured",
+                ),
+                "installed spectral fact crossed fingerprints",
+            ),
+            (
+                "installed V0 survived the flip",
+                "installed",
+                _two_axis_evidence(
+                    spectral_grade=None, spectral_subject=None,
+                    spectral_provenance=None,
+                    v0_metric=AlbumQualityV0Metric(
+                        subject="installed", provenance="measured",
+                        avg_bitrate_kbps=245,
+                    ),
+                ),
+                "installed V0 fact crossed fingerprints",
+            ),
+            (
+                "installed spectral markers stamped carried",
+                "installed",
+                _two_axis_evidence(
+                    spectral_grade=None, spectral_subject="installed",
+                    spectral_provenance="carried",
+                ),
+                "installed spectral fact cannot be carried",
+            ),
+            (
+                "installed V0 stamped carried",
+                "installed",
+                _two_axis_evidence(
+                    spectral_grade=None, spectral_subject=None,
+                    spectral_provenance=None,
+                    v0_metric=AlbumQualityV0Metric(
+                        subject="installed", provenance="carried",
+                        avg_bitrate_kbps=245,
+                    ),
+                ),
+                "installed V0 fact cannot be carried",
+            ),
+            (
+                "verified-lossless proof dropped",
+                "source",
+                _two_axis_evidence(
+                    v0_metric=self.SOURCE_V0, proof_provenance=None,
+                ),
+                "verified-lossless proof was dropped",
+            ),
+            (
+                "verified-lossless proof still marked measured",
+                "source",
+                _two_axis_evidence(
+                    v0_metric=self.SOURCE_V0, proof_provenance="measured",
+                ),
+                "verified-lossless proof was not marked carried",
             ),
         )
-        with self.assertRaises(AssertionError):
-            assert_fingerprint_flip_two_axis_carry(
-                original_subject="installed",
-                evidence=known_bad,
-            )
 
-    def test_trips_when_source_fact_is_not_marked_carried(self):
-        known_bad = make_album_quality_evidence(
-            lineage_version=3,
-            measurement=AudioQualityMeasurement(
-                spectral_grade="genuine",
-                spectral_subject="source",
-                spectral_provenance="measured",
-            ),
-            v0_metric=AlbumQualityV0Metric(
-                subject="source",
-                provenance="measured",
-                avg_bitrate_kbps=245,
-            ),
-            verified_lossless_proof=VerifiedLosslessProof(
-                provenance="measured",
-                source="flac",
-                classifier="spectral_verified_lossless",
+    def test_every_clause_trips_with_its_own_message(self):
+        for description, subject, evidence, message in self._cases():
+            with self.subTest(description=description), self.assertRaisesRegex(
+                AssertionError, re.escape(message),
+            ):
+                assert_fingerprint_flip_two_axis_carry(
+                    original_subject=subject,
+                    evidence=evidence,
+                )
+
+    def test_legal_carried_rebuild_is_accepted(self):
+        """The must-still-work control: both legal rebuilt shapes pass."""
+        assert_fingerprint_flip_two_axis_carry(
+            original_subject="source",
+            evidence=_two_axis_evidence(v0_metric=self.SOURCE_V0),
+        )
+        assert_fingerprint_flip_two_axis_carry(
+            original_subject="installed",
+            evidence=_two_axis_evidence(
+                spectral_grade=None, spectral_subject=None,
+                spectral_provenance=None,
             ),
         )
-        with self.assertRaises(AssertionError):
-            assert_fingerprint_flip_two_axis_carry(
-                original_subject="source",
-                evidence=known_bad,
-            )
 
 
 _POISONED_LINK_IDENTITIES = (
@@ -1184,18 +1526,63 @@ def poisoned_link_identity_pairs(
     )
 
 
-def assert_no_poisoned_link_facts(evidence: AlbumQualityEvidence) -> None:
+def _single_fact_evidence(
+    *,
+    spectral_grade: str | None = None,
+    spectral_bitrate_kbps: int | None = None,
+    spectral_subject: EvidenceSubject | None = None,
+    spectral_provenance: EvidenceProvenance | None = None,
+    v0_metric: AlbumQualityV0Metric | None = None,
+    verified_lossless_proof: VerifiedLosslessProof | None = None,
+    on_disk_v0_research_attempted: bool = False,
+) -> AlbumQualityEvidence:
+    """A rebuilt row carrying exactly one linked HAVE fact, or none."""
+    evidence = make_album_quality_evidence(
+        measurement=AudioQualityMeasurement(
+            min_bitrate_kbps=128, format="MP3",
+        ),
+        v0_metric=v0_metric,
+        verified_lossless_proof=verified_lossless_proof,
+        on_disk_v0_research_attempted=on_disk_v0_research_attempted,
+    )
+    return msgspec.structs.replace(
+        evidence,
+        measurement=msgspec.structs.replace(
+            evidence.measurement,
+            spectral_grade=spectral_grade,
+            spectral_bitrate_kbps=spectral_bitrate_kbps,
+            spectral_subject=spectral_subject,
+            spectral_provenance=spectral_provenance,
+        ),
+    )
+
+
+def poisoned_link_facts(evidence: AlbumQualityEvidence) -> list[str]:
+    """Name every HAVE fact that survived a mismatched exact identity.
+
+    Naming the facts (issue #1094) keeps the seven disjuncts individually
+    provable: one shared message could only ever witness whichever fact the
+    known-bad world happened to set.
+    """
     measurement = evidence.measurement
-    if any((
-        measurement.spectral_grade is not None,
-        measurement.spectral_bitrate_kbps is not None,
-        measurement.spectral_subject is not None,
-        measurement.spectral_provenance is not None,
-        evidence.v0_metric is not None,
-        evidence.verified_lossless_proof is not None,
-        evidence.on_disk_v0_research_attempted,
-    )):
-        raise AssertionError("poisoned linked HAVE facts crossed exact identity")
+    crossed = (
+        ("spectral_grade", measurement.spectral_grade is not None),
+        ("spectral_bitrate_kbps", measurement.spectral_bitrate_kbps is not None),
+        ("spectral_subject", measurement.spectral_subject is not None),
+        ("spectral_provenance", measurement.spectral_provenance is not None),
+        ("v0_metric", evidence.v0_metric is not None),
+        ("verified_lossless_proof", evidence.verified_lossless_proof is not None),
+        ("on_disk_v0_research_attempted", evidence.on_disk_v0_research_attempted),
+    )
+    return [name for name, present in crossed if present]
+
+
+def assert_no_poisoned_link_facts(evidence: AlbumQualityEvidence) -> None:
+    facts = poisoned_link_facts(evidence)
+    if facts:
+        raise AssertionError(
+            "poisoned linked HAVE facts crossed exact identity: "
+            + ", ".join(facts))
 
 
 class TestGeneratedPoisonedCurrentLink(unittest.TestCase):
@@ -1267,16 +1654,57 @@ class TestGeneratedPoisonedCurrentLink(unittest.TestCase):
         finally:
             shutil.rmtree(root, ignore_errors=True)
 
-    def test_checker_rejects_a_known_bad_poisoned_carry(self):
-        known_bad = make_album_quality_evidence(
-            measurement=AudioQualityMeasurement(
-                spectral_grade="genuine",
-                spectral_subject="source",
-                spectral_provenance="carried",
+    def test_every_carried_fact_trips_the_checker_by_name(self):
+        """One known-bad world per fact the poisoned-link clause enumerates."""
+        cases: tuple[tuple[str, AlbumQualityEvidence], ...] = (
+            (
+                "spectral_grade",
+                _single_fact_evidence(spectral_grade="genuine"),
+            ),
+            (
+                "spectral_bitrate_kbps",
+                _single_fact_evidence(spectral_bitrate_kbps=228),
+            ),
+            (
+                "spectral_subject",
+                _single_fact_evidence(spectral_subject="source"),
+            ),
+            (
+                "spectral_provenance",
+                _single_fact_evidence(spectral_provenance="measured"),
+            ),
+            (
+                "v0_metric",
+                _single_fact_evidence(v0_metric=AlbumQualityV0Metric(
+                    subject="source", provenance="measured",
+                    avg_bitrate_kbps=245,
+                )),
+            ),
+            (
+                "verified_lossless_proof",
+                _single_fact_evidence(
+                    verified_lossless_proof=_carried_proof("measured"),
+                ),
+            ),
+            (
+                "on_disk_v0_research_attempted",
+                _single_fact_evidence(on_disk_v0_research_attempted=True),
             ),
         )
-        with self.assertRaises(AssertionError):
-            assert_no_poisoned_link_facts(known_bad)
+        for fact, known_bad in cases:
+            with self.subTest(fact=fact):
+                self.assertEqual(poisoned_link_facts(known_bad), [fact])
+                with self.assertRaisesRegex(
+                    AssertionError,
+                    re.escape(
+                        "poisoned linked HAVE facts crossed exact identity: "
+                        f"{fact}"),
+                ):
+                    assert_no_poisoned_link_facts(known_bad)
+
+    def test_fact_free_rebuild_is_accepted(self):
+        """The must-still-work control: a fact-free rebuild carries nothing."""
+        assert_no_poisoned_link_facts(_single_fact_evidence())
 
 # ---------------------------------------------------------------------------
 # 2026-07-18 proof-mint incident (Passenger / request 8877) — two invariants:
@@ -1298,16 +1726,25 @@ def assert_minted_proof_consistent(
     spectral_grade: Any,
     proof: Any,
 ) -> None:
-    """Checker: mint output obeys the proof-construction contract."""
+    """Checker: mint output obeys the proof-construction contract.
+
+    Every clause carries its own message (issue #1094) so a known-bad world
+    proves the clause it is named for rather than whichever one happens to
+    evaluate first.
+    """
     if not will_be:
         assert proof is None, "unverified attempt must not mint a proof"
         return
     assert proof is not None, "verified attempt must mint a proof"
-    assert proof.provenance == "measured", proof.provenance
-    assert proof.classifier == "spectral_verified_lossless", proof.classifier
+    assert proof.provenance == "measured", (
+        f"minted proof provenance must be measured: {proof.provenance!r}")
+    assert proof.classifier == "spectral_verified_lossless", (
+        f"minted proof classifier must be the base name: {proof.classifier!r}")
     assert proof.source, "minted proof source must be non-empty"
-    assert proof.source == proof.source.strip().lower(), proof.source
-    assert proof.detail == spectral_grade
+    assert proof.source == proof.source.strip().lower(), (
+        f"minted proof source must be normalised: {proof.source!r}")
+    assert proof.detail == spectral_grade, (
+        f"minted proof detail must be the spectral grade: {proof.detail!r}")
 
 
 def assert_crashed_result_never_persists(
@@ -1319,7 +1756,9 @@ def assert_crashed_result_never_persists(
         assert build_result.evidence is None, (
             "a crashed ImportResult must never become candidate evidence"
         )
-        assert build_result.status == "crashed_result", build_result.status
+        assert build_result.status == "crashed_result", (
+            "a crashed ImportResult must report status crashed_result: "
+            f"{build_result.status!r}")
 
 
 _filetype_token = st.one_of(
@@ -1343,6 +1782,14 @@ class TestGeneratedProofMint(unittest.TestCase):
     @example(  # the live Passenger world that crashed on args.filetype
         will_be=True, was_converted_from="flac", detected="FLAC",
         grade="genuine",
+    )
+    @example(  # #1094: the only world where the source fallback decides
+        will_be=True, was_converted_from=None, detected="UNKNOWN",
+        grade="genuine",
+    )
+    @example(  # #1094: the only world where source normalisation decides
+        will_be=True, was_converted_from="  FLAC ", detected=None,
+        grade="marginal",
     )
     def test_mint_is_total_and_consistent(
         self, will_be, was_converted_from, detected, grade,
@@ -1413,35 +1860,113 @@ class EvidenceBuildResultForTest:
     status: str
 
 
+def _planted_proof(
+    *,
+    provenance: EvidenceProvenance = "measured",
+    source: str = "flac",
+    classifier: str = "spectral_verified_lossless",
+    detail: str | None = "genuine",
+) -> VerifiedLosslessProof:
+    return VerifiedLosslessProof(
+        provenance=provenance, source=source,
+        classifier=classifier, detail=detail,
+    )
+
+
 class TestProofMintCheckersTripOnViolations(unittest.TestCase):
-    def test_trips_on_missing_proof_for_verified_attempt(self):
-        with self.assertRaises(AssertionError):
-            assert_minted_proof_consistent(
-                True, "flac", "FLAC", "genuine", None)
+    """Per-clause known-bad worlds for both mint checkers (issue #1094)."""
 
-    def test_trips_on_phantom_proof_for_unverified_attempt(self):
-        planted = VerifiedLosslessProof(
-            provenance="measured", source="flac",
-            classifier="spectral_verified_lossless",
+    # (description, will_be_verified_lossless, planted proof, message)
+    MINT_CASES: tuple[
+        tuple[str, bool, VerifiedLosslessProof | None, str], ...
+    ] = (
+        (
+            "phantom proof on an unverified attempt",
+            False, _planted_proof(),
+            "unverified attempt must not mint a proof",
+        ),
+        (
+            "no proof on a verified attempt",
+            True, None,
+            "verified attempt must mint a proof",
+        ),
+        (
+            "proof minted as carried",
+            True, _planted_proof(provenance="carried"),
+            "minted proof provenance must be measured: 'carried'",
+        ),
+        (
+            "proof minted with a leg classifier no leg adjudicated",
+            True, _planted_proof(classifier="spectral_verified_lossless_v3"),
+            ("minted proof classifier must be the base name: "
+             "'spectral_verified_lossless_v3'"),
+        ),
+        (
+            "proof minted with an empty source",
+            True, _planted_proof(source=""),
+            "minted proof source must be non-empty",
+        ),
+        (
+            "proof minted with an unnormalised source",
+            True, _planted_proof(source="FLAC "),
+            "minted proof source must be normalised: 'FLAC '",
+        ),
+        (
+            "proof detail is not the measured grade",
+            True, _planted_proof(detail=None),
+            "minted proof detail must be the spectral grade: None",
+        ),
+    )
+
+    # (description, planted build result, message) — decision is always "crash"
+    CRASH_CASES: tuple[
+        tuple[str, EvidenceBuildResultForTest, str], ...
+    ] = (
+        (
+            "crashed result built evidence",
+            EvidenceBuildResultForTest(
+                evidence=object(), status="crashed_result"),
+            "a crashed ImportResult must never become candidate evidence",
+        ),
+        (
+            "crashed result reported another status",
+            EvidenceBuildResultForTest(evidence=None, status="incomplete"),
+            ("a crashed ImportResult must report status crashed_result: "
+             "'incomplete'"),
+        ),
+    )
+
+    def test_every_mint_clause_trips_with_its_own_message(self):
+        for description, will_be, proof, message in self.MINT_CASES:
+            with self.subTest(description=description), self.assertRaisesRegex(
+                AssertionError, re.escape(message),
+            ):
+                assert_minted_proof_consistent(
+                    will_be, "flac", "FLAC", "genuine", proof,
+                )
+
+    def test_every_crash_clause_trips_with_its_own_message(self):
+        for description, build_result, message in self.CRASH_CASES:
+            with self.subTest(description=description), self.assertRaisesRegex(
+                AssertionError, re.escape(message),
+            ):
+                assert_crashed_result_never_persists(
+                    "crash", build_result,
+                )
+
+    def test_legal_mint_and_crash_worlds_are_accepted(self):
+        """The must-still-work control for both mint-side checkers."""
+        assert_minted_proof_consistent(
+            True, "flac", "FLAC", "genuine", _planted_proof())
+        assert_minted_proof_consistent(False, "flac", "FLAC", "genuine", None)
+        assert_crashed_result_never_persists(
+            "crash",
+            EvidenceBuildResultForTest(evidence=None, status="crashed_result"),
         )
-        with self.assertRaises(AssertionError):
-            assert_minted_proof_consistent(
-                False, "flac", "FLAC", "genuine", planted)
-
-    def test_trips_on_unnormalised_source(self):
-        planted = VerifiedLosslessProof(
-            provenance="measured", source="FLAC ",
-            classifier="spectral_verified_lossless", detail="genuine",
+        assert_crashed_result_never_persists(
+            "import", EvidenceBuildResultForTest(
+                evidence=object(), status="ready"),
         )
-        with self.assertRaises(AssertionError):
-            assert_minted_proof_consistent(
-                True, "FLAC ", None, "genuine", planted)
-
-    def test_trips_when_crashed_result_builds_evidence(self):
-        planted = EvidenceBuildResultForTest(
-            evidence=object(), status="ready")
-        with self.assertRaises(AssertionError):
-            assert_crashed_result_never_persists("crash", planted)
 
 
 if __name__ == "__main__":

--- a/tests/test_quality_generated.py
+++ b/tests/test_quality_generated.py
@@ -27,6 +27,7 @@ Full usage guide: docs/generated-testing.md.
 """
 
 import os
+import re
 import sys
 import unittest
 from collections.abc import Callable
@@ -251,6 +252,20 @@ def assert_post_import_action_matches(
         raise AssertionError(
             f"post-import mapping drift for {decision}: {actual!r} != {expected!r}"
         )
+
+
+def assert_search_override_is_a_string(raw_override: object) -> str | None:
+    """The gate's search override crosses the transition as a string or None.
+
+    A module function rather than an inline narrowing guard so the known-bad
+    self-test can call it directly (docs/generated-testing.md § "Per-clause
+    proof").
+    """
+    if raw_override is not None and not isinstance(raw_override, str):
+        raise AssertionError(
+            f"quality gate wrote a non-string override: {raw_override!r}"
+        )
+    return raw_override
 
 
 def assert_quality_decision_failure_reopens_full_tier(
@@ -1042,6 +1057,32 @@ def assert_counterfactual_is_the_deferred_stage2(
         )
 
 
+def assert_carve_out_lever_is_stage2_inert(
+    decision: dict[str, object],
+    levered: dict[str, object],
+    *,
+    context: str = "",
+) -> None:
+    """The Stage-1 carve-out lever disables the short-circuit and nothing else.
+
+    Qualifies the counterfactual reference used by
+    ``assert_counterfactual_is_the_deferred_stage2``: over worlds where Stage
+    1 does not short-circuit anyway, the levered and unlevered runs must reach
+    the same Stage-2 decision and the same basis.
+    """
+    if (
+        decision["stage2_import"] != levered["stage2_import"]
+        or decision["comparison_basis"] != levered["comparison_basis"]
+    ):
+        raise AssertionError(
+            "the Stage-1 carve-out lever moved Stage 2: "
+            f"{decision['stage2_import']!r}/{decision['comparison_basis']!r} "
+            f"vs {levered['stage2_import']!r}/"
+            f"{levered['comparison_basis']!r}"
+            + (f" [{context}]" if context else "")
+        )
+
+
 def assert_counterfactual_reported_exactly_when_stage1_short_circuits(
     decision: dict[str, object],
     *,
@@ -1259,6 +1300,22 @@ def assert_basis_consistent(result: SimResult) -> None:
     if branch == "transcode_rank_regression" and verdict != "worse":
         raise AssertionError(
             f"transcode rank regression must be worse: {basis!r}")
+
+
+_COMPARED_STAGE2_DECISIONS = (
+    "import", "downgrade", "transcode_upgrade", "transcode_downgrade",
+)
+
+
+def assert_measured_decision_carries_basis(result: SimResult) -> None:
+    """A measured decision against an existing album always explains itself."""
+    if (
+        result.stage2_import in _COMPARED_STAGE2_DECISIONS
+        and result.comparison_basis is None
+    ):
+        raise AssertionError(
+            f"measured decision {result.stage2_import!r} against an "
+            f"existing album lost its comparison basis: {result!r}")
 
 
 def assert_basis_metrics_truthful(
@@ -2091,14 +2148,9 @@ class TestGeneratedSimulatorInvariants(unittest.TestCase):
                 )
                 self.assertIsNotNone(plan)
                 assert plan is not None
-                raw_override = plan.transition.fields.get(
-                    "search_filetype_override",
+                raw_override = assert_search_override_is_a_string(
+                    plan.transition.fields.get("search_filetype_override"),
                 )
-                if raw_override is not None and not isinstance(raw_override, str):
-                    raise AssertionError(
-                        "quality gate wrote a non-string override: "
-                        f"{raw_override!r}"
-                    )
                 assert_post_import_action_matches(
                     decision=decision,
                     status=plan.transition.target_status,
@@ -2555,17 +2607,11 @@ class TestGeneratedSimulatorInvariants(unittest.TestCase):
         """
         decision = _stage_parity_decision(world)
         assume(decision["stage1_spectral"] != "reject")
-        levered = _stage_parity_deferred_decision(world)
-        if (
-            decision["stage2_import"] != levered["stage2_import"]
-            or decision["comparison_basis"] != levered["comparison_basis"]
-        ):
-            raise AssertionError(
-                "the Stage-1 carve-out lever moved Stage 2: "
-                f"{decision['stage2_import']!r}/{decision['comparison_basis']!r} "
-                f"vs {levered['stage2_import']!r}/"
-                f"{levered['comparison_basis']!r} [{world!r}]"
-            )
+        assert_carve_out_lever_is_stage2_inert(
+            decision,
+            _stage_parity_deferred_decision(world),
+            context=repr(world),
+        )
 
     @given(world=inadmissible_spectral_pair_worlds())
     @example(world=_PINNED_INADMISSIBLE_WORLDS[0])
@@ -2689,18 +2735,7 @@ class TestGeneratedSimulatorInvariants(unittest.TestCase):
     def test_measured_decisions_with_existing_carry_basis(
             self, album, download):
         result = simulate(album, download)
-        if (
-            result.stage2_import in (
-                "import",
-                "downgrade",
-                "transcode_upgrade",
-                "transcode_downgrade",
-            )
-            and result.comparison_basis is None
-        ):
-            raise AssertionError(
-                f"measured decision {result.stage2_import!r} against an "
-                    f"existing album lost its comparison basis: {result!r}")
+        assert_measured_decision_carries_basis(result)
         assert_basis_consistent(result)
 
 
@@ -3360,7 +3395,14 @@ _VALID_VERDICTS = ("confident_reject", "would_import", "uncertain")
 
 
 def assert_classification_coherent(
-    decision: dict, expected_early_exit_key: str | None) -> None:
+    decision: dict,
+    expected_early_exit_key: str | None,
+    *,
+    classify_fn: Callable[
+        [dict[str, object]], tuple[str, bool, str | None]
+    ] = classify_full_pipeline_decision,
+    name_fn: Callable[[dict[str, object]], str] = evidence_decision_name,
+) -> None:
     """The classification layer (cleanup eligibility + dispatch decision
     name) must be coherent with the decision dict it classifies.
 
@@ -3368,9 +3410,17 @@ def assert_classification_coherent(
     ``classify_full_pipeline_decision`` / ``evidence_decision_name``
     (which gate wrong-match folder cleanup) were the one decision-policy
     layer no generated test reached.
+
+    Three of the clauses below key on what the classifiers RETURN, not on the
+    decision dict, and today's production pair cannot return those shapes at
+    all — an unknown verdict, a falsy dispatch name, or ``cleanup_eligible``
+    decoupled from ``confident_reject``. They are the fail-closed half of the
+    checker, so the classifiers are kwarg-injected (house DI seam) and the
+    known-bad self-test drives them with a planted classifier rather than
+    asserting the clauses in prose.
     """
-    verdict, cleanup_eligible, reason = classify_full_pipeline_decision(decision)
-    name = evidence_decision_name(decision)
+    verdict, cleanup_eligible, reason = classify_fn(decision)
+    name = name_fn(decision)
     if verdict not in _VALID_VERDICTS:
         raise AssertionError(f"unknown classification verdict: {verdict!r}")
     if not name or not isinstance(name, str):
@@ -3550,6 +3600,18 @@ def _planted_bad_import(
         backfill_override=None,
         search_filetype_override_after=None,
     )
+
+
+def _ill_typed_sim_result(field: str, value: object) -> SimResult:
+    """A ``SimResult`` whose runtime type for one field violates its annotation.
+
+    The totality clauses of ``assert_decision_is_definitive`` exist for exactly
+    the values the annotations forbid, so their world can only be built by
+    going around the frozen dataclass rather than through it.
+    """
+    result = _planted_bad_import()
+    object.__setattr__(result, field, value)
+    return result
 
 
 class TestInadmissiblePairDomainIsWhatItClaims(unittest.TestCase):
@@ -6347,18 +6409,41 @@ class TestStoredFormatCheckerSelfTests(unittest.TestCase):
 class TestInvariantCheckersTripOnViolations(unittest.TestCase):
     """Known-bad self-tests: prove the harness detects what it claims to."""
 
-    def test_definitive_checker_trips_on_bogus_status(self):
-        bad = SimResult(
+    def test_definitive_checker_trips_on_every_clause(self):
+        """All four totality clauses, each proven by its own message.
+
+        The three type clauses short-circuit ahead of the status clause, so a
+        single bogus world only ever proved the one it reached.
+        """
+        bogus_status = SimResult(
             imported=False, keep_searching=False, denylisted=False,
             final_status=None, stage0_spectral_gate=None,
             stage1_spectral=None, stage2_import=None,
             stage3_quality_gate=None, backfill_override=None,
             search_filetype_override_after=None)
-        with self.assertRaises(AssertionError):
-            assert_decision_is_definitive(bad)
+        for label, bad, expected in (
+            ("imported", _ill_typed_sim_result("imported", "yes"),
+             r"^imported is not bool: 'yes'$"),
+            ("keep_searching", _ill_typed_sim_result("keep_searching", "no"),
+             r"^keep_searching is not bool: 'no'$"),
+            ("denylisted", _ill_typed_sim_result("denylisted", 1),
+             r"^denylisted is not bool: 1$"),
+            ("final_status", bogus_status,
+             (r"^auto-mode decision must end imported/wanted, "
+              r"got final_status=None$")),
+            ("final_status_value",
+             replace(_planted_bad_import(), final_status="processing"),
+             (r"^auto-mode decision must end imported/wanted, "
+              r"got final_status='processing'$")),
+        ):
+            with self.subTest(clause=label), self.assertRaisesRegex(
+                    AssertionError, expected):
+                assert_decision_is_definitive(bad)
 
     def test_verified_lossless_checker_trips_on_import(self):
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+                AssertionError,
+                r"^lossy candidate imported over raw verified-lossless FLAC: "):
             assert_lossy_not_imported_over_verified_lossless(
                 _planted_bad_import())
 
@@ -6387,34 +6472,133 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
             ),
             current_verified_lossless_proof=False,
         )
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+                AssertionError,
+                r"^proof-bearing HAVE was automatically replaced$"):
             assert_verified_lossless_proof_locks_candidate(mutant)
 
-    def test_evidence_proof_lock_checker_trips_on_integrity_reject(self):
-        with self.assertRaises(AssertionError):
-            assert_evidence_proof_lock_preserves_imported({
-                "stage2_import": None,
-                "final_status": "wanted",
-                "imported": False,
-                "denylisted": True,
-                "keep_searching": True,
-                "preimport_audio": "reject_corrupt",
-                "preimport_bad_hash": None,
-                "preimport_nested": None,
-                "preimport_empty_fileset": None,
-                "preimport_mixed_source": None,
-            })
+    def test_proof_lock_checker_trips_on_every_clause(self):
+        """Each proof-lock clause proven from a real proof-locked decision.
+
+        The baseline is what ``simulate`` really produces under a current
+        proof, so every planted violation below mutates a shape production
+        emits rather than a hand-written one (Rule C).
+        """
+        locked = simulate(
+            AlbumState(
+                "proof_locked", 245, False, "genuine", None, True, None,
+                existing_format="FLAC", avg_bitrate=245),
+            DownloadScenario(
+                "candidate", is_flac=False, min_bitrate=320, is_cbr=True,
+                avg_bitrate=320, new_format="MP3"),
+            current_verified_lossless_proof=True)
+        assert_verified_lossless_proof_locks_candidate(locked)
+        for label, bad, expected in (
+            ("replaced", replace(locked, imported=True),
+             r"^proof-bearing HAVE was automatically replaced$"),
+            ("missed_lock", replace(locked, stage2_import="import"),
+             r"^proof-bearing HAVE missed verified_lossless_locked: 'import'$"),
+            ("not_terminal", replace(locked, final_status="wanted"),
+             (r"^proof lock did not preserve terminal imported state: "
+              r"status='wanted', keep=False$")),
+            ("keep_searching", replace(locked, keep_searching=True),
+             (r"^proof lock did not preserve terminal imported state: "
+              r"status='imported', keep=True$")),
+            ("punished", replace(locked, denylisted=True),
+             r"^proof lock punished the candidate source$"),
+        ):
+            with self.subTest(clause=label), self.assertRaisesRegex(
+                    AssertionError, expected):
+                assert_verified_lossless_proof_locks_candidate(bad)
+
+    def _evidence_proof_locked_decision(self, **overrides: object) -> dict:
+        """A real proof-locked evidence decision, optionally corrupted."""
+        current = build_parity_current_evidence(
+            min_bitrate=128, avg_bitrate=128, format="Opus")
+        assert current is not None
+        decision = full_pipeline_decision_from_evidence(
+            build_parity_candidate_evidence(
+                is_flac=False, min_bitrate=245, is_cbr=False),
+            msgspec.structs.replace(
+                current,
+                verified_lossless_proof=VerifiedLosslessProof(
+                    provenance="measured",
+                    source="generated",
+                    classifier="generated",
+                ),
+            ),
+        )
+        assert decision["stage2_import"] == "verified_lossless_locked"
+        decision.update(overrides)
+        return decision
+
+    def test_evidence_proof_lock_checker_trips_on_every_clause(self):
+        """Each evidence proof-lock clause proven by its own message."""
+        clean = self._evidence_proof_locked_decision()
+        assert_evidence_proof_lock_preserves_imported(clean)
+        for label, overrides, expected in (
+            ("missed_lock", {"stage2_import": "import"},
+             r"^evidence proof lock missed: 'import'$"),
+            ("lost_have", {"final_status": "wanted"},
+             r"^evidence proof lock did not preserve the installed HAVE$"),
+            ("replaced", {"imported": True},
+             r"^evidence proof lock did not preserve the installed HAVE$"),
+            ("punished", {"denylisted": True},
+             r"^evidence proof lock reopened or punished source$"),
+            ("reopened", {"keep_searching": True},
+             r"^evidence proof lock reopened or punished source$"),
+            ("leaked_reject", {"preimport_audio": "reject_corrupt"},
+             (r"^evidence proof lock leaked candidate reject "
+              r"preimport_audio='reject_corrupt'$")),
+        ):
+            with self.subTest(clause=label), self.assertRaisesRegex(
+                    AssertionError, expected):
+                assert_evidence_proof_lock_preserves_imported(
+                    self._evidence_proof_locked_decision(**overrides))
 
     def test_downgrade_checker_trips_on_accept(self):
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+                AssertionError,
+                r"^obvious lower-rank lossy candidate accepted: "):
             assert_obvious_downgrade_not_accepted(_planted_bad_import())
 
-    def test_unverified_lossy_checker_trips_on_terminal_import(self):
-        with self.assertRaises(AssertionError):
-            assert_unverified_lossy_never_terminal(_planted_bad_import())
+    def test_unverified_lossy_checker_trips_on_every_clause(self):
+        """All four retained-inventory clauses, from a real retained world."""
+        retained = simulate(
+            _FRESH_ALBUM,
+            DownloadScenario(
+                "usable_lossy", is_flac=False, min_bitrate=245, is_cbr=False,
+                is_vbr=True, avg_bitrate=245, new_format="MP3"))
+        assert_unverified_lossy_never_terminal(retained)
+        for label, bad, expected in (
+            ("not_retained", replace(retained, imported=False),
+             r"^usable lossy first copy was not retained: "),
+            ("terminal_accept",
+             replace(retained, stage3_quality_gate="accept"),
+             r"^unverified lossy copy was accepted terminally: "),
+            ("stopped_searching",
+             replace(retained, final_status="imported", keep_searching=False),
+             r"^unverified lossy copy stopped searching: "),
+            ("not_denylisted", replace(retained, denylisted=False),
+             r"^retained lossy source was not denylisted: "),
+        ):
+            with self.subTest(clause=label), self.assertRaisesRegex(
+                    AssertionError, expected):
+                assert_unverified_lossy_never_terminal(bad)
+
+    def test_search_override_checker_trips_on_a_non_string(self):
+        self.assertIsNone(assert_search_override_is_a_string(None))
+        self.assertEqual(assert_search_override_is_a_string("lossless"),
+                         "lossless")
+        with self.assertRaisesRegex(
+                AssertionError,
+                r"^quality gate wrote a non-string override: 7$"):
+            assert_search_override_is_a_string(7)
 
     def test_proof_backed_target_checker_trips_on_transcode_routing(self):
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+                AssertionError,
+                r"^proof-backed configured target was not terminal: "):
             assert_proof_backed_target_uses_terminal_gate({
                 "stage2_import": "transcode_upgrade",
                 "stage3_quality_gate": "accept",
@@ -6437,11 +6621,18 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
                 "denylist": True,
                 **overrides,
             }
-            with self.subTest(field=field), self.assertRaises(AssertionError):
+            with self.subTest(field=field), self.assertRaisesRegex(
+                    AssertionError,
+                    r"^post-import mapping drift for requeue_upgrade: "):
                 assert_post_import_action_matches(**kwargs)
 
-    def test_quality_failure_checker_trips_on_terminal_acceptance(self):
+    def test_quality_failure_checker_trips_on_both_clauses(self):
         from lib import transitions
+
+        with self.assertRaisesRegex(
+                AssertionError,
+                r"^quality decision failure returned no recovery plan$"):
+            assert_quality_decision_failure_reopens_full_tier(None)
 
         bad = QualityGatePlan(
             transition=transitions.RequestTransition.to_imported(
@@ -6449,11 +6640,17 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
             ),
             successful_terminal_acceptance=True,
         )
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+                AssertionError,
+                r"^quality decision failure did not reopen full tiers: "):
             assert_quality_decision_failure_reopens_full_tier(bad)
 
     def test_affirmative_verification_checker_trips_on_absent_evidence(self):
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+                AssertionError,
+                r"^verified lossless minted without affirmative spectral "
+                r"evidence: grade=None, probe_kind='lossless_source_v0', "
+                r"avg=300, min=250$"):
             assert_verified_lossless_has_affirmative_evidence(
                 True,
                 spectral_grade=None,
@@ -6464,7 +6661,11 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
 
     def test_strictly_lower_spectral_checker_trips_on_violations(self):
         # Planted tie-reject (the Mark DeNardo bug): equal floor rejected.
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+                AssertionError,
+                r"^spectral 128 vs 128 \(grade=suspect\) is a tie or upgrade "
+                r"but was rejected at Stage 1 instead of deferring to Stage 2: "
+                r"'reject'$"):
             assert_only_strictly_lower_spectral_rejects(
                 "reject",
                 grade="suspect",
@@ -6472,7 +6673,10 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
                 existing_spectral=128,
             )
         # Planted strictly-lower non-reject: worse content that failed to reject.
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+                AssertionError,
+                r"^strictly-lower spectral 96 < 128 \(grade=likely_transcode\) "
+                r"must reject at Stage 1, got 'import'$"):
             assert_only_strictly_lower_spectral_rejects(
                 "import",
                 grade="likely_transcode",
@@ -6480,23 +6684,34 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
                 existing_spectral=128,
             )
 
-    def test_existing_override_noop_checker_trips_on_divergence(self):
+    def test_existing_override_noop_checker_trips_on_both_clauses(self):
         # Planted phantom upgrade (the Deerhunter bug): applying the existing-
-        # side spectral override flips the verdict from equivalent to better.
-        with self.assertRaises(AssertionError):
+        # side spectral override flips the Stage-2 decision.
+        with self.assertRaisesRegex(
+                AssertionError,
+                r"^existing-side spectral override changed the Stage-2 "
+                r"decision under a shared spectral clamp: 'import' "
+                r"\(override\) vs 'downgrade' \(none\)$"):
             assert_existing_override_noop_under_shared_clamp(
                 {"stage2_import": "import",
                  "comparison_basis": {"verdict": "better"}},
                 {"stage2_import": "downgrade",
                  "comparison_basis": {"verdict": "equivalent"}},
             )
-        # A stage2-only divergence must also trip (verdict alone is not enough).
-        with self.assertRaises(AssertionError):
+        # The verdict clause, which the decision clause short-circuits past:
+        # the two runs agree on the decision and disagree on WHY. Both of the
+        # worlds this self-test used to carry moved ``stage2_import``, so the
+        # verdict clause had no proof at all.
+        with self.assertRaisesRegex(
+                AssertionError,
+                r"^existing-side spectral override changed the comparison "
+                r"verdict under a shared spectral clamp: 'better' "
+                r"\(override\) vs 'equivalent' \(none\)$"):
             assert_existing_override_noop_under_shared_clamp(
                 {"stage2_import": "import",
                  "comparison_basis": {"verdict": "better"}},
-                {"stage2_import": "downgrade",
-                 "comparison_basis": {"verdict": "better"}},
+                {"stage2_import": "import",
+                 "comparison_basis": {"verdict": "equivalent"}},
             )
         # An invariant (identical) pair must NOT trip.
         assert_existing_override_noop_under_shared_clamp(
@@ -6511,7 +6726,11 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
         reject alongside a planted Stage-2 "better" must trip the checker;
         every other verdict pairing (including a real reject-vs-worse
         agreement) must NOT."""
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+                AssertionError,
+                r"^Stage 1 rejected a candidate Stage 2 scores as an upgrade: "
+                r"stage1='reject' stage2\.verdict='better' "
+                r"stage2\.branch='spectral_tiebreak'$"):
             assert_stage1_never_contradicts_stage2(
                 "reject",
                 QualityComparisonBasis(
@@ -6580,9 +6799,36 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
             ("keep_searching", False),
             ("imported", True),
         ):
-            with self.subTest(field=field), self.assertRaises(AssertionError):
+            with self.subTest(field=field), self.assertRaisesRegex(
+                    AssertionError,
+                    r"^Stage-2 state leaked onto a Stage-1 reject decision: "
+                    + re.escape(f"{field}={leaked!r}")):
                 assert_stage1_reject_leaks_no_stage2_state(
                     self._stage1_reject_decision(**{field: leaked}))
+
+    def test_carve_out_lever_checker_trips_on_a_moved_stage_2(self):
+        """Issue #829 Phase 5 PR2d: the lever-inertness clause, proven.
+
+        Extracted from the property body so it can be driven directly — the
+        baseline is a real deferring decision and its real levered twin.
+        """
+        world = replace(_STAGE1_REJECT_COUNTERFACTUAL_WORLD, new_spectral=192)
+        decision = _stage_parity_decision(world)
+        levered = _stage_parity_deferred_decision(world)
+        assert decision["stage1_spectral"] != "reject", repr(decision)
+        assert_carve_out_lever_is_stage2_inert(decision, levered)
+        for label, moved in (
+            ("stage2_import", {"stage2_import": "planted_other_decision"}),
+            ("comparison_basis",
+             {"comparison_basis": {"verdict": "planted_other_verdict"}}),
+        ):
+            planted = dict(levered)
+            planted.update(moved)
+            assert planted[label] != decision[label], repr(decision)
+            with self.subTest(field=label), self.assertRaisesRegex(
+                    AssertionError,
+                    r"^the Stage-1 carve-out lever moved Stage 2: "):
+                assert_carve_out_lever_is_stage2_inert(decision, planted)
 
     def test_counterfactual_truth_checker_trips_on_a_fabricated_value(self):
         """Issue #829 Phase 5 PR2d known-bad self-test: a counterfactual that
@@ -6601,7 +6847,10 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
             planted = dict(short_circuited)
             planted[field] = fabricated
             with self.subTest(field=field, value=fabricated), \
-                    self.assertRaises(AssertionError):
+                    self.assertRaisesRegex(
+                        AssertionError,
+                        r"^the reported Stage-2 counterfactual is not what "
+                        r"Stage 2 decides: " + re.escape(f"{field}=")):
                 assert_counterfactual_is_the_deferred_stage2(planted, deferred)
 
     def test_counterfactual_reporting_checker_trips_on_all_three_violations(self):
@@ -6616,13 +6865,20 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
 
         dropped = dict(deferring)
         del dropped["comparison_basis_if_stage1_deferred"]
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+                AssertionError,
+                r"^decision dict is missing audit keys "
+                r"\['comparison_basis_if_stage1_deferred'\]$"):
             assert_counterfactual_reported_exactly_when_stage1_short_circuits(
                 dropped)
 
         doubled = dict(deferring)
         doubled["stage2_import_if_stage1_deferred"] = "downgrade"
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+                AssertionError,
+                r"^a Stage-2 counterfactual was reported alongside a real "
+                r"Stage-2 decision: "
+                r"stage2_import_if_stage1_deferred='downgrade'$"):
             assert_counterfactual_reported_exactly_when_stage1_short_circuits(
                 doubled)
 
@@ -6636,7 +6892,10 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
             short_circuited)
         silent = dict(short_circuited)
         silent["stage2_import_if_stage1_deferred"] = None
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+                AssertionError,
+                r"^Stage 1 short-circuited but reported no Stage-2 "
+                r"counterfactual at all"):
             assert_counterfactual_reported_exactly_when_stage1_short_circuits(
                 silent)
 
@@ -6647,13 +6906,19 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
         HAVE ranked ``transparent`` on its 320 container while its own
         cliff-derived class of 128 ranks ``acceptable``.
         """
-        with self.assertRaises(AssertionError) as caught:
+        with self.assertRaisesRegex(
+                AssertionError,
+                r"^the installed copy was ranked above its own spectral class: "
+                r"existing_rank='transparent' but its class alone ranks "
+                r"'acceptable' — neither the symmetric clamp nor the one-sided "
+                r"override represented it by its real content$"):
             assert_have_is_represented_by_its_own_class(
                 "transparent", "acceptable")
-        self.assertIn("ranked above its own spectral class",
-                      str(caught.exception))
         # One tier over is still a violation.
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+                AssertionError,
+                r"^the installed copy was ranked above its own spectral class: "
+                r"existing_rank='good'"):
             assert_have_is_represented_by_its_own_class("good", "acceptable")
         # Equal is the normal clamped/overridden case, and BELOW the class
         # is fine too — the raw metric can be the tighter of the two.
@@ -6664,20 +6929,30 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
     def test_inadmissible_existing_class_checker_trips(self):
         """Issue #829 PR2c known-bad self-test — both clauses trip."""
         # Clause 1: a Stage-1 rejection built on an inadmissible pair.
-        with self.assertRaises(AssertionError) as caught:
+        with self.assertRaisesRegex(
+                AssertionError,
+                r"^Stage 1 rejected on a spectral comparison Stage 2 is not "
+                r"permitted to make: the two spectral classes are not "
+                r"comparable, so the existing side contributes no class at "
+                r"all$"):
             assert_stage1_ignores_inadmissible_existing_spectral(
                 "reject", "import_no_exist")
-        self.assertIn("not permitted to make", str(caught.exception))
         # Clause 2: the silent direction — no rejection, but the withheld
         # evidence still moved the verdict.
-        with self.assertRaises(AssertionError) as caught:
+        with self.assertRaisesRegex(
+                AssertionError,
+                r"^an inadmissible existing-side spectral class changed the "
+                r"Stage 1 verdict: 'import_upgrade' \(evidence present\) vs "
+                r"'import_no_exist' \(evidence withheld\)$"):
             assert_stage1_ignores_inadmissible_existing_spectral(
                 "import_upgrade", "import_no_exist")
-        self.assertIn("changed the Stage 1 verdict", str(caught.exception))
         # A rejection trips even when the withheld run rejects too — a
         # mutant that fabricates a class from nothing must not slip through
         # the equality clause.
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+                AssertionError,
+                r"^Stage 1 rejected on a spectral comparison Stage 2 is not "
+                r"permitted to make: "):
             assert_stage1_ignores_inadmissible_existing_spectral(
                 "reject", "reject")
         # Invariant worlds must NOT trip, including the gate-skipped shape.
@@ -6686,21 +6961,34 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
         assert_stage1_ignores_inadmissible_existing_spectral("import", "import")
         assert_stage1_ignores_inadmissible_existing_spectral(None, None)
 
-    def test_unmapped_codec_checker_trips_on_terminal_narrowing(self):
-        bad = SimResult(
-            imported=True,
-            keep_searching=False,
-            denylisted=False,
-            final_status="imported",
-            stage0_spectral_gate="skip_vbr_high",
-            stage1_spectral=None,
-            stage2_import="import",
-            stage3_quality_gate="accept",
-            backfill_override=None,
-            search_filetype_override_after="lossless",
-        )
-        with self.assertRaises(AssertionError):
-            assert_unmapped_first_copy_stays_searchable(bad)
+    def test_unmapped_codec_checker_trips_on_every_clause(self):
+        """All four retained-without-a-ceiling clauses, from a real world."""
+        retained = simulate(
+            _FRESH_ALBUM,
+            DownloadScenario(
+                name="generated_unmapped_codec", is_flac=False,
+                min_bitrate=192, is_cbr=True, is_vbr=False, avg_bitrate=192,
+                spectral_grade=None, new_format="zzz"))
+        assert_unmapped_first_copy_stays_searchable(retained)
+        for label, bad, expected in (
+            ("not_imported", replace(retained, imported=False),
+             r"^unmapped first copy was not retained: "),
+            ("not_stage2_import",
+             replace(retained, stage2_import="downgrade"),
+             r"^unmapped first copy was not retained: "),
+            ("terminal",
+             replace(retained, final_status="imported", keep_searching=False),
+             r"^unmapped first copy became terminal: "),
+            ("claimed_ceiling",
+             replace(retained, stage3_quality_gate="accept"),
+             r"^unmapped first copy claimed a quality ceiling: "),
+            ("narrowed",
+             replace(retained, search_filetype_override_after="lossless"),
+             r"^unmapped first copy narrowed to lossless: "),
+        ):
+            with self.subTest(clause=label), self.assertRaisesRegex(
+                    AssertionError, expected):
+                assert_unmapped_first_copy_stays_searchable(bad)
 
     def test_classification_checker_trips_on_bad_verdict(self):
         # A dict claiming both imported and a reject-stage decision would
@@ -6710,7 +6998,10 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
             "stage2_import": "downgrade",
             "stage3_quality_gate": None,
         }
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+                AssertionError,
+                r"^imported decision classified as \('confident_reject', "
+                r"cleanup_eligible=True\)$"):
             assert_classification_coherent(bad, None)
 
     def test_classification_checker_trips_on_misnamed_fact(self):
@@ -6720,8 +7011,79 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
             "preimport_audio": "reject_nested",  # planted wrong value
             "imported": False,
         }
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+                AssertionError,
+                r"^integrity fact audio_corrupt classified as "
+                r"\('uncertain', False, 'unknown'\)$"):
             assert_classification_coherent(bad, "preimport_audio")
+
+    def test_classification_checker_trips_on_a_fact_named_for_dispatch(self):
+        """The name clause, which the classification clause short-circuits past.
+
+        Both facts are really present, so ``classify_full_pipeline_decision``
+        answers with the higher-priority ``nested_layout`` while
+        ``evidence_decision_name`` answers ``audio_corrupt`` — the two
+        production functions disagreeing about the same dict.
+        """
+        both = {
+            "preimport_nested": "reject_nested",
+            "preimport_audio": "reject_corrupt",
+            "imported": False,
+        }
+        with self.assertRaisesRegex(
+                AssertionError,
+                r"^integrity fact nested_layout named 'audio_corrupt' for "
+                r"dispatch$"):
+            assert_classification_coherent(both, "preimport_nested")
+
+    def test_classification_checker_trips_on_a_planted_classifier(self):
+        """The three clauses keyed on what the classifiers RETURN.
+
+        No decision dict can reach them: ``classify_full_pipeline_decision``
+        only ever returns one of three verdicts and only ever pairs
+        ``cleanup_eligible=True`` with ``confident_reject``, and
+        ``evidence_decision_name`` is typed ``str`` and never returns an empty
+        one. They are fail-closed legislation over the classifier pair, so the
+        world that fires them is a planted classifier, injected through the
+        checker's own kwarg seam rather than patched.
+        """
+        clean = {"imported": True, "stage2_import": "import"}
+        assert_classification_coherent(clean, None)
+
+        with self.assertRaisesRegex(
+                AssertionError, r"^unknown classification verdict: 'vibes'$"):
+            assert_classification_coherent(
+                clean, None,
+                classify_fn=lambda _decision: ("vibes", False, None))
+
+        with self.assertRaisesRegex(
+                AssertionError, r"^evidence_decision_name returned ''$"):
+            assert_classification_coherent(
+                clean, None, name_fn=lambda _decision: "")
+
+        with self.assertRaisesRegex(
+                AssertionError,
+                r"^cleanup_eligible without confident_reject: "
+                r"'would_import'/'import'$"):
+            assert_classification_coherent(
+                clean, None,
+                classify_fn=lambda _decision: ("would_import", True, "import"))
+
+    def test_integrity_fact_builder_refuses_an_unknown_fact(self):
+        """The generated taxonomy's own fall-through, proven.
+
+        ``_INTEGRITY_FACTS`` drives the strategy; a fact added there and not
+        here must fail loudly rather than silently return a clean candidate.
+        """
+        candidate = build_parity_candidate_evidence(
+            is_flac=False, min_bitrate=245, is_cbr=False)
+        for fact in _INTEGRITY_FACTS:
+            with self.subTest(fact=fact):
+                self.assertIsNotNone(_with_integrity_fact(candidate, fact))
+        with self.assertRaisesRegex(
+                AssertionError,
+                r"^unknown generated integrity fact: not_a_real_fact$"):
+            _with_integrity_fact(candidate, "not_a_real_fact")
 
     def _planted_basis(self, **overrides):
         basis = {
@@ -6745,24 +7107,66 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
             backfill_override=None, search_filetype_override_after=None,
             comparison_basis=basis)
 
-    def test_basis_checker_trips_on_lost_basis(self):
-        with self.assertRaises(AssertionError):
-            assert_basis_consistent(self._result_with_basis("downgrade", None))
+    def test_basis_checker_trips_on_every_clause(self):
+        """All ten basis clauses, each proven by its own message.
 
-    def test_basis_checker_trips_on_verdict_contradiction(self):
-        bad = self._planted_basis(verdict="worse")
-        with self.assertRaises(AssertionError):
-            assert_basis_consistent(self._result_with_basis("import", bad))
+        The checker raises rather than accumulating, so the four clauses that
+        used to have a self-test only ever proved the four they reached first;
+        the remaining six were unfalsified.
+        """
+        for label, stage2, basis, expected in (
+            ("lost_basis", "downgrade", None,
+             r"^stage2='downgrade' requires a comparison but lost its basis$"),
+            ("non_compared", "verified_lossless_locked", self._planted_basis(),
+             (r"^basis present on non-compared stage2 "
+              r"'verified_lossless_locked'$")),
+            ("transcode_first", "transcode_first", self._planted_basis(),
+             r"^basis present on non-compared stage2 'transcode_first'$"),
+            ("unknown_branch", "import", self._planted_basis(branch="vibes"),
+             r"^unknown basis branch: 'vibes'$"),
+            ("malformed_metric", "import",
+             self._planted_basis(new_metric="p95"),
+             r"^malformed basis metrics: "),
+            ("import_contradiction", "import",
+             self._planted_basis(verdict="worse"),
+             r"^import decision contradicts basis verdict: "),
+            ("reject_contradiction", "downgrade",
+             self._planted_basis(verdict="better"),
+             r"^reject decision contradicts basis verdict: "),
+            ("reject_claims_bypass", "downgrade",
+             self._planted_basis(verdict="worse",
+                                 verified_lossless_bypass=True),
+             r"^reject decision claims a verified-lossless bypass: "),
+            ("rank_branch_equal_ranks", "import",
+             self._planted_basis(existing_rank="transparent"),
+             r"^rank branch with equal ranks: "),
+            ("same_rank_branch_differing_ranks", "import",
+             self._planted_basis(branch="metric_tiebreak"),
+             r"^same-rank branch with differing ranks: "),
+            ("transcode_regression_not_worse", "import",
+             self._planted_basis(branch="transcode_rank_regression"),
+             r"^transcode rank regression must be worse: "),
+        ):
+            with self.subTest(clause=label), self.assertRaisesRegex(
+                    AssertionError, expected):
+                assert_basis_consistent(
+                    self._result_with_basis(stage2, basis))
 
-    def test_basis_checker_trips_on_rank_incoherence(self):
-        bad = self._planted_basis(existing_rank="transparent")
-        with self.assertRaises(AssertionError):
-            assert_basis_consistent(self._result_with_basis("import", bad))
-
-    def test_basis_checker_trips_on_unknown_branch(self):
-        bad = self._planted_basis(branch="vibes")
-        with self.assertRaises(AssertionError):
-            assert_basis_consistent(self._result_with_basis("import", bad))
+    def test_measured_decision_basis_checker_trips_on_a_lost_basis(self):
+        """The extracted per-property clause, proven directly."""
+        compared = simulate(
+            AlbumState("transparent_mp3", 320, True, None, None, False, None,
+                       existing_format="MP3", avg_bitrate=320),
+            DownloadScenario("candidate", is_flac=False, min_bitrate=192,
+                             is_cbr=True, avg_bitrate=192, new_format="MP3"))
+        assert compared.comparison_basis is not None, repr(compared)
+        assert_measured_decision_carries_basis(compared)
+        with self.assertRaisesRegex(
+                AssertionError,
+                r"^measured decision 'downgrade' against an existing album "
+                r"lost its comparison basis: "):
+            assert_measured_decision_carries_basis(
+                replace(compared, comparison_basis=None))
 
     def test_metric_truthfulness_trips_on_fabricated_flac_avg(self):
         # The dl 36660 shape: a FLAC-source world whose basis claims the
@@ -6778,7 +7182,9 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
             new_metric="avg", new_value_kbps=216,
             branch="cross_family_same_rank", verdict="equivalent",
             new_rank="transparent", existing_rank="transparent")
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+                AssertionError,
+                r"^candidate basis claims 'avg' but the world measured none: "):
             assert_basis_metrics_truthful(
                 album, download, self._result_with_basis("downgrade", bad))
 
@@ -6790,7 +7196,9 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
             "planted", is_flac=False, min_bitrate=200, is_cbr=False,
             avg_bitrate=245)
         bad = self._planted_basis(existing_metric="avg")
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+                AssertionError,
+                r"^existing basis claims 'avg' but the album measured none: "):
             assert_basis_metrics_truthful(
                 album, download, self._result_with_basis("import", bad))
 
@@ -6802,7 +7210,9 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
             "planted", is_flac=False, min_bitrate=200, is_cbr=False,
             avg_bitrate=245)
         bad = self._planted_basis(new_metric="median")
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+                AssertionError,
+                r"^median never crosses the flat interface: "):
             assert_basis_metrics_truthful(
                 album, download, self._result_with_basis("import", bad))
 
@@ -6826,7 +7236,11 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
         evidence_result = {field: getattr(sim, field) for field in _PARITY_FIELDS}
         evidence_result["stage2_import"] = "downgrade"
         evidence_result["imported"] = False
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+                AssertionError,
+                r"^decision twins diverged on the same world:\n"
+                r"  imported: simulator=True evidence=False\n"
+                r"  stage2_import: simulator='import' evidence='downgrade'$"):
             assert_twins_agree(sim, evidence_result)
 
     def test_hypothesis_harness_detects_planted_bad_decider(self):
@@ -6841,7 +7255,9 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
             assert_lossy_not_imported_over_verified_lossless(
                 _planted_bad_import(album, download))
 
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+                AssertionError,
+                r"lossy candidate imported over raw verified-lossless FLAC: "):
             prop()
 
 

--- a/tests/test_quality_generated.py
+++ b/tests/test_quality_generated.py
@@ -2326,6 +2326,19 @@ class TestGeneratedSimulatorInvariants(unittest.TestCase):
         candidate_spectral=192, existing_spectral=192,
         grade="likely_transcode", existing_grade="likely_transcode",
     )
+    # The Deerhunter pin moves the DECISION, so it proves the first clause and
+    # short-circuits before the second. This world moves only the VERDICT
+    # ('equivalent' with the override, 'worse' without) — both map to
+    # ``downgrade``, so ``stage2_import`` holds and the verdict clause is the
+    # only one that can fire. 356 such worlds exist in this strategy's domain
+    # but the derandomized budget draws the bucket twice, and any edit to this
+    # property body reshuffles the sequence, so it is pinned rather than left
+    # to the draw (#1094 round-2 review).
+    @example(
+        candidate_container=64, existing_container=128,
+        candidate_spectral=96, existing_spectral=96,
+        grade="suspect", existing_grade="suspect",
+    )
     def test_existing_spectral_override_is_noop_when_candidate_has_spectral(
         self, candidate_container, existing_container,
         candidate_spectral, existing_spectral, grade, existing_grade,

--- a/tests/test_verdict_tiers_generated.py
+++ b/tests/test_verdict_tiers_generated.py
@@ -65,6 +65,7 @@ import contextlib
 import datetime
 import io
 import os
+import re
 import sys
 import unittest
 from collections.abc import Callable, Sequence
@@ -621,14 +622,49 @@ class TestVerdictTierProperties(unittest.TestCase):
         interpret_spectral_cliff("lossless", spectral_grade="likely_transcode"),
         "likely_transcode", None, None,
     ))
+    @example(world=(
+        # The tier-4 band: the ultrasonic leg DENIES and nothing else
+        # fires. Pinned rather than left to the strategy because
+        # ``derandomize=True`` seeds from the test function's digest, so
+        # editing this body reshuffles the whole example sequence — the
+        # arm ran 4 times in 150 examples before issue #1094's audit
+        # touched the body and 0 times after, silently taking the
+        # ladder's NO_ULTRASONIC branch out of the deterministic tier.
+        interpret_spectral_cliff("lossless", spectral_grade="genuine"),
+        "genuine",
+        ultrasonic_proof_leg(
+            deficit_db=61.0,
+            spectral_measurement_version=2,
+            decode_path=SPECTRAL_DECODE_PATH_SOX_NATIVE,
+            preserved_source_spectral=False,
+        ),
+        None,
+    ))
+    @example(world=(
+        # A DENYING lattice leg, pinned for the same reason: it is the
+        # only world in which a leg can fire, and the fired-legs-subset
+        # clause is the only guard that sees it.
+        interpret_spectral_cliff("aac", spectral_grade="genuine"),
+        "genuine",
+        None,
+        aac_lattice_proof_leg(AacLatticeCapture(
+            modal_count=4, scored_tracks=6, max_z=9.0)),
+    ))
     @given(world=_verdict_worlds())
     def test_tier_and_legs_hold(self, world) -> None:
         spectral, grade, ultra, lattice = world
         verdict = album_proof_verdict(
             spectral=spectral, spectral_grade=grade,
             ultrasonic_leg=ultra, aac_lattice_leg=lattice)
-        check_tier_follows_fired_legs(verdict)
+        # The reserved-tier guard runs FIRST deliberately (issue #1094's
+        # per-clause audit). ``check_tier_follows_fired_legs`` re-derives
+        # the ladder, and that re-derivation only ever expects a
+        # PRODUCIBLE tier — so run before it, no world that emits tier 2,
+        # 3 or an unknown number can ever reach the reserved-tier clauses.
+        # Both orders kill the same mutants; this one attributes each kill
+        # to the clause that actually legislates it.
         check_reserved_ceiling_tiers_unused(verdict)
+        check_tier_follows_fired_legs(verdict)
         check_audit_only_codec_has_no_spectral_finding(
             verdict, spectral.codec_family)
         statement = proof_tier_statement(verdict)
@@ -650,6 +686,30 @@ class TestVerdictTierProperties(unittest.TestCase):
         "spectral_measurement_version": 2,
         "aac_lattice": None,
     })
+    @example(facts={
+        # The ONLY tier-4 world these columns see. ``_evidence_facts``
+        # must clear four independent gates at once for the ultrasonic
+        # leg to DENY through ``album_ultrasonic_proof_leg`` — v2+
+        # measurement, a non-NULL deficit at or above 59.5 dB, an
+        # all-sox-native container set, and no cliff or lattice firing —
+        # and in the deterministic ``suite`` tier it never did: the leg
+        # adjudicated 6 times in 150 examples and denied 0 of them, so
+        # the NO_ULTRASONIC band of the ladder ran through the flat
+        # columns and the render adapter exactly never (issue #1094 Q3).
+        "spectral_grade": "genuine",
+        "spectral_bitrate_kbps": None,
+        "cliff_hz": None,
+        "codec_family": "lossless",
+        "format": "FLAC",
+        "storage_format": "FLAC",
+        "filetype_band": "flac",
+        "spectral_subject": "installed",
+        "was_converted_from": None,
+        "container_labels": [".flac"],
+        "ultrasonic_deficit_db": 61.0,
+        "spectral_measurement_version": 2,
+        "aac_lattice": None,
+    })
     @given(facts=_evidence_facts())
     def test_render_path_and_cli_agree(self, facts) -> None:
         """V4 over any world: one album, one verdict, every surface."""
@@ -662,8 +722,10 @@ class TestVerdictTierProperties(unittest.TestCase):
             proof_gate_projection(_row_aliases_from_facts(facts)),
             facts_verdict,
         )
-        check_tier_follows_fired_legs(facts_verdict)
+        # Reserved-tier guard first, for the reason given in
+        # ``test_tier_and_legs_hold``.
         check_reserved_ceiling_tiers_unused(facts_verdict)
+        check_tier_follows_fired_legs(facts_verdict)
         statement = proof_tier_statement(facts_verdict)
         check_statement_does_not_widen_the_claim(statement)
         check_untested_album_is_not_a_clearance(facts_verdict, statement)
@@ -794,8 +856,21 @@ class TestVerdictTierProperties(unittest.TestCase):
         )
 
 
+def _exactly(message: str) -> str:
+    """A pattern matching one clause's whole message and nothing else."""
+    return f"^{re.escape(message)}$"
+
+
 class TestInvariantCheckersTripOnViolations(unittest.TestCase):
-    """Every checker owes a planted violation proving it can fail."""
+    """Every CLAUSE owes a planted violation naming its own message.
+
+    Per-clause proof, issue #1094 (``docs/generated-testing.md`` § "Per-clause
+    proof"). Each world below makes exactly ONE clause's condition true while
+    every earlier clause in the same checker passes, and asserts that clause's
+    own message — a bare ``assertRaises(AssertionError)`` over a world that
+    violates several clauses only ever exercises the first, because these are
+    short-circuiting ``raise`` chains.
+    """
 
     def _verdict(self, **overrides) -> AlbumProofVerdict:
         base = AlbumProofVerdict(
@@ -806,92 +881,207 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
         )
         return replace(base, **overrides)
 
-    def test_tier_checker_trips_on_a_mismatched_ladder(self):
-        with self.assertRaises(AssertionError):
-            check_tier_follows_fired_legs(
+    def test_tier_checker_clauses_each_trip(self):
+        """V1's two clauses: the ladder, then the fired-subset rule."""
+        cases = (
+            (
+                "ladder mismatch against the injected resolver",
                 self._verdict(
                     fired_legs=(PROOF_LEG_NO_ULTRASONIC,),
                     evaluated_legs=(PROOF_LEG_NO_ULTRASONIC,),
                 ),
-                tier_of=lambda _fired: PROOF_TIER_DETECTED,
-            )
+                {"tier_of": lambda _fired: PROOF_TIER_DETECTED},
+                ("tier 5 does not follow fired legs ('no_ultrasonic',) "
+                 "(expected 1)"),
+            ),
+            (
+                # The world mutant M1 reaches through production: collapse
+                # the ladder's NO_ULTRASONIC branch into NO_FINDING.
+                "ladder mismatch against the real severity bands",
+                self._verdict(
+                    fired_legs=(PROOF_LEG_NO_ULTRASONIC,),
+                    evaluated_legs=(PROOF_LEG_NO_ULTRASONIC,),
+                ),
+                {},
+                ("tier 5 does not follow fired legs ('no_ultrasonic',) "
+                 "(expected 4)"),
+            ),
+            (
+                # Ladder-consistent, so the first clause passes and the
+                # subset clause is the one under test.
+                "a leg fired without ever being evaluated",
+                self._verdict(
+                    tier=PROOF_TIER_DETECTED,
+                    fired_legs=(PROOF_LEG_AAC_LATTICE,),
+                    evaluated_legs=(),
+                ),
+                {},
+                ("fired legs ('aac_lattice',) are not a subset of evaluated "
+                 "legs ()"),
+            ),
+        )
+        for desc, verdict, kwargs, message in cases:
+            with self.subTest(desc=desc), self.assertRaisesRegex(
+                AssertionError, _exactly(message)
+            ):
+                check_tier_follows_fired_legs(verdict, **kwargs)
 
-    def test_tier_checker_trips_when_a_leg_fired_without_being_evaluated(self):
-        with self.assertRaises(AssertionError):
-            check_tier_follows_fired_legs(self._verdict(
-                tier=PROOF_TIER_DETECTED,
-                fired_legs=(PROOF_LEG_AAC_LATTICE,),
-                evaluated_legs=(),
-            ))
+    def test_reserved_tier_checker_clauses_each_trip(self):
+        """V2's two clauses: the reserved band, then any unknown number."""
+        reserved = (
+            "is reserved for the ceiling leg production does not measure, "
+            "and has no operator copy"
+        )
+        cases = (
+            ("ceiling + no-ultrasonic", PROOF_TIER_CEILING_AND_NO_ULTRASONIC,
+             f"tier 2 {reserved}"),
+            ("ceiling only", PROOF_TIER_CEILING_ONLY, f"tier 3 {reserved}"),
+            # 7 is outside the reserved pair, so the first clause passes
+            # and the producible-set clause is the one under test.
+            ("a tier number no ladder produces", 7,
+             "tier 7 is not a producible tier"),
+        )
+        for desc, tier, message in cases:
+            with self.subTest(desc=desc), self.assertRaisesRegex(
+                AssertionError, _exactly(message)
+            ):
+                check_reserved_ceiling_tiers_unused(self._verdict(tier=tier))
 
-    def test_reserved_tier_checker_trips(self):
-        with self.assertRaises(AssertionError):
-            check_reserved_ceiling_tiers_unused(
-                self._verdict(tier=PROOF_TIER_CEILING_ONLY))
-        with self.assertRaises(AssertionError):
-            check_reserved_ceiling_tiers_unused(self._verdict(tier=7))
-
-    def test_audit_only_checker_trips_on_an_aac_accusation(self):
-        with self.assertRaises(AssertionError):
-            check_audit_only_codec_has_no_spectral_finding(
-                self._verdict(spectral_accusation_admissible=True), "aac")
-        with self.assertRaises(AssertionError):
-            check_audit_only_codec_has_no_spectral_finding(
+    def test_audit_only_checker_clauses_each_trip(self):
+        """V3's three clauses: admissible, fired, then merely evaluated."""
+        cases = (
+            (
+                "an audit-only family admitting an accusation",
+                self._verdict(spectral_accusation_admissible=True),
+                "aac",
+                "codec family 'aac' must never admit a transcode accusation",
+            ),
+            (
+                "an unresolved family admitting an accusation",
+                self._verdict(spectral_accusation_admissible=True),
+                None,
+                "codec family None must never admit a transcode accusation",
+            ),
+            (
+                # Inadmissible, so the first clause passes; the cliff leg
+                # is in ``fired`` anyway, which is the second.
+                "the cliff leg fired on an audit-only family",
                 self._verdict(
                     tier=PROOF_TIER_DETECTED,
                     fired_legs=(PROOF_LEG_IN_WINDOW_CLIFF,),
                     evaluated_legs=(PROOF_LEG_IN_WINDOW_CLIFF,),
                 ),
                 "opus",
-            )
+                "codec family 'opus' fired the in-window cliff leg",
+            ),
+            (
+                # Inadmissible AND unfired, so both earlier clauses pass.
+                # This is the fail-open mutant M7 reaches through
+                # production: an album the cliff leg never ran on reads as
+                # one it ran on and cleared.
+                "the cliff leg counted as evaluated on an audit-only family",
+                self._verdict(fired_legs=()),
+                "opus",
+                ("codec family 'opus' counted the cliff leg as evaluated "
+                 "— an untested album must never read as a cleared one"),
+            ),
+        )
+        for desc, verdict, family, message in cases:
+            with self.subTest(desc=desc), self.assertRaisesRegex(
+                AssertionError, _exactly(message)
+            ):
+                check_audit_only_codec_has_no_spectral_finding(verdict, family)
 
     def test_surface_agreement_checker_trips(self):
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+            AssertionError,
+            "^pipeline-cli and the render path disagree about one album: "
+            r"AlbumProofVerdict\(tier=5",
+        ):
             check_surfaces_agree(
                 self._verdict(), self._verdict(tier=PROOF_TIER_DETECTED))
 
-    def test_accusation_agreement_checker_trips_on_a_split_surface(self):
-        with self.assertRaises(AssertionError):
+    def test_accusation_agreement_checker_clauses_each_trip(self):
+        """V7's two clauses: no surfaces at all, then a split pair."""
+        with self.subTest(desc="no surfaces supplied"), self.assertRaisesRegex(
+            AssertionError, _exactly("no surfaces supplied to compare")
+        ):
+            check_accusation_flags_agree([])
+        with self.subTest(desc="a split pair"), self.assertRaisesRegex(
+            AssertionError,
+            _exactly(
+                "long-tail console and Recents disagree about one album: "
+                "AccusationFlags(admissible=True, withheld=None) vs "
+                "AccusationFlags(admissible=False, "
+                "withheld='audit_only_codec')"
+            ),
+        ):
             check_accusation_flags_agree([
                 ("Recents", AccusationFlags(
                     admissible=False,
                     withheld=ACCUSATION_WITHHELD_AUDIT_ONLY_CODEC)),
                 ("long-tail console", AccusationFlags(admissible=True)),
             ])
-        with self.assertRaises(AssertionError):
-            check_accusation_flags_agree([])
 
-    def test_withheld_reason_checker_trips_on_a_fabricated_codec_claim(self):
-        # The Rule C failure this checker exists for: describing native
-        # encoder rolloff on a row where no encoder was ever resolved.
-        with self.assertRaises(AssertionError):
-            check_withheld_reason_matches_the_world(
-                AccusationFlags(
-                    admissible=False,
-                    withheld=ACCUSATION_WITHHELD_AUDIT_ONLY_CODEC),
-                None,
-            )
-        with self.assertRaises(AssertionError):
-            check_withheld_reason_matches_the_world(
-                AccusationFlags(
-                    admissible=False,
-                    withheld=ACCUSATION_WITHHELD_CODEC_UNRESOLVED),
-                "aac",
-            )
-        with self.assertRaises(AssertionError):
-            check_withheld_reason_matches_the_world(
+    def test_withheld_reason_checker_clauses_each_trip(self):
+        """V7's three clauses, in the order the checker evaluates them."""
+        cases = (
+            (
+                "a reason withheld from a grade that was admitted",
                 AccusationFlags(
                     admissible=True,
                     withheld=ACCUSATION_WITHHELD_AUDIT_ONLY_CODEC),
                 "aac",
-            )
+                ("withheld reason 'audit_only_codec' on an admissible "
+                 "grade (True)"),
+            ),
+            (
+                # ``None`` is not ``False``: a reason on a row with no
+                # accusation to withhold is the same clause.
+                "a reason on a grade that could not accuse at all",
+                AccusationFlags(
+                    withheld=ACCUSATION_WITHHELD_CODEC_UNRESOLVED),
+                None,
+                ("withheld reason 'codec_unresolved' on an admissible "
+                 "grade (None)"),
+            ),
+            (
+                # The Rule C failure this checker exists for: describing
+                # native encoder rolloff on a row where no encoder was
+                # ever resolved.
+                "a codec claim on a row where no codec resolved",
+                AccusationFlags(
+                    admissible=False,
+                    withheld=ACCUSATION_WITHHELD_AUDIT_ONLY_CODEC),
+                None,
+                ("reason 'audit_only_codec' describes a codec, but none "
+                 "resolved"),
+            ),
+            (
+                "the unresolved reason on a row whose codec resolved",
+                AccusationFlags(
+                    admissible=False,
+                    withheld=ACCUSATION_WITHHELD_CODEC_UNRESOLVED),
+                "aac",
+                "reason 'codec_unresolved' on a resolved 'aac' album",
+            ),
+        )
+        for desc, pair, family, message in cases:
+            with self.subTest(desc=desc), self.assertRaisesRegex(
+                AssertionError, _exactly(message)
+            ):
+                check_withheld_reason_matches_the_world(pair, family)
 
-    def test_attribution_checker_trips_on_an_ungated_cli_read(self) -> None:
-        """Known-bad: the pre-fix CLI read, planted as an explicit decoy.
+    def test_attribution_checker_clauses_each_trip(self) -> None:
+        """V8's two clauses: the surfaces split, then both agree and lie.
 
-        The decoy is the shipped line — print the generation whenever a
-        proof object exists — so the checker is proved against the real
-        divergence rather than a hypothetical one.
+        The first decoy is the shipped line — print the generation whenever
+        a proof object exists — so the checker is proved against the real
+        divergence rather than a hypothetical one. The second needs no
+        decoy at all: both real surfaces answer through the one production
+        rule, and the planted violation is an expectation they contradict,
+        which is the "agreed, and both wrong" world the split clause
+        cannot see.
         """
         from lib.quality import verified_lossless_generation_label
 
@@ -901,18 +1091,54 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
                 print(f"      verified lossless {side}: proved by "
                       f"{verified_lossless_generation_label(proof.classifier)}")
 
-        evidence = _proof_evidence(
+        legacy = _proof_evidence(
             lineage=1,
             provenance=EVIDENCE_PROVENANCE_MEASURED,
             classifier="spectral_verified_lossless",
         )
-        self.assertTrue(cli_states_a_proof(evidence, printer=ungated))
-        self.assertFalse(recents_states_a_proof(evidence))
-        with self.assertRaisesRegex(AssertionError, "while Recents says"):
+        self.assertTrue(cli_states_a_proof(legacy, printer=ungated))
+        self.assertFalse(recents_states_a_proof(legacy))
+        with self.subTest(desc="one surface ungated"), self.assertRaisesRegex(
+            AssertionError,
+            _exactly("pipeline-cli says proved=True while Recents says "
+                     "proved=False for the same album"),
+        ):
             check_proof_attribution_agrees(
-                cli_states_a_proof(evidence, printer=ungated),
-                recents_states_a_proof(evidence),
+                cli_states_a_proof(legacy, printer=ungated),
+                recents_states_a_proof(legacy),
                 attributable=False,
+            )
+
+        # Both surfaces agree — the split clause passes — and the world
+        # says they are wrong. Mutant M17 reaches this through production
+        # by widening the ONE shared rule
+        # (``evidence_is_source_semantic``), which moves both surfaces at
+        # once and is therefore invisible to the clause above.
+        current = _proof_evidence(
+            lineage=4,
+            provenance=EVIDENCE_PROVENANCE_MEASURED,
+            classifier="spectral_verified_lossless_v4",
+        )
+        agreed = cli_states_a_proof(current)
+        self.assertTrue(agreed)
+        self.assertEqual(agreed, recents_states_a_proof(current))
+        with self.subTest(desc="an unearned proof"), self.assertRaisesRegex(
+            AssertionError,
+            _exactly("surfaces say proved=True for an album whose proof "
+                     "is attributable=False"),
+        ):
+            check_proof_attribution_agrees(
+                agreed, recents_states_a_proof(current), attributable=False,
+            )
+        withheld = cli_states_a_proof(legacy)
+        self.assertFalse(withheld)
+        with self.subTest(desc="an earned proof withheld"), self.assertRaisesRegex(
+            AssertionError,
+            _exactly("surfaces say proved=False for an album whose proof "
+                     "is attributable=True"),
+        ):
+            check_proof_attribution_agrees(
+                withheld, recents_states_a_proof(legacy), attributable=True,
             )
 
     def test_projection_checker_trips_on_a_lineage_gated_read(self):
@@ -945,29 +1171,86 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
         row = _row_aliases_from_facts(facts)
         lineage_gated = dict(row)
         lineage_gated["_evidence_format"] = lineage_gated["source_format"]
-        with self.assertRaises(AssertionError):
+        # The expected half comes from the producer, never a copy literal
+        # (``.claude/rules/test-fidelity.md`` Rule C).
+        expected = (
+            verdict.tier, proof_tier_statement(verdict),
+            list(verdict.fired_legs),
+        )
+        with self.assertRaisesRegex(
+            AssertionError,
+            _exactly(
+                "the render adapter projected a different verdict than the "
+                f"derivation produced: (None, None, []) vs {expected}"
+            ),
+        ):
             check_projection_matches_verdict(
                 proof_gate_projection(lineage_gated), verdict)
         # …and the real adapter over the real row agrees with the verdict.
         check_projection_matches_verdict(proof_gate_projection(row), verdict)
 
     def test_projection_checker_trips_on_a_drifted_reduction(self):
-        with self.assertRaises(AssertionError):
-            check_projection_matches_verdict(
-                ProofGateProjection(),
-                self._verdict(evaluated_legs=(PROOF_LEG_IN_WINDOW_CLIFF,)),
-            )
+        verdict = self._verdict(evaluated_legs=(PROOF_LEG_IN_WINDOW_CLIFF,))
+        expected = (
+            verdict.tier, proof_tier_statement(verdict),
+            list(verdict.fired_legs),
+        )
+        with self.assertRaisesRegex(
+            AssertionError,
+            _exactly(
+                "the render adapter projected a different verdict than the "
+                f"derivation produced: (None, None, []) vs {expected}"
+            ),
+        ):
+            check_projection_matches_verdict(ProofGateProjection(), verdict)
 
-    def test_claim_checker_trips_on_widened_copy(self):
-        with self.assertRaises(AssertionError):
-            check_statement_does_not_widen_the_claim(
-                "Verified lossless: guaranteed bit-perfect")
+    def test_claim_checker_trips_on_every_widening_token(self):
+        """V5's one clause, once per token, so none of them is decoration.
+
+        ``guaranteed`` is deliberately expected to be NAMED as
+        ``guarantee``: it is a superstring of an earlier entry, so the
+        clause fires on the shorter one first. The entry is redundant
+        rather than wrong, and pinning that here stops a future reader
+        from "fixing" the list on a guess.
+        """
+        cases = (
+            ("Tier statement: bit-perfect copy", "bit-perfect"),
+            ("Tier statement: bit perfect copy", "bit perfect"),
+            ("Tier statement: bit-faithful to its source", "bit-faithful"),
+            ("Tier statement: bit faithful to its source", "bit faithful"),
+            ("Tier statement: we guarantee the source", "guarantee"),
+            ("Tier statement: guaranteed clean", "guarantee"),
+            ("Tier statement: certain to be a genuine rip", "certain"),
+            ("Tier statement: probably fake", "probably fake"),
+            ("Tier statement: definitely lossy in origin", "definitely"),
+            ("Tier statement: proven lossless", "proven lossless"),
+            ("Tier statement: an authentic pressing", "authentic"),
+        )
+        self.assertEqual(
+            {token for _statement, token in cases} | {"guaranteed"},
+            set(_CLAIM_WIDENING_TOKENS),
+            "every widening token owes a statement that reaches it",
+        )
+        for statement, token in cases:
+            with self.subTest(token=token), self.assertRaisesRegex(
+                AssertionError,
+                _exactly(f"tier statement {statement!r} widens the claim "
+                         f"via {token!r}"),
+            ):
+                check_statement_does_not_widen_the_claim(statement)
 
     def test_clearance_checker_trips_on_an_untested_album(self):
-        with self.assertRaises(AssertionError):
+        # The clearance sentence comes from the producer, so the pin
+        # cannot outlive the copy it claims to reject (Rule C).
+        clearance = proof_tier_statement(
+            self._verdict(evaluated_legs=(PROOF_LEG_IN_WINDOW_CLIFF,)))
+        with self.assertRaisesRegex(
+            AssertionError,
+            _exactly(f"verdict with no evaluated leg rendered {clearance!r}, "
+                     "which reads as a clearance nothing tested for"),
+        ):
             check_untested_album_is_not_a_clearance(
-                self._verdict(evaluated_legs=()),
-                "No evidence of lossy origin from the tests that ran")
+                self._verdict(evaluated_legs=()), clearance)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Refs #1094. Second pass of the standing per-clause audit: the **quality-decision core**, four modules, audited by one agent each. Follows #1103, which shipped the rule and the filesystem-authority pass.

## Why this area first

These four modules guard `full_pipeline_decision_from_evidence` — the single source of truth for every import decision in the product — plus its simulator twin, the importer's outcome routing, evidence propagation, and the verdict/render adapter parity. Highest blast radius in the repository.

## Measured before / after

| module | clauses | bare `assertRaises` before | after | `assertRaisesRegex` before → after |
|---|---|---|---|---|
| `test_quality_generated.py` | 64 | 37 | **0** | 0 → 44 |
| `test_dispatch_outcomes_generated.py` | 50 | 17 | 1 † | 10 → 34 |
| `test_evidence_generated.py` | 34 ‡ | 17 | **0** | 1 → 8 |
| `test_verdict_tiers_generated.py` | 18 | 16 | 1 § | 1 → 14 |
| **total** | **166** | **87** | **2** | **12 → 100** |

† one sanctioned use: `test_hypothesis_harness_detects_planted_bad_router` proves the *Hypothesis harness itself* catches a planted bad router, which `code-quality.md` explicitly permits ("a deterministic integration test may invoke a tiny Hypothesis property when the boundary under test is Hypothesis integration itself").
§ inside a docstring explaining why bare `assertRaises` is insufficient.
‡ **the brief said 26 and was wrong** — see "one grep is not an inventory" below. Review notes 34 is itself approximate: three of those clauses are accumulator wrappers whose expansion can be counted as 4 + 8 + a 7-fact loop, giving 31/32/38 depending on convention. The two specific sub-claims (nine `assert x, msg` clauses; one `raise` in a stub) are exact.

## The headline finding: a clause with zero proof, on a live-bug checker

`assert_existing_override_noop_under_shared_clamp` is the #813 Finding 1 / Deerhunter checker (`download_log` 37725) — an identical transcode read as an upgrade purely because the existing side was spectrally floored and the candidate was not. It has two clauses. **Both existing known-bad worlds moved `stage2_import`, so the verdict clause had never executed.**

It is not decoration: `equivalent` and `worse` both map to `downgrade`, so the one-sided override can flip the *verdict* while the *decision* holds. Disarming the shared-clamp gate shows **356 verdict-only worlds** in this strategy's domain, every one `'equivalent' → 'worse'`.

**Corrected after review:** the first draft of this body said the suite tier draws that bucket 6 times in 151 examples. Measured, it is **2**. Non-zero, so the PR's own rule was satisfied — but a 2-draw bucket on a live-bug checker is one property edit away from zero, which is exactly the `pg_partial` defect #1103 shipped. It is now an `@example` pin.

Verified independently after integration: mutating that clause's message now fails with

```
"^existing-side spectral override changed the comparison verdict under a shared
 spectral clamp: 'better' (override) vs 'equivalent' (none)$" does not match ...
```

— the exact phantom-"better" shape the Deerhunter bug produced.

## Three ways a clause audit can lie to you (new docs section)

All measured during this pass, not theorised. Committed to `docs/generated-testing.md` § "Per-clause proof".

**1. Editing a property body reshuffles its worlds.** `derandomize=True` seeds from the test function's own digest, so *any* edit — an added assertion, a renamed local, two reordered statements — changes the entire example sequence. A `tier4_only` world ran **4/150 before** the audit touched its property and **0/150 after**, silently removing a real ladder branch from every gating run. That is #1103's blocking defect arriving through a door nobody was watching, and it means the pin requirement is not limited to *widened* strategies.

**2. Clause ordering masks across checkers, not just within one.** A property calling checker A then checker B hides every clause of B that A also rejects. `check_reserved_ceiling_tiers_unused` could never fire, because `check_tier_follows_fired_legs` re-derived the ladder first and only ever expects a *producible* tier — so both reserved-tier mutants died on the earlier checker's message. Reordering independent checker *calls* is the fix and is legitimate; reordering clauses *inside* a checker is not.

**3. One grep is not an inventory.** `grep -c "raise AssertionError"` misses bare `assert cond, "msg"` clauses and counts `raise` sites belonging to in-world stubs. The evidence module was briefed at 26 clauses and really has **34** — nine `assert x, msg` clauses in two checkers, and one `raise` inside a test stub.

## Kill matrices

**The full per-clause matrices are recorded as a comment on this PR** (review finding 2: summarising them left ~130 mutant claims with no durable record, against the rule this series itself strengthened). Summary per module:

- **quality (64)** — 25 mutants planted, all reverted, **all killed in the `suite` tier; zero fuzz-only kills**, so #1103's defect did not recur. Non-killed rows are either N-A (real Q1 world on a live property, no mutant this round) or fail-closed legislation (C45 — decision is computed *as* `basis.verdict`, so the pair is true by construction; C59/C60 — structurally-typed returns; C26 — shadowed by a production coupling it guards against being split). Nothing deleted.
- **dispatch outcomes (50)** — 45 mutants, 41 KILLED covering 42 clauses, **0 SURVIVED**, 7 refused by a real production boundary (a DB CHECK constraint, `VALID_TRANSITIONS`, or an explicit "requires a diagnostic" / "must fail the job" guard) and kept as fail-closed legislation. 5 of the kills are fake-tier — state written by the DB terminal command, whose stand-in here is `FakePipelineDB`'s mirror of the production SQL; the real-SQL half is covered by real-PostgreSQL tests elsewhere. Stated plainly rather than counted as production kills.
- **evidence (34)** — 32 killed through the real path in the gating tiers; 3 fail-closed legislation (two of them proven unreachable because the *production* validators raise first: "installed spectral evidence cannot be carried" / "installed v0 evidence cannot be carried"). A vacuity probe — all 8 checkers neutered to no-ops — produces **43 failures**, so every clause world is falsifiable.
- **verdict tiers (18)** — all 18 accounted for, 17 killed at the `suite` tier, 1 fail-closed. Every claimed adapter mutated **separately** per the "agree by construction stops at the outermost real adapter" rule: `album_proof_verdict`, `proof_tier_statement`, `interpret_spectral_cliff`, `proof_verdict_from_evidence`, `web.classify.proof_gate_projection`, both accusation-flag builders, `_accusation_withheld_reason`, the CLI printer, and `evidence_is_source_semantic`. M9 reinstates the PR #973 defect (the projection reading `source_format`) and dies.

## Structural conversions, scoped

Two checkers were converted from short-circuiting `raise` chains to accumulating `list[str]` + a raising wrapper — **only where the audit showed ordering actually hid a clause** (`fingerprint_flip_two_axis_violations`, `integrity_precedence_violations`), which is the narrow case `docs/generated-testing.md` sanctions. Three clauses that lived inline in property bodies and could not be called were extracted verbatim so they could have known-bads. `assert_classification_coherent` gained `classify_fn`/`name_fn` kwarg DI defaults (house seam #2 — injected, never patched; `test_mock_audit` and `test_property_input_audit` stay green).

## Production defects

**None.** All four agents were instructed to *report* rather than fix any production defect, so that quality-decision changes get their own PR and review instead of being buried in a test audit. None was found. **No production file is touched by this PR.**

Four observations recorded for the next reader, none a defect: the lossless fail-closed early return in `ensure_current_evidence_for_action` is unobservable to its module (the backfill path re-applies the same policy — only an uncovered state *write* differs); `evidence_from_album_info` re-stamps `measured → carried` downstream of the backfill's own re-stamp, so single-site regressions there are invisible by design; `assert_outcome_is_operator_visible` is latently over-narrow against a legitimate bundle-less *success* path that no world in that module can currently reach; and a mutant making every FLAC rank `POOR` passes the quality module entirely, because `quality_rank`'s lossless step is owned by `tests/test_quality_decisions.py` — an honest scope boundary, not a hole.

## Evidence

- **Independently cross-checked, not taken on report.** After integration I planted message-collision mutants — one clause emitting a *sibling* clause's message, the exact mutant bare `assertRaises` cannot catch since the checker still raises. Killed with exact diagnoses in the quality module, including on the zero-proof Deerhunter clause above. Both reverted; tree clean and green after.
- **Canonical suite**: `scripts/run_final_gate.sh` → **pass**, receipt `cratedigger-final-gate.aZ4QiKvm`, on this exact commit (an earlier receipt `…BHFVfxfd` passed on the pre-review tree).
- Targeted gate `bash scripts/test.sh` selected 27 selectors (all four generated modules, deterministic siblings, typing ratchet, every audit) — 6 phases green.
- The typing ratchet caught a real regression in one agent's draft (`any 9 → 23`, `cast 3 → 11` from `dict[str, Any]` case tables); rewritten to typed tuples and back at baseline exactly.
- No Hypothesis added to any known-bad self-test. No scanner, AST analyzer, or reachability inference added.

### A note on four failed gate runs before this one

The first four `run_final_gate.sh` attempts failed and **none was caused by this change**: two were tmpfs infrastructure errors, and two were wall-clock/headroom flakes in `test_decision_corpus_export`, `test_node_jsonl_worker` and `test_ruff_lsp_worker` while three other full suites ran concurrently on the same box (load average 37, `/run/user/1000` down to 802 MB against a 1 GB requirement). All three modules pass in isolation at load 37, and the gate passes cleanly at load 2.7. This is the standing flake shape already recorded as #1086 item 4 — wall-clock-bounded subprocesses inside a parallel scheduler. I did not delete the competing sessions' 1.9 GB of live scratch directories to make room.

## Review round 1 — no blocking findings

An independent adversarial review attacked this by measurement, not reading: a raise-site attribution probe recording the exact production line each known-bad world reaches, a regex-ambiguity cross-match, base-vs-current production branch coverage at the gating tier, and an in-memory mutant of the #813 gate.

**The two hardest attacks both failed, which is the substantive result:**

- **Q1 correctness.** All 166 clauses are reached at their own raise site. Because raise-chains short-circuit, reaching a clause's own line *is* proof every earlier clause passed — so no world here trips an earlier clause.
- **The PR's own reshuffle hazard, turned on itself.** Production line+arc coverage at the suite tier, base `54503dff` vs this PR: verdict tiers **0 lost** / +6 gained, evidence **0/0**, dispatch **0 lost** / +82, quality **0/0**. 2,321 insertions across four properties-bearing modules and **not one production arc dropped out of the gating tier**.

Also verified clean: no `@example` deleted (50→50 in quality, +6 net elsewhere), both accumulator conversions semantics-preserving, the three extracted clauses still called from the same properties, DI seams injected rather than patched, Rule C satisfied on the verdict-tier pins, and every audit/ratchet green.

**Two non-blocking findings fixed** (commit `933edf53`): the corrected draw count plus an `@example` pin for the verdict-only world, and four substring regexes in the dispatch module anchored — `"download_log row"` matched *both* clauses of `assert_download_log_row_created`, `"reported success=True"` matched two checkers, `"non-terminal status"` named the clause but not the world. Every affected clause already had an exactly-anchored proof elsewhere, so nothing was unproven, but the loose sites taught the wrong pattern.

**A third finding fixed by recording rather than code:** the kill matrices are now a PR comment. The body had summarised them, which left ~130 mutant claims with no durable record — a fair hit against the rule this series itself strengthened.

Noted, not changed: commit `c9fcc3b0` rewords a docstring so the module's clause grep reports 50 rather than 51, in the same PR that says "one grep is not an inventory" — harmless (an AST inventory independently returns 50) but the wrong habit to model.

## Scope

Cumulative across #1103 and this PR: **227 clauses across 6 modules**. Remaining in the #1094 priority list: processing ownership (~123), manifest guards (~54), slskd ingestion (~35) — roughly 212 clauses across ~13 modules, to be scoped area by area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
