### PR TITLE
docs(#1111): three rule amendments from post-batch reflection

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -157,15 +157,15 @@ Any type that **crosses JSON** — harness stdout, an HTTP response, a JSONB blo
   a single-point mutant immediately proved was the load-bearing half).
   Subagent implementation briefs state the pair requirement verbatim and
   never offer a deterministic-only alternative.
-- **A regression pin added to resolve a review finding is accepted only
-  with planted-mutant evidence in both directions** — the pin must fail on
-  the defect and pass on the fix, proven with an actual planted mutant, not
-  asserted from reading the pin. Earned three times in the #1088/#1090
-  series, none caught by the suite: a pin whose fixture raised
-  `RuntimeError` where only `AttributeError` distinguishes fixed from
-  defective code (inert against the exact mutant it named); a test whose
-  name promised a True-case assertion its body never made; and an
-  exit-code distinctness test comparing a constant to a hand-typed literal.
+- **A regression pin is accepted only with planted-mutant evidence in
+  both directions** — the pin must fail on the defect and pass on the
+  fix, proven with an actual planted mutant, not asserted from reading
+  the pin. Earned three times in the #1088/#1090 series, none caught by
+  the suite: a pin whose fixture raised `RuntimeError` where only
+  `AttributeError` distinguishes fixed from defective code (inert
+  against the exact mutant it named); a test whose name promised a
+  True-case assertion its body never made; and an exit-code distinctness
+  test comparing a constant to a hand-typed literal.
 - **Never property-test the test machinery.** Hypothesis and
   `test_*_generated.py` are reserved for production behavior and
   production-facing operator tools. Test runners and schedulers, suite and
@@ -254,13 +254,15 @@ Any type that **crosses JSON** — harness stdout, an HTTP response, a JSONB blo
   budget miss (pin the decisive world as an `@example`). The driver is an
   operator/agent one-shot — never committed (`scope.md`); record the kill
   matrix in the issue/PR. Canonical run: issue #548, 2026-07-08 — 13
