### PR TITLE
test(#1094): per-clause proof for processing ownership

### DIFF
--- a/tests/test_automation_startup_recovery_generated.py
+++ b/tests/test_automation_startup_recovery_generated.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import os
+import re
 import shutil
 import sys
 import tempfile
 import unittest
+from collections.abc import Callable, Sequence
 from typing import Literal
 
 from hypothesis import example, given, settings
@@ -183,6 +185,17 @@ def assert_recovery_never_parks(
     Anything else is a park: an attached ``recovery_required`` owner, a
     terminal owner still holding the request, or a released request that still
     names one.
+
+    Clause reachability (issue #1094 audit). The ``recovery_required`` clause
+    is patrolled by the historical-owner worlds: deleting the sweep's
+    ``recovery_required`` exemption strands the request behind a parked owner
+    and fires it. The four owner-equivalence clauses and the missing-owner
+    clause are fail-closed legislation — every write that would violate them
+    is refused at the database boundary (migration 066's owner-equivalence
+    CHECK, mirrored here by a fake that declines to terminalize an automation
+    owner outside the atomic owner-aware command), so no production caller
+    reaches them today. They stay because this guard legislates for every
+    future writer of the owner pointer, not only for the sweep.
     """
     row = db.request(request_id)
     status = row["status"]
@@ -225,29 +238,50 @@ def assert_unproven_execution_untouched(
     before: ImportJob,
     request_status_before: str,
 ) -> None:
-    """An unproven execution keeps its work; recovery may not steal it."""
+    """An unproven execution keeps its work; recovery may not steal it.
+
+    Accumulating on purpose (issue #1094 per-clause audit). As a
+    short-circuiting chain the job-movement clause masked the three that
+    follow it: the one realistic production mutant — a liveness verdict that
+    fails open to ``dead`` — moves the job status in EVERY world, so the
+    lease, request-status, and audit-row clauses could never be the reported
+    violation and none of them had a reachable world. Collecting every
+    violation attributes each consequence to the clause that legislates it,
+    and each clause keeps its own message on its own line.
+
+    With that mutant planted, the terminal-branch worlds (launched or
+    journalled) fire job-moved + request-moved + audit-row and the
+    requeue-branch worlds fire job-moved + lease-cleared, so all four clauses
+    have a named world. The missing-row precondition below has none: nothing
+    in production deletes an import-job row.
+    """
     after = db.get_import_job(before.id)
     if after is None:
+        # A precondition, not a clause: with no row there is nothing to
+        # compare the remaining clauses against.
         raise AssertionError("an unproven owner's job row disappeared")
+    violations: list[str] = []
     if (after.status, after.preview_status) != (
         before.status,
         before.preview_status,
     ):
-        raise AssertionError(
+        violations.append(
             f"unproven execution moved from {before.status}/"
             f"{before.preview_status} to {after.status}/{after.preview_status}"
         )
     if after.execution_invocation_id != before.execution_invocation_id:
-        raise AssertionError("unproven execution had its lease cleared")
+        violations.append("unproven execution had its lease cleared")
     row = db.request(_REQUEST_ID)
     if row["status"] != request_status_before:
-        raise AssertionError(
+        violations.append(
             f"unproven execution's request moved to {row['status']!r}"
         )
     if db.download_logs:
-        raise AssertionError(
+        violations.append(
             "unproven execution produced a world-failure audit row"
         )
+    if violations:
+        raise AssertionError("\n".join(violations))
 
 
 def assert_cleanup_refusal_preserved_tree(
@@ -288,6 +322,7 @@ class _World:
         lane: Lane,
         launched: bool,
         journal: JournalState,
+        historical: bool = False,
     ) -> None:
         root = tempfile.mkdtemp(prefix="generated-startup-recovery-")
         case.addCleanup(shutil.rmtree, root, ignore_errors=True)
@@ -372,6 +407,26 @@ class _World:
                 ),
             )
 
+        if historical:
+            # The one owner shape no current writer can build, applied last
+            # because that is the order it arose in: a live owner did its
+            # work, then a pre-#933 writer parked it. CLAUDE.md invariant 11
+            # retired ``recovery_required`` as a resting state, so rows in it
+            # are historical and are seeded directly for exactly that reason.
+            # Production still owns them —
+            # ``recover_abandoned_automation_owners`` exempts a leaseless
+            # ``recovery_required`` owner from its "waiting to be claimed"
+            # skip precisely so the sweep converges them automatically, and
+            # ``never_claimed`` is their exact death proof.
+            row = next(
+                item
+                for item in self.db._import_jobs
+                if item["id"] == owner.id
+            )
+            row["status"] = IMPORT_JOB_RECOVERY_REQUIRED
+            self.db._clear_execution_lease(row)
+            self.lease = None
+
     def make_cleanup_refuse(self, *, payload: bytes) -> None:
         """Drift a real persisted journal so the real executor refuses it."""
         if (
@@ -450,24 +505,76 @@ class TestAutomationStartupRecoveryGenerated(unittest.TestCase):
         launched=st.booleans(),
         journal=st.sampled_from(("absent", "present")),
         liveness=st.sampled_from(("dead", "live", "unknown", "stale")),
+        historical=st.booleans(),
     )
-    @example(lane="import", launched=True, journal="absent", liveness="dead")
-    @example(lane="import", launched=True, journal="present", liveness="dead")
+    @example(
+        lane="import",
+        launched=True,
+        journal="absent",
+        liveness="dead",
+        historical=False,
+    )
+    @example(
+        lane="import",
+        launched=True,
+        journal="present",
+        liveness="dead",
+        historical=False,
+    )
     @example(
         lane="preview",
         launched=False,
         journal="present",
         liveness="dead",
+        historical=False,
     )
-    @example(lane="preview", launched=False, journal="absent", liveness="dead")
-    @example(lane="import", launched=True, journal="present", liveness="live")
+    @example(
+        lane="preview",
+        launched=False,
+        journal="absent",
+        liveness="dead",
+        historical=False,
+    )
+    @example(
+        lane="import",
+        launched=True,
+        journal="present",
+        liveness="live",
+        historical=False,
+    )
     @example(
         lane="import",
         launched=True,
         journal="present",
         liveness="unknown",
+        historical=False,
     )
-    @example(lane="import", launched=True, journal="present", liveness="stale")
+    @example(
+        lane="import",
+        launched=True,
+        journal="present",
+        liveness="stale",
+        historical=False,
+    )
+    # Issue #1094: the two historical-owner worlds the park clause needs.
+    # Without them, deleting the ``recovery_required`` exemption in
+    # ``recover_abandoned_automation_owners`` — a production fail-open that
+    # strands the request behind a parked owner forever — changed nothing any
+    # generated world could observe.
+    @example(
+        lane="import",
+        launched=True,
+        journal="present",
+        liveness="dead",
+        historical=True,
+    )
+    @example(
+        lane="preview",
+        launched=False,
+        journal="absent",
+        liveness="live",
+        historical=True,
+    )
     def test_recovery_never_parks_any_abandoned_owner(
         self,
         *,
@@ -475,11 +582,18 @@ class TestAutomationStartupRecoveryGenerated(unittest.TestCase):
         launched: bool,
         journal: JournalState,
         liveness: Liveness,
+        historical: bool,
     ) -> None:
         """Drive the real recovery sweep over every abandoned-owner world."""
         from scripts import importer
 
-        world = _World(self, lane=lane, launched=launched, journal=journal)
+        world = _World(
+            self,
+            lane=lane,
+            launched=launched,
+            journal=journal,
+            historical=historical,
+        )
         before = world.snapshot()
         request_status_before = str(world.db.request(_REQUEST_ID)["status"])
 
@@ -489,7 +603,11 @@ class TestAutomationStartupRecoveryGenerated(unittest.TestCase):
         )
 
         assert_recovery_never_parks(world.db)
-        if liveness != "dead":
+        if liveness != "dead" and not historical:
+            # A historical owner is leaseless, so there is no execution to
+            # prove alive: ``never_claimed`` is its exact death proof and the
+            # sweep converges it whatever the probe says. Every other world
+            # holds a real lease, and an unproven one keeps its work.
             assert_unproven_execution_untouched(
                 world.db,
                 before=before,
@@ -577,8 +695,28 @@ class TestAutomationStartupRecoveryGenerated(unittest.TestCase):
         )
 
 
+_ClauseCase = tuple[str, Callable[[], tuple[str, Callable[[], None]]]]
+
+
 class TestInvariantCheckersTripOnViolations(unittest.TestCase):
-    """Known-bad self-tests: a planted park must be caught."""
+    """Known-bad self-tests: one named world per clause (issue #1094).
+
+    Every clause of every checker in this module names the minimal world that
+    makes it fire while each earlier clause in the same function passes, and
+    each assertion is anchored to that clause's own complete message. A bare
+    ``assertRaises(AssertionError)`` proved nothing: the previous five
+    self-tests matched substrings, and two of those substrings
+    (``owner equivalence is broken``) belong to two different clauses, so a
+    message-collision mutant would have survived both. The table therefore
+    also proves that no clause's pattern matches any sibling clause's
+    message.
+
+    Deterministic by policy — this is test machinery, never a generated
+    subject.
+    """
+
+    def _world(self) -> _World:
+        return _World(self, lane="import", launched=True, journal="absent")
 
     def _automation_row(self, db: FakePipelineDB) -> dict[str, object]:
         return next(
@@ -587,55 +725,221 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
             if item["job_type"] == IMPORT_JOB_AUTOMATION
         )
 
-    def test_attached_recovery_required_owner_is_rejected(self) -> None:
-        world = _World(self, lane="import", launched=True, journal="absent")
-        self._automation_row(world.db)["status"] = IMPORT_JOB_RECOVERY_REQUIRED
-
-        with self.assertRaises(AssertionError) as caught:
-            assert_recovery_never_parks(world.db)
-
-        self.assertIn("recovery_required", str(caught.exception))
-
-    def test_terminal_owner_still_holding_the_request_is_rejected(
-        self,
-    ) -> None:
-        world = _World(self, lane="import", launched=True, journal="absent")
-        self._automation_row(world.db)["status"] = "failed"
-
-        with self.assertRaises(AssertionError) as caught:
-            assert_recovery_never_parks(world.db)
-
-        self.assertIn("non-claimable owner status", str(caught.exception))
-
-    def test_owner_pointer_left_behind_a_released_request_is_rejected(
-        self,
-    ) -> None:
-        world = _World(self, lane="import", launched=True, journal="absent")
-        world.db._requests[_REQUEST_ID]["status"] = "wanted"
-
-        with self.assertRaises(AssertionError) as caught:
-            assert_recovery_never_parks(world.db)
-
-        self.assertIn("owner equivalence is broken", str(caught.exception))
-
-    def test_stolen_unproven_execution_is_rejected(self) -> None:
-        world = _World(self, lane="import", launched=True, journal="absent")
-        before = world.snapshot()
-        self._automation_row(world.db)["status"] = "queued"
-
-        with self.assertRaises(AssertionError) as caught:
-            assert_unproven_execution_untouched(
-                world.db,
-                before=before,
-                request_status_before="processing",
+    def _prove_clauses(self, cases: Sequence[_ClauseCase]) -> None:
+        """Fire each clause on its own world and pin its exact message."""
+        produced: dict[str, str] = {}
+        patterns: dict[str, str] = {}
+        for name, build in cases:
+            with self.subTest(clause=name):
+                expected, call = build()
+                pattern = "(?m)^" + re.escape(expected) + "$"
+                patterns[name] = pattern
+                with self.assertRaisesRegex(AssertionError, pattern) as caught:
+                    call()
+                produced[name] = str(caught.exception)
+        for name, message in produced.items():
+            matched = sorted(
+                other
+                for other, pattern in patterns.items()
+                if re.search(pattern, message)
+            )
+            self.assertEqual(
+                matched,
+                [name],
+                f"clause {name}'s message is also matched by {matched} — a "
+                "sibling clause could satisfy this test's assertion",
             )
 
-        self.assertIn("unproven execution moved", str(caught.exception))
+    def test_every_recovery_park_clause_fires_with_its_own_message(
+        self,
+    ) -> None:
+        def released_request_still_names_owner() -> tuple[
+            str, Callable[[], None]
+        ]:
+            world = self._world()
+            world.db._requests[_REQUEST_ID]["status"] = "wanted"
+            return (
+                (
+                    f"request left 'wanted' while still naming automation "
+                    f"owner {world.owner_id} — the 066 owner equivalence is "
+                    f"broken"
+                ),
+                lambda: assert_recovery_never_parks(world.db),
+            )
 
-    def test_refusal_checker_rejects_a_deleted_remaining_file(self) -> None:
-        before = (("albums/owner/01.flac", "file", b"audio"),)
+        def released_request_left_non_runnable() -> tuple[
+            str, Callable[[], None]
+        ]:
+            world = self._world()
+            request = world.db._requests[_REQUEST_ID]
+            request["status"] = "downloading"
+            request["active_automation_import_job_id"] = None
+            return (
+                "recovery left request in non-runnable status 'downloading'",
+                lambda: assert_recovery_never_parks(world.db),
+            )
 
-        with self.assertRaises(AssertionError) as caught:
-            assert_cleanup_refusal_preserved_tree(before, ())
+        def processing_without_owner() -> tuple[str, Callable[[], None]]:
+            world = self._world()
+            world.db._requests[
+                _REQUEST_ID
+            ]["active_automation_import_job_id"] = None
+            return (
+                (
+                    "request left 'processing' with no owner — the 066 owner "
+                    "equivalence is broken"
+                ),
+                lambda: assert_recovery_never_parks(world.db),
+            )
 
-        self.assertIn("mutated, renamed, or deleted", str(caught.exception))
+        def owner_pointer_names_no_row() -> tuple[str, Callable[[], None]]:
+            world = self._world()
+            missing = world.owner_id + 5000
+            world.db._requests[
+                _REQUEST_ID
+            ]["active_automation_import_job_id"] = missing
+            return (
+                f"owner {missing} does not exist",
+                lambda: assert_recovery_never_parks(world.db),
+            )
+
+        def owner_parked_at_recovery_required() -> tuple[
+            str, Callable[[], None]
+        ]:
+            world = self._world()
+            self._automation_row(
+                world.db
+            )["status"] = IMPORT_JOB_RECOVERY_REQUIRED
+            return (
+                (
+                    f"owner {world.owner_id} parked at 'recovery_required' "
+                    f"while still holding request {_REQUEST_ID} — invariant "
+                    "11 forbids a state whose only exit is an operator command"
+                ),
+                lambda: assert_recovery_never_parks(world.db),
+            )
+
+        def terminal_owner_still_holds_request() -> tuple[
+            str, Callable[[], None]
+        ]:
+            world = self._world()
+            self._automation_row(world.db)["status"] = "failed"
+            return (
+                (
+                    "request 'processing' behind non-claimable owner status "
+                    "'failed'"
+                ),
+                lambda: assert_recovery_never_parks(world.db),
+            )
+
+        self._prove_clauses((
+            ("released_request_still_names_owner",
+             released_request_still_names_owner),
+            ("released_request_left_non_runnable",
+             released_request_left_non_runnable),
+            ("processing_without_owner", processing_without_owner),
+            ("owner_pointer_names_no_row", owner_pointer_names_no_row),
+            ("owner_parked_at_recovery_required",
+             owner_parked_at_recovery_required),
+            ("terminal_owner_still_holds_request",
+             terminal_owner_still_holds_request),
+        ))
+
+    def test_every_unproven_execution_clause_fires_with_its_own_message(
+        self,
+    ) -> None:
+        def job_row_disappeared() -> tuple[str, Callable[[], None]]:
+            world = self._world()
+            before = world.snapshot()
+            world.db._import_jobs.remove(self._automation_row(world.db))
+            return (
+                "an unproven owner's job row disappeared",
+                lambda: assert_unproven_execution_untouched(
+                    world.db,
+                    before=before,
+                    request_status_before="processing",
+                ),
+            )
+
+        def execution_moved() -> tuple[str, Callable[[], None]]:
+            world = self._world()
+            before = world.snapshot()
+            self._automation_row(world.db)["status"] = "queued"
+            return (
+                (
+                    f"unproven execution moved from {before.status}/"
+                    f"{before.preview_status} to queued/"
+                    f"{before.preview_status}"
+                ),
+                lambda: assert_unproven_execution_untouched(
+                    world.db,
+                    before=before,
+                    request_status_before="processing",
+                ),
+            )
+
+        def lease_cleared() -> tuple[str, Callable[[], None]]:
+            world = self._world()
+            before = world.snapshot()
+            self._automation_row(world.db)["execution_invocation_id"] = None
+            return (
+                "unproven execution had its lease cleared",
+                lambda: assert_unproven_execution_untouched(
+                    world.db,
+                    before=before,
+                    request_status_before="processing",
+                ),
+            )
+
+        def request_moved() -> tuple[str, Callable[[], None]]:
+            world = self._world()
+            before = world.snapshot()
+            world.db._requests[_REQUEST_ID]["status"] = "wanted"
+            return (
+                "unproven execution's request moved to 'wanted'",
+                lambda: assert_unproven_execution_untouched(
+                    world.db,
+                    before=before,
+                    request_status_before="processing",
+                ),
+            )
+
+        def world_failure_audit_written() -> tuple[str, Callable[[], None]]:
+            world = self._world()
+            before = world.snapshot()
+            world.db.log_download(
+                request_id=_REQUEST_ID,
+                outcome="failed",
+                error_message="planted world-failure audit row",
+            )
+            return (
+                "unproven execution produced a world-failure audit row",
+                lambda: assert_unproven_execution_untouched(
+                    world.db,
+                    before=before,
+                    request_status_before="processing",
+                ),
+            )
+
+        self._prove_clauses((
+            ("job_row_disappeared", job_row_disappeared),
+            ("execution_moved", execution_moved),
+            ("lease_cleared", lease_cleared),
+            ("request_moved", request_moved),
+            ("world_failure_audit_written", world_failure_audit_written),
+        ))
+
+    def test_refusal_clause_fires_with_its_own_message(self) -> None:
+        def deleted_remaining_file() -> tuple[str, Callable[[], None]]:
+            before = (("albums/owner/01.flac", "file", b"audio"),)
+            return (
+                (
+                    "cleanup refusal mutated, renamed, or deleted remaining "
+                    "filesystem"
+                ),
+                lambda: assert_cleanup_refusal_preserved_tree(before, ()),
+            )
+
+        self._prove_clauses((
+            ("deleted_remaining_file", deleted_remaining_file),
+        ))

--- a/tests/test_automation_startup_recovery_generated.py
+++ b/tests/test_automation_startup_recovery_generated.py
@@ -707,9 +707,11 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
     ``assertRaises(AssertionError)`` proved nothing: the previous five
     self-tests matched substrings, and two of those substrings
     (``owner equivalence is broken``) belong to two different clauses, so a
-    message-collision mutant would have survived both. The table therefore
-    also proves that no clause's pattern matches any sibling clause's
-    message.
+    message-collision mutant would have survived both. Each table therefore
+    also proves that no clause's pattern matches any sibling clause's message
+    **within that checker** — ``_prove_clauses`` cross-checks the cases it is
+    given, which is one checker per call, not across the module's three
+    (round-3 review N4).
 
     Deterministic by policy — this is test machinery, never a generated
     subject.

--- a/tests/test_cleanup_journal_generated.py
+++ b/tests/test_cleanup_journal_generated.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 import sys
 import unittest
 from dataclasses import dataclass
@@ -25,6 +26,21 @@ from lib.pipeline_db import (
 TEST_DSN = os.environ["TEST_DB_DSN"]
 GuardMutation = Literal["none", "owner_blind", "revision_blind"]
 
+# Per-clause proof (#1094). Every clause of ``assert_owner_revision_guard``
+# is named here so a self-test can anchor on that clause's own message rather
+# than a substring a sibling could also satisfy.
+CLAUSE_FOREIGN_MUTATION = (
+    "cleanup journal mutated without exact owner and revision"
+)
+CLAUSE_EXACT_REFUSED = (
+    "exact owner and revision did not admit its checkpoint"
+)
+
+
+def _exact_clause(message: str) -> str:
+    """Anchor a clause message so no sibling clause can satisfy the regex."""
+    return "^" + re.escape(message) + "$"
+
 
 @dataclass(frozen=True)
 class GuardWorld:
@@ -44,13 +60,9 @@ def assert_owner_revision_guard(
         or world.expected_revision_delta != 0
     )
     if guard_is_wrong and mutation_committed:
-        raise AssertionError(
-            "cleanup journal mutated without exact owner and revision"
-        )
+        raise AssertionError(CLAUSE_FOREIGN_MUTATION)
     if not guard_is_wrong and not mutation_committed:
-        raise AssertionError(
-            "exact owner and revision did not admit its checkpoint"
-        )
+        raise AssertionError(CLAUSE_EXACT_REFUSED)
 
 
 class TestCleanupJournalGenerated(unittest.TestCase):
@@ -107,6 +119,15 @@ class TestCleanupJournalGenerated(unittest.TestCase):
     @example(
         mutation="revision_blind",
         expected_revision_delta=-1,
+        progress_key="published",
+    )
+    # Pins the ONLY world that can fire ``CLAUSE_EXACT_REFUSED``: the exact
+    # owner at the exact revision. Measured at 6 / 150 in the gating `suite`
+    # tier before this pin, so any future edit to the property body could
+    # reshuffle it to zero and retire the clause silently (#1094 Q4).
+    @example(
+        mutation="none",
+        expected_revision_delta=0,
         progress_key="published",
     )
     @given(
@@ -185,35 +206,64 @@ class TestCleanupJournalGenerated(unittest.TestCase):
         else:
             self.assertEqual(persisted["step_progress"], {})
 
-    def test_checker_rejects_owner_blind_known_bad_mutant(self) -> None:
-        world = GuardWorld(
-            mutation="owner_blind",
-            expected_revision_delta=0,
-            progress_key="published",
-        )
-        with self.assertRaisesRegex(
-            AssertionError,
-            "without exact owner and revision",
-        ):
-            assert_owner_revision_guard(
-                world,
-                mutation_committed=True,
-            )
+    def test_every_guard_clause_has_a_named_world(self) -> None:
+        """One world per clause, anchored on that clause's own message.
 
-    def test_checker_rejects_revision_blind_known_bad_mutant(self) -> None:
-        world = GuardWorld(
-            mutation="revision_blind",
-            expected_revision_delta=-1,
-            progress_key="published",
+        Both historical known-bad self-tests asserted the substring
+        ``"without exact owner and revision"``, which only the
+        foreign-mutation clause can emit — so the exact-refusal clause had no
+        proof at all. Each row below is the minimal world that makes exactly
+        one clause's condition true.
+        """
+        cases: tuple[tuple[str, GuardWorld, bool, str], ...] = (
+            (
+                "owner_blind committed",
+                GuardWorld("owner_blind", 0, "published"),
+                True,
+                CLAUSE_FOREIGN_MUTATION,
+            ),
+            (
+                "revision_blind committed",
+                GuardWorld("revision_blind", -1, "published"),
+                True,
+                CLAUSE_FOREIGN_MUTATION,
+            ),
+            (
+                "stale revision committed under the exact owner",
+                GuardWorld("none", 1, "published"),
+                True,
+                CLAUSE_FOREIGN_MUTATION,
+            ),
+            (
+                "exact owner and revision refused",
+                GuardWorld("none", 0, "published"),
+                False,
+                CLAUSE_EXACT_REFUSED,
+            ),
         )
-        with self.assertRaisesRegex(
-            AssertionError,
-            "without exact owner and revision",
-        ):
-            assert_owner_revision_guard(
-                world,
-                mutation_committed=True,
-            )
+        for description, world, committed, message in cases:
+            with (
+                self.subTest(description),
+                self.assertRaisesRegex(
+                    AssertionError,
+                    _exact_clause(message),
+                ),
+            ):
+                assert_owner_revision_guard(
+                    world,
+                    mutation_committed=committed,
+                )
+
+    def test_guard_admits_the_only_two_correct_worlds(self) -> None:
+        """Must-still-work: neither clause fires on a correctly guarded world."""
+        assert_owner_revision_guard(
+            GuardWorld("none", 0, "published"),
+            mutation_committed=True,
+        )
+        assert_owner_revision_guard(
+            GuardWorld("owner_blind", 0, "published"),
+            mutation_committed=False,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_download_incarnation_generated.py
+++ b/tests/test_download_incarnation_generated.py
@@ -18,8 +18,9 @@ the explicit PR2 boundary.
 from __future__ import annotations
 
 import copy
+import re
 import unittest
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta, timezone
 from typing import Literal
@@ -33,6 +34,7 @@ from lib.download import (
     _admit_download_incarnations,
     _decode_valid_download_incarnations,
 )
+from lib.import_queue import AutomationHandoffResult
 from lib.pipeline_db.rows import AlbumRequestRow
 from lib.quality import ActiveDownloadFileState, ActiveDownloadState
 from tests.fakes import FakePipelineDB
@@ -73,6 +75,25 @@ _ADMISSION_KINDS: tuple[AdmissionKind, ...] = (
     "invalid",
 )
 _DETERMINISTIC_PATH = "/processing/albums/Artist - Album [same-attempt-path]"
+# The four rows whose stored state is undecodable or witness-less are the SAME
+# row observed twice: they are already degenerate in the pre-snapshot, so a
+# dropped decode guard admits a matching pair instead of excluding nothing.
+_DEGENERATE_PRE_KINDS: dict[int, AdmissionKind] = {
+    4: "missing",
+    5: "empty",
+    6: "malformed",
+    7: "invalid",
+}
+
+
+def _anchored(message: str) -> str:
+    """Anchor a full clause message so no sibling clause can satisfy it."""
+    return "^" + re.escape(message) + "$"
+
+
+def _anchored_prefix(prefix: str) -> str:
+    """Anchor a clause message whose tail carries generated values."""
+    return "^" + re.escape(prefix)
 
 
 @dataclass(frozen=True)
@@ -482,15 +503,6 @@ def _build_admission_inputs(
     list[AlbumRequestRow],
     tuple[tuple[int, str], ...],
 ]:
-    pre_db = FakePipelineDB()
-    for request_id in range(1, 9):
-        witness = world.witness_b if request_id == 8 else world.witness_a
-        pre_db.seed_request(_admission_row(request_id, witness=witness))
-    pre_snapshot = _decode_valid_download_incarnations(
-        pre_db.get_downloading(),
-        phase="generated pre-snapshot",
-    )
-
     refreshed_by_kind: dict[AdmissionKind, dict[str, object]] = {
         "unchanged": _admission_row(1, witness=world.witness_a),
         "unchanged_alt": _admission_row(8, witness=world.witness_b),
@@ -519,6 +531,20 @@ def _build_admission_inputs(
         ),
         "invalid": _admission_row(7, witness="not-an-iso-witness"),
     }
+
+    pre_db = FakePipelineDB()
+    for request_id in range(1, 9):
+        degenerate_kind = _DEGENERATE_PRE_KINDS.get(request_id)
+        if degenerate_kind is not None:
+            pre_db.seed_request(copy.deepcopy(refreshed_by_kind[degenerate_kind]))
+            continue
+        witness = world.witness_b if request_id == 8 else world.witness_a
+        pre_db.seed_request(_admission_row(request_id, witness=witness))
+    pre_snapshot = _decode_valid_download_incarnations(
+        pre_db.get_downloading(),
+        phase="generated pre-snapshot",
+    )
+
     refreshed_db = FakePipelineDB()
     for kind in world.refreshed_order:
         refreshed_db.seed_request(refreshed_by_kind[kind])
@@ -561,8 +587,12 @@ def assert_handoff_contract(
         raise AssertionError("exact handoff did not publish one processor owner")
 
 
-def _exercise_handoff(world: HandoffWorld) -> None:
-    db = FakePipelineDB()
+def _exercise_handoff(
+    world: HandoffWorld,
+    *,
+    db_factory: Callable[[], FakePipelineDB] = FakePipelineDB,
+) -> None:
+    db = db_factory()
     request_id = db.add_request(
         "Artist",
         "Album",
@@ -613,13 +643,14 @@ def _exercise_handoff(world: HandoffWorld) -> None:
         job_count=len(jobs),
     )
     if exact:
-        assert result.job is not None
+        if result.job is None:
+            raise AssertionError("committed handoff returned no job record")
         active_state = after["active_download_state"]
         if (
             after["active_automation_import_job_id"] != result.job.id
             or result.job.expected_request_status != "processing"
             or not isinstance(active_state, dict)
-            or active_state["current_path"] != world.canonical_path
+            or active_state.get("current_path") != world.canonical_path
         ):
             raise AssertionError("handoff owner, job, and canonical path diverged")
         before_rejected_writes = copy.deepcopy(after)
@@ -638,8 +669,12 @@ def _exercise_handoff(world: HandoffWorld) -> None:
             raise AssertionError("rejected post-handoff writer changed metadata")
 
 
-def _exercise_rejected_handoff(world: HandoffRejectionWorld) -> None:
-    db = FakePipelineDB()
+def _exercise_rejected_handoff(
+    world: HandoffRejectionWorld,
+    *,
+    db_factory: Callable[[], FakePipelineDB] = FakePipelineDB,
+) -> None:
+    db = db_factory()
     request_id = db.add_request(
         "Artist",
         "Album",
@@ -729,8 +764,8 @@ class TestDeterministicDownloadIncarnationContract(unittest.TestCase):
             ),
             replacement_is_new_id=False,
         )
-        pre_snapshot, refreshed_rows, expected = _build_admission_inputs(world)
         with self.assertLogs("cratedigger", level="WARNING"):
+            pre_snapshot, refreshed_rows, expected = _build_admission_inputs(world)
             admitted = _admit_download_incarnations(
                 pre_snapshot,
                 refreshed_rows,
@@ -842,12 +877,21 @@ class TestGeneratedDownloadIncarnationContract(unittest.TestCase):
         refreshed_order=_ADMISSION_KINDS,
         replacement_is_new_id=True,
     ))
+    # Issue #1094: the same-ID replacement arm is the one that separates exact
+    # pair admission from request-ID admission, so it is pinned rather than
+    # left to the derandomized sweep.
+    @example(world=AdmissionWorld(
+        witness_a="2026-07-28T01:00:00.000000Z",
+        witness_b="2026-07-28T09:00:01.000000+08:00",
+        refreshed_order=tuple(reversed(_ADMISSION_KINDS)),
+        replacement_is_new_id=False,
+    ))
     def test_post_event_cohort_matches_exact_pair_oracle(
         self,
         world: AdmissionWorld,
     ) -> None:
-        pre_snapshot, refreshed_rows, expected = _build_admission_inputs(world)
         with self.assertLogs("cratedigger", level="WARNING"):
+            pre_snapshot, refreshed_rows, expected = _build_admission_inputs(world)
             admitted = _admit_download_incarnations(
                 pre_snapshot,
                 refreshed_rows,
@@ -871,7 +915,10 @@ class TestGeneratedDownloadIncarnationContract(unittest.TestCase):
         )
         with self.assertRaisesRegex(
             AssertionError,
-            "exact incarnation oracle",
+            _anchored_prefix(
+                "post-event poll admission diverged from exact incarnation "
+                "oracle: expected="
+            ),
         ):
             assert_exact_admission(expected, request_id_only_mutant)
 
@@ -880,6 +927,15 @@ class TestGeneratedDownloadIncarnationContract(unittest.TestCase):
         current_witness="2026-07-29T08:00:00+08:00",
         attempted_witness="2026-07-29T00:00:00Z",
         canonical_path=_DETERMINISTIC_PATH,
+    ))
+    # Issue #1094: the exact-commit arm owns every post-handoff clause
+    # (publication, canonical path, and both refused post-handoff writers).
+    # Pinned so a future edit to this body cannot reshuffle it out of the
+    # derandomized gating tier.
+    @example(world=HandoffWorld(
+        current_witness="2026-07-29T08:00:00+08:00",
+        attempted_witness="2026-07-29T08:00:00+08:00",
+        canonical_path="/processing/albums/Ártist - 音 [pressing]",
     ))
     def test_handoff_requires_exact_textual_witness(
         self,
@@ -893,6 +949,24 @@ class TestGeneratedDownloadIncarnationContract(unittest.TestCase):
         witness="2026-07-29T00:00:00Z",
         canonical_path=_DETERMINISTIC_PATH,
     ))
+    # Issue #1094: each rejection kind is the only world that attributes its
+    # own outcome/metadata/job clauses, so all four are pinned into the
+    # derandomized gating tier rather than left to the sweep.
+    @example(world=HandoffRejectionWorld(
+        kind="missing_state",
+        witness="2026-07-29T00:00:00Z",
+        canonical_path=_DETERMINISTIC_PATH,
+    ))
+    @example(world=HandoffRejectionWorld(
+        kind="non_downloading",
+        witness="2026-07-29T00:00:00Z",
+        canonical_path="/processing/albums/Ártist - 音 [rejected]",
+    ))
+    @example(world=HandoffRejectionWorld(
+        kind="active_conflict",
+        witness="2026-07-29T00:00:00Z",
+        canonical_path=_DETERMINISTIC_PATH,
+    ))
     def test_non_admissible_handoffs_preserve_all_state(
         self,
         world: HandoffRejectionWorld,
@@ -900,8 +974,220 @@ class TestGeneratedDownloadIncarnationContract(unittest.TestCase):
         _exercise_rejected_handoff(world)
 
 
+_PLANTED_UPDATED_AT = datetime(2030, 1, 1, tzinfo=UTC)
+_EXACT_HANDOFF_WORLD = HandoffWorld(
+    current_witness="2026-07-29T08:00:00+08:00",
+    attempted_witness="2026-07-29T08:00:00+08:00",
+    canonical_path=_DETERMINISTIC_PATH,
+)
+_STALE_HANDOFF_WORLD = HandoffWorld(
+    current_witness="2026-07-29T08:00:01+08:00",
+    attempted_witness="2026-07-29T00:00:00Z",
+    canonical_path=_DETERMINISTIC_PATH,
+)
+
+
+def _rejection_world(kind: HandoffRejectionKind) -> HandoffRejectionWorld:
+    return HandoffRejectionWorld(
+        kind=kind,
+        witness="2026-07-29T00:00:00Z",
+        canonical_path=_DETERMINISTIC_PATH,
+    )
+
+
+class _PlantedHandoffFake(FakePipelineDB):
+    """Run the real handoff transcript, then plant exactly one defect."""
+
+    def _plant(
+        self,
+        request_id: int,
+        result: AutomationHandoffResult,
+    ) -> AutomationHandoffResult:
+        del request_id
+        return result
+
+    def handoff_automation_import(
+        self,
+        *,
+        request_id: int,
+        expected_enqueued_at: str,
+        canonical_path: str,
+        message: str,
+    ) -> AutomationHandoffResult:
+        return self._plant(request_id, super().handoff_automation_import(
+            request_id=request_id,
+            expected_enqueued_at=expected_enqueued_at,
+            canonical_path=canonical_path,
+            message=message,
+        ))
+
+
+class _NoDownloadingEntry(FakePipelineDB):
+    """The fixture can never enter ``downloading``."""
+
+    def set_downloading(
+        self,
+        request_id: int,
+        state_json: str,
+        *,
+        expected_status: str = "wanted",
+    ) -> bool:
+        del request_id, state_json, expected_status
+        return False
+
+
+class _UnfencedHandoff(FakePipelineDB):
+    """The exact-witness fence is disabled, so a stale attempt commits."""
+
+    def _automation_handoff_enforce_witness(self) -> bool:
+        return False
+
+
+class _NeverCommittingHandoff(FakePipelineDB):
+    """Every handoff attempt reports a witness mismatch."""
+
+    def handoff_automation_import(
+        self,
+        *,
+        request_id: int,
+        expected_enqueued_at: str,
+        canonical_path: str,
+        message: str,
+    ) -> AutomationHandoffResult:
+        del request_id, expected_enqueued_at, canonical_path, message
+        return AutomationHandoffResult("witness_mismatch")
+
+
+class _CommitsWithoutJobRecord(_PlantedHandoffFake):
+    """A committed handoff returns no job record."""
+
+    def _plant(
+        self,
+        request_id: int,
+        result: AutomationHandoffResult,
+    ) -> AutomationHandoffResult:
+        del request_id
+        if result.committed:
+            return AutomationHandoffResult(result.outcome)
+        return result
+
+
+class _PublishesWrongCanonicalPath(_PlantedHandoffFake):
+    """Ownership publishes a canonical path the caller never asked for."""
+
+    def _plant(
+        self,
+        request_id: int,
+        result: AutomationHandoffResult,
+    ) -> AutomationHandoffResult:
+        if result.committed:
+            state = self.request(request_id)["active_download_state"]
+            if isinstance(state, dict):
+                state["current_path"] = "/processing/albums/another-attempt"
+        return result
+
+
+class _RejectionReportsWrongOutcome(_PlantedHandoffFake):
+    """A refused handoff reports the wrong rejection tag."""
+
+    def _plant(
+        self,
+        request_id: int,
+        result: AutomationHandoffResult,
+    ) -> AutomationHandoffResult:
+        del request_id
+        if not result.committed:
+            return AutomationHandoffResult("request_missing")
+        return result
+
+
+class _RejectionTouchesRequestRow(_PlantedHandoffFake):
+    """A refused handoff still stamps the request row."""
+
+    def _plant(
+        self,
+        request_id: int,
+        result: AutomationHandoffResult,
+    ) -> AutomationHandoffResult:
+        if not result.committed:
+            self.request(request_id)["updated_at"] = _PLANTED_UPDATED_AT
+        return result
+
+
+class _RejectionCreatesJob(_PlantedHandoffFake):
+    """A refused handoff still mints an import job."""
+
+    def _plant(
+        self,
+        request_id: int,
+        result: AutomationHandoffResult,
+    ) -> AutomationHandoffResult:
+        if not result.committed:
+            self._append_import_job(
+                "automation_import",
+                request_id=request_id,
+                dedupe_key=None,
+                payload={},
+                message="planted rejection job",
+            )
+        return result
+
+
+class _CasCrossesHandoff(FakePipelineDB):
+    """The whole-state writer accepts a row the processor already owns."""
+
+    def update_download_state_if_downloading(
+        self,
+        request_id: int,
+        state_json: str,
+        *,
+        expected_enqueued_at: str,
+    ) -> bool:
+        del state_json, expected_enqueued_at
+        return self.request(request_id)["status"] in ("downloading", "processing")
+
+
+class _ResetCrossesHandoff(FakePipelineDB):
+    """The reset writer accepts a row the processor already owns."""
+
+    def reset_downloading_to_wanted(
+        self,
+        request_id: int,
+        *,
+        expected_status: str = "downloading",
+        **fields: object,
+    ) -> bool:
+        del request_id, expected_status, fields
+        return True
+
+
+class _RejectedWriterTouchesRow(FakePipelineDB):
+    """A refused whole-state write still stamps the row it refused."""
+
+    def update_download_state_if_downloading(
+        self,
+        request_id: int,
+        state_json: str,
+        *,
+        expected_enqueued_at: str,
+    ) -> bool:
+        self.request(request_id)["updated_at"] = _PLANTED_UPDATED_AT
+        return super().update_download_state_if_downloading(
+            request_id,
+            state_json,
+            expected_enqueued_at=expected_enqueued_at,
+        )
+
+
 class TestIncarnationInvariantCheckersTripOnKnownBad(unittest.TestCase):
-    """Committed known-bad inputs qualify every U5 invariant checker."""
+    """Committed known-bad inputs qualify every U5 invariant checker.
+
+    Issue #1094 per-clause proof: each test below names the minimal world that
+    makes exactly one clause fire while every earlier clause in the same
+    function passes, and asserts that clause's own anchored message. A bare
+    ``assertRaises`` or a loose substring would let a sibling clause satisfy
+    the assertion.
+    """
 
     @staticmethod
     def _planted_applied_row(
@@ -913,11 +1199,39 @@ class TestIncarnationInvariantCheckersTripOnKnownBad(unittest.TestCase):
         after["updated_at"] = datetime(2030, 1, 1, tzinfo=UTC)
         return after
 
+    _PREDICATE_CLAUSE = (
+        "whole-state CAS result diverged from status/stored/outgoing witness "
+        "predicates: expected={expected} actual={actual}"
+    )
+
+    @staticmethod
+    def _published_state() -> dict[str, object]:
+        state = _state_dict(_admission_state("2026-07-29T00:00:00Z"))
+        state["processing_started_at"] = "2026-07-29T00:00:01+00:00"
+        state["current_path"] = _DETERMINISTIC_PATH
+        return state
+
+    @classmethod
+    def _published_row(cls, **overrides: object) -> dict[str, object]:
+        row = _admission_row(
+            1,
+            witness="2026-07-29T00:00:00Z",
+            status="processing",
+            raw_state=cls._published_state(),
+        )
+        row["active_automation_import_job_id"] = 7
+        row.update(overrides)
+        return row
+
     def test_checker_kills_missing_status_predicate(self) -> None:
         witness = "2026-07-28T01:00:00Z"
         outgoing = _admission_state(witness)
         before = _admission_row(1, witness=witness, status="wanted")
-        with self.assertRaisesRegex(AssertionError, "predicates"):
+        with self.assertRaisesRegex(
+            AssertionError,
+            _anchored(self._PREDICATE_CLAUSE.format(
+                expected=False, actual=True)),
+        ):
             assert_witnessed_write_contract(
                 before_row=before,
                 outgoing_state=outgoing,
@@ -933,7 +1247,11 @@ class TestIncarnationInvariantCheckersTripOnKnownBad(unittest.TestCase):
             1,
             witness="2026-07-28T01:00:01Z",
         )
-        with self.assertRaisesRegex(AssertionError, "predicates"):
+        with self.assertRaisesRegex(
+            AssertionError,
+            _anchored(self._PREDICATE_CLAUSE.format(
+                expected=False, actual=True)),
+        ):
             assert_witnessed_write_contract(
                 before_row=before_b,
                 outgoing_state=outgoing_a,
@@ -946,7 +1264,11 @@ class TestIncarnationInvariantCheckersTripOnKnownBad(unittest.TestCase):
         witness_a = "2026-07-28T01:00:00Z"
         outgoing_b = _admission_state("2026-07-28T01:00:01Z")
         before_a = _admission_row(1, witness=witness_a)
-        with self.assertRaisesRegex(AssertionError, "predicates"):
+        with self.assertRaisesRegex(
+            AssertionError,
+            _anchored(self._PREDICATE_CLAUSE.format(
+                expected=False, actual=True)),
+        ):
             assert_witnessed_write_contract(
                 before_row=before_a,
                 outgoing_state=outgoing_b,
@@ -954,6 +1276,86 @@ class TestIncarnationInvariantCheckersTripOnKnownBad(unittest.TestCase):
                 applied=True,
                 after_row=self._planted_applied_row(before_a, outgoing_b),
             )
+
+    def test_checker_kills_fail_closed_witnessed_write(self) -> None:
+        """All three predicates hold, so refusing the write is a violation."""
+        witness = "2026-07-28T01:00:00Z"
+        outgoing = _admission_state(witness)
+        before = _admission_row(1, witness=witness)
+        with self.assertRaisesRegex(
+            AssertionError,
+            _anchored(self._PREDICATE_CLAUSE.format(
+                expected=True, actual=False)),
+        ):
+            assert_witnessed_write_contract(
+                before_row=before,
+                outgoing_state=outgoing,
+                expected_witness=witness,
+                applied=False,
+                after_row=copy.deepcopy(before),
+            )
+
+    def test_checker_kills_rejected_write_that_changed_the_row(self) -> None:
+        """The CAS result agrees; the refused write still moved the row."""
+        witness = "2026-07-28T01:00:00Z"
+        outgoing = _admission_state(witness)
+        before = _admission_row(1, witness=witness, status="wanted")
+        after = copy.deepcopy(before)
+        after["updated_at"] = _PLANTED_UPDATED_AT
+        with self.assertRaisesRegex(
+            AssertionError,
+            _anchored("rejected whole-state CAS changed row state or metadata"),
+        ):
+            assert_witnessed_write_contract(
+                before_row=before,
+                outgoing_state=outgoing,
+                expected_witness=witness,
+                applied=False,
+                after_row=after,
+            )
+
+    def test_checker_kills_accepted_write_beyond_state_and_stamp(self) -> None:
+        """The accepted write carried a field the CAS may not touch."""
+        witness = "2026-07-28T01:00:00Z"
+        outgoing = _admission_state(witness)
+        before = _admission_row(1, witness=witness)
+        after = self._planted_applied_row(before, outgoing)
+        after["validation_attempts"] = 3
+        with self.assertRaisesRegex(
+            AssertionError,
+            _anchored(
+                "accepted whole-state CAS changed fields beyond "
+                "state/updated_at"
+            ),
+        ):
+            assert_witnessed_write_contract(
+                before_row=before,
+                outgoing_state=outgoing,
+                expected_witness=witness,
+                applied=True,
+                after_row=after,
+            )
+
+    def test_witnessed_write_checker_accepts_lawful_worlds(self) -> None:
+        """Must-still-work control: the two lawful shapes raise nothing."""
+        witness = "2026-07-28T01:00:00Z"
+        outgoing = _admission_state(witness)
+        accepted_before = _admission_row(1, witness=witness)
+        assert_witnessed_write_contract(
+            before_row=accepted_before,
+            outgoing_state=outgoing,
+            expected_witness=witness,
+            applied=True,
+            after_row=self._planted_applied_row(accepted_before, outgoing),
+        )
+        rejected_before = _admission_row(1, witness=witness, status="wanted")
+        assert_witnessed_write_contract(
+            before_row=rejected_before,
+            outgoing_state=outgoing,
+            expected_witness=witness,
+            applied=False,
+            after_row=copy.deepcopy(rejected_before),
+        )
 
     def test_checker_kills_request_id_only_admission(self) -> None:
         expected = ((1, "2026-07-28T01:00:00Z"),)
@@ -963,28 +1365,216 @@ class TestIncarnationInvariantCheckersTripOnKnownBad(unittest.TestCase):
         )
         with self.assertRaisesRegex(
             AssertionError,
-            "exact incarnation oracle",
+            _anchored(
+                "post-event poll admission diverged from exact incarnation "
+                f"oracle: expected={expected!r} actual={request_id_only!r}"
+            ),
         ):
             assert_exact_admission(expected, request_id_only)
 
     def test_checker_kills_stale_handoff_mutant(self) -> None:
+        """Both disjuncts of the stale-handoff clause, one world each."""
         before = make_request_row(
             status="downloading",
             active_download_state={"enqueued_at": "B"},
         )
-        after = copy.deepcopy(before)
-        after["status"] = "processing"
-        after["active_automation_import_job_id"] = 1
-        active_state = after["active_download_state"]
-        assert isinstance(active_state, dict)
-        active_state["processing_started_at"] = "now"
+        published = copy.deepcopy(before)
+        published["status"] = "processing"
+        published["active_automation_import_job_id"] = 1
+        published_state = published["active_download_state"]
+        if isinstance(published_state, dict):
+            published_state["processing_started_at"] = "now"
+        cases: tuple[tuple[str, dict[str, object], int], ...] = (
+            ("row changed only", published, 0),
+            ("job created only", copy.deepcopy(before), 1),
+            ("row changed and job created", published, 1),
+        )
+        for description, after, job_count in cases:
+            with self.subTest(world=description), self.assertRaisesRegex(
+                AssertionError,
+                _anchored("stale handoff produced an observable change"),
+            ):
+                assert_handoff_contract(
+                    exact=False,
+                    before=before,
+                    after=after,
+                    job_count=job_count,
+                )
+        assert_handoff_contract(
+            exact=False,
+            before=before,
+            after=copy.deepcopy(before),
+            job_count=0,
+        )
+
+    def test_checker_kills_incomplete_exact_handoff_publication(self) -> None:
+        """Every disjunct of the exact-publication clause, one world each."""
+        stampless_state = self._published_state()
+        del stampless_state["processing_started_at"]
+        cases: tuple[tuple[str, dict[str, object], int], ...] = (
+            ("status is not processing", self._published_row(
+                status="downloading"), 1),
+            ("owner id is not an int", self._published_row(
+                active_automation_import_job_id="7"), 1),
+            ("owner id is not positive", self._published_row(
+                active_automation_import_job_id=0), 1),
+            ("state is not an object", self._published_row(
+                active_download_state=None), 1),
+            ("processing stamp missing", self._published_row(
+                active_download_state=stampless_state), 1),
+            ("no job published", self._published_row(), 0),
+            ("two jobs published", self._published_row(), 2),
+        )
+        for description, after, job_count in cases:
+            with self.subTest(world=description), self.assertRaisesRegex(
+                AssertionError,
+                _anchored("exact handoff did not publish one processor owner"),
+            ):
+                assert_handoff_contract(
+                    exact=True,
+                    before=self._published_row(),
+                    after=after,
+                    job_count=job_count,
+                )
+        assert_handoff_contract(
+            exact=True,
+            before=self._published_row(),
+            after=self._published_row(),
+            job_count=1,
+        )
+
+    def test_transcript_driver_rejects_alphabet_drift(self) -> None:
+        """Fail-closed legislation: a future strategy edit cannot go quiet."""
         with self.assertRaisesRegex(
             AssertionError,
-            "stale handoff",
+            _anchored_prefix("operation alphabet drifted outside PR1: "),
         ):
-            assert_handoff_contract(
-                exact=False,
-                before=before,
-                after=after,
-                job_count=1,
+            _exercise_transcript(TranscriptWorld(
+                witness_a="2026-07-28T01:00:00.000000Z",
+                witness_b="2026-07-28T09:00:01.000000+08:00",
+                operation_order=("enqueue",),
+                username="peer",
+                filename="Music\\Artist\\Album\\01 track.flac",
+                size=1000,
+                progress_bytes=400,
+            ))
+
+    def test_drivers_kill_fixtures_that_never_enter_downloading(self) -> None:
+        with self.subTest(driver="handoff"), self.assertRaisesRegex(
+            AssertionError,
+            _anchored("generated fixture failed to enter downloading"),
+        ):
+            _exercise_handoff(
+                _EXACT_HANDOFF_WORLD,
+                db_factory=_NoDownloadingEntry,
+            )
+        with self.subTest(driver="rejection"), self.assertRaisesRegex(
+            AssertionError,
+            _anchored("rejection fixture failed to enter downloading"),
+        ):
+            _exercise_rejected_handoff(
+                _rejection_world("missing_state"),
+                db_factory=_NoDownloadingEntry,
+            )
+
+    def test_driver_kills_unfenced_stale_handoff_commit(self) -> None:
+        with self.assertRaisesRegex(
+            AssertionError,
+            _anchored("handoff outcome 'committed' disagreed with exact=False"),
+        ):
+            _exercise_handoff(
+                _STALE_HANDOFF_WORLD,
+                db_factory=_UnfencedHandoff,
+            )
+
+    def test_driver_kills_committed_handoff_without_a_job_record(self) -> None:
+        with self.assertRaisesRegex(
+            AssertionError,
+            _anchored("committed handoff returned no job record"),
+        ):
+            _exercise_handoff(
+                _EXACT_HANDOFF_WORLD,
+                db_factory=_CommitsWithoutJobRecord,
+            )
+
+    def test_driver_kills_wrong_published_canonical_path(self) -> None:
+        with self.assertRaisesRegex(
+            AssertionError,
+            _anchored("handoff owner, job, and canonical path diverged"),
+        ):
+            _exercise_handoff(
+                _EXACT_HANDOFF_WORLD,
+                db_factory=_PublishesWrongCanonicalPath,
+            )
+
+    def test_driver_kills_post_handoff_whole_state_writer(self) -> None:
+        with self.assertRaisesRegex(
+            AssertionError,
+            _anchored("poll/event writer crossed the handoff"),
+        ):
+            _exercise_handoff(
+                _EXACT_HANDOFF_WORLD,
+                db_factory=_CasCrossesHandoff,
+            )
+
+    def test_driver_kills_post_handoff_reset_writer(self) -> None:
+        with self.assertRaisesRegex(
+            AssertionError,
+            _anchored("reset writer crossed the handoff"),
+        ):
+            _exercise_handoff(
+                _EXACT_HANDOFF_WORLD,
+                db_factory=_ResetCrossesHandoff,
+            )
+
+    def test_driver_kills_refused_writer_that_stamps_the_row(self) -> None:
+        with self.assertRaisesRegex(
+            AssertionError,
+            _anchored("rejected post-handoff writer changed metadata"),
+        ):
+            _exercise_handoff(
+                _EXACT_HANDOFF_WORLD,
+                db_factory=_RejectedWriterTouchesRow,
+            )
+
+    def test_driver_kills_conflict_seed_that_never_commits(self) -> None:
+        with self.assertRaisesRegex(
+            AssertionError,
+            _anchored("conflict fixture failed to create active job"),
+        ):
+            _exercise_rejected_handoff(
+                _rejection_world("active_conflict"),
+                db_factory=_NeverCommittingHandoff,
+            )
+
+    def test_driver_kills_wrong_rejection_outcome(self) -> None:
+        with self.assertRaisesRegex(
+            AssertionError,
+            _anchored(
+                "missing_state returned request_missing, expected missing_state"
+            ),
+        ):
+            _exercise_rejected_handoff(
+                _rejection_world("missing_state"),
+                db_factory=_RejectionReportsWrongOutcome,
+            )
+
+    def test_driver_kills_rejection_that_stamps_the_request(self) -> None:
+        with self.assertRaisesRegex(
+            AssertionError,
+            _anchored("non_downloading changed request metadata"),
+        ):
+            _exercise_rejected_handoff(
+                _rejection_world("non_downloading"),
+                db_factory=_RejectionTouchesRequestRow,
+            )
+
+    def test_driver_kills_rejection_that_creates_a_job(self) -> None:
+        with self.assertRaisesRegex(
+            AssertionError,
+            _anchored("non_downloading created or changed a job"),
+        ):
+            _exercise_rejected_handoff(
+                _rejection_world("non_downloading"),
+                db_factory=_RejectionCreatesJob,
             )

--- a/tests/test_import_operation_fence_generated.py
+++ b/tests/test_import_operation_fence_generated.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import os
+import re
 import tempfile
 import unittest
+from collections.abc import Callable
 from dataclasses import dataclass
 from unittest.mock import patch
 
@@ -15,6 +17,7 @@ import tests._hypothesis_profiles  # noqa: F401  (loads the active profile)
 from lib.config import CratediggerConfig
 from lib.dispatch import DISPATCH_CODE_REQUEUE_FAILED, dispatch_import_core
 from lib.dispatch.types import DispatchOutcome, EvidenceImportGate, ImportOneRun
+from lib.failure_presentation import non_automation_import_failure_message
 from lib.import_execution import (
     ExecutionCancelled,
     ExecutionLeaseSnapshot,
@@ -29,6 +32,7 @@ from lib.import_queue import (
     IMPORT_JOB_YOUTUBE,
     youtube_import_payload,
 )
+from lib.pipeline_db.rows import DownloadLogWithEvidenceRow
 from lib.quality import DownloadInfo
 from lib.quality_evidence import snapshot_audio_files
 from scripts.importer import (
@@ -267,14 +271,39 @@ def assert_non_automation_failure_lifecycle(
         raise AssertionError("Recents lost the failed job-type identity")
 
 
+class AuditReadBackLostDB(FakePipelineDB):
+    """Model the one shape that loses a committed terminal audit row.
+
+    ``PipelineDB.get_download_log_entry`` INNER JOINs ``album_requests``
+    (``lib/pipeline_db/download_log.py``), so a terminal audit row that a
+    bundle claims to have committed can be enumerable and still not read
+    back. Today's writers cannot produce that world — the audit row is
+    written inside the terminal transaction against the locked request, and
+    the foreign key keeps the joined request alive — so this is the only
+    world that reaches ``assert_non_automation_failure_lifecycle``'s
+    read-back clause. The switch stays off while the world is driven so the
+    production path under test sees the ordinary reader.
+    """
+
+    audit_read_back_lost: bool = False
+
+    def get_download_log_entry(
+        self, log_id: int,
+    ) -> DownloadLogWithEvidenceRow | None:
+        if self.audit_read_back_lost:
+            return None
+        return super().get_download_log_entry(log_id)
+
+
 def _drive_non_automation_failure(
     *,
     job_type: str,
     failure_class: str,
     request_status: str,
+    db_factory: Callable[[], FakePipelineDB] = FakePipelineDB,
 ) -> tuple[FakePipelineDB, int]:
     """Drive each residual path through importer/startup production code."""
-    db = FakePipelineDB()
+    db = db_factory()
     request_id = _OPERATION_FENCE_REQUEST_ID
     db.seed_request(make_request_row(
         id=request_id,
@@ -919,7 +948,27 @@ class TestGeneratedImportOperationFence(unittest.TestCase):
         )
 
 
+def _exact(message: str) -> str:
+    """Anchor a clause message so a sibling clause cannot satisfy it.
+
+    ``assertRaisesRegex`` searches, so a bare substring is proof only that
+    *some* clause fired. Every known-bad world below names its own clause
+    end to end.
+    """
+    return "^" + re.escape(message) + "$"
+
+
 class TestImportOperationFenceChecker(unittest.TestCase):
+    """Per-clause proof (#1094) for this module's three fence checkers.
+
+    Twenty-one clauses live in ``assert_operation_fence`` (10),
+    ``assert_startup_force_action_lifecycle`` (4) and
+    ``assert_non_automation_failure_lifecycle`` (7). Each table row below
+    names one world that makes THAT clause's condition true while every
+    earlier clause in the same function passes, and asserts that clause's
+    own message anchored end to end.
+    """
+
     def _db(self, **overrides: object) -> FakePipelineDB:
         overrides.setdefault("status", "wanted")
         db = FakePipelineDB()
@@ -928,136 +977,435 @@ class TestImportOperationFenceChecker(unittest.TestCase):
         ))
         return db
 
-    def test_checker_rejects_the_old_automatic_replay_policy(self) -> None:
-        with self.assertRaisesRegex(AssertionError, "more than once"):
-            assert_operation_fence(
-                job_type=IMPORT_JOB_AUTOMATION,
-                authorized=True,
-                final_status="queued",
-                beets_invocations=[703, 703],
-                replay_claimed=True,
-                db=self._db(),
-            )
-
-    def test_checker_rejects_planted_recovery_required_park(self) -> None:
-        """Known-bad: reviving the removed ``recovery_required`` rest state
-        (the pre-#933 policy this file used to require) trips the checker."""
-        with self.assertRaisesRegex(AssertionError, "recovery_required"):
-            assert_operation_fence(
-                job_type=IMPORT_JOB_AUTOMATION,
-                authorized=True,
-                final_status=IMPORT_JOB_RECOVERY_REQUIRED,
-                beets_invocations=[703],
-                replay_claimed=False,
-                db=self._db(
-                    status="processing", active_automation_import_job_id=7,
-                ),
-            )
-
-    def test_checker_rejects_replay_after_ambiguous_operation(self) -> None:
-        """Known-bad: an ambiguous operation whose job became claimable again."""
-        with self.assertRaisesRegex(AssertionError, "became claimable"):
-            assert_operation_fence(
-                job_type=IMPORT_JOB_FORCE,
-                authorized=True,
-                final_status="failed",
-                beets_invocations=[703],
-                replay_claimed=True,
-                db=self._db(),
-            )
-
-    def test_checker_rejects_automation_self_heal_with_owner_attached(self) -> None:
-        """Known-bad: self-heal that failed to clear the automation owner."""
-        with self.assertRaisesRegex(AssertionError, "owner attached"):
-            assert_operation_fence(
-                job_type=IMPORT_JOB_AUTOMATION,
-                authorized=True,
-                final_status="failed",
-                beets_invocations=[703],
-                replay_claimed=False,
-                db=self._db(
-                    status="wanted", active_automation_import_job_id=7,
-                ),
-            )
-
-    def test_checker_rejects_automation_self_heal_missing_audit_row(self) -> None:
-        """Known-bad: a silent self-heal with no Recents-visible trace."""
-        with self.assertRaisesRegex(AssertionError, "world-failure audit row"):
-            assert_operation_fence(
-                job_type=IMPORT_JOB_AUTOMATION,
-                authorized=True,
-                final_status="failed",
-                beets_invocations=[703],
-                replay_claimed=False,
-                db=self._db(status="wanted"),
-            )
-
-    def test_checker_rejects_force_import_self_healing_the_request(self) -> None:
-        """Known-bad: a force/YouTube job that mutated the caller's request
-        lifecycle — invariant 11 reserves that self-heal for automation,
-        which is the only job type that owns ``processing``."""
-        db = self._db(status="unsearchable")
+    def _db_with_linked_audit(
+        self,
+        *,
+        status: str,
+        audits: int = 1,
+    ) -> FakePipelineDB:
+        """A request whose Recents trail already carries linked failures."""
+        db = self._db(status=status)
         source = db.log_download(
             _OPERATION_FENCE_REQUEST_ID,
             outcome="rejected",
         )
-        db.log_download(
-            _OPERATION_FENCE_REQUEST_ID,
-            outcome="failed",
-            source_download_log_id=source,
-            error_message="Force import attempt failed: known-bad",
+        for index in range(audits):
+            db.log_download(
+                _OPERATION_FENCE_REQUEST_ID,
+                outcome="failed",
+                source_download_log_id=source,
+                error_message=non_automation_import_failure_message(
+                    IMPORT_JOB_FORCE,
+                    f"generated linked audit {index}",
+                ),
+            )
+        return db
+
+    # ---- assert_operation_fence: clauses 1-10 -------------------------
+
+    def test_operation_fence_clause_worlds(self) -> None:
+        """Every ``assert_operation_fence`` clause has a world that fires it."""
+        cases: list[tuple[str, Callable[[], None], str]] = [
+            (
+                "1 one identity reached Beets twice (the old replay policy)",
+                lambda: assert_operation_fence(
+                    job_type=IMPORT_JOB_AUTOMATION,
+                    authorized=True,
+                    final_status="queued",
+                    beets_invocations=[703, 703],
+                    replay_claimed=True,
+                    db=self._db(),
+                ),
+                "one operation identity reached Beets more than once",
+            ),
+            (
+                "2 Beets ran while the launch fence refused authority",
+                lambda: assert_operation_fence(
+                    job_type=IMPORT_JOB_AUTOMATION,
+                    authorized=False,
+                    final_status="queued",
+                    beets_invocations=[703],
+                    replay_claimed=True,
+                    db=self._db(),
+                ),
+                "Beets ran without exact current authority",
+            ),
+            (
+                "3 the removed pre-#933 recovery_required park revived",
+                lambda: assert_operation_fence(
+                    job_type=IMPORT_JOB_AUTOMATION,
+                    authorized=True,
+                    final_status=IMPORT_JOB_RECOVERY_REQUIRED,
+                    beets_invocations=[703],
+                    replay_claimed=False,
+                    db=self._db(
+                        status="processing",
+                        active_automation_import_job_id=7,
+                    ),
+                ),
+                f"{IMPORT_JOB_AUTOMATION} ambiguous Beets operation parked at "
+                "'recovery_required' — CLAUDE.md invariant 11 forbids a state "
+                "whose only exit is an operator command",
+            ),
+            (
+                "4 an ambiguous operation left a non-terminal queue status",
+                lambda: assert_operation_fence(
+                    job_type=IMPORT_JOB_FORCE,
+                    authorized=True,
+                    final_status="queued",
+                    beets_invocations=[703],
+                    replay_claimed=False,
+                    db=self._db(),
+                ),
+                f"{IMPORT_JOB_FORCE} ambiguous Beets operation left job status "
+                "'queued', want 'failed'",
+            ),
+            (
+                "5 the terminalized ambiguous job became claimable again",
+                lambda: assert_operation_fence(
+                    job_type=IMPORT_JOB_FORCE,
+                    authorized=True,
+                    final_status="failed",
+                    beets_invocations=[703],
+                    replay_claimed=True,
+                    db=self._db(),
+                ),
+                "ambiguous Beets operation became claimable",
+            ),
+            (
+                "6 automation self-heal left the request out of the pool",
+                lambda: assert_operation_fence(
+                    job_type=IMPORT_JOB_AUTOMATION,
+                    authorized=True,
+                    final_status="failed",
+                    beets_invocations=[703],
+                    replay_claimed=False,
+                    db=self._db(
+                        status="processing",
+                        active_automation_import_job_id=7,
+                    ),
+                ),
+                "automation self-heal left request status 'processing', want "
+                "'wanted' — the request must go back into the search pool",
+            ),
+            (
+                "7 automation self-heal left its owner pointer attached",
+                lambda: assert_operation_fence(
+                    job_type=IMPORT_JOB_AUTOMATION,
+                    authorized=True,
+                    final_status="failed",
+                    beets_invocations=[703],
+                    replay_claimed=False,
+                    db=self._db(
+                        status="wanted",
+                        active_automation_import_job_id=7,
+                    ),
+                ),
+                "automation self-heal left the automation owner attached",
+            ),
+            (
+                "8a automation self-heal wrote no audit row at all",
+                lambda: assert_operation_fence(
+                    job_type=IMPORT_JOB_AUTOMATION,
+                    authorized=True,
+                    final_status="failed",
+                    beets_invocations=[703],
+                    replay_claimed=False,
+                    db=self._db(status="wanted"),
+                ),
+                "automation self-heal recorded no world-failure audit row "
+                f"carrying {_WORLD_FAILURE_AUDIT_PREFIX!r}",
+            ),
+            (
+                "8b the newest audit row carries no world-failure label",
+                lambda: assert_operation_fence(
+                    job_type=IMPORT_JOB_AUTOMATION,
+                    authorized=True,
+                    final_status="failed",
+                    beets_invocations=[703],
+                    replay_claimed=False,
+                    db=self._db_with_linked_audit(status="wanted"),
+                ),
+                "automation self-heal recorded no world-failure audit row "
+                f"carrying {_WORLD_FAILURE_AUDIT_PREFIX!r}",
+            ),
+            (
+                "9 a force job mutated the caller's request lifecycle",
+                lambda: assert_operation_fence(
+                    job_type=IMPORT_JOB_FORCE,
+                    authorized=True,
+                    final_status="failed",
+                    beets_invocations=[703],
+                    replay_claimed=False,
+                    db=self._db_with_linked_audit(status="unsearchable"),
+                ),
+                f"{IMPORT_JOB_FORCE} ambiguous operation changed request "
+                "status to 'unsearchable'; force/YouTube own no request "
+                "lifecycle to self-heal",
+            ),
+            (
+                "10a a terminal force job surfaced nothing in Recents",
+                lambda: assert_operation_fence(
+                    job_type=IMPORT_JOB_FORCE,
+                    authorized=True,
+                    final_status="failed",
+                    beets_invocations=[703],
+                    replay_claimed=False,
+                    db=self._db(),
+                ),
+                "non-automation failure recorded no linked Recents audit row",
+            ),
+            (
+                "10b one attempt surfaced as two linked Recents rows",
+                lambda: assert_operation_fence(
+                    job_type=IMPORT_JOB_FORCE,
+                    authorized=True,
+                    final_status="failed",
+                    beets_invocations=[703],
+                    replay_claimed=False,
+                    db=self._db_with_linked_audit(status="wanted", audits=2),
+                ),
+                "non-automation failure recorded no linked Recents audit row",
+            ),
+        ]
+        for clause, invoke, message in cases:
+            with self.subTest(clause=clause):
+                with self.assertRaisesRegex(AssertionError, _exact(message)):
+                    invoke()
+
+    def test_operation_fence_accepts_its_two_early_returns(self) -> None:
+        """Must-still-work: the checker's non-violating worlds stay silent."""
+        assert_operation_fence(
+            job_type=IMPORT_JOB_FORCE,
+            authorized=False,
+            final_status="queued",
+            beets_invocations=[],
+            replay_claimed=True,
+            db=self._db(),
         )
-        with self.assertRaisesRegex(AssertionError, "own no request lifecycle"):
-            assert_operation_fence(
-                job_type=IMPORT_JOB_FORCE,
-                authorized=True,
-                final_status="failed",
-                beets_invocations=[703],
-                replay_claimed=False,
-                db=db,
+        assert_operation_fence(
+            job_type=IMPORT_JOB_FORCE,
+            authorized=True,
+            final_status="completed",
+            beets_invocations=[703],
+            replay_claimed=False,
+            db=self._db(),
+        )
+
+    # ---- assert_startup_force_action_lifecycle: clauses 11-14 ---------
+
+    def test_startup_force_action_clause_worlds(self) -> None:
+        """Every startup action-copy clause has a world that fires it."""
+        cases: list[tuple[str, bool, str, bool, str]] = [
+            (
+                "11 a launched force recovery did not terminalize",
+                True, "queued", True,
+                "launched force recovery ended 'queued', want 'failed'",
+            ),
+            (
+                "12 a terminal force recovery kept its private copy",
+                True, "failed", True,
+                "terminal force recovery leaked its private action copy",
+            ),
+            (
+                "13 an unlaunched force recovery terminalized anyway",
+                False, "failed", True,
+                "unlaunched force recovery ended 'failed', want 'queued'",
+            ),
+            (
+                "14 a retryable force recovery destroyed its own retry input",
+                False, "queued", False,
+                "retryable force recovery deleted the action copy it still "
+                "needs",
+            ),
+        ]
+        for clause, launched, final_status, exists, message in cases:
+            with self.subTest(clause=clause), tempfile.TemporaryDirectory() as root:
+                action_path = os.path.join(root, "action")
+                if exists:
+                    os.mkdir(action_path, 0o700)
+                with self.assertRaisesRegex(AssertionError, _exact(message)):
+                    assert_startup_force_action_lifecycle(
+                        launched=launched,
+                        final_status=final_status,
+                        action_path=action_path,
+                    )
+
+    def test_startup_force_action_accepts_both_correct_worlds(self) -> None:
+        """Must-still-work: terminal removes its copy, retry retains it."""
+        with tempfile.TemporaryDirectory() as root:
+            removed = os.path.join(root, "removed")
+            retained = os.path.join(root, "retained")
+            os.mkdir(retained, 0o700)
+            assert_startup_force_action_lifecycle(
+                launched=True, final_status="failed", action_path=removed,
+            )
+            assert_startup_force_action_lifecycle(
+                launched=False, final_status="queued", action_path=retained,
             )
 
-    def test_checker_rejects_silent_non_automation_terminal(self) -> None:
-        """Known-bad: a terminal force job with no Recents-visible audit."""
-        with self.assertRaisesRegex(AssertionError, "linked Recents audit"):
-            assert_operation_fence(
-                job_type=IMPORT_JOB_FORCE,
-                authorized=True,
-                final_status="failed",
-                beets_invocations=[703],
-                replay_claimed=False,
-                db=self._db(),
-            )
+    # ---- assert_non_automation_failure_lifecycle: clauses 15-21 -------
 
-    def test_checker_rejects_terminal_source_drift(self) -> None:
-        """Known-bad: a YT failure that defaulted to slskd must trip."""
-        db, source_download_log_id = _drive_non_automation_failure(
-            job_type=IMPORT_JOB_YOUTUBE,
+    def _driven(
+        self,
+        *,
+        job_type: str = IMPORT_JOB_FORCE,
+        db_factory: Callable[[], FakePipelineDB] = FakePipelineDB,
+    ) -> tuple[FakePipelineDB, int]:
+        return _drive_non_automation_failure(
+            job_type=job_type,
             failure_class="bundle_less_failure",
             request_status="wanted",
+            db_factory=db_factory,
         )
-        failed = next(row for row in db.download_logs if row.outcome == "failed")
-        failed.source = "slskd"
-        with self.assertRaisesRegex(AssertionError, "source drifted"):
-            assert_non_automation_failure_lifecycle(
-                db=db,
-                job_type=IMPORT_JOB_YOUTUBE,
-                request_id=_OPERATION_FENCE_REQUEST_ID,
-                request_status="wanted",
-                source_download_log_id=source_download_log_id,
-            )
 
-    def test_checker_rejects_leaked_terminal_force_action_copy(self) -> None:
-        """Known-bad: a terminal force job left its private copy behind."""
-        with tempfile.TemporaryDirectory() as leaked_path, self.assertRaisesRegex(
-            AssertionError,
-            "leaked its private action copy",
-        ):
-            assert_startup_force_action_lifecycle(
-                launched=True,
-                final_status="failed",
-                action_path=leaked_path,
+    def _check_driven(
+        self,
+        db: FakePipelineDB,
+        source_download_log_id: int,
+        *,
+        job_type: str = IMPORT_JOB_FORCE,
+        request_status: str = "wanted",
+    ) -> None:
+        assert_non_automation_failure_lifecycle(
+            db=db,
+            job_type=job_type,
+            request_id=_OPERATION_FENCE_REQUEST_ID,
+            request_status=request_status,
+            source_download_log_id=source_download_log_id,
+        )
+
+    def _terminal_audit(self, db: FakePipelineDB, source_id: int):
+        return next(
+            row for row in db.download_logs
+            if row.outcome == "failed"
+            and row.source_download_log_id == source_id
+        )
+
+    def test_non_automation_lifecycle_clause_worlds(self) -> None:
+        """Every non-automation lifecycle clause has a world that fires it.
+
+        Each world is a real driven force/YouTube failure — importer,
+        terminal-outcome and Recents production code — with exactly one
+        planted deviation, so no earlier clause can absorb the violation.
+        """
+        def clause_15() -> None:
+            db, source_id = self._driven()
+            job = next(
+                row for row in db._import_jobs
+                if row.get("request_id") == _OPERATION_FENCE_REQUEST_ID
+                and row.get("job_type") == IMPORT_JOB_FORCE
             )
+            job["status"] = "completed"
+            self._check_driven(db, source_id)
+
+        def clause_16() -> None:
+            db, source_id = self._driven()
+            db.request(_OPERATION_FENCE_REQUEST_ID)["status"] = "imported"
+            self._check_driven(db, source_id)
+
+        def clause_17() -> None:
+            db, source_id = self._driven(job_type=IMPORT_JOB_YOUTUBE)
+            origin = next(
+                row for row in db.download_logs if row.id == source_id
+            )
+            # The pre-handoff state ``insert_youtube_running`` writes: the
+            # enqueue never promoted it to ``youtube_success``.
+            origin.outcome = "youtube_running"
+            self._check_driven(db, source_id, job_type=IMPORT_JOB_YOUTUBE)
+
+        def clause_18_missing() -> None:
+            db, source_id = self._driven()
+            db.download_logs.remove(self._terminal_audit(db, source_id))
+            self._check_driven(db, source_id)
+
+        def clause_18_duplicated() -> None:
+            db, source_id = self._driven()
+            db.log_download(
+                _OPERATION_FENCE_REQUEST_ID,
+                outcome="failed",
+                source_download_log_id=source_id,
+                error_message=non_automation_import_failure_message(
+                    IMPORT_JOB_FORCE, "generated duplicate attempt audit",
+                ),
+            )
+            self._check_driven(db, source_id)
+
+        def clause_19() -> None:
+            db, source_id = self._driven(job_type=IMPORT_JOB_YOUTUBE)
+            self._terminal_audit(db, source_id).source = "slskd"
+            self._check_driven(db, source_id, job_type=IMPORT_JOB_YOUTUBE)
+
+        def clause_20() -> None:
+            db, source_id = self._driven(db_factory=AuditReadBackLostDB)
+            assert isinstance(db, AuditReadBackLostDB)
+            db.audit_read_back_lost = True
+            self._check_driven(db, source_id)
+
+        def clause_21() -> None:
+            db, source_id = self._driven()
+            # The other producer's identity prefix: a real string from
+            # ``non_automation_import_failure_message``, wrong for this job.
+            self._terminal_audit(db, source_id).error_message = (
+                non_automation_import_failure_message(
+                    IMPORT_JOB_YOUTUBE, "generated cross-identity diagnostic",
+                )
+            )
+            self._check_driven(db, source_id)
+
+        cases: list[tuple[str, Callable[[], None], str]] = [
+            (
+                "15 the attempt terminalized as a success, not a failure",
+                clause_15,
+                "non-automation job ended 'completed'",
+            ),
+            (
+                "16 a force job moved the request's lifecycle",
+                clause_16,
+                "non-automation failure changed request lifecycle",
+            ),
+            (
+                "17 a YouTube import skipped the canonical success handoff",
+                clause_17,
+                "YouTube import did not use the canonical handoff",
+            ),
+            (
+                "18a the terminal bundle wrote no linked audit row",
+                clause_18_missing,
+                "non-automation failure did not write one audit row",
+            ),
+            (
+                "18b one attempt wrote two linked audit rows",
+                clause_18_duplicated,
+                "non-automation failure did not write one audit row",
+            ),
+            (
+                "19 the terminal audit defaulted its source away from origin",
+                clause_19,
+                "terminal audit source drifted from its origin",
+            ),
+            (
+                "20 the committed audit row did not read back",
+                clause_20,
+                "linked terminal audit disappeared",
+            ),
+            (
+                "21 Recents rendered the other job type's failure identity",
+                clause_21,
+                "Recents lost the failed job-type identity",
+            ),
+        ]
+        for clause, invoke, message in cases:
+            with self.subTest(clause=clause):
+                with self.assertRaisesRegex(AssertionError, _exact(message)):
+                    invoke()
+
+    def test_non_automation_lifecycle_accepts_the_driven_worlds(self) -> None:
+        """Must-still-work: an undisturbed driven failure passes every clause."""
+        for job_type in (IMPORT_JOB_FORCE, IMPORT_JOB_YOUTUBE):
+            with self.subTest(job_type=job_type):
+                db, source_id = self._driven(job_type=job_type)
+                self._check_driven(db, source_id, job_type=job_type)
 
 
 if __name__ == "__main__":

--- a/tests/test_import_operation_fence_generated.py
+++ b/tests/test_import_operation_fence_generated.py
@@ -146,6 +146,11 @@ def assert_operation_fence(
         # A genuine, positively-captured success. Nothing ambiguous to fence.
         return
     if final_status == IMPORT_JOB_RECOVERY_REQUIRED:
+        # Fail-closed legislation (#1094 clause audit): no current writer
+        # creates ``recovery_required``, and a planted revival is refused
+        # upstream by ``validate_automation_terminal_authority`` before this
+        # clause can see it. Kept so a future writer that bypasses that
+        # validation fails loudly here instead of parking silently.
         raise AssertionError(
             f"{job_type} ambiguous Beets operation parked at "
             "'recovery_required' — CLAUDE.md invariant 11 forbids a state "
@@ -160,6 +165,14 @@ def assert_operation_fence(
         raise AssertionError("ambiguous Beets operation became claimable")
     row = db.request(request_id)
     if job_type == IMPORT_JOB_AUTOMATION:
+        # Fail-closed legislation (#1094 clause audit) for the request-status
+        # and owner-pointer clauses immediately below (NOT the audit-row
+        # clause after them, which an importer-side mutant does reach): both
+        # are decided by the terminal SQL ``_finish_processing_request_last``,
+        # which this module stands in for, and every importer-side mutant that
+        # declares a non-wanted edge is refused first by
+        # ``validate_automation_terminal_authority``. They patrol the DB-layer
+        # writer, not this drive path.
         if row["status"] != "wanted":
             raise AssertionError(
                 f"automation self-heal left request status {row['status']!r}, "
@@ -248,6 +261,11 @@ def assert_non_automation_failure_lifecycle(
         row for row in db.download_logs if row.id == source_download_log_id
     )
     if job_type == IMPORT_JOB_YOUTUBE and origin.outcome != "youtube_success":
+        # Fail-closed legislation (#1094 clause audit): the canonical handoff
+        # is written by ``lib/youtube_ingest_service.py``, which no world here
+        # executes — the driver enqueues through the same atomic DB command
+        # the service uses. Kept so a future ingest path that enqueues an
+        # import without promoting its origin row fails loudly.
         raise AssertionError("YouTube import did not use the canonical handoff")
     failed = [
         row for row in db.download_logs
@@ -257,9 +275,20 @@ def assert_non_automation_failure_lifecycle(
     if len(failed) != 1:
         raise AssertionError("non-automation failure did not write one audit row")
     if failed[0].source != origin.source:
+        # Fail-closed legislation (#1094 clause audit): the terminal INSERT
+        # COALESCEs ``source`` out of the origin row and sets
+        # ``source_download_log_id`` from the same subquery, so today the two
+        # cannot disagree — dropping the origin trips the clause above first.
+        # Kept so a future writer that defaults ``source`` by job type while
+        # keeping the link fails loudly.
         raise AssertionError("terminal audit source drifted from its origin")
     audit = db.get_download_log_entry(failed[0].id)
     if audit is None:
+        # Fail-closed legislation (#1094 clause audit): the audit row is
+        # written inside the terminal transaction against the locked request
+        # and its foreign key keeps the joined request alive, so the read-back
+        # cannot miss. Kept so a bundle that reports an id it did not commit
+        # fails loudly instead of rendering nothing in Recents.
         raise AssertionError("linked terminal audit disappeared")
     rendered = classify_log_entry(LogEntry.from_row(dict(audit)))
     expected_prefix = (
@@ -728,8 +757,10 @@ class TestGeneratedImportOperationFence(unittest.TestCase):
                     authorized, status, invocations, replay_claimed, db = (
                         _exercise_world(world, beets=self.beets)
                     )
-                    self.assertFalse(authorized)
-                    self.assertEqual(invocations, [])
+                    # The fence checker runs FIRST: the narrow assertions
+                    # below are a superset of its "Beets ran without exact
+                    # current authority" clause, and running them first
+                    # masked that clause's own message (#1094 Q2).
                     assert_operation_fence(
                         job_type=job_type,
                         authorized=authorized,
@@ -738,6 +769,8 @@ class TestGeneratedImportOperationFence(unittest.TestCase):
                         replay_claimed=replay_claimed,
                         db=db,
                     )
+                    self.assertFalse(authorized)
+                    self.assertEqual(invocations, [])
 
     def test_definitely_not_started_recovery_may_retry(self) -> None:
         for job_type in (

--- a/tests/test_import_operation_fence_generated.py
+++ b/tests/test_import_operation_fence_generated.py
@@ -1076,9 +1076,11 @@ class TestImportOperationFenceChecker(unittest.TestCase):
                         active_automation_import_job_id=7,
                     ),
                 ),
-                f"{IMPORT_JOB_AUTOMATION} ambiguous Beets operation parked at "
-                "'recovery_required' — CLAUDE.md invariant 11 forbids a state "
-                "whose only exit is an operator command",
+                (
+                    f"{IMPORT_JOB_AUTOMATION} ambiguous Beets operation "
+                    "parked at 'recovery_required' — CLAUDE.md invariant 11 "
+                    "forbids a state whose only exit is an operator command"
+                ),
             ),
             (
                 "4 an ambiguous operation left a non-terminal queue status",
@@ -1090,8 +1092,10 @@ class TestImportOperationFenceChecker(unittest.TestCase):
                     replay_claimed=False,
                     db=self._db(),
                 ),
-                f"{IMPORT_JOB_FORCE} ambiguous Beets operation left job status "
-                "'queued', want 'failed'",
+                (
+                    f"{IMPORT_JOB_FORCE} ambiguous Beets operation left job "
+                    "status 'queued', want 'failed'"
+                ),
             ),
             (
                 "5 the terminalized ambiguous job became claimable again",
@@ -1118,8 +1122,11 @@ class TestImportOperationFenceChecker(unittest.TestCase):
                         active_automation_import_job_id=7,
                     ),
                 ),
-                "automation self-heal left request status 'processing', want "
-                "'wanted' — the request must go back into the search pool",
+                (
+                    "automation self-heal left request status 'processing', "
+                    "want 'wanted' — the request must go back into the "
+                    "search pool"
+                ),
             ),
             (
                 "7 automation self-heal left its owner pointer attached",
@@ -1146,8 +1153,10 @@ class TestImportOperationFenceChecker(unittest.TestCase):
                     replay_claimed=False,
                     db=self._db(status="wanted"),
                 ),
-                "automation self-heal recorded no world-failure audit row "
-                f"carrying {_WORLD_FAILURE_AUDIT_PREFIX!r}",
+                (
+                    "automation self-heal recorded no world-failure audit "
+                    f"row carrying {_WORLD_FAILURE_AUDIT_PREFIX!r}"
+                ),
             ),
             (
                 "8b the newest audit row carries no world-failure label",
@@ -1159,8 +1168,10 @@ class TestImportOperationFenceChecker(unittest.TestCase):
                     replay_claimed=False,
                     db=self._db_with_linked_audit(status="wanted"),
                 ),
-                "automation self-heal recorded no world-failure audit row "
-                f"carrying {_WORLD_FAILURE_AUDIT_PREFIX!r}",
+                (
+                    "automation self-heal recorded no world-failure audit "
+                    f"row carrying {_WORLD_FAILURE_AUDIT_PREFIX!r}"
+                ),
             ),
             (
                 "9 a force job mutated the caller's request lifecycle",
@@ -1172,9 +1183,11 @@ class TestImportOperationFenceChecker(unittest.TestCase):
                     replay_claimed=False,
                     db=self._db_with_linked_audit(status="unsearchable"),
                 ),
-                f"{IMPORT_JOB_FORCE} ambiguous operation changed request "
-                "status to 'unsearchable'; force/YouTube own no request "
-                "lifecycle to self-heal",
+                (
+                    f"{IMPORT_JOB_FORCE} ambiguous operation changed request "
+                    "status to 'unsearchable'; force/YouTube own no request "
+                    "lifecycle to self-heal"
+                ),
             ),
             (
                 "10a a terminal force job surfaced nothing in Recents",
@@ -1202,9 +1215,10 @@ class TestImportOperationFenceChecker(unittest.TestCase):
             ),
         ]
         for clause, invoke, message in cases:
-            with self.subTest(clause=clause):
-                with self.assertRaisesRegex(AssertionError, _exact(message)):
-                    invoke()
+            with self.subTest(clause=clause), self.assertRaisesRegex(
+                AssertionError, _exact(message),
+            ):
+                invoke()
 
     def test_operation_fence_accepts_its_two_early_returns(self) -> None:
         """Must-still-work: the checker's non-violating worlds stay silent."""
@@ -1248,8 +1262,10 @@ class TestImportOperationFenceChecker(unittest.TestCase):
             (
                 "14 a retryable force recovery destroyed its own retry input",
                 False, "queued", False,
-                "retryable force recovery deleted the action copy it still "
-                "needs",
+                (
+                    "retryable force recovery deleted the action copy it "
+                    "still needs"
+                ),
             ),
         ]
         for clause, launched, final_status, exists, message in cases:
@@ -1429,9 +1445,10 @@ class TestImportOperationFenceChecker(unittest.TestCase):
             ),
         ]
         for clause, invoke, message in cases:
-            with self.subTest(clause=clause):
-                with self.assertRaisesRegex(AssertionError, _exact(message)):
-                    invoke()
+            with self.subTest(clause=clause), self.assertRaisesRegex(
+                AssertionError, _exact(message),
+            ):
+                invoke()
 
     def test_non_automation_lifecycle_accepts_the_driven_worlds(self) -> None:
         """Must-still-work: an undisturbed driven failure passes every clause."""

--- a/tests/test_processing_cleanup_generated.py
+++ b/tests/test_processing_cleanup_generated.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import tempfile
 import unittest
 from pathlib import Path
@@ -25,6 +26,54 @@ GeneratedAction = Literal[
     "no_op",
 ]
 
+# Per-clause proof (#1094). Each clause of
+# ``assert_exact_cleanup_postcondition`` is named so a self-test can anchor on
+# that clause's own message instead of a substring a sibling could satisfy.
+CLAUSE_NO_RECEIPT = "cleanup completed without a typed receipt"
+CLAUSE_SOURCE_RETAINED = "completed cleanup retained its source"
+CLAUSE_UNSELECTED_DESTINATION = (
+    "quarantine did not use the one journal-selected destination"
+)
+CLAUSE_INVENTED_DESTINATION = "non-quarantine cleanup invented a destination"
+
+
+def _exact_clause(message: str) -> str:
+    """Anchor a clause message so no sibling clause can satisfy the regex."""
+    return "^" + re.escape(message) + "$"
+
+
+def observed_cleanup_destination(
+    base: Path,
+    *,
+    source: Path,
+    selected: Path | None,
+) -> str | None:
+    """Whatever tree the executor actually left behind outside the source.
+
+    #1094 Q2: reading only ``selected`` made ``CLAUSE_INVENTED_DESTINATION``
+    unfalsifiable — a non-quarantine journal carries no destination, so a
+    production mutant that renamed the source aside instead of removing it
+    (a "soft delete" regression) left the whole property green. The observation
+    is therefore the base directory's real post-state: a surviving tree that
+    is neither the source nor the journal-selected destination (nor one of its
+    ancestors) is exactly the invented destination the clause legislates
+    against, and it also names a recomputed quarantine target precisely.
+    """
+    excluded = {base, source}
+    if selected is not None:
+        excluded.add(selected)
+        excluded.update(selected.parents)
+    strays = sorted(
+        str(path)
+        for path in base.rglob("*")
+        if path.is_dir() and path not in excluded
+    )
+    if strays:
+        return strays[0]
+    if selected is not None and selected.exists():
+        return str(selected)
+    return None
+
 
 def assert_exact_cleanup_postcondition(
     *,
@@ -35,19 +84,17 @@ def assert_exact_cleanup_postcondition(
     receipt_present: bool,
 ) -> None:
     if not receipt_present:
-        raise AssertionError("cleanup completed without a typed receipt")
+        raise AssertionError(CLAUSE_NO_RECEIPT)
     if source_exists:
-        raise AssertionError("completed cleanup retained its source")
+        raise AssertionError(CLAUSE_SOURCE_RETAINED)
     if action == PROCESSING_CLEANUP_QUARANTINE_SOURCE:
         if (
             selected_destination is None
             or observed_destination != selected_destination
         ):
-            raise AssertionError(
-                "quarantine did not use the one journal-selected destination"
-            )
+            raise AssertionError(CLAUSE_UNSELECTED_DESTINATION)
     elif observed_destination is not None:
-        raise AssertionError("non-quarantine cleanup invented a destination")
+        raise AssertionError(CLAUSE_INVENTED_DESTINATION)
 
 
 class TestProcessingCleanupGenerated(unittest.TestCase):
@@ -55,6 +102,17 @@ class TestProcessingCleanupGenerated(unittest.TestCase):
         action=PROCESSING_CLEANUP_QUARANTINE_SOURCE,
         files=[("a", b"one"), ("b", b"two")],
     )
+    # #1094 Q3/Q4: one pin per decisive arm. ``remove_source_tree`` is the
+    # only arm that can fire ``CLAUSE_SOURCE_RETAINED``, and the two
+    # non-quarantine arms are the only ones that can fire
+    # ``CLAUSE_INVENTED_DESTINATION``. Editing this property body reshuffles
+    # the whole generated sequence, so the arms are pinned rather than left to
+    # the deterministic draw.
+    @example(
+        action=PROCESSING_CLEANUP_REMOVE_SOURCE,
+        files=[("a", b"one"), ("b", b"two")],
+    )
+    @example(action=PROCESSING_CLEANUP_NO_OP, files=[])
     @given(
         action=st.sampled_from(
             (
@@ -112,10 +170,10 @@ class TestProcessingCleanupGenerated(unittest.TestCase):
                 owner_checkpoint=lambda: None,
             )
 
-            observed_destination = (
-                str(destination)
-                if destination is not None and destination.exists()
-                else None
+            observed_destination = observed_cleanup_destination(
+                base,
+                source=source,
+                selected=destination,
             )
             assert_exact_cleanup_postcondition(
                 action=action,
@@ -135,32 +193,179 @@ class TestProcessingCleanupGenerated(unittest.TestCase):
                     dict(files),
                 )
 
-    def test_checker_rejects_recomputed_destination_known_bad(self) -> None:
-        with self.assertRaisesRegex(
-            AssertionError,
-            "one journal-selected destination",
-        ):
-            assert_exact_cleanup_postcondition(
-                action=PROCESSING_CLEANUP_QUARANTINE_SOURCE,
-                source_exists=False,
-                selected_destination="/quarantine/album",
-                observed_destination="/quarantine/album_1",
-                receipt_present=True,
+    def test_every_postcondition_clause_has_a_named_world(self) -> None:
+        """One minimal world per clause, anchored on that clause's message.
+
+        Each row makes exactly one clause's condition true while every EARLIER
+        clause in the function passes, so a short-circuiting ``raise`` chain
+        cannot attribute a world to the wrong clause (#1094 Q1). The two
+        historical known-bad tests are rows 4 and 2; they asserted unanchored
+        substrings and left the receipt and invented-destination clauses with
+        no proof at all.
+        """
+        cases: tuple[
+            tuple[str, GeneratedAction, bool, str | None, str | None, bool, str],
+            ...,
+        ] = (
+            (
+                "completed without a receipt",
+                PROCESSING_CLEANUP_REMOVE_SOURCE,
+                False,
+                None,
+                None,
+                False,
+                CLAUSE_NO_RECEIPT,
+            ),
+            (
+                "post-cancellation rollback restored the source",
+                PROCESSING_CLEANUP_REMOVE_SOURCE,
+                True,
+                None,
+                None,
+                True,
+                CLAUSE_SOURCE_RETAINED,
+            ),
+            (
+                "quarantine ran with no journal-selected destination",
+                PROCESSING_CLEANUP_QUARANTINE_SOURCE,
+                False,
+                None,
+                "/quarantine/album",
+                True,
+                CLAUSE_UNSELECTED_DESTINATION,
+            ),
+            (
+                "quarantine recomputed a collision suffix",
+                PROCESSING_CLEANUP_QUARANTINE_SOURCE,
+                False,
+                "/quarantine/album",
+                "/quarantine/album_1",
+                True,
+                CLAUSE_UNSELECTED_DESTINATION,
+            ),
+            (
+                "remove-source relocated instead of removing",
+                PROCESSING_CLEANUP_REMOVE_SOURCE,
+                False,
+                None,
+                "/processing/albums/source.quarantined",
+                True,
+                CLAUSE_INVENTED_DESTINATION,
+            ),
+            (
+                "no-op invented a destination",
+                PROCESSING_CLEANUP_NO_OP,
+                False,
+                None,
+                "/quarantine/album",
+                True,
+                CLAUSE_INVENTED_DESTINATION,
+            ),
+        )
+        for (
+            description,
+            action,
+            source_exists,
+            selected,
+            observed,
+            receipt,
+            message,
+        ) in cases:
+            with (
+                self.subTest(description),
+                self.assertRaisesRegex(
+                    AssertionError,
+                    _exact_clause(message),
+                ),
+            ):
+                assert_exact_cleanup_postcondition(
+                    action=action,
+                    source_exists=source_exists,
+                    selected_destination=selected,
+                    observed_destination=observed,
+                    receipt_present=receipt,
+                )
+
+    def test_checker_admits_every_correct_postcondition(self) -> None:
+        """Must-still-work: no clause fires on a correctly executed cleanup."""
+        cases: tuple[
+            tuple[GeneratedAction, str | None, str | None],
+            ...,
+        ] = (
+            ("remove_source_tree", None, None),
+            ("no_op", None, None),
+            (
+                "quarantine_source_tree",
+                "/quarantine/album",
+                "/quarantine/album",
+            ),
+        )
+        for action, selected, observed in cases:
+            with self.subTest(action):
+                assert_exact_cleanup_postcondition(
+                    action=action,
+                    source_exists=False,
+                    selected_destination=selected,
+                    observed_destination=observed,
+                    receipt_present=True,
+                )
+
+    def test_observation_names_a_stray_tree_outside_the_journal(self) -> None:
+        """The widened observation is what makes the invented-destination
+        clause reachable, so it gets its own direct contract."""
+        with tempfile.TemporaryDirectory() as raw:
+            # A correct remove/no-op world: nothing survives outside the source.
+            base = Path(raw) / "clean"
+            base.mkdir()
+            source = base / "source"
+            source.mkdir()
+            self.assertIsNone(
+                observed_cleanup_destination(
+                    base,
+                    source=source,
+                    selected=None,
+                )
             )
 
-    def test_checker_rejects_post_cancellation_rollback_known_bad(
-        self,
-    ) -> None:
-        with self.assertRaisesRegex(
-            AssertionError,
-            "retained its source",
-        ):
-            assert_exact_cleanup_postcondition(
-                action=PROCESSING_CLEANUP_REMOVE_SOURCE,
-                source_exists=True,
-                selected_destination=None,
-                observed_destination=None,
-                receipt_present=True,
+            # A correct quarantine world: only the selected destination.
+            base = Path(raw) / "quarantined"
+            base.mkdir()
+            source = base / "source"
+            selected = base / "quarantine" / "selected"
+            selected.mkdir(parents=True)
+            self.assertEqual(
+                observed_cleanup_destination(
+                    base,
+                    source=source,
+                    selected=selected,
+                ),
+                str(selected),
+            )
+
+            # The mutant world: a relocated source with no journaled
+            # destination is named, for both journal shapes.
+            base = Path(raw) / "relocated"
+            base.mkdir()
+            source = base / "source"
+            stray = base / "source.quarantined"
+            stray.mkdir()
+            self.assertEqual(
+                observed_cleanup_destination(
+                    base,
+                    source=source,
+                    selected=None,
+                ),
+                str(stray),
+            )
+            selected = base / "quarantine" / "selected"
+            selected.mkdir(parents=True)
+            self.assertEqual(
+                observed_cleanup_destination(
+                    base,
+                    source=source,
+                    selected=selected,
+                ),
+                str(stray),
             )
 
 

--- a/tests/test_processing_cleanup_generated.py
+++ b/tests/test_processing_cleanup_generated.py
@@ -103,11 +103,18 @@ class TestProcessingCleanupGenerated(unittest.TestCase):
         files=[("a", b"one"), ("b", b"two")],
     )
     # #1094 Q3/Q4: one pin per decisive arm. ``remove_source_tree`` is the
-    # only arm that can fire ``CLAUSE_SOURCE_RETAINED``, and the two
-    # non-quarantine arms are the only ones that can fire
+    # only arm that can fire ``CLAUSE_SOURCE_RETAINED`` or
     # ``CLAUSE_INVENTED_DESTINATION``. Editing this property body reshuffles
     # the whole generated sequence, so the arms are pinned rather than left to
     # the deterministic draw.
+    #
+    # The ``no_op`` pin is a coverage pin, not a clause pin: this property
+    # never creates ``source`` for that action, so ``base`` holds no directory
+    # and ``observed_cleanup_destination`` returns ``None`` whatever
+    # ``execute_processing_cleanup`` does — no mutant can make that arm fire
+    # the invented-destination clause. Giving a no-op journal a source tree it
+    # must leave untouched is a real entropy gap in this property, pre-dating
+    # #1094 and not closed here (round-3 review N2).
     @example(
         action=PROCESSING_CLEANUP_REMOVE_SOURCE,
         files=[("a", b"one"), ("b", b"two")],

--- a/tests/test_processing_lifecycle_generated.py
+++ b/tests/test_processing_lifecycle_generated.py
@@ -3,12 +3,20 @@
 The state machine drives the production-parity database commands and services
 for the whole bounded lifecycle:
 
-``wanted -> downloading -> processing -> {wanted, imported}``
+``wanted -> downloading -> processing -> wanted``
 
 It deliberately interleaves stale A/B download witnesses, exact and wrong job
 IDs, preview/import execution death, automatic world-failure recovery, and
 operator invalidators. A small independent oracle checks the ownership
 predicate, handoff witness, and terminal all-or-none shape.
+
+Known gap (#1094 per-clause audit): the machine has no successful-acceptance
+rule, so ``imported`` is unreachable and ``requeue_imported`` never fires. The
+terminal edge exercised here is the world-failure one, via
+``recover_dead_import`` — which IS a real terminal transaction (cleanup
+receipt consumed, audit, job outcome, request released), and is what makes
+``_assert_terminal_all_or_none`` live. Reaching ``imported`` needs a dispatch
+acceptance lane this module does not model.
 
 Profiles, promotion policy, and fault-injection qualification:
 ``docs/generated-testing.md``.
@@ -18,6 +26,7 @@ from __future__ import annotations
 
 import copy
 import os
+import re
 import unittest
 from collections.abc import Mapping
 from contextlib import contextmanager
@@ -67,6 +76,37 @@ _WITNESS_A = "2026-07-29T00:00:00+00:00"
 _WITNESS_B = "2026-07-29T00:00:01+00:00"
 _WITNESSES = (_WITNESS_A, _WITNESS_B)
 _CANONICAL_PATH = "/tmp/cratedigger-generated-processing-owner-898"
+
+# --- clause vocabulary (per-clause proof, #1094) ---------------------------
+# Every checker clause in this module carries its own message so a self-test
+# can name the world that fires it and anchor on that clause alone. The
+# historical ``assert_or_raise("generated lifecycle assertion failed")``
+# collapsed twenty-nine distinct lifecycle assertions onto one string, which
+# made per-clause attribution impossible for the whole state machine.
+CLAUSE_LOCK_MISS_STATE = "lock miss created execution state"
+CLAUSE_NO_PROGRESS = "did not progress after contention cleared"
+CLAUSE_UNPINNED_LOCK = "generated IMPORT lock used an unpinned session"
+CLAUSE_UNEXPECTED_LOCK = "unexpected generated advisory lock"
+CLAUSE_PARTIAL_TERMINAL = "partial terminal bundle"
+CLAUSE_FORCE_FENCE = (
+    "owned request admitted stale force execution state or effects"
+)
+CLAUSE_CANDIDATE_REFUSED = "exact preview owner rejected candidate evidence"
+CLAUSE_STALE_FORCE_PREVIEW = "stale force preview crossed owner fence"
+CLAUSE_STALE_FORCE_IMPORT = "stale force import crossed owner fence"
+CLAUSE_MISS_REACHED_PREVIEW = "lock miss reached force preview"
+CLAUSE_MISS_REACHED_IMPORT = "lock miss reached force import"
+
+
+def _exact_clause(message: str) -> str:
+    """Anchor a whole clause message so no sibling clause can satisfy it."""
+    return "^" + re.escape(message) + "$"
+
+
+def _clause_prefix(prefix: str) -> str:
+    """Anchor a clause whose tail carries generated values."""
+    return "^" + re.escape(prefix)
+
 
 LifecycleStatus = Literal[
     "wanted",
@@ -127,6 +167,25 @@ def _claim_progress_facts(
     )
 
 
+def _assert_lock_miss_is_zero_state(
+    *,
+    lane: ClaimLane,
+    before: _ClaimProgressFacts,
+    after_miss: _ClaimProgressFacts,
+) -> None:
+    """The zero-state half, callable per poll so the clause owns attribution.
+
+    #1094: the property re-checked this with a bare ``assertEqual`` inside its
+    miss loop, which fired before the composite checker was ever reached — so
+    a real claim-before-lock mutant was reported as an anonymous dict diff and
+    the clause it violated could never be named.
+    """
+    if after_miss != before:
+        raise AssertionError(
+            f"{lane} {CLAUSE_LOCK_MISS_STATE}: {after_miss!r}"
+        )
+
+
 def _assert_lock_miss_then_progress(
     *,
     lane: ClaimLane,
@@ -135,10 +194,11 @@ def _assert_lock_miss_then_progress(
     after_progress: _ClaimProgressFacts,
 ) -> None:
     """A transient IMPORT miss creates no claim and the next poll advances."""
-    if after_miss != before:
-        raise AssertionError(
-            f"{lane} lock miss created execution state: {after_miss!r}"
-        )
+    _assert_lock_miss_is_zero_state(
+        lane=lane,
+        before=before,
+        after_miss=after_miss,
+    )
     if lane == "preview":
         progressed = (
             after_progress.preview_attempts == before.preview_attempts + 1
@@ -148,8 +208,7 @@ def _assert_lock_miss_then_progress(
         progressed = after_progress.attempts == before.attempts + 1
     if not progressed:
         raise AssertionError(
-            f"{lane} did not progress after contention cleared: "
-            f"{after_progress!r}"
+            f"{lane} {CLAUSE_NO_PROGRESS}: {after_progress!r}"
         )
 
 
@@ -184,10 +243,10 @@ class _GeneratedStageSession:
         from lib.pipeline_db import ADVISORY_LOCK_NAMESPACE_IMPORT
 
         if not self.pinned:
-            raise AssertionError("generated IMPORT lock used an unpinned session")
+            raise AssertionError(CLAUSE_UNPINNED_LOCK)
         if namespace != ADVISORY_LOCK_NAMESPACE_IMPORT or key != _REQUEST_ID:
             raise AssertionError(
-                f"unexpected generated advisory lock {(namespace, key)!r}"
+                f"{CLAUSE_UNEXPECTED_LOCK} {(namespace, key)!r}"
             )
         yield self.acquire
 
@@ -321,6 +380,31 @@ def _exact_processing_owner(
     )
 
 
+def _terminal_facts(db: FakePipelineDB, job_id: int) -> _TerminalFacts:
+    """Read the four durable facts one terminal transaction must co-commit.
+
+    Invariant 10: the terminal transaction consumes the cleanup receipt and
+    writes audit/policy/job outcome, clearing owner and state last. Reading
+    them independently of the command that writes them is what makes the
+    all-or-none shape falsifiable.
+    """
+    request = db.request(_REQUEST_ID)
+    job = db.get_import_job(job_id)
+    return _TerminalFacts(
+        request_released=(
+            request.get("status") != "processing"
+            and request.get("active_automation_import_job_id") is None
+        ),
+        audit_present=bool(db.download_logs),
+        job_terminal=(
+            job is not None and job.status not in IMPORT_JOB_ACTIVE_STATUSES
+        ),
+        cleanup_consumed=(
+            (job_id, _REQUEST_ID) not in db._processing_cleanup_journals
+        ),
+    )
+
+
 def _assert_terminal_all_or_none(
     before: _TerminalFacts,
     after: _TerminalFacts,
@@ -329,7 +413,7 @@ def _assert_terminal_all_or_none(
     if after == before:
         return
     if after != _TerminalFacts(True, True, True, True):
-        raise AssertionError(f"partial terminal bundle: {after!r}")
+        raise AssertionError(f"{CLAUSE_PARTIAL_TERMINAL}: {after!r}")
 
 
 
@@ -358,9 +442,7 @@ def _assert_force_owner_fence(
     effect_count: int,
 ) -> None:
     if after != before or effect_count:
-        raise AssertionError(
-            "owned request admitted stale force execution state or effects"
-        )
+        raise AssertionError(CLAUSE_FORCE_FENCE)
 
 
 def _database_snapshot(db: FakePipelineDB) -> object:
@@ -397,7 +479,7 @@ def _seed_candidate(
         persisted.id,
         expected_execution_lease=execution_lease,
     ):
-        raise AssertionError("exact preview owner rejected candidate evidence")
+        raise AssertionError(CLAUSE_CANDIDATE_REFUSED)
 
 
 def _new_owner_db(
@@ -458,11 +540,14 @@ class ProcessingLifecycleMachine(RuleBasedStateMachine):
     @precondition(lambda self: self.oracle.status == "wanted")
     @rule(witness=st.sampled_from(_WITNESSES))
     def begin_download(self, witness: str) -> None:
-        self.assert_or_raise(self.db.set_downloading(
-            _REQUEST_ID,
-            _active_state(witness).to_json(),
-            expected_status="wanted",
-        ))
+        self.assert_or_raise(
+            self.db.set_downloading(
+                _REQUEST_ID,
+                _active_state(witness).to_json(),
+                expected_status="wanted",
+            ),
+            "wanted request refused its own download start",
+        )
         self.oracle.status = "downloading"
         self.oracle.witness = witness
 
@@ -483,15 +568,24 @@ class ProcessingLifecycleMachine(RuleBasedStateMachine):
             message="generated lifecycle handoff",
         )
         if expected:
-            self.assert_or_raise(result.committed and result.job is not None)
+            self.assert_or_raise(
+                result.committed and result.job is not None,
+                "exact download witness did not mint the processing owner",
+            )
             assert result.job is not None
             self.oracle.status = "processing"
             self.oracle.stage = "preview_waiting"
             self.oracle.owner_job_id = result.job.id
             self.generation += 1
         else:
-            self.assert_or_raise(result.outcome == "witness_mismatch")
-            self.assert_or_raise(_database_snapshot(self.db) == before)
+            self.assert_or_raise(
+                result.outcome == "witness_mismatch",
+                "stale download witness was not refused as a mismatch",
+            )
+            self.assert_or_raise(
+                _database_snapshot(self.db) == before,
+                "refused handoff still mutated the database",
+            )
 
     @precondition(
         lambda self: self.oracle.stage == "preview_waiting"
@@ -508,7 +602,8 @@ class ProcessingLifecycleMachine(RuleBasedStateMachine):
         claimed = claim_next_import_preview_job(self.db, worker_id="generated-preview",
         execution_lease=lease,)
         self.assert_or_raise(
-            claimed is not None and claimed.id == self.oracle.owner_job_id
+            claimed is not None and claimed.id == self.oracle.owner_job_id,
+            "preview claim did not select the exact owner job",
         )
         self.oracle.preview_lease = lease
         self.oracle.stage = "preview_running"
@@ -544,12 +639,21 @@ class ProcessingLifecycleMachine(RuleBasedStateMachine):
             expected_execution_lease=supplied,
         )
         if exact_lease:
-            self.assert_or_raise(result is not None)
+            self.assert_or_raise(
+                result is not None,
+                "exact preview lease could not complete its own preview",
+            )
             self.oracle.preview_lease = None
             self.oracle.stage = "preview_ready"
         else:
-            self.assert_or_raise(result is None)
-            self.assert_or_raise(_database_snapshot(self.db) == before)
+            self.assert_or_raise(
+                result is None,
+                "stale preview lease completed the owner's preview",
+            )
+            self.assert_or_raise(
+                _database_snapshot(self.db) == before,
+                "stale preview lease mutated the database",
+            )
 
     @precondition(
         lambda self: self.oracle.stage == "preview_running"
@@ -565,7 +669,8 @@ class ProcessingLifecycleMachine(RuleBasedStateMachine):
             liveness_probe=_ChangedBootProbe(),
         )
         self.assert_or_raise(
-            [job.id for job in recovered] == [self.oracle.owner_job_id]
+            [job.id for job in recovered] == [self.oracle.owner_job_id],
+            "dead preview recovery did not requeue exactly the owner job",
         )
         self.oracle.preview_lease = None
         self.oracle.stage = "preview_waiting"
@@ -585,7 +690,8 @@ class ProcessingLifecycleMachine(RuleBasedStateMachine):
         claimed = claim_next_import_job(self.db, worker_id="generated-import",
         execution_lease=lease,)
         self.assert_or_raise(
-            claimed is not None and claimed.id == self.oracle.owner_job_id
+            claimed is not None and claimed.id == self.oracle.owner_job_id,
+            "import claim did not select the exact owner job",
         )
         self.oracle.import_lease = lease
         self.oracle.stage = "import_running"
@@ -629,11 +735,20 @@ class ProcessingLifecycleMachine(RuleBasedStateMachine):
             expected_execution_lease=lease,
         )
         if authority == "exact":
-            self.assert_or_raise(result is not None)
+            self.assert_or_raise(
+                result is not None,
+                "exact owner authority could not authorize its own launch",
+            )
             self.oracle.launched = True
         else:
-            self.assert_or_raise(result is None)
-            self.assert_or_raise(_database_snapshot(self.db) == before)
+            self.assert_or_raise(
+                result is None,
+                f"{authority} authority authorized a beets launch",
+            )
+            self.assert_or_raise(
+                _database_snapshot(self.db) == before,
+                f"{authority} launch attempt mutated the database",
+            )
 
     @precondition(
         lambda self: self.oracle.stage == "import_running"
@@ -658,17 +773,39 @@ class ProcessingLifecycleMachine(RuleBasedStateMachine):
                 beets_pid=child.pid,
                 beets_start_ticks=child.start_ticks,
             )
-            self.assert_or_raise(recorded is not None)
+            self.assert_or_raise(
+                recorded is not None,
+                "exact import lease could not record its own beets child",
+            )
             self.oracle.import_lease = replace(
                 self.oracle.import_lease,
                 beets=child,
             )
+        # A launched owner's recovery IS the terminal transaction: it consumes
+        # the cleanup receipt and writes audit, job outcome, and the request
+        # release together. Before #1094 this was the module's only terminal
+        # write and ``_assert_terminal_all_or_none`` had no caller but its own
+        # known-bad self-test, so the all-or-none half of invariant 10 was
+        # unpatrolled here despite the module docstring claiming it.
+        owner_job_id = self.oracle.owner_job_id
+        terminal_before = _terminal_facts(self.db, owner_job_id)
         recovered = importer.recover_abandoned_automation_owners(
             self.db,
             liveness_probe=_ChangedBootProbe(),
         )
+        # Order matters (#1094): the persisted-facts checker runs FIRST. The
+        # returned-list assertion also rejects a partially committed terminal
+        # world, so putting it first attributed every partial bundle to the
+        # wrong clause and left ``_assert_terminal_all_or_none`` unable to
+        # fire. These two checkers are independent, so reordering the CALLS
+        # (never the clauses inside a checker) is the legitimate fix.
+        _assert_terminal_all_or_none(
+            terminal_before,
+            _terminal_facts(self.db, owner_job_id),
+        )
         self.assert_or_raise(
-            [job.id for job in recovered] == [self.oracle.owner_job_id]
+            [job.id for job in recovered] == [self.oracle.owner_job_id],
+            "dead import recovery did not release exactly the owner job",
         )
         self.oracle.status = "wanted"
         self.oracle.stage = "none"
@@ -696,14 +833,19 @@ class ProcessingLifecycleMachine(RuleBasedStateMachine):
                 ),
             )
         self.assert_or_raise(
-            isinstance(result, transitions.TransitionConflict)
+            isinstance(result, transitions.TransitionConflict),
+            f"operator {action} was admitted against an owned request",
         )
         assert isinstance(result, transitions.TransitionConflict)
         self.assert_or_raise(
             result.kind
-            == transitions.TransitionConflictKind.processing_locked
+            == transitions.TransitionConflictKind.processing_locked,
+            f"operator {action} refusal was not processing_locked",
         )
-        self.assert_or_raise(_database_snapshot(self.db) == before)
+        self.assert_or_raise(
+            _database_snapshot(self.db) == before,
+            f"refused operator {action} mutated the database",
+        )
 
     @precondition(
         lambda self: self.oracle.status == "processing"
@@ -755,8 +897,14 @@ class ProcessingLifecycleMachine(RuleBasedStateMachine):
                 source_path=_CANONICAL_PATH,
                 expected_execution_lease=lease,
             )
-        self.assert_or_raise(result is None or result is False)
-        self.assert_or_raise(_database_snapshot(self.db) == before)
+        self.assert_or_raise(
+            result is None or result is False,
+            f"wrong job id advanced the owner command {command}",
+        )
+        self.assert_or_raise(
+            _database_snapshot(self.db) == before,
+            f"wrong job id command {command} mutated the database",
+        )
 
     @precondition(lambda self: self.oracle.status == "imported")
     @rule()
@@ -769,32 +917,44 @@ class ProcessingLifecycleMachine(RuleBasedStateMachine):
             ),
         )
         self.assert_or_raise(
-            isinstance(result, transitions.TransitionApplied)
+            isinstance(result, transitions.TransitionApplied),
+            "imported request refused an unowned operator requeue",
         )
         self.oracle.status = "wanted"
 
     @invariant()
     def exact_owner_and_stage_match_oracle(self) -> None:
         request = self.db.request(_REQUEST_ID)
-        self.assert_or_raise(request["status"] == self.oracle.status)
+        self.assert_or_raise(
+            request["status"] == self.oracle.status,
+            "request status drifted from the lifecycle oracle",
+        )
         self.assert_or_raise(
             _exact_processing_owner(
                 request,
                 self.oracle.owner_job_id or -1,
             )
-            == (self.oracle.owner_job_id is not None)
+            == (self.oracle.owner_job_id is not None),
+            "processing status and exact owner pointer came apart",
         )
         if self.oracle.witness is None:
             self.assert_or_raise(
-                request.get("active_download_state") is None
+                request.get("active_download_state") is None,
+                "released request kept an active download state",
             )
         else:
             state = ActiveDownloadState.from_raw(
                 request["active_download_state"]
             )
-            self.assert_or_raise(state.enqueued_at == self.oracle.witness)
+            self.assert_or_raise(
+                state.enqueued_at == self.oracle.witness,
+                "download witness changed under the owner",
+            )
             if self.oracle.status == "processing":
-                self.assert_or_raise(state.current_path == _CANONICAL_PATH)
+                self.assert_or_raise(
+                    state.current_path == _CANONICAL_PATH,
+                    "owned request lost its canonical processing path",
+                )
         active = [
             job
             for job in self.db.list_import_jobs(limit=100)
@@ -802,10 +962,14 @@ class ProcessingLifecycleMachine(RuleBasedStateMachine):
             and job.status in IMPORT_JOB_ACTIVE_STATUSES
         ]
         if self.oracle.owner_job_id is None:
-            self.assert_or_raise(not active)
+            self.assert_or_raise(
+                not active,
+                "unowned request still has an active automation job",
+            )
             return
         self.assert_or_raise(
-            [job.id for job in active] == [self.oracle.owner_job_id]
+            [job.id for job in active] == [self.oracle.owner_job_id],
+            "owned request does not have exactly one active job",
         )
         job = self._current_job()
         assert job is not None
@@ -822,13 +986,20 @@ class ProcessingLifecycleMachine(RuleBasedStateMachine):
             ),
         }[self.oracle.stage]
         self.assert_or_raise(
-            (job.status, job.preview_status) == expected_stage
+            (job.status, job.preview_status) == expected_stage,
+            "owner job stage drifted from the lifecycle oracle",
         )
 
     @staticmethod
-    def assert_or_raise(condition: bool) -> None:
+    def assert_or_raise(condition: bool, message: str) -> None:
+        """Raise the caller's own clause message, never a shared one.
+
+        #1094: a single shared message across twenty-nine assertions makes
+        per-clause attribution impossible — every failure reads the same and
+        no self-test can name which invariant broke.
+        """
         if not condition:
-            raise AssertionError("generated lifecycle assertion failed")
+            raise AssertionError(message)
 
 
 class TestProcessingLifecycleGenerated(unittest.TestCase):
@@ -924,6 +1095,10 @@ class TestProcessingLifecycleGenerated(unittest.TestCase):
         misses=st.integers(min_value=1, max_value=4),
     )
     @example(lane="import", misses=2)
+    # #1094 Q3/Q4: the preview lane is the arm that kills the claim-before-lock,
+    # unpinned-session, and wrong-lock-key mutants. Pinned so an edit to this
+    # body cannot reshuffle it out of the gating tier.
+    @example(lane="preview", misses=1)
     def test_transient_stage_lock_contention_stays_claimable(
         self,
         lane: ClaimLane,
@@ -971,7 +1146,11 @@ class TestProcessingLifecycleGenerated(unittest.TestCase):
                     execution_lease_factory=lambda **_kwargs: lease,
                 )
             self.assertIsNone(result)
-            self.assertEqual(_claim_progress_facts(db, job_id), before)
+            _assert_lock_miss_is_zero_state(
+                lane=lane,
+                before=before,
+                after_miss=_claim_progress_facts(db, job_id),
+            )
 
         after_miss = _claim_progress_facts(db, job_id)
         if lane == "preview":
@@ -1079,14 +1258,14 @@ class TestProcessingLifecycleGenerated(unittest.TestCase):
             **_kwargs: object,
         ) -> ImportPreviewResult:
             effects.append("preview")
-            raise AssertionError("stale force preview crossed owner fence")
+            raise AssertionError(CLAUSE_STALE_FORCE_PREVIEW)
 
         def forbidden_import(
             *_args: object,
             **_kwargs: object,
         ) -> DispatchOutcome:
             effects.append("import")
-            raise AssertionError("stale force import crossed owner fence")
+            raise AssertionError(CLAUSE_STALE_FORCE_IMPORT)
 
         for poll in range(polls):
             if lane == "preview":
@@ -1151,6 +1330,12 @@ class TestProcessingLifecycleGenerated(unittest.TestCase):
                 preview_result={"verdict": "evidence_ready"},
             ))
         before = _claim_progress_facts(db, force_job.id)
+        # #1094 Q2: raising from the stub is NOT sufficient signal —
+        # ``importer.run_once`` deliberately catches an executor crash and
+        # records it as a failed job (invariant 11: nothing is parked), so the
+        # clause message never reaches the operator. The recorded effect is
+        # what makes a fence breach attributable either way.
+        effects: list[str] = []
 
         def no_systemd(**_kwargs: object) -> Never:
             raise ValueError("generated force worker has no systemd lease")
@@ -1159,13 +1344,15 @@ class TestProcessingLifecycleGenerated(unittest.TestCase):
             *_args: object,
             **_kwargs: object,
         ) -> ImportPreviewResult:
-            raise AssertionError("lock miss reached force preview")
+            effects.append(CLAUSE_MISS_REACHED_PREVIEW)
+            raise AssertionError(CLAUSE_MISS_REACHED_PREVIEW)
 
         def forbidden_import(
             *_args: object,
             **_kwargs: object,
         ) -> DispatchOutcome:
-            raise AssertionError("lock miss reached force import")
+            effects.append(CLAUSE_MISS_REACHED_IMPORT)
+            raise AssertionError(CLAUSE_MISS_REACHED_IMPORT)
 
         if lane == "preview":
             result = import_preview_worker.run_once(
@@ -1190,6 +1377,7 @@ class TestProcessingLifecycleGenerated(unittest.TestCase):
                 execute_fn=forbidden_import,
             )
         self.assertIsNone(result)
+        self.assertEqual(effects, [])
         self.assertEqual(_claim_progress_facts(db, force_job.id), before)
 
         if request_changed:
@@ -1281,15 +1469,129 @@ class TestProcessingLifecycleGenerated(unittest.TestCase):
         ))
 
     def test_known_bad_split_terminal_bundle_is_detected(self) -> None:
+        """Q1 for the partial-terminal clause, one row per dropped fact."""
         before = _TerminalFacts(False, False, False, False)
-        mutant = _TerminalFacts(
-            request_released=True,
-            audit_present=True,
-            job_terminal=False,
-            cleanup_consumed=False,
+        complete = _TerminalFacts(True, True, True, True)
+        for field in (
+            "request_released",
+            "audit_present",
+            "job_terminal",
+            "cleanup_consumed",
+        ):
+            mutant = replace(complete, **{field: False})
+            with (
+                self.subTest(dropped=field),
+                self.assertRaisesRegex(
+                    AssertionError,
+                    _clause_prefix(CLAUSE_PARTIAL_TERMINAL),
+                ),
+            ):
+                _assert_terminal_all_or_none(before, mutant)
+
+    def test_terminal_checker_admits_invisible_and_complete_writes(
+        self,
+    ) -> None:
+        """Must-still-work: an untouched world and a full bundle both pass."""
+        before = _TerminalFacts(False, False, False, True)
+        _assert_terminal_all_or_none(before, before)
+        _assert_terminal_all_or_none(
+            before,
+            _TerminalFacts(True, True, True, True),
         )
-        with self.assertRaisesRegex(AssertionError, "partial terminal bundle"):
-            _assert_terminal_all_or_none(before, mutant)
+
+    def test_generated_stage_session_lock_clauses_have_named_worlds(
+        self,
+    ) -> None:
+        """Q1 for both in-world advisory-lock clauses.
+
+        These legislate the production ordering the workers must follow: the
+        owner session is pinned BEFORE the IMPORT lock is taken, and the lock
+        is keyed on ``IMPORT(request_id)`` exactly.
+        """
+        from lib.pipeline_db import ADVISORY_LOCK_NAMESPACE_IMPORT
+
+        db, _job_id = _new_owner_db()
+        session = _GeneratedStageSession(db, acquire=True)
+
+        with (
+            self.assertRaisesRegex(
+                AssertionError,
+                _exact_clause(CLAUSE_UNPINNED_LOCK),
+            ),
+            session.advisory_lock(
+                ADVISORY_LOCK_NAMESPACE_IMPORT,
+                _REQUEST_ID,
+            ),
+        ):
+            pass
+
+        session.pinned = True
+        for namespace, key in (
+            (ADVISORY_LOCK_NAMESPACE_IMPORT + 1, _REQUEST_ID),
+            (ADVISORY_LOCK_NAMESPACE_IMPORT, _REQUEST_ID + 1),
+        ):
+            with (
+                self.subTest(namespace=namespace, key=key),
+                self.assertRaisesRegex(
+                    AssertionError,
+                    _clause_prefix(CLAUSE_UNEXPECTED_LOCK),
+                ),
+                session.advisory_lock(namespace, key),
+            ):
+                pass
+
+        # Must still work: the exact pinned IMPORT(request_id) lock is admitted.
+        with session.advisory_lock(
+            ADVISORY_LOCK_NAMESPACE_IMPORT,
+            _REQUEST_ID,
+        ) as acquired:
+            self.assertTrue(acquired)
+
+    def test_candidate_evidence_clause_has_a_named_world(self) -> None:
+        """Q1: only the exact preview lease may attach candidate evidence."""
+        db, job_id = _new_owner_db()
+        lease = _execution_lease("preview", job_id, 1)
+        self.assertIsNotNone(claim_next_import_preview_job(
+            db,
+            worker_id="generated-preview",
+            execution_lease=lease,
+        ))
+        with self.assertRaisesRegex(
+            AssertionError,
+            _exact_clause(CLAUSE_CANDIDATE_REFUSED),
+        ):
+            _seed_candidate(
+                db,
+                job_id=job_id,
+                execution_lease=replace(
+                    lease,
+                    invocation_id="stale-preview-invocation",
+                ),
+            )
+        # Must still work: the exact lease is admitted.
+        _seed_candidate(db, job_id=job_id, execution_lease=lease)
+
+    def test_assert_or_raise_reports_its_callers_own_clause(self) -> None:
+        """Q1 for the state machine's assertion site.
+
+        Before #1094 every one of its call sites raised the same string, so a
+        failing lifecycle rule could not be attributed to the invariant it
+        broke and no self-test could name one.
+        """
+        for message in (
+            "exact download witness did not mint the processing owner",
+            "processing status and exact owner pointer came apart",
+            "owned request lost its canonical processing path",
+        ):
+            with (
+                self.subTest(message),
+                self.assertRaisesRegex(
+                    AssertionError,
+                    _exact_clause(message),
+                ),
+            ):
+                ProcessingLifecycleMachine.assert_or_raise(False, message)
+        ProcessingLifecycleMachine.assert_or_raise(True, "never raised")
 
 
     def test_known_bad_claim_before_lock_is_detected(self) -> None:
@@ -1333,7 +1635,7 @@ class TestProcessingLifecycleGenerated(unittest.TestCase):
                 self.subTest(lane=lane),
                 self.assertRaisesRegex(
                     AssertionError,
-                    f"{lane} lock miss created execution state",
+                    _clause_prefix(f"{lane} {CLAUSE_LOCK_MISS_STATE}"),
                 ),
             ):
                 _assert_lock_miss_then_progress(
@@ -1342,6 +1644,86 @@ class TestProcessingLifecycleGenerated(unittest.TestCase):
                     after_miss=mutant,
                     after_progress=mutant,
                 )
+
+    def test_known_bad_stuck_after_contention_is_detected(self) -> None:
+        """Q1 for the second clause: the miss was clean but nothing advanced.
+
+        This clause had no self-test at all before #1094 — the sibling above
+        short-circuits, so a world violating both only ever exercised the
+        first one while the test name advertised the pair. Every row here
+        passes the first clause (``after_miss == before``) and then fails to
+        progress, which is the never-parked half of invariant 11: a transient
+        IMPORT lock miss must cost nothing AND must still be claimable.
+        """
+        cases: tuple[tuple[ClaimLane, _ClaimProgressFacts], ...] = (
+            (
+                "preview",
+                _ClaimProgressFacts(
+                    status="queued",
+                    preview_status=IMPORT_JOB_PREVIEW_WAITING,
+                    attempts=0,
+                    preview_attempts=0,
+                ),
+            ),
+            (
+                "import",
+                _ClaimProgressFacts(
+                    status="queued",
+                    preview_status=IMPORT_JOB_PREVIEW_EVIDENCE_READY,
+                    attempts=0,
+                    preview_attempts=1,
+                ),
+            ),
+        )
+        for lane, before in cases:
+            with (
+                self.subTest(lane=lane),
+                self.assertRaisesRegex(
+                    AssertionError,
+                    _clause_prefix(f"{lane} {CLAUSE_NO_PROGRESS}"),
+                ),
+            ):
+                _assert_lock_miss_then_progress(
+                    lane=lane,
+                    before=before,
+                    after_miss=before,
+                    after_progress=before,
+                )
+
+    def test_lock_miss_checker_admits_a_clean_miss_then_progress(self) -> None:
+        """Must-still-work: neither clause fires on the correct sequence."""
+        preview_before = _ClaimProgressFacts(
+            status="queued",
+            preview_status=IMPORT_JOB_PREVIEW_WAITING,
+            attempts=0,
+            preview_attempts=0,
+        )
+        _assert_lock_miss_then_progress(
+            lane="preview",
+            before=preview_before,
+            after_miss=preview_before,
+            after_progress=replace(
+                preview_before,
+                preview_status=IMPORT_JOB_PREVIEW_RUNNING,
+                preview_attempts=1,
+            ),
+        )
+        import_before = _ClaimProgressFacts(
+            status="queued",
+            preview_status=IMPORT_JOB_PREVIEW_EVIDENCE_READY,
+            attempts=0,
+            preview_attempts=1,
+        )
+        _assert_lock_miss_then_progress(
+            lane="import",
+            before=import_before,
+            after_miss=import_before,
+            after_progress=replace(
+                import_before,
+                status="running",
+                attempts=1,
+            ),
+        )
 
     def test_known_bad_force_claim_after_owner_handoff_is_detected(self) -> None:
         before = _ClaimProgressFacts(
@@ -1355,15 +1737,25 @@ class TestProcessingLifecycleGenerated(unittest.TestCase):
             preview_status=IMPORT_JOB_PREVIEW_RUNNING,
             preview_attempts=1,
         )
-        with self.assertRaisesRegex(
-            AssertionError,
-            "owned request admitted stale force",
+        for description, after, effect_count in (
+            ("claim state advanced", mutant, 0),
+            ("worker effect executed", before, 1),
+            ("both", mutant, 1),
         ):
-            _assert_force_owner_fence(
-                before,
-                mutant,
-                effect_count=1,
-            )
+            with (
+                self.subTest(description),
+                self.assertRaisesRegex(
+                    AssertionError,
+                    _exact_clause(CLAUSE_FORCE_FENCE),
+                ),
+            ):
+                _assert_force_owner_fence(
+                    before,
+                    after,
+                    effect_count=effect_count,
+                )
+        # Must still work: an untouched force job with no effects is admitted.
+        _assert_force_owner_fence(before, before, effect_count=0)
 
 
 TestProcessingLifecycleMachine = ProcessingLifecycleMachine.TestCase

--- a/tests/test_request_lifecycle_generated.py
+++ b/tests/test_request_lifecycle_generated.py
@@ -26,7 +26,12 @@ Alongside scenario-shaped rules, ``attempt_any_transition`` deliberately drives
 every target from every current status (including ``replaced``), with both
 current and stale explicit source snapshots. The production transition DAG and
 SQL compare-and-set boundary must reject every invalid/stale world without
-caller-side eligibility filtering.
+caller-side eligibility filtering. ``TestTransitionMatrixPins`` pins that same
+matrix deterministically, including the private ``processing`` edge, because
+the machine's derandomized sequence reshuffles whenever any rule body changes.
+
+Every clause of every checker here carries its own named world and anchored
+message in ``TestLifecycleCheckersTripOnViolations`` (issue #1094).
 
 Profiles, promotion policy, fault-injection qualification:
 docs/generated-testing.md.
@@ -34,10 +39,12 @@ docs/generated-testing.md.
 
 import copy
 import os
+import re
 import sys
 import unittest
 from collections.abc import Mapping
 from itertools import product
+from typing import ClassVar
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -68,6 +75,7 @@ from lib.transitions import (
     RequestTransition,
     TransitionApplied,
     TransitionConflict,
+    TransitionConflictKind,
     TransitionResult,
     finalize_request,
 )
@@ -91,6 +99,18 @@ LEGAL_STATUSES = frozenset({
 _IDENTITY_FIELDS = ("mb_release_id", "source", "created_at")
 
 _RETRY_COUNTERS = ("search_attempts", "download_attempts", "validation_attempts")
+
+
+def exact_clause(message: str) -> str:
+    """Anchor one clause's own message end to end (issue #1094).
+
+    A bare substring is not proof: several clauses here share a prefix
+    (``min_bitrate drifted`` is a substring of ``prev_min_bitrate
+    drifted``; three distinct clauses open with ``replaced request N``),
+    so an unanchored pattern can be satisfied by a sibling clause and a
+    message-collision mutant survives.
+    """
+    return "^" + re.escape(message) + "$"
 
 
 def attach_fake_processing_owner(
@@ -176,8 +196,8 @@ def assert_replacement_linked(
 
 
 def assert_transition_result_matches(
-    before: dict,
-    after: dict,
+    before: Mapping[str, object],
+    after: Mapping[str, object],
     target_status: str,
     result: TransitionResult,
 ) -> None:
@@ -209,6 +229,36 @@ def assert_read_only_cas_result(
         )
     if after != before:
         raise AssertionError(f"read-only CAS mutated row: {before} -> {after}")
+
+
+def resolver_cas_violations(
+    *,
+    applied: bool,
+    should_apply: bool,
+    before_row: Mapping[str, object] | None,
+    after_row: Mapping[str, object] | None,
+    before_tracks: list[dict],
+    after_tracks: list[dict],
+) -> list[str]:
+    """Accumulate every resolver-CAS violation (issue #1094 per-clause proof).
+
+    Accumulating rather than raising: a stale CAS that both lies about its
+    outcome AND mutates rows used to be reported as the outcome clause only,
+    because the raise short-circuited before the mutation clause ran.
+    """
+    violations: list[str] = []
+    if applied is not should_apply:
+        violations.append(
+            f"resolver apply reported {applied}, expected {should_apply}"
+        )
+    if should_apply:
+        if after_row is None or after_row.get("release_group_year") != 1999:
+            violations.append("matching resolver CAS lost parent metadata")
+        if not after_tracks or after_tracks[0]["track_artist"] != "Late Artist":
+            violations.append("matching resolver CAS lost child metadata")
+    elif after_row != before_row or after_tracks != before_tracks:
+        violations.append("stale resolver CAS mutated ancestor or child rows")
+    return violations
 
 
 def assert_wanted_quality_fields(
@@ -315,7 +365,13 @@ class TestReadOnlyMetadataCasGenerated(unittest.TestCase):
         )
         before = copy.deepcopy(db.get_request(request_id))
 
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(
+            ValueError,
+            exact_clause(
+                "metadata CAS cannot mutate reserved lifecycle/identity "
+                f"fields: {field}"
+            ),
+        ):
             db.update_request_fields(request_id, **{field: value})
 
         self.assertEqual(db.get_request(request_id), before)
@@ -323,7 +379,12 @@ class TestReadOnlyMetadataCasGenerated(unittest.TestCase):
 
 class TestWantedQualityFieldsGenerated(unittest.TestCase):
     @given(
-        source_status=st.sampled_from(["downloading", "imported", "unsearchable"]),
+        source_status=st.sampled_from(
+            # ``wanted`` is the same-status field-bearing repeat: it must take
+            # the ordinary CAS writer path, not the status-only idempotent
+            # short circuit that reports success without writing anything.
+            ["wanted", "downloading", "imported", "unsearchable"]
+        ),
         current_min_bitrate=st.one_of(st.none(), st.integers(1, 2000)),
         current_prev_min_bitrate=st.one_of(st.none(), st.integers(1, 2000)),
         next_min_bitrate=st.one_of(st.none(), st.integers(1, 2000)),
@@ -342,6 +403,13 @@ class TestWantedQualityFieldsGenerated(unittest.TestCase):
         current_prev_min_bitrate=128,
         next_min_bitrate=192,
         explicit_prev_min_bitrate=None,
+    )
+    @example(
+        source_status="wanted",
+        current_min_bitrate=128,
+        current_prev_min_bitrate=None,
+        next_min_bitrate=320,
+        explicit_prev_min_bitrate=128,
     )
     def test_explicit_wanted_quality_fields_match_typed_contract(
         self,
@@ -514,7 +582,18 @@ class TestProcessingOwnerGuardsGenerated(unittest.TestCase):
         result = finalize_request(db, request_id, command)
 
         self.assertIsInstance(result, TransitionConflict)
+        assert isinstance(result, TransitionConflict)
         assert before is not None
+        # The conflict must name the exact owner, not a generic stale source:
+        # a fail-open ``processing_locked_conflict`` still produces a refusal
+        # (the writers refuse owned rows too) and is invisible without this.
+        self.assertIs(result.kind, TransitionConflictKind.processing_locked)
+        self.assertIsNotNone(result.processing_owner)
+        assert result.processing_owner is not None
+        self.assertEqual(
+            result.processing_owner.job_id,
+            before["active_automation_import_job_id"],
+        )
         assert_processing_owner_unchanged(
             before,
             copy.deepcopy(db.get_request(request_id)),
@@ -540,8 +619,176 @@ class TestProcessingOwnerGuardsGenerated(unittest.TestCase):
         if (status == "processing") == (owner is not None):
             assert_processing_owner_equivalent(row)
         else:
-            with self.assertRaises(AssertionError):
+            with self.assertRaisesRegex(
+                AssertionError,
+                exact_clause(
+                    f"request 1 has status={status!r} with owner={owner!r}"
+                ),
+            ):
                 assert_processing_owner_equivalent(row)
+
+
+class TestTransitionMatrixPins(unittest.TestCase):
+    """Deterministic pins for every (status, target, source-claim) world.
+
+    ``attempt_any_transition`` explores this matrix randomly, and the
+    machine's derandomized sequence reshuffles whenever ANY rule body
+    changes: during this audit four arms measured at 8 / 4 / 4 / 1
+    executions per suite run dropped to 0 after an unrelated edit to one
+    rule (issue #1094 Q4). These pins hold the whole matrix — invalid
+    edges, stale snapshots, auto-detected sources, and the private
+    ``processing`` edge — independently of that sequence.
+    """
+
+    TARGETS = ("wanted", "downloading", "imported", "unsearchable")
+    SOURCES = (
+        "wanted", "downloading", "imported", "unsearchable", "replaced",
+    )
+
+    @staticmethod
+    def _command(target: str, claimed_source: str | None) -> RequestTransition:
+        if target == "wanted":
+            return RequestTransition.to_wanted(from_status=claimed_source)
+        if target == "downloading":
+            return RequestTransition.to_downloading(
+                from_status=claimed_source,
+                state_json=make_active_download_state_json([]),
+            )
+        if target == "imported":
+            return RequestTransition.to_imported(from_status=claimed_source)
+        return RequestTransition.to_unsearchable(from_status=claimed_source)
+
+    @staticmethod
+    def _row_in(status: str) -> tuple[FakePipelineDB, int]:
+        db = FakePipelineDB()
+        request_id = db.add_request(
+            "Artist", "Album", "request", mb_release_id="matrix-pin")
+        if status == "wanted":
+            return db, request_id
+        if status == "processing":
+            attach_fake_processing_owner(db, request_id)
+            return db, request_id
+        if status == "replaced":
+            db.supersede_request_mbid(
+                request_id,
+                new_mb_release_id="matrix-pin-successor",
+                new_mb_release_group_id=None,
+                new_mb_artist_id=None,
+                new_artist_name="Artist",
+                new_album_title="Album (correct pressing)",
+                new_year=None,
+                new_country=None,
+                new_tracks=[],
+            )
+            return db, request_id
+        if status == "unsearchable":
+            finalize_request(
+                db, request_id,
+                RequestTransition.to_unsearchable(from_status="wanted"))
+            return db, request_id
+        finalize_request(
+            db, request_id,
+            RequestTransition.to_downloading(
+                state_json=make_active_download_state_json([])))
+        if status == "downloading":
+            return db, request_id
+        finalize_request(
+            db, request_id,
+            RequestTransition.to_imported(from_status="downloading"))
+        return db, request_id
+
+    def test_every_ordinary_transition_world(self) -> None:
+        for source in self.SOURCES:
+            for target in self.TARGETS:
+                for claim in ("none", "current", "stale"):
+                    with self.subTest(
+                        source=source, target=target, claim=claim,
+                    ):
+                        self._assert_transition_world(source, target, claim)
+
+    def _assert_transition_world(
+        self, source: str, target: str, claim: str,
+    ) -> None:
+        db, request_id = self._row_in(source)
+        before = copy.deepcopy(db.get_request(request_id))
+        assert before is not None
+        self.assertEqual(before["status"], source)
+        if claim == "none":
+            claimed_source = None
+        elif claim == "current":
+            claimed_source = source
+        else:
+            claimed_source = "wanted" if source != "wanted" else "unsearchable"
+
+        result = finalize_request(
+            db, request_id, self._command(target, claimed_source))
+
+        after = copy.deepcopy(db.get_request(request_id))
+        assert after is not None
+        should_apply = (
+            (claimed_source is None or claimed_source == source)
+            and (source, target) in VALID_TRANSITIONS
+        )
+        assert_transition_result_matches(before, after, target, result)
+        self.assertIsInstance(
+            result,
+            TransitionApplied if should_apply else TransitionConflict,
+        )
+
+    def test_two_writer_requeue_is_all_or_nothing(self) -> None:
+        """The one transition with two writers is the only single-threaded
+        world that can return a conflict AFTER a committed write — which is
+        what the byte-identical-no-op clause legislates against."""
+        db, request_id = self._row_in("downloading")
+        before = copy.deepcopy(db.get_request(request_id))
+        assert before is not None
+
+        result = finalize_request(
+            db, request_id,
+            RequestTransition.to_wanted(
+                from_status="downloading", attempt_type="download"),
+        )
+
+        after = copy.deepcopy(db.get_request(request_id))
+        assert after is not None
+        # The no-op checker runs FIRST so a conflict-after-write world is
+        # attributed to the clause that legislates it, not to the coarser
+        # result-type assertion below (issue #1094 cross-checker masking).
+        assert_transition_result_matches(before, after, "wanted", result)
+        self.assertIsInstance(result, TransitionApplied)
+        self.assertEqual(after["download_attempts"], 1)
+
+    def test_every_processing_world_returns_the_exact_owner_conflict(
+        self,
+    ) -> None:
+        for target in self.TARGETS:
+            for claim in ("none", "current", "stale"):
+                with self.subTest(target=target, claim=claim):
+                    db, request_id = self._row_in("processing")
+                    before = copy.deepcopy(db.get_request(request_id))
+                    assert before is not None
+                    claimed_source = {
+                        "none": None,
+                        "current": "processing",
+                        "stale": "wanted",
+                    }[claim]
+
+                    result = finalize_request(
+                        db, request_id, self._command(target, claimed_source))
+
+                    self.assertIsInstance(result, TransitionConflict)
+                    assert isinstance(result, TransitionConflict)
+                    self.assertIs(
+                        result.kind, TransitionConflictKind.processing_locked)
+                    assert result.processing_owner is not None
+                    self.assertEqual(
+                        result.processing_owner.job_id,
+                        before["active_automation_import_job_id"],
+                    )
+                    assert_processing_owner_unchanged(
+                        before, copy.deepcopy(db.get_request(request_id)))
+                    assert_processing_owner_equivalent(
+                        db.request(request_id))
 
 
 class TestResolverSourceStatusGenerated(unittest.TestCase):
@@ -602,23 +849,16 @@ class TestResolverSourceStatusGenerated(unittest.TestCase):
             ),
             expected_status=expected_status,
         )
-        should_apply = exists and status == expected_status
-        if applied is not should_apply:
-            raise AssertionError(
-                f"resolver apply reported {applied}, expected {should_apply}"
-            )
-        after_row = db.get_request(request_id)
-        after_tracks = db.get_tracks(request_id)
-        if should_apply:
-            assert after_row is not None
-            if after_row["release_group_year"] != 1999:
-                raise AssertionError("matching resolver CAS lost parent metadata")
-            if after_tracks[0]["track_artist"] != "Late Artist":
-                raise AssertionError("matching resolver CAS lost child metadata")
-        elif after_row != before_row or after_tracks != before_tracks:
-            raise AssertionError(
-                "stale resolver CAS mutated ancestor or child rows"
-            )
+        violations = resolver_cas_violations(
+            applied=applied,
+            should_apply=exists and status == expected_status,
+            before_row=before_row,
+            after_row=db.get_request(request_id),
+            before_tracks=before_tracks,
+            after_tracks=db.get_tracks(request_id),
+        )
+        if violations:
+            raise AssertionError("; ".join(violations))
 
 
 class RequestLifecycleMachine(RuleBasedStateMachine):
@@ -832,6 +1072,26 @@ class RequestLifecycleMachine(RuleBasedStateMachine):
                 self._ids_with_status(
                     "wanted", "downloading", "imported", "unsearchable")),
             label="replace target")
+        if not self.db.get_tracks(rid):
+            # Without real child rows the frozen-tracks invariant compares
+            # [] with [] forever and patrols nothing (issue #1094 Q2: a
+            # mutation-on-refusal writer survived against empty tracks).
+            self.db.set_tracks(rid, [
+                {
+                    "disc_number": 1,
+                    "track_number": 1,
+                    "title": f"Track one of {rid}",
+                    "length_seconds": 210,
+                    "track_artist": "Lifecycle Artist",
+                },
+                {
+                    "disc_number": 1,
+                    "track_number": 2,
+                    "title": f"Track two of {rid}",
+                    "length_seconds": 180,
+                    "track_artist": None,
+                },
+            ])
         if self._row(rid).get("active_plan_id") is None:
             self.db.create_successful_search_plan(
                 request_id=rid,
@@ -1035,123 +1295,401 @@ TestRequestLifecycleMachine = RequestLifecycleMachine.TestCase
 
 
 class TestLifecycleCheckersTripOnViolations(unittest.TestCase):
-    """Known-bad self-tests for every lifecycle invariant checker."""
+    """Per-clause known-bad self-tests (issue #1094).
 
-    def test_trips_on_illegal_status(self):
-        with self.assertRaises(AssertionError):
-            assert_statuses_legal([{"id": 1, "status": "zombie"}])
+    Every clause of every lifecycle checker gets its own minimal world —
+    the one that makes THAT clause's condition true while every earlier
+    clause in the same function passes — and asserts THAT clause's own
+    message, anchored end to end. Deterministic by construction: this is
+    test machinery, never a generated target.
+    """
 
-    def test_trips_on_thawed_replaced_row(self):
+    def test_illegal_status_clause(self):
+        with self.assertRaisesRegex(
+            AssertionError,
+            exact_clause("request 7 has illegal status 'zombie'"),
+        ):
+            assert_statuses_legal([{"id": 7, "status": "zombie"}])
+
+    def test_illegal_status_clause_stays_quiet_for_every_legal_status(self):
+        assert_statuses_legal([
+            {"id": index, "status": status}
+            for index, status in enumerate(sorted(LEGAL_STATUSES))
+        ])
+
+    def test_replaced_row_frozen_clause_on_field_drift(self):
         snapshot = {"id": 1, "status": "replaced", "min_bitrate": 245}
         thawed = {"id": 1, "status": "replaced", "min_bitrate": 320}
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+            AssertionError,
+            exact_clause(
+                "replaced request 1 mutated after supersede: "
+                "{'min_bitrate': (245, 320)}"
+            ),
+        ):
             assert_replaced_row_frozen(snapshot, thawed)
 
-    def test_trips_on_rewritten_replaced_tracks(self):
-        with self.assertRaises(AssertionError):
-            assert_replaced_tracks_frozen(
-                1,
-                [{"track_number": 1, "title": "Original"}],
-                [{"track_number": 1, "title": "Late resolver result"}],
-            )
-
-    def test_trips_on_resurrected_replaced_row(self):
+    def test_replaced_row_frozen_clause_on_resurrection(self):
         snapshot = {"id": 1, "status": "replaced"}
         resurrected = {"id": 1, "status": "wanted"}
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+            AssertionError,
+            exact_clause(
+                "replaced request 1 mutated after supersede: "
+                "{'status': ('replaced', 'wanted')}"
+            ),
+        ):
             assert_replaced_row_frozen(snapshot, resurrected)
 
-    def test_trips_on_identity_drift(self):
+    def test_replaced_tracks_frozen_clause(self):
+        snapshot = [{"track_number": 1, "title": "Original"}]
+        rewritten = [{"track_number": 1, "title": "Late resolver result"}]
+        with self.assertRaisesRegex(
+            AssertionError,
+            exact_clause(
+                f"replaced request 1 tracks mutated after supersede: "
+                f"{snapshot!r} -> {rewritten!r}"
+            ),
+        ):
+            assert_replaced_tracks_frozen(1, snapshot, rewritten)
+
+    def test_identity_drift_clause(self):
         row = {"id": 1, "mb_release_id": "mbid-B", "source": "request",
                "created_at": "t0"}
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+            AssertionError,
+            exact_clause(
+                "request 1 identity drifted: ('mbid-A', 'request', 't0') -> "
+                "('mbid-B', 'request', 't0')"
+            ),
+        ):
             assert_identity_immutable(("mbid-A", "request", "t0"), row)
 
-    def test_trips_on_stray_download_state(self):
-        with self.assertRaises(AssertionError):
-            assert_download_state_coherent(
-                {"id": 1, "status": "imported",
-                 "active_download_state": "{}"})
+    def test_stray_download_state_clause_for_every_forbidden_status(self):
+        forbidden = sorted(
+            LEGAL_STATUSES - {"downloading", "processing", "replaced"})
+        for status in forbidden:
+            with self.subTest(status=status), self.assertRaisesRegex(
+                AssertionError,
+                exact_clause(
+                    f"request 1 carries active_download_state while "
+                    f"{status!r}"
+                ),
+            ):
+                assert_download_state_coherent({
+                    "id": 1,
+                    "status": status,
+                    "active_download_state": "{}",
+                })
 
-    def test_trips_on_processing_without_owner_and_owner_without_processing(self):
-        with self.assertRaises(AssertionError):
-            assert_processing_owner_equivalent({
-                "id": 1,
-                "status": "processing",
-                "active_automation_import_job_id": None,
-            })
-        with self.assertRaises(AssertionError):
-            assert_processing_owner_equivalent({
-                "id": 1,
-                "status": "wanted",
-                "active_automation_import_job_id": 9,
-            })
+    def test_download_state_clause_allows_the_three_carrying_statuses(self):
+        for status in ("downloading", "processing", "replaced"):
+            with self.subTest(status=status):
+                assert_download_state_coherent({
+                    "id": 1,
+                    "status": status,
+                    "active_download_state": "{}",
+                })
 
-    def test_processing_owner_guard_checker_trips_on_mutation_and_delete(self):
+    def test_processing_owner_equivalence_clause_both_directions(self):
+        cases = (
+            ("processing", None),
+            ("wanted", 9),
+        )
+        for status, owner in cases:
+            with self.subTest(status=status, owner=owner), self.assertRaisesRegex(
+                AssertionError,
+                exact_clause(
+                    f"request 1 has status={status!r} with owner={owner!r}"
+                ),
+            ):
+                assert_processing_owner_equivalent({
+                    "id": 1,
+                    "status": status,
+                    "active_automation_import_job_id": owner,
+                })
+
+    def test_processing_owner_unchanged_clause_on_mutation(self):
         before = {
             "id": 1,
             "status": "processing",
             "active_automation_import_job_id": 9,
         }
-        with self.assertRaises(AssertionError):
-            assert_processing_owner_unchanged(
-                before,
-                {**before, "status": "wanted"},
-            )
-        with self.assertRaises(AssertionError):
+        after = {**before, "status": "wanted"}
+        with self.assertRaisesRegex(
+            AssertionError,
+            exact_clause(f"processing owner mutated: {before} -> {after}"),
+        ):
+            assert_processing_owner_unchanged(before, after)
+
+    def test_processing_owner_unchanged_clause_on_delete(self):
+        before = {
+            "id": 1,
+            "status": "processing",
+            "active_automation_import_job_id": 9,
+        }
+        with self.assertRaisesRegex(
+            AssertionError,
+            exact_clause(f"processing owner mutated: {before} -> None"),
+        ):
             assert_processing_owner_unchanged(before, None)
 
-    def test_trips_on_dropped_explicit_previous_bitrate(self):
-        with self.assertRaises(AssertionError):
+    def test_wanted_quality_clause_on_wrong_landing_status(self):
+        with self.assertRaisesRegex(
+            AssertionError,
+            exact_clause("wanted transition landed as 'imported'"),
+        ):
             assert_wanted_quality_fields(
-                {
-                    "status": "wanted",
-                    "min_bitrate": 245,
-                    "prev_min_bitrate": 320,
-                },
+                {"status": "imported", "min_bitrate": 245,
+                 "prev_min_bitrate": 320},
+                min_bitrate=245,
+                prev_min_bitrate=320,
+            )
+
+    def test_wanted_quality_clause_on_dropped_min_bitrate(self):
+        # Anchored end to end on purpose: ``min_bitrate drifted`` is a
+        # substring of the prev_min_bitrate clause below, so an unanchored
+        # pattern would be satisfied by the wrong clause.
+        with self.assertRaisesRegex(
+            AssertionError,
+            exact_clause("min_bitrate drifted: 320 != 245"),
+        ):
+            assert_wanted_quality_fields(
+                {"status": "wanted", "min_bitrate": 320,
+                 "prev_min_bitrate": 128},
+                min_bitrate=245,
+                prev_min_bitrate=128,
+            )
+
+    def test_wanted_quality_clause_on_dropped_previous_bitrate(self):
+        with self.assertRaisesRegex(
+            AssertionError,
+            exact_clause("prev_min_bitrate drifted: 320 != 256"),
+        ):
+            assert_wanted_quality_fields(
+                {"status": "wanted", "min_bitrate": 245,
+                 "prev_min_bitrate": 320},
                 min_bitrate=245,
                 prev_min_bitrate=256,
             )
 
-    def test_trips_on_missing_descendant(self):
-        with self.assertRaises(AssertionError):
+    def test_missing_descendant_clause(self):
+        with self.assertRaisesRegex(
+            AssertionError,
+            exact_clause("replaced request 1 has no linked descendant row"),
+        ):
             assert_replacement_linked(1, None)
-        with self.assertRaises(AssertionError):
+
+    def test_descendant_backlink_clause(self):
+        # Fail-closed legislation: the machine reaches this checker through
+        # ``get_request_by_replaces_request_id``, whose result always points
+        # back, so only a future caller resolving the descendant some other
+        # way (by id, by mbid) can reach this clause. Kept so that caller
+        # fails loudly instead of silently accepting a foreign descendant.
+        with self.assertRaisesRegex(
+            AssertionError,
+            exact_clause(
+                "descendant of 1 does not point back "
+                "(replaces_request_id=99)"
+            ),
+        ):
             assert_replacement_linked(1, {"replaces_request_id": 99})
 
-    def test_trips_when_conflict_mutates_row(self):
-        from lib.transitions import TransitionConflictKind
+    def test_transition_result_clause_when_applied_target_did_not_land(self):
+        row = {"id": 1, "status": "wanted"}
+        applied = TransitionApplied(1, "wanted", "unsearchable")
+        with self.assertRaisesRegex(
+            AssertionError,
+            exact_clause(
+                "applied transition reported 'unsearchable' but row is "
+                "'wanted'"
+            ),
+        ):
+            assert_transition_result_matches(row, row, "unsearchable", applied)
 
+    def test_transition_result_clause_when_conflict_mutates_row(self):
         before = {"id": 1, "status": "replaced"}
         after = {"id": 1, "status": "wanted"}
         conflict = TransitionConflict(
             1, "wanted", TransitionConflictKind.invalid_edge,
             "replaced", "replaced",
         )
-        with self.assertRaises(AssertionError):
+        with self.assertRaisesRegex(
+            AssertionError,
+            exact_clause(
+                f"conflicted transition mutated request 1: {before} -> {after}"
+            ),
+        ):
             assert_transition_result_matches(before, after, "wanted", conflict)
 
-    def test_trips_when_applied_target_did_not_land(self):
-        row = {"id": 1, "status": "wanted"}
-        applied = TransitionApplied(1, "wanted", "unsearchable")
-        with self.assertRaises(AssertionError):
-            assert_transition_result_matches(row, row, "unsearchable", applied)
+    def test_transition_result_checker_accepts_honest_results(self):
+        row = {"id": 1, "status": "unsearchable"}
+        assert_transition_result_matches(
+            {"id": 1, "status": "wanted"}, row, "unsearchable",
+            TransitionApplied(1, "wanted", "unsearchable"),
+        )
+        assert_transition_result_matches(
+            row, row, "imported",
+            TransitionConflict(
+                1, "imported", TransitionConflictKind.invalid_edge,
+                None, "unsearchable",
+            ),
+        )
 
-    def test_read_only_cas_checker_trips_on_false_success_and_mutation(self):
-        with self.assertRaises(AssertionError):
-            assert_read_only_cas_result(
-                applied=True,
-                expected_applied=False,
-                before=None,
-                after=None,
-            )
-        with self.assertRaises(AssertionError):
+    def test_read_only_cas_outcome_clause_both_directions(self):
+        for applied, expected in ((True, False), (False, True)):
+            with self.subTest(
+                applied=applied, expected=expected,
+            ), self.assertRaisesRegex(
+                AssertionError,
+                exact_clause(
+                    f"read-only CAS reported applied={applied}, "
+                    f"expected={expected}"
+                ),
+            ):
+                assert_read_only_cas_result(
+                    applied=applied,
+                    expected_applied=expected,
+                    before=None,
+                    after=None,
+                )
+
+    def test_read_only_cas_mutation_clause(self):
+        before = {"id": 1, "updated_at": "before"}
+        after = {"id": 1, "updated_at": "after"}
+        with self.assertRaisesRegex(
+            AssertionError,
+            exact_clause(f"read-only CAS mutated row: {before} -> {after}"),
+        ):
             assert_read_only_cas_result(
                 applied=True,
                 expected_applied=True,
-                before={"id": 1, "updated_at": "before"},
-                after={"id": 1, "updated_at": "after"},
+                before=before,
+                after=after,
             )
+
+
+class TestResolverCasViolationClauses(unittest.TestCase):
+    """Per-clause proof for the accumulating resolver-CAS checker."""
+
+    ROW_BEFORE: ClassVar[dict[str, object]] = {
+        "id": 1, "status": "wanted", "release_group_year": None}
+    ROW_AFTER: ClassVar[dict[str, object]] = {
+        "id": 1, "status": "wanted", "release_group_year": 1999}
+    TRACKS_BEFORE: ClassVar[list[dict]] = [
+        {"track_number": 1, "track_artist": None}]
+    TRACKS_AFTER: ClassVar[list[dict]] = [
+        {"track_number": 1, "track_artist": "Late Artist"}]
+
+    def test_clean_matching_world_has_no_violations(self):
+        self.assertEqual(
+            resolver_cas_violations(
+                applied=True,
+                should_apply=True,
+                before_row=self.ROW_BEFORE,
+                after_row=self.ROW_AFTER,
+                before_tracks=self.TRACKS_BEFORE,
+                after_tracks=self.TRACKS_AFTER,
+            ),
+            [],
+        )
+
+    def test_clean_stale_world_has_no_violations(self):
+        self.assertEqual(
+            resolver_cas_violations(
+                applied=False,
+                should_apply=False,
+                before_row=self.ROW_BEFORE,
+                after_row=self.ROW_BEFORE,
+                before_tracks=self.TRACKS_BEFORE,
+                after_tracks=self.TRACKS_BEFORE,
+            ),
+            [],
+        )
+
+    def test_outcome_clause(self):
+        self.assertEqual(
+            resolver_cas_violations(
+                applied=False,
+                should_apply=True,
+                before_row=self.ROW_BEFORE,
+                after_row=self.ROW_AFTER,
+                before_tracks=self.TRACKS_BEFORE,
+                after_tracks=self.TRACKS_AFTER,
+            ),
+            ["resolver apply reported False, expected True"],
+        )
+
+    def test_lost_parent_metadata_clause(self):
+        self.assertEqual(
+            resolver_cas_violations(
+                applied=True,
+                should_apply=True,
+                before_row=self.ROW_BEFORE,
+                after_row=self.ROW_BEFORE,
+                before_tracks=self.TRACKS_BEFORE,
+                after_tracks=self.TRACKS_AFTER,
+            ),
+            ["matching resolver CAS lost parent metadata"],
+        )
+
+    def test_lost_child_metadata_clause(self):
+        self.assertEqual(
+            resolver_cas_violations(
+                applied=True,
+                should_apply=True,
+                before_row=self.ROW_BEFORE,
+                after_row=self.ROW_AFTER,
+                before_tracks=self.TRACKS_BEFORE,
+                after_tracks=self.TRACKS_BEFORE,
+            ),
+            ["matching resolver CAS lost child metadata"],
+        )
+
+    def test_stale_mutation_clause(self):
+        self.assertEqual(
+            resolver_cas_violations(
+                applied=False,
+                should_apply=False,
+                before_row=self.ROW_BEFORE,
+                after_row=self.ROW_AFTER,
+                before_tracks=self.TRACKS_BEFORE,
+                after_tracks=self.TRACKS_BEFORE,
+            ),
+            ["stale resolver CAS mutated ancestor or child rows"],
+        )
+
+    def test_accumulating_checker_reports_every_violated_clause(self):
+        """A raise-chain used to report only the first of these two."""
+        self.assertEqual(
+            resolver_cas_violations(
+                applied=True,
+                should_apply=False,
+                before_row=self.ROW_BEFORE,
+                after_row=self.ROW_AFTER,
+                before_tracks=self.TRACKS_BEFORE,
+                after_tracks=self.TRACKS_AFTER,
+            ),
+            [
+                "resolver apply reported True, expected False",
+                "stale resolver CAS mutated ancestor or child rows",
+            ],
+        )
+        self.assertEqual(
+            resolver_cas_violations(
+                applied=False,
+                should_apply=True,
+                before_row=self.ROW_BEFORE,
+                after_row=self.ROW_BEFORE,
+                before_tracks=self.TRACKS_BEFORE,
+                after_tracks=self.TRACKS_BEFORE,
+            ),
+            [
+                "resolver apply reported False, expected True",
+                "matching resolver CAS lost parent metadata",
+                "matching resolver CAS lost child metadata",
+            ],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Refs #1094. Third pass of the standing per-clause audit: **processing ownership**, seven modules, five agents. Follows #1103 (the rule + filesystem authority) and #1108 (the quality-decision core).

## Why this area

These modules guard invariant 10 (#898 — `processing` has exactly one durable owner; every mutation after the atomic `downloading → processing` handoff is fenced by the exact owner job) and invariant 11 (**broken worlds surface and restart; nothing is parked**). Migration 066 is a hard forward-only boundary behind them.

## Measured before / after

| module | clause sites (grep) | real clauses | bare `assertRaises` before → after |
|---|---|---|---|
| `test_request_lifecycle_generated.py` | 42 | **43** | 18 → 0 |
| `test_import_operation_fence_generated.py` | 22 | **21** | 0 → 0 |
| `test_processing_lifecycle_generated.py` | 17 | **45** ‡ | 0 → 0 |
| `test_download_incarnation_generated.py` | 18 | **19** | 0 → 0 |
| `test_automation_startup_recovery_generated.py` | 18 | **12** | 5 → 0 † |
| `test_processing_cleanup_generated.py` | 4 | 4 | 0 → 0 |
| `test_cleanup_journal_generated.py` | 2 | 2 | 0 → 0 |

† one docstring occurrence remains, explaining why bare `assertRaises` proves nothing.
‡ see the `assert_or_raise` finding below.

**Every count disagreed with my brief in at least one direction.** Round 2's "one grep is not an inventory" lesson, applied five times independently.

## Four findings, each a check that could not fail

**1. One raise site standing in for 29 clauses.** `test_processing_lifecycle_generated.py` routed 29 distinct call sites through a single `assert_or_raise` helper that raised the *same string* every time. No failure could be attributed to an invariant and no self-test could name one, so the module's real clause count is **45, not 17**. Each call site now raises its own message.

**2. A property that patrolled nothing.** In that same module, `_assert_terminal_all_or_none` executed **once** in the gating tier — and that single execution was its *own known-bad self-test*. Zero production drive. It is now at **82 executions**, 81 with a visible state change.

**3. A vacuous archivist invariant.** `assert_replaced_tracks_frozen` enforces "replaced rows are frozen", which is load-bearing for the archivist frame. Replaced rows never had child tracks seeded, so it compared `[] == []` forever. `replace` now seeds real tracks; the mutant dies with actual content (`[{'track_number': 1, 'title': 'Original'}] -> [... 'Late resolver result'}]`).

**4. An unfalsifiable invariant-11 guard.** `scripts/importer.py`'s `job.status != IMPORT_JOB_RECOVERY_REQUIRED` exemption is the only thing that automatically converges a historical leaseless `recovery_required` owner. Delete it and the request sits `processing` behind a parked owner forever — the exact park invariant 11 forbids. **The module stayed fully green** before this PR, because no generated world had ever held a `recovery_required` owner. Two pinned worlds now kill it. The code was correct; the guard was unenforced.

## The reshuffle hazard, now characterised

Round 2 documented that `derandomize=True` seeds from the test function's digest, so editing a property body reshuffles its worlds. This round measured it repeatedly and pinned down the mechanism:

- `test_request_lifecycle_generated.py`: **4 arms went to zero** from touching one rule body. Verified directly — inserting a two-line no-op into `claim_download` moved 175 count lines; adding a **module-level** function changed **zero**. So machine/property-body edits reshuffle everything; module-level additions are free.
- `test_download_incarnation_generated.py`: `non_downloading` fell **37 → 13**.
- `test_processing_cleanup_generated.py`: action arms moved 57→32 / 50→56 / 44→65.

Remedies: every decisive arm pinned as an `@example`, plus a deterministic `TestTransitionMatrixPins` (60 worlds: 5 statuses × 4 targets × 3 source-claims, and 12 processing worlds) driven through the real `finalize_request`. Final measurement: **0 base arms at zero**, 62 → 76 finalize arms, 150 total; re-measured after lint fixes with zero drift.

## Cross-checker masking, found four more times

Round 2's lesson recurred in every module that had it: `_assert_terminal_all_or_none` after a returned-list assertion; `test_stale_authority_never_launches_beets` asserting `invocations == []` *before* the fence checker (so a stale-authority fail-open died on a list diff, never on its own clause); the lock-miss zero-state clause masked by a bare `assertEqual`; and clause 8B masked by a pin. All fixed by reordering **independent checker calls** — never clauses inside a checker.

## Kill matrices

Complete per-clause matrices for all seven modules are in [this PR comment](https://github.com/abl030/cratedigger/pull/1113#issuecomment-5266424747) (round 2's review correctly flagged that summarising leaves the mutant claims unverifiable).

Headline totals: **~140 production mutants planted and reverted; every kill at the `suite` tier — none fuzz-only**, so #1103's defect did not recur anywhere.

## Real production defects

**None in ownership logic.** Every dangerous shape probed was correctly refused: stale launch authority by `dispatch_import_core`'s `launch_authority_conflict`; the `recovery_required` park and a non-wanted self-heal edge by `validate_automation_terminal_authority`; a non-owner cleanup journal by migration 066's deferred trigger (`CheckViolation: cleanup journal must belong to the exact active processing owner`). Invariant 10's fence held against every mutant. **No production file is touched by this PR.**

**One test-fidelity defect found and reported, not fixed:** `FakePipelineDB.persist_import_terminal_outcome` (`tests/fakes/pipeline_db.py:3065`) branches `completed`/else-`failed`, while production writes `SET status = %s` verbatim (`lib/pipeline_db/terminal_outcomes.py:1305`). It is precisely why two fence clauses have no reachable mutant. Out of scope here; worth its own issue.

  **Scoped down after review (N1):** the draft called this "whole-suite blast radius". Reaching the divergence requires a payload violating `ImportJobTerminal.status: Literal["completed", "failed"]` and its `__post_init__` guard (`lib/terminal_outcomes.py:115`), so it is real but narrow. Review also found a **second, unreported divergence in the same method**: the fake asserts `command.job.error is not None` on the non-completed branch, stricter than production's `error = None if completed else job.error`. Both belong in the follow-up issue.

## Stated limits — read these before trusting the totals

This round has more honest gaps than the previous two, and they are recorded rather than smoothed over:

- **Fake-tier kills.** Where a clause's deciding writer is `lib/pipeline_db/*` SQL that `FakePipelineDB` reimplements, a mutant only proves the fake. This affects most of `test_download_incarnation_generated.py`'s CAS/handoff mutants (only `_admit_download_incarnations` / `_decode_valid_download_incarnations` are real production there), the owner-equivalence clauses in startup recovery, and C6/C7/C17/C19 in the fence module. Each agent classified these explicitly rather than counting them as production kills.

  **Corrected after review (N3):** the first draft said this audit "did not verify parity exists". That was both too pessimistic and imprecise. Real-PG parity *does* exist — `tests/test_pipeline_db.py` covers `handoff_automation_import` (`:2880-2886`, incl. `missing_state` / `witness_mismatch` / `committed`) and `update_download_state_if_downloading` (`:9547-9556`), plus real-PG behavioural coverage for `lock_unavailable` (`:1595`) and `not_downloading` (`:2238`). The one genuine hole is **`owner_conflict`, which has no real-PG test anywhere** — so `test_download_incarnation_generated.py`'s `active_conflict` arm really is fake-only, and the rest are better covered than the draft admitted.
- **27 of the 29 newly-named `assert_or_raise` clauses** have anchored Q1 worlds and named rules but no individual Q2 mutant (budget). They are strictly better than before — attributable and self-tested — but not mutant-qualified.
- **One widening still owed:** `{lane} did not progress after contention cleared` is producible in principle (a worker that never retries after contention) and was not planted.
- **One dead strategy arm:** `test_processing_lifecycle_generated.py`'s `imported` arm and `requeue_imported` rule are unreachable because the machine models no acceptance lane. The docstring previously claimed the `{wanted, imported}` terminal set; corrected, and the gap recorded there.
- **Two clauses not widenable single-threaded** (a lost CAS reported as applied) — they need a concurrent writer; covered deterministically by `tests/test_transitions.py`.

## Evidence

- **Independently cross-checked**, not taken on report. After integration I planted a message-collision mutant on the previously-vacuous frozen-tracks clause — the mutant class bare `assertRaises` cannot catch — and it died with an exact diagnosis carrying real track content. Reverted; tree clean.
- **Canonical suite**: `scripts/run_final_gate.sh` → **pass**, receipt `cratedigger-final-gate.dEEirMTe`, on this exact commit (an earlier receipt `…P62Dih1v` passed on the pre-review tree, first attempt).
- Targeted gate `bash scripts/test.sh` selected **33 selectors** — all seven generated modules, deterministic siblings, typing ratchet, every audit — 6 phases green.
- Zero real bare `assertRaises(AssertionError)` across all seven modules.
- No Hypothesis added to any known-bad self-test. No scanner, AST analyzer, or reachability inference added. Every production mutant reverted.

## Review round 1 — no blocking code findings

The review attacked by measurement and **independently reproduced all four headline findings**, with its own instrumentation:

| claim | verified |
|---|---|
| `_assert_terminal_all_or_none` 1 → 82 | **exact** — base `{calls: 1, changed: 1}`, branch `{calls: 82, changed: 81}` |
| `assert_replaced_tracks_frozen` was vacuous | **confirmed** — base 12,933 calls, **1** with a non-empty snapshot (its own self-test); branch 15,141 of 15,141 non-empty |
| one `assert_or_raise` for 29 clauses | **confirmed** by AST diff of both trees — same 29 sites, **conditions byte-identical**, 29 distinct messages |
| the `recovery_required` guard was unfalsifiable | **confirmed by mutant** — reverting it leaves the base tree at 9 tests OK; the branch fails on both pinned worlds with the exact clause message |
| 62 → 76 finalize arms | **exact**, wrapping the real `lib.transitions.finalize_request` |

It also planted **its own** mutant not in this PR — `lib/transitions.py` `kind=processing_locked` → `stale_source` — which **survives on base (22 tests OK)** and takes down **13 deterministic tests** here. The `processing_locked` coverage gain is load-bearing.

Swept for the failure mode that would have been blocking: **no decisive arm at zero** in any of the seven modules. The only zeros are the dead arm this PR already admits and fence-breach stubs that must be zero. Anchoring: **550 `assertRaisesRegex` invocations, 373 fully `^…$`-anchored**, the rest correctly line- or prefix-anchored with every prefix checked against its checker's siblings — no collision possible; round 2's four loose sites are gone. No coverage regression: `given`/`rule`/`invariant` counts identical, examples 42 → 54, one strategy *widened*, both accumulating conversions preserve raise-iff-any-violation and are slightly hardened.

**Two non-blocking findings fixed** (commit `6b9b333a`), both the same defect class as this series one level up — a comment claiming coverage the code does not establish:

- `test_processing_cleanup_generated.py` claimed both non-quarantine arms can fire `CLAUSE_INVENTED_DESTINATION`. They cannot — the property only creates `source` when the action is not `no_op`, so that arm returns `None` whatever production does. Corrected, and the real entropy gap it exposes recorded at the site.
- The startup-recovery class docstring claimed its table proves no clause pattern matches a sibling's; `_prove_clauses` only cross-checks the cases handed to it, i.e. one checker per call. Scoped.

The other two findings are corrections to this body, applied above (N1, N3).

**One process failure, mine.** The review reported the kill-matrix comment missing — and it was, at the moment it looked: I spawned the reviewer *before* posting the matrices. The evidence exists (`#issuecomment-5266424747`, 11:50:35Z), but the reviewer could not see it and correctly refused to trust ~140 unbacked mutant claims. Evidence goes up before review starts, not after.

## Scope

Cumulative across #1103, #1108 and this PR: **~373 clauses across 13 modules**. Remaining in the #1094 priority list: manifest / canonical-album guards (~54) and slskd event + ledger ingestion (~35).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