-  mutants, incl. reverting fix `6cf26a4`, led to PR #555. **Injection must
-  cover every site the diff adds, named individually — a killed mutant at
-  one site does not qualify any other.** Lesson (#1110): the implementer
-  honestly reported "verified against revert", true of `renderConvergeControls`
-  alone; mutants at the three `deleteWrongMatchGroup` restore paths and at
-  `removeWrongMatchEntry` survived every JS assertion, and one recreated the
-  very dead end the PR existed to remove.
+  mutants, incl. reverting fix `6cf26a4`, led to PR #555. **When you
+  inject at all, cover every site the diff adds, named individually — a
+  killed mutant at one site does not qualify any other** (the "Agree by
+  construction" rule above, generalized from claimed adapters to diff
+  sites). Lesson (#1110): the implementer reported reverting each fix and
+  watching its own pin go red — true only of `renderConvergeControls`;
+  mutants at the three `deleteWrongMatchGroup` restore paths and at
+  `removeWrongMatchEntry` survived every JS assertion, and one recreated
+  the very dead end the PR existed to remove.
 
 ### Generated-test performance is a coverage contract
 
@@ -694,13 +696,14 @@ rationale; never allowlist a pure decision.
   - A symlink does not widen grep scope: `grep -r` and `rg` both skip symlinks
     during recursive traversal, so `AGENTS.md` never matches on `CLAUDE.md`'s
     content without an explicit `-R`/`-L`. Do not rely on one for coverage.
-- **Correction commits are high-risk sites for new false claims.** A round
-  that fixes a reviewer finding writes with the highest confidence and gets
-  the least scrutiny — exactly backwards. The final review round must
-  specifically re-read every claim (comment, docstring, PR prose) the
-  correction commits themselves added. Earned four times in one batch
-  (#1101, #1102, #1107, #1110); each false claim was caught only by the
-  NEXT independent read, never by the round that wrote it.
+- **No round catches its own false claims.** A commit's author must
+  re-read every claim (comment, docstring, PR prose) that commit itself
+  added before committing it, then the next independent read — human or
+  agent — must re-read it again. This matters most on a correction
+  commit, where confidence is highest and scrutiny lowest right where a
+  new false claim can hide. Earned four times in one batch (#1101,
+  #1102, #1107, #1110); in each, the false claim was caught only by the
+  next independent read, never by the round that wrote it.
 - Fix everything it finds before committing. This is not optional.
 
 ## Commits & PRs

--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -157,6 +157,15 @@ Any type that **crosses JSON** — harness stdout, an HTTP response, a JSONB blo
   a single-point mutant immediately proved was the load-bearing half).
   Subagent implementation briefs state the pair requirement verbatim and
   never offer a deterministic-only alternative.
+- **A regression pin added to resolve a review finding is accepted only
+  with planted-mutant evidence in both directions** — the pin must fail on
+  the defect and pass on the fix, proven with an actual planted mutant, not
+  asserted from reading the pin. Earned three times in the #1088/#1090
+  series, none caught by the suite: a pin whose fixture raised
+  `RuntimeError` where only `AttributeError` distinguishes fixed from
+  defective code (inert against the exact mutant it named); a test whose
+  name promised a True-case assertion its body never made; and an
+  exit-code distinctness test comparing a constant to a hand-typed literal.
 - **Never property-test the test machinery.** Hypothesis and
   `test_*_generated.py` are reserved for production behavior and
   production-facing operator tools. Test runners and schedulers, suite and
@@ -245,7 +254,13 @@ Any type that **crosses JSON** — harness stdout, an HTTP response, a JSONB blo
   budget miss (pin the decisive world as an `@example`). The driver is an
   operator/agent one-shot — never committed (`scope.md`); record the kill
   matrix in the issue/PR. Canonical run: issue #548, 2026-07-08 — 13
-  mutants, incl. reverting fix `6cf26a4`, led to PR #555.
+  mutants, incl. reverting fix `6cf26a4`, led to PR #555. **Injection must
+  cover every site the diff adds, named individually — a killed mutant at
+  one site does not qualify any other.** Lesson (#1110): the implementer
+  honestly reported "verified against revert", true of `renderConvergeControls`
+  alone; mutants at the three `deleteWrongMatchGroup` restore paths and at
+  `removeWrongMatchEntry` survived every JS assertion, and one recreated the
+  very dead end the PR existed to remove.
 
 ### Generated-test performance is a coverage contract
 
@@ -679,6 +694,13 @@ rationale; never allowlist a pure decision.
   - A symlink does not widen grep scope: `grep -r` and `rg` both skip symlinks
     during recursive traversal, so `AGENTS.md` never matches on `CLAUDE.md`'s
     content without an explicit `-R`/`-L`. Do not rely on one for coverage.
+- **Correction commits are high-risk sites for new false claims.** A round
+  that fixes a reviewer finding writes with the highest confidence and gets
+  the least scrutiny — exactly backwards. The final review round must
+  specifically re-read every claim (comment, docstring, PR prose) the
+  correction commits themselves added. Earned four times in one batch
+  (#1101, #1102, #1107, #1110); each false claim was caught only by the
+  NEXT independent read, never by the round that wrote it.
 - Fix everything it finds before committing. This is not optional.
 
 ## Commits & PRs

--- a/docs/generated-testing.md
+++ b/docs/generated-testing.md
@@ -765,7 +765,10 @@ only. How to pick mutants:
 - revert a real past bug fix (the strongest single check);
 - break each adapter derivation the parity property claims to pin;
 - flip decision comparisons; remove early-exit guards and readiness gates;
-- for each property, plant the exact violation it claims to catch.
+- for each property, plant the exact violation it claims to catch;
+- when the diff adds several sites, mutate and name each one — a killed
+  mutant at one site does not qualify any other
+  (`.claude/rules/code-quality.md` § "Testing — Red/Green TDD").
 
 Interpret results per mutant: **killed** = the property works; **killed only at
 fuzz entropy** = the deterministic suite budget misses the decisive world, so


### PR DESCRIPTION
Part of #1111 (item 3 + the comment's third amendment). Docs-only.

Three amendments to `.claude/rules/code-quality.md`, each earned three or more times across the #1097–#1110 batch and the #1088/#1090 series:

1. **Fault injection covers every site the diff adds** — when you inject at all, mutate and name each site; a killed mutant at one site does not qualify any other. Mirrored into `docs/generated-testing.md`'s mutant-picking list (per-clause-rule precedent: ships in both files).
2. **No round catches its own false claims** — the commit's author re-reads every claim that commit added before committing; the next independent read re-reads it again, correction rounds most of all.
3. **A regression pin is accepted only with planted-mutant evidence in both directions** — fails on the defect, passes on the fix, proven with a planted mutant.

**Review round note:** the independent review checked the amendments' citations against the git record and found issue #1111's own framing of amendment 2 overstated — only #1101's false claim was written by a correction commit; #1102/#1107/#1110's were written by initial implementation commits and caught by the first independent read. The rule was rescoped to the generalized form the record supports (all four citations retained, now accurate). Amendment 3 was similarly widened from "review-finding pins" to all regression pins (the third cited instance was an implementation-round pin). Six further wording/placement findings applied.

Canonical suite: pass (receipt `cratedigger-final-gate.UxwSi77a` on `c3adb6de`). One transient host-contention flake (`test_discogs_artist_concurrency` FlakyFailure under concurrent suites) cleared on re-run — the very failure mode #1111 item 1 describes, being fixed in the companion suite-admission PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)