### PR TITLE
fix(#1122): replay force-import wrong-match receipts across a crash

### DIFF
--- a/docs/pipeline-db-schema.md
+++ b/docs/pipeline-db-schema.md
@@ -1121,7 +1121,13 @@ below — see `lib.wrong_match_delete_service`).
    reverses the mid-July "dismiss but preserve" regression, which had
    stranded 64 of 90 wrong-match-sourced force imports as invisible disk
    folders (verified live 2026-08-12) by preserving on both outcomes. The
-   failed job and `download_log` audit rows always remain regardless.
+   failed job and `download_log` audit rows always remain regardless. A
+   crash between the terminal `completed`/`failed` write and this receipt
+   is durably retried, never lost (issue #1122): every importer startup
+   replays the same decision, from the persisted `result` JSONB alone, for
+   any terminal force job still missing its `wrong_match_dismissal` or
+   `cleanup` key — see `docs/rejection-routing.md` § "Force-import outcomes
+   (D7)" for the exact query and replay function names.
 
 ```bash
 pipeline_cli.py force-import <download_log_id>

--- a/docs/pipeline-db-schema.md
+++ b/docs/pipeline-db-schema.md
@@ -1125,9 +1125,10 @@ below — see `lib.wrong_match_delete_service`).
    crash between the terminal `completed`/`failed` write and this receipt
    is durably retried, never lost (issue #1122): every importer startup
    replays the same decision, from the persisted `result` JSONB alone, for
-   any terminal force job still missing its `wrong_match_dismissal` or
-   `cleanup` key — see `docs/rejection-routing.md` § "Force-import outcomes
-   (D7)" for the exact query and replay function names.
+   any terminal force job whose era-marked receipt is not yet PROVEN
+   successful — see `docs/rejection-routing.md` § "Force-import outcomes
+   (D7)" for the exact positive selection rule, query, and replay function
+   names.
 
 ```bash
 pipeline_cli.py force-import <download_log_id>

--- a/docs/rejection-routing.md
+++ b/docs/rejection-routing.md
@@ -197,22 +197,38 @@ behavior load-bearing rather than incidental:
   cleanup of the raw source requires a distinct operator action, never a
   quality result.
 - **A crash between the terminal commit and this receipt is durably
-  retried, not lost** (issue #1122): `lib/pipeline_db/import_jobs.py::
-  list_terminal_force_wrong_match_cleanup_jobs` names any terminal force
-  job whose `result` lacks `wrong_match_dismissal` (success) or `cleanup`
-  (failure), and `scripts/importer.py::recover_abandoned_running_jobs`
-  replays `_dismiss_successful_force_import` /
-  `_cleanup_failed_force_import` for exactly those rows on every importer
-  startup — the SAME helper the live path calls, driven from the `result`
-  JSONB alone (never a live `DispatchOutcome`), so the delete/preserve
-  decision above is identical whether it ran live or was replayed. Two
-  failure-arm rows are excluded because the LIVE path never reaches a
-  cleanup decision for them either: `code = 'requeue_failed'` (the requeue
-  UPDATE itself failed, never even calls the cleanup helper) and
-  `deferred = true` (e.g. release-lock contention — the cleanup helper IS
-  called live but its own first line skips the decision). Replay must
-  reach that identical no-op, not invent a verdict the live path never
-  made.
+  retried, not lost** (issue #1122): `scripts/importer.py::
+  recover_abandoned_running_jobs` replays `_dismiss_successful_force_import`
+  / `_cleanup_failed_force_import` — the SAME helper the live path calls,
+  driven from the `result` JSONB alone, never a live `DispatchOutcome` —
+  for every row `lib/pipeline_db/import_jobs.py::
+  list_terminal_force_wrong_match_cleanup_jobs` names, on every importer
+  startup.
+- **That predicate is a POSITIVE selection rule, not an exclusion
+  enumeration** (issue #1122 review round corrected an unsound draft that
+  shipped as an exclusion list): a row qualifies only if (1) its `result`
+  carries `post_commit_wrong_match_scenario` — an era-AND-lane marker only
+  `scripts/importer.py::_job_result` ever writes, so every historical
+  (pre-#1122) or otherwise non-adjudicating shape is excluded by
+  construction, not by naming each one — measured live on doc2: 619
+  pre-feature rows would have matched a presence-only predicate at first
+  startup (477 completed, 142 failed), none of them actual crash-window
+  rows, and they stay receiptless forever by design; and (2) its existing
+  receipt, if any, is not PROVEN successful
+  (`result #>> '{wrong_match_dismissal,success}'` /
+  `result #>> '{cleanup,success}'` `IS DISTINCT FROM 'true'`) — a receipt
+  can be PRESENT with `success: false` (entry not found, an unsafe path,
+  an `rmtree` failure, an EACCES-shaped `path_unavailable` — the #1063
+  shape), and a presence-only check would treat that failed receipt as
+  "done," parking the row forever; keying on proven success instead means
+  a persistently failing cleanup is retried every startup, never parked.
+  Two failure-arm rows carry the marker but are still excluded, because
+  the LIVE path never reaches a cleanup decision for them either:
+  `code = 'requeue_failed'` (the requeue UPDATE itself failed, never even
+  calls the cleanup helper) and `deferred = true` (e.g. release-lock
+  contention — the cleanup helper IS called live but its own first line
+  skips the decision). Replay must reach that identical no-op, not invent
+  a verdict the live path never made.
 
 ## The `wrong_match_triage` audit block is reducer-only
 

--- a/docs/rejection-routing.md
+++ b/docs/rejection-routing.md
@@ -196,6 +196,23 @@ behavior load-bearing rather than incidental:
   force/quarantine directory is operator authority and audit evidence;
   cleanup of the raw source requires a distinct operator action, never a
   quality result.
+- **A crash between the terminal commit and this receipt is durably
+  retried, not lost** (issue #1122): `lib/pipeline_db/import_jobs.py::
+  list_terminal_force_wrong_match_cleanup_jobs` names any terminal force
+  job whose `result` lacks `wrong_match_dismissal` (success) or `cleanup`
+  (failure), and `scripts/importer.py::recover_abandoned_running_jobs`
+  replays `_dismiss_successful_force_import` /
+  `_cleanup_failed_force_import` for exactly those rows on every importer
+  startup — the SAME helper the live path calls, driven from the `result`
+  JSONB alone (never a live `DispatchOutcome`), so the delete/preserve
+  decision above is identical whether it ran live or was replayed. Two
+  failure-arm rows are excluded because the LIVE path never reaches a
+  cleanup decision for them either: `code = 'requeue_failed'` (the requeue
+  UPDATE itself failed, never even calls the cleanup helper) and
+  `deferred = true` (e.g. release-lock contention — the cleanup helper IS
+  called live but its own first line skips the decision). Replay must
+  reach that identical no-op, not invent a verdict the live path never
+  made.
 
 ## The `wrong_match_triage` audit block is reducer-only
 

--- a/lib/pipeline_db/import_jobs.py
+++ b/lib/pipeline_db/import_jobs.py
@@ -713,6 +713,53 @@ class _ImportJobsMixin(
         """)
         return [ImportJob.from_row(dict(row)) for row in cur.fetchall()]
 
+    def list_terminal_force_wrong_match_cleanup_jobs(self) -> list[ImportJob]:
+        """Return terminal force jobs whose wrong-match source receipt is missing.
+
+        A crash between the terminal commit (the job status write) and the
+        live success dismissal (``wrong_match_dismissal``) or failure
+        cleanup (``cleanup``) call leaves that receipt durably missing
+        (issue #1122). This sibling of
+        ``list_terminal_force_action_cleanup_jobs`` selects exactly those
+        rows so ``scripts/importer.py``'s startup sweep can replay the same
+        decision from durable state alone.
+
+        Two exclusions in the failure arm mirror the live path exactly,
+        because both leave a terminal ``failed`` row with no ``cleanup``
+        key by DESIGN, not by omission:
+
+        - ``code = 'requeue_failed'``: ``process_claimed_job`` never even
+          calls ``_cleanup_failed_force_import`` for this code — the
+          requeue UPDATE itself failed (a DB transient), not a verdict
+          about the candidate.
+        - ``deferred = true`` (e.g. release-lock contention —
+          ``lib/dispatch/core.py``'s ``"Another import is already in
+          progress"`` outcome): ``_cleanup_failed_force_import`` IS called
+          live, but its own first line (``if outcome.deferred: return
+          None``) skips the decision — the outcome never adjudicated the
+          candidate at all. Replay must reach that identical no-op, not
+          invent a decision the live path deliberately never made.
+
+        Treating a missing ``result`` as an empty object keeps a
+        historical NULL-result row eligible instead of silently excluded.
+        """
+        cur = self._execute("""
+            SELECT *
+            FROM import_jobs
+            WHERE job_type = 'force_import'
+              AND (
+                  (status = 'completed'
+                   AND NOT (COALESCE(result, '{}'::jsonb) ? 'wrong_match_dismissal'))
+                  OR
+                  (status = 'failed'
+                   AND NOT (COALESCE(result, '{}'::jsonb) ? 'cleanup')
+                   AND result ->> 'code' IS DISTINCT FROM 'requeue_failed'
+                   AND result ->> 'deferred' IS DISTINCT FROM 'true')
+              )
+            ORDER BY created_at ASC, id ASC
+        """)
+        return [ImportJob.from_row(dict(row)) for row in cur.fetchall()]
+
 
     def peek_import_job_candidates(
         self,

--- a/lib/pipeline_db/import_jobs.py
+++ b/lib/pipeline_db/import_jobs.py
@@ -737,7 +737,11 @@ class _ImportJobsMixin(
            stay receiptless forever by design: they never adjudicated the
            candidate, so replaying anything for them would be a fabricated
            verdict, and their quarantine folders (if any) were already
-           swept by the #1077 D10 cleanup sweep.
+           swept by the #1077 D10 cleanup sweep. This closure is a
+           single-writer invariant, review-enforced: only
+           ``scripts/importer.py::_job_result`` may ever write
+           ``post_commit_wrong_match_scenario``; a second writer
+           re-widens this predicate back to pre-#1122 behavior.
         2. The receipt itself must be PROVEN successful, not merely
            PRESENT: ``result #>> '{wrong_match_dismissal,success}'`` /
            ``result #>> '{cleanup,success}'`` ``IS DISTINCT FROM 'true'``.

--- a/lib/pipeline_db/import_jobs.py
+++ b/lib/pipeline_db/import_jobs.py
@@ -714,19 +714,55 @@ class _ImportJobsMixin(
         return [ImportJob.from_row(dict(row)) for row in cur.fetchall()]
 
     def list_terminal_force_wrong_match_cleanup_jobs(self) -> list[ImportJob]:
-        """Return terminal force jobs whose wrong-match source receipt is missing.
+        """Return terminal force jobs whose wrong-match source receipt is not proven done.
 
-        A crash between the terminal commit (the job status write) and the
-        live success dismissal (``wrong_match_dismissal``) or failure
-        cleanup (``cleanup``) call leaves that receipt durably missing
-        (issue #1122). This sibling of
-        ``list_terminal_force_action_cleanup_jobs`` selects exactly those
-        rows so ``scripts/importer.py``'s startup sweep can replay the same
-        decision from durable state alone.
+        Positive selection rule (issue #1122, review round: MAJOR-1/2/3
+        corrected an unsound exclusion-enumeration draft):
 
-        Two exclusions in the failure arm mirror the live path exactly,
-        because both leave a terminal ``failed`` row with no ``cleanup``
-        key by DESIGN, not by omission:
+        1. ``result ? 'post_commit_wrong_match_scenario'`` — the era-AND-lane
+           marker. Only a row whose terminal commit went through
+           ``scripts/importer.py::_job_result`` carries this key (written
+           unconditionally, including a ``null`` value for
+           ``scenario=None`` — JSONB ``?`` matches a null-valued key, it
+           only fails on a genuinely ABSENT key or a NULL ``result``
+           column). This is what makes the rule closed: every OTHER
+           terminalization shape — pre-#1122 historical rows (measured
+           live: 619 on doc2 at first startup, 477 completed + 142 failed,
+           none of them actual crash-window rows), preview-stage
+           terminalization, the executor-crash literal
+           ``{"success": false}`` (``process_claimed_job``'s top exception
+           handler, which returns before ``_job_result`` is ever computed),
+           and ad hoc operator terminalization — lacks this key and is
+           excluded by construction, not by naming each shape. Those rows
+           stay receiptless forever by design: they never adjudicated the
+           candidate, so replaying anything for them would be a fabricated
+           verdict, and their quarantine folders (if any) were already
+           swept by the #1077 D10 cleanup sweep.
+        2. The receipt itself must be PROVEN successful, not merely
+           PRESENT: ``result #>> '{wrong_match_dismissal,success}'`` /
+           ``result #>> '{cleanup,success}'`` ``IS DISTINCT FROM 'true'``.
+           Both ``_dismiss_successful_force_import`` and
+           ``cleanup_wrong_match_source`` (via ``_cleanup_failed_force_import``'s
+           ``audio_corrupt`` branch) can and routinely do write a receipt
+           with ``success: false`` — entry not found, an unsafe path, an
+           ``rmtree`` failure, or an EACCES-shaped ``path_unavailable`` (the
+           #1063 shape). A presence-only check (``NOT result ?
+           'wrong_match_dismissal'``) would treat that failed receipt as
+           "done" and park the row forever — the exact duplicate-import
+           park this method exists to close, and a violation of CLAUDE.md
+           invariant 11. Keying on proven success instead means a
+           persistently failing cleanup is retried every startup
+           (acceptable cadence) rather than parked (never acceptable).
+           This sibling of ``list_terminal_force_action_cleanup_jobs``
+           mirrors that method's own success-keyed check
+           (``#>> '{force_action_cleanup,removed}' IS DISTINCT FROM
+           'true'``) rather than the presence check this method used
+           before the fix.
+
+        Two exclusions remain in the failure arm. Both rows carry the era
+        marker (``_job_result`` computed their ``result`` before the branch
+        below), but the live path still never reaches a wrong-match
+        decision for them, so replay must not either:
 
         - ``code = 'requeue_failed'``: ``process_claimed_job`` never even
           calls ``_cleanup_failed_force_import`` for this code — the
@@ -737,22 +773,20 @@ class _ImportJobsMixin(
           progress"`` outcome): ``_cleanup_failed_force_import`` IS called
           live, but its own first line (``if outcome.deferred: return
           None``) skips the decision — the outcome never adjudicated the
-          candidate at all. Replay must reach that identical no-op, not
-          invent a decision the live path deliberately never made.
-
-        Treating a missing ``result`` as an empty object keeps a
-        historical NULL-result row eligible instead of silently excluded.
+          candidate at all.
         """
         cur = self._execute("""
             SELECT *
             FROM import_jobs
             WHERE job_type = 'force_import'
+              AND result ? 'post_commit_wrong_match_scenario'
               AND (
                   (status = 'completed'
-                   AND NOT (COALESCE(result, '{}'::jsonb) ? 'wrong_match_dismissal'))
+                   AND result #>> '{wrong_match_dismissal,success}'
+                       IS DISTINCT FROM 'true')
                   OR
                   (status = 'failed'
-                   AND NOT (COALESCE(result, '{}'::jsonb) ? 'cleanup')
+                   AND result #>> '{cleanup,success}' IS DISTINCT FROM 'true'
                    AND result ->> 'code' IS DISTINCT FROM 'requeue_failed'
                    AND result ->> 'deferred' IS DISTINCT FROM 'true')
               )

--- a/scripts/importer.py
+++ b/scripts/importer.py
@@ -94,6 +94,7 @@ from lib.terminal_outcomes import (
     PendingImportTerminalOutcome,
     non_automation_failure_terminal_outcome,
 )
+from lib.wrong_matches import WrongMatchSourceDB
 from lib.youtube_ingest_service import (
     YOUTUBE_IMPORT_ALLOWED_REQUEST_STATUSES,
 )
@@ -134,6 +135,13 @@ def _job_result(outcome: DispatchOutcome) -> dict[str, Any]:
         "message": outcome.message,
         "deferred": outcome.deferred,
         "code": outcome.code,
+        # Durably records the decision ``_cleanup_failed_force_import`` (the
+        # failure lane) needs, so a startup replay can rebuild an equivalent
+        # ``DispatchOutcome`` from persisted state alone after a crash
+        # between the terminal commit and the live wrong-match cleanup call
+        # (issue #1122) — never from a live outcome the process may not
+        # still have.
+        "post_commit_wrong_match_scenario": outcome.post_commit_wrong_match_scenario,
     }
 
 
@@ -177,9 +185,23 @@ class _ForceActionCleanupDB(Protocol):
     ) -> ImportJob | None: ...
 
 
+class _ForceWrongMatchCleanupDB(_ForceActionCleanupDB, WrongMatchSourceDB, Protocol):
+    """Persistence surface for durable force wrong-match source receipts.
+
+    Sibling of ``_ForceActionCleanupDB`` for the OTHER terminal force
+    receipt (issue #1122): the original Wrong Matches source's row
+    consumption and folder deletion/preservation. Extends
+    ``WrongMatchSourceDB`` because the replay calls the exact same
+    ``_dismiss_successful_force_import`` / ``_cleanup_failed_force_import``
+    helpers the live path calls.
+    """
+
+    def list_terminal_force_wrong_match_cleanup_jobs(self) -> list[ImportJob]: ...
+
+
 class _StartupRecoveryDB(
     _AutomationRecoveryDB,
-    _ForceActionCleanupDB,
+    _ForceWrongMatchCleanupDB,
     Protocol,
 ):
     """Complete persistence surface used by the one-shot startup sweep."""
@@ -433,7 +455,7 @@ def _record_terminal_force_action_cleanup(
 
 
 def _cleanup_failed_force_import(
-    db: PipelineDB,
+    db: WrongMatchSourceDB,
     job: ImportJob,
     outcome: DispatchOutcome,
 ) -> dict[str, object] | None:
@@ -497,7 +519,7 @@ def _cleanup_failed_force_import(
 
 
 def _dismiss_successful_force_import(
-    db: PipelineDB,
+    db: WrongMatchSourceDB,
     job: ImportJob,
 ) -> dict[str, object] | None:
     """Consume a successfully imported source's Wrong Matches folder.
@@ -552,6 +574,79 @@ def _dismiss_successful_force_import(
             "failed_path_hint": failed_path_hint,
             "error": f"{type(exc).__name__}: {exc}",
         }
+
+
+def _replay_force_wrong_match_outcome(job: ImportJob) -> DispatchOutcome:
+    """Rebuild a minimal outcome from durable state, never a live one.
+
+    Startup replay (issue #1122) has no ``DispatchOutcome`` — the process
+    that produced it may be long gone. ``_cleanup_failed_force_import``
+    reads ``deferred``, the wrong-match ``post_commit_wrong_match_scenario``
+    decision, and ``code``/``message`` for audit text — every one of those
+    was durably persisted into ``result`` by ``_job_result`` at the SAME
+    terminal commit that wrote the job's ``failed`` status, so they are
+    read back here instead of invented.
+
+    ``deferred`` matters even at a terminal ``failed`` status: a force job
+    can reach ``failed`` with ``deferred=True`` (e.g. release-lock
+    contention — ``lib/dispatch/core.py``'s ``"Another import is already
+    in progress"`` outcome) — the live call still skips the wrong-match
+    decision via ``_cleanup_failed_force_import``'s own first line, and
+    replay must reach that identical no-op rather than invent a delete/
+    preserve verdict the live path never made. The startup query's own
+    predicate already excludes these rows from ever reaching this
+    function; reconstructing ``deferred`` here too is defense in depth,
+    not the only guard.
+    """
+    stored = job.result or {}
+    message = stored.get("message")
+    code = stored.get("code")
+    scenario = stored.get("post_commit_wrong_match_scenario")
+    return DispatchOutcome(
+        success=False,
+        message=message if isinstance(message, str) else "",
+        deferred=stored.get("deferred") is True,
+        code=code if isinstance(code, str) else None,
+        post_commit_wrong_match_scenario=(
+            scenario if isinstance(scenario, str) else None
+        ),
+    )
+
+
+def _record_terminal_force_wrong_match_cleanup(
+    db: _ForceWrongMatchCleanupDB,
+    job: ImportJob,
+) -> ImportJob | None:
+    """Replay the durable wrong-match source receipt for one terminal force job.
+
+    Sibling of ``_record_terminal_force_action_cleanup`` (issue #1122): a
+    crash between the terminal commit and the live
+    ``_dismiss_successful_force_import`` (success) /
+    ``_cleanup_failed_force_import`` (failure) call leaves that receipt
+    missing. This calls the SAME helper the live path calls — so the
+    delete/preserve policy is identical either way — over durably
+    persisted state alone, and is idempotent: retried every startup until
+    the receipt lands (CLAUDE.md invariant 11).
+    """
+    if job.status == "completed":
+        dismissal = _dismiss_successful_force_import(db, job)
+        key = "wrong_match_dismissal"
+    elif job.status == "failed":
+        dismissal = _cleanup_failed_force_import(
+            db, job, _replay_force_wrong_match_outcome(job),
+        )
+        key = "cleanup"
+    else:
+        return None
+    if dismissal is None:
+        return None
+    try:
+        return db.merge_import_job_result(job.id, {key: dismissal})
+    except Exception:
+        logger.exception(
+            "Failed to record wrong-match cleanup receipt for job %s", job.id,
+        )
+        return None
 
 
 def execute_import_job(
@@ -2019,6 +2114,8 @@ def recover_abandoned_running_jobs(
     # the job result; every missing/failed marker is retried on this startup.
     for job in db.list_terminal_force_action_cleanup_jobs():
         _record_terminal_force_action_cleanup(db, job, job)
+    for job in db.list_terminal_force_wrong_match_cleanup_jobs():
+        _record_terminal_force_wrong_match_cleanup(db, job)
     recovered.extend(recover_abandoned_automation_owners(
         db,
         liveness_probe=liveness_probe,

--- a/scripts/importer.py
+++ b/scripts/importer.py
@@ -2115,7 +2115,24 @@ def recover_abandoned_running_jobs(
     for job in db.list_terminal_force_action_cleanup_jobs():
         _record_terminal_force_action_cleanup(db, job, job)
     for job in db.list_terminal_force_wrong_match_cleanup_jobs():
-        _record_terminal_force_wrong_match_cleanup(db, job)
+        try:
+            _record_terminal_force_wrong_match_cleanup(db, job)
+        except Exception:
+            # One unrecoverable job must not crash the whole importer
+            # process (issue #1122 review MEDIUM-4): unlike
+            # ``_record_terminal_force_action_cleanup``'s own callee
+            # (fully exception-safe internally), ``_cleanup_failed_force_import``'s
+            # ``audio_corrupt`` branch calls DB methods with no internal
+            # guard, and an escape here would otherwise propagate through
+            # this startup sweep into ``main()`` — a full process exit
+            # under ``Restart=on-failure`` takes the entire import queue
+            # down in a 5s crash loop over one bad row. The row is left
+            # exactly as it was and retried on the next startup.
+            logger.exception(
+                "Recovery pass failed for wrong-match cleanup job %s; "
+                "continuing",
+                job.id,
+            )
     recovered.extend(recover_abandoned_automation_owners(
         db,
         liveness_probe=liveness_probe,

--- a/tests/fakes/pipeline_db.py
+++ b/tests/fakes/pipeline_db.py
@@ -453,6 +453,27 @@ def _reject_nonstandard_json_constant(value: str) -> None:
     raise ValueError(f"nonstandard JSON constant: {value}")
 
 
+def _jsonb_scalar_text(value: object) -> str | None:
+    """Mirror Postgres jsonb ``->>``/``#>>`` text-extraction semantics.
+
+    Real SQL's ``->>``/``#>>`` return the JSON value's TEXT form: a JSON
+    boolean becomes the literal ``"true"``/``"false"``, a JSON string
+    passes through unchanged, and a missing key or JSON ``null`` becomes
+    SQL NULL. Comparing a Python ``bool`` via ``is not True`` (the pre-fix
+    shape) diverges from this the moment a value is stored as the JSON
+    STRING ``"true"`` rather than the JSON boolean ``true`` — the real
+    query's ``IS DISTINCT FROM 'true'`` treats both identically, since both
+    stringify to the same text (issue #1122 review MINOR-6).
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
 class FakePipelineDB:
     """In-memory fake for PipelineDB — records mutations for test assertions.
 
@@ -1564,19 +1585,46 @@ class FakePipelineDB:
         for row in self._import_jobs:
             if row.get("job_type") != IMPORT_JOB_FORCE:
                 continue
-            status = row.get("status")
             result = row.get("result")
             result_dict = result if isinstance(result, dict) else {}
-            if (
-                status == "completed"
-                and "wrong_match_dismissal" not in result_dict
-            ) or (
-                status == "failed"
-                and "cleanup" not in result_dict
-                and result_dict.get("code") != DISPATCH_CODE_REQUEUE_FAILED
-                and result_dict.get("deferred") is not True
-            ):
-                rows.append(row)
+            # Era-AND-lane marker (issue #1122 review MAJOR-2/3): only a row
+            # whose terminal commit went through ``_job_result`` carries this
+            # key. Absent for every historical/non-adjudicating shape
+            # (pre-#1122 rows, preview-stage terminalization, the
+            # executor-crash literal, ad hoc operator terminalization) and
+            # for a genuinely NULL ``result`` column — all stay receiptless
+            # forever by design, mirroring the real SQL's ``result ?
+            # 'post_commit_wrong_match_scenario'`` top-level AND clause.
+            if "post_commit_wrong_match_scenario" not in result_dict:
+                continue
+            status = row.get("status")
+            if status == "completed":
+                dismissal = result_dict.get("wrong_match_dismissal")
+                success = (
+                    dismissal.get("success")
+                    if isinstance(dismissal, dict) else None
+                )
+                # Success-KEYED, not presence-keyed (MAJOR-1): a receipt
+                # can be present with success=false (entry not found, an
+                # unsafe path, an rmtree failure, EACCES-shaped
+                # path_unavailable — the #1063 shape) and must still be
+                # retried, never parked.
+                if _jsonb_scalar_text(success) != "true":
+                    rows.append(row)
+            elif status == "failed":
+                cleanup = result_dict.get("cleanup")
+                success = (
+                    cleanup.get("success")
+                    if isinstance(cleanup, dict) else None
+                )
+                if (
+                    _jsonb_scalar_text(success) != "true"
+                    and _jsonb_scalar_text(result_dict.get("code"))
+                        != DISPATCH_CODE_REQUEUE_FAILED
+                    and _jsonb_scalar_text(result_dict.get("deferred"))
+                        != "true"
+                ):
+                    rows.append(row)
         rows.sort(key=lambda row: (
             _as_datetime(row.get("created_at")),
             int(row["id"]),

--- a/tests/fakes/pipeline_db.py
+++ b/tests/fakes/pipeline_db.py
@@ -1557,6 +1557,32 @@ class FakePipelineDB:
         ))
         return [ImportJob.from_row(copy.deepcopy(row)) for row in rows]
 
+    def list_terminal_force_wrong_match_cleanup_jobs(self) -> list[ImportJob]:
+        from lib.dispatch import DISPATCH_CODE_REQUEUE_FAILED
+
+        rows = []
+        for row in self._import_jobs:
+            if row.get("job_type") != IMPORT_JOB_FORCE:
+                continue
+            status = row.get("status")
+            result = row.get("result")
+            result_dict = result if isinstance(result, dict) else {}
+            if (
+                status == "completed"
+                and "wrong_match_dismissal" not in result_dict
+            ) or (
+                status == "failed"
+                and "cleanup" not in result_dict
+                and result_dict.get("code") != DISPATCH_CODE_REQUEUE_FAILED
+                and result_dict.get("deferred") is not True
+            ):
+                rows.append(row)
+        rows.sort(key=lambda row: (
+            _as_datetime(row.get("created_at")),
+            int(row["id"]),
+        ))
+        return [ImportJob.from_row(copy.deepcopy(row)) for row in rows]
+
     def _import_job_candidate_rows(
         self,
         *,

--- a/tests/read_projection_registry.py
+++ b/tests/read_projection_registry.py
@@ -625,6 +625,8 @@ ALLOWLIST: dict[str, str] = {
         "list[ImportJob] — typed dataclass rows, no dict projection",
     "list_terminal_force_action_cleanup_jobs":
         "list[ImportJob] — typed terminal cleanup rows, no dict projection",
+    "list_terminal_force_wrong_match_cleanup_jobs":
+        "list[ImportJob] — typed terminal cleanup rows, no dict projection",
     "list_automation_import_jobs_for_startup_recovery":
         "list[ImportJob] — exact processing-owner typed dataclass rows, "
         "no dict projection",

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -5161,8 +5161,11 @@ class TestFakePipelineDBNewStubs(unittest.TestCase):
 
         Real-PG proof of the same predicate lives in
         ``tests/test_pipeline_db.py`` — this pins the fake against an
-        identical scenario matrix so the two never silently drift
-        (test-fidelity.md's fake-vs-SQL predicate drift class).
+        IDENTICAL scenario matrix so the two never silently drift
+        (test-fidelity.md's fake-vs-SQL predicate drift class). Covers the
+        review-round corrections: MAJOR-1 (success-keyed, not
+        presence-keyed), MAJOR-2/3 (the era-AND-lane marker excludes every
+        historical/non-adjudicating shape by construction).
         """
         from lib.import_queue import IMPORT_JOB_FORCE, force_import_payload
 
@@ -5180,6 +5183,8 @@ class TestFakePipelineDBNewStubs(unittest.TestCase):
                 ),
             )
 
+        # -- completed arm --------------------------------------------------
+
         completed_missing = _force_job("completed-missing")
         db.mark_import_job_completed(
             completed_missing.id,
@@ -5190,15 +5195,31 @@ class TestFakePipelineDBNewStubs(unittest.TestCase):
             message="done",
         )
 
-        completed_done = _force_job("completed-done")
+        completed_failed_receipt = _force_job("completed-failed-receipt")
         db.mark_import_job_completed(
-            completed_done.id,
+            completed_failed_receipt.id,
             result={
-                "success": True,
+                "success": True, "message": "done", "deferred": False,
+                "code": None, "post_commit_wrong_match_scenario": None,
+                "wrong_match_dismissal": {
+                    "success": False, "error": "path_unavailable: EACCES",
+                },
+            },
+            message="done",
+        )
+
+        completed_successful_receipt = _force_job("completed-successful-receipt")
+        db.mark_import_job_completed(
+            completed_successful_receipt.id,
+            result={
+                "success": True, "message": "done", "deferred": False,
+                "code": None, "post_commit_wrong_match_scenario": None,
                 "wrong_match_dismissal": {"success": True},
             },
             message="done",
         )
+
+        # -- failed arm -------------------------------------------------
 
         failed_missing = _force_job("failed-missing")
         db.mark_import_job_failed(
@@ -5212,6 +5233,38 @@ class TestFakePipelineDBNewStubs(unittest.TestCase):
             message="rejected",
         )
 
+        failed_failed_receipt = _force_job("failed-failed-receipt")
+        db.mark_import_job_failed(
+            failed_failed_receipt.id,
+            error="beets rejected: audio_corrupt",
+            result={
+                "success": False, "message": "rejected", "deferred": False,
+                "code": None,
+                "post_commit_wrong_match_scenario": "audio_corrupt",
+                "cleanup": {
+                    "success": False, "outcome": "deleted_operator_force_source",
+                    "error": "path_unavailable: EACCES",
+                },
+            },
+            message="rejected",
+        )
+
+        failed_successful_receipt = _force_job("failed-successful-receipt")
+        db.mark_import_job_failed(
+            failed_successful_receipt.id,
+            error="beets rejected",
+            result={
+                "success": False, "message": "rejected", "deferred": False,
+                "code": None,
+                "post_commit_wrong_match_scenario": "high_distance",
+                "cleanup": {
+                    "success": True,
+                    "outcome": "preserved_operator_force_source",
+                },
+            },
+            message="rejected",
+        )
+
         failed_requeue = _force_job("failed-requeue")
         db.mark_import_job_failed(
             failed_requeue.id,
@@ -5219,19 +5272,9 @@ class TestFakePipelineDBNewStubs(unittest.TestCase):
             result={
                 "success": False, "message": "requeue UPDATE failed",
                 "deferred": False, "code": "requeue_failed",
+                "post_commit_wrong_match_scenario": None,
             },
             message="requeue UPDATE failed",
-        )
-
-        failed_done = _force_job("failed-done")
-        db.mark_import_job_failed(
-            failed_done.id,
-            error="beets rejected",
-            result={
-                "success": False,
-                "cleanup": {"outcome": "preserved_operator_force_source"},
-            },
-            message="rejected",
         )
 
         failed_deferred = _force_job("failed-deferred")
@@ -5242,20 +5285,54 @@ class TestFakePipelineDBNewStubs(unittest.TestCase):
                 "success": False,
                 "message": "Another import is already in progress",
                 "deferred": True, "code": None,
+                "post_commit_wrong_match_scenario": None,
             },
             message="Another import is already in progress",
         )
+
+        # -- historical / non-adjudicating shapes (MAJOR-2/3) ------------
+
+        historical_completed = _force_job("historical-completed-no-marker")
+        db.mark_import_job_completed(
+            historical_completed.id,
+            result={"success": True},
+            message="done",
+        )
+
+        historical_failed = _force_job("historical-failed-no-marker")
+        db.mark_import_job_failed(
+            historical_failed.id,
+            error="RuntimeError: boom",
+            result={"success": False},
+            message="Executor crashed",
+        )
+
+        # A genuinely NULL ``result`` column has no public-API constructor
+        # on the fake either (``mark_import_job_failed`` always writes
+        # ``result or {}``) — reach into the fake's own row store directly,
+        # mirroring the real-PG test's raw ``UPDATE ... result = NULL``.
+        historical_null_result = _force_job("historical-null-result")
+        db.mark_import_job_failed(historical_null_result.id, error="boom")
+        for row in db._import_jobs:
+            if row["id"] == historical_null_result.id:
+                row["result"] = None
+                break
 
         selected = {
             job.id
             for job in db.list_terminal_force_wrong_match_cleanup_jobs()
         }
         self.assertIn(completed_missing.id, selected)
-        self.assertNotIn(completed_done.id, selected)
+        self.assertIn(completed_failed_receipt.id, selected)
+        self.assertNotIn(completed_successful_receipt.id, selected)
         self.assertIn(failed_missing.id, selected)
+        self.assertIn(failed_failed_receipt.id, selected)
+        self.assertNotIn(failed_successful_receipt.id, selected)
         self.assertNotIn(failed_requeue.id, selected)
-        self.assertNotIn(failed_done.id, selected)
         self.assertNotIn(failed_deferred.id, selected)
+        self.assertNotIn(historical_completed.id, selected)
+        self.assertNotIn(historical_failed.id, selected)
+        self.assertNotIn(historical_null_result.id, selected)
 
     def test_search_log_history(self):
         db = FakePipelineDB()

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -5154,6 +5154,109 @@ class TestFakePipelineDBNewStubs(unittest.TestCase):
         self.assertNotIn("failed_path", stored)
         self.assertEqual(stored["x"], 1)
 
+    def test_list_terminal_force_wrong_match_cleanup_jobs_mirrors_sql_predicate(
+        self,
+    ) -> None:
+        """Issue #1122: the fake must select the same rows the real SQL does.
+
+        Real-PG proof of the same predicate lives in
+        ``tests/test_pipeline_db.py`` — this pins the fake against an
+        identical scenario matrix so the two never silently drift
+        (test-fidelity.md's fake-vs-SQL predicate drift class).
+        """
+        from lib.import_queue import IMPORT_JOB_FORCE, force_import_payload
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1))
+
+        def _force_job(suffix: str):
+            return db.enqueue_import_job(
+                IMPORT_JOB_FORCE,
+                request_id=1,
+                dedupe_key=f"force-wrong-match-predicate:{suffix}",
+                payload=force_import_payload(
+                    download_log_id=1,
+                    failed_path="/tmp/predicate-source",
+                ),
+            )
+
+        completed_missing = _force_job("completed-missing")
+        db.mark_import_job_completed(
+            completed_missing.id,
+            result={
+                "success": True, "message": "done", "deferred": False,
+                "code": None, "post_commit_wrong_match_scenario": None,
+            },
+            message="done",
+        )
+
+        completed_done = _force_job("completed-done")
+        db.mark_import_job_completed(
+            completed_done.id,
+            result={
+                "success": True,
+                "wrong_match_dismissal": {"success": True},
+            },
+            message="done",
+        )
+
+        failed_missing = _force_job("failed-missing")
+        db.mark_import_job_failed(
+            failed_missing.id,
+            error="beets rejected: audio_corrupt",
+            result={
+                "success": False, "message": "rejected", "deferred": False,
+                "code": None,
+                "post_commit_wrong_match_scenario": "audio_corrupt",
+            },
+            message="rejected",
+        )
+
+        failed_requeue = _force_job("failed-requeue")
+        db.mark_import_job_failed(
+            failed_requeue.id,
+            error="requeue failed",
+            result={
+                "success": False, "message": "requeue UPDATE failed",
+                "deferred": False, "code": "requeue_failed",
+            },
+            message="requeue UPDATE failed",
+        )
+
+        failed_done = _force_job("failed-done")
+        db.mark_import_job_failed(
+            failed_done.id,
+            error="beets rejected",
+            result={
+                "success": False,
+                "cleanup": {"outcome": "preserved_operator_force_source"},
+            },
+            message="rejected",
+        )
+
+        failed_deferred = _force_job("failed-deferred")
+        db.mark_import_job_failed(
+            failed_deferred.id,
+            error="Another import is already in progress",
+            result={
+                "success": False,
+                "message": "Another import is already in progress",
+                "deferred": True, "code": None,
+            },
+            message="Another import is already in progress",
+        )
+
+        selected = {
+            job.id
+            for job in db.list_terminal_force_wrong_match_cleanup_jobs()
+        }
+        self.assertIn(completed_missing.id, selected)
+        self.assertNotIn(completed_done.id, selected)
+        self.assertIn(failed_missing.id, selected)
+        self.assertNotIn(failed_requeue.id, selected)
+        self.assertNotIn(failed_done.id, selected)
+        self.assertNotIn(failed_deferred.id, selected)
+
     def test_search_log_history(self):
         db = FakePipelineDB()
         db.log_search(1, query="a b", outcome="found", result_count=10,

--- a/tests/test_import_queue.py
+++ b/tests/test_import_queue.py
@@ -9773,9 +9773,19 @@ class TestForceWrongMatchReceiptStartupReplayGenerated(unittest.TestCase):
         elif outcome == "historical_completed_no_marker":
             # Live-row evidence: 477 of the 619 pre-feature rows doc2
             # measured were exactly this shape — a 'completed' force job
-            # from before ``_job_result`` ever wrote the era marker.
+            # from before ``_job_result`` ever wrote the era marker. The
+            # measured live shape is the older three-key
+            # ``{deferred, message, success}`` payload (review round 3,
+            # MINOR-2), not a bare ``{"success": True}`` — selection is
+            # identical either way (both lack the marker), but the fixture
+            # should say what was actually measured.
             db.mark_import_job_completed(
-                job.id, result={"success": True}, message="imported",
+                job.id,
+                result={
+                    "deferred": False, "message": "imported",
+                    "success": True,
+                },
+                message="imported",
             )
         elif outcome == "historical_executor_crash":
             # The literal shape ``process_claimed_job``'s own top-level
@@ -9798,14 +9808,34 @@ class TestForceWrongMatchReceiptStartupReplayGenerated(unittest.TestCase):
             # terminalization outside the adjudicating decision path.
             db.mark_import_job_failed(job.id, error="operator cancelled")
         elif outcome == "historical_preview_shape":
-            # Live-row evidence (issue #1122 review MAJOR-3, doc2
-            # measurement): 130 of 142 pre-feature failed rows carried
-            # this shape. No CURRENT production code path writes it;
-            # registered as a HISTORICAL trigger per test-fidelity.md
-            # Rule C's escape hatch.
-            db.mark_import_job_failed(
-                job.id, error="preview lifecycle",
-                result={"preview": {"stale": True}},
+            # Real producer (review round 3, MEDIUM-1 corrected a false
+            # "no current producer" claim): TWO live paths write the
+            # literal ``{"preview": <preview_result>}`` shape into
+            # ``result`` —
+            # ``lib/pipeline_db/import_jobs.py::mark_import_job_preview_failed``
+            # (called from ``scripts/import_preview_worker.py``'s
+            # ``job.request_id is None or request is None`` branch) and
+            # ``lib/pipeline_db/terminal_outcomes.py::
+            # persist_preview_terminal_outcome``'s non-automation branch
+            # (called via ``lib.dispatch._record_preview_measurement_failed``,
+            # ``import_preview_worker.py:952``). Live proof: force job
+            # 59313 (2026-07-25). Driven directly through the simpler of
+            # the two real producers — the write method itself decides
+            # the exact ``result`` shape, so calling it directly is the
+            # real producer, not a stand-in for it (freshly enqueued
+            # ``job`` is already ``status='queued',
+            # preview_status='waiting'``, exactly this method's
+            # precondition).
+            db.mark_import_job_preview_failed(
+                job.id,
+                preview_status="measurement_failed",
+                error="measurement_crashed",
+                preview_result={
+                    "reason": "measurement_crashed",
+                    "detail": "measurement_failed",
+                    "source_path": "",
+                },
+                message="Preview measurement failed: measurement_crashed",
             )
         elif outcome == "historical_null_result":
             # A genuinely NULL ``result`` column has no public-API

--- a/tests/test_import_queue.py
+++ b/tests/test_import_queue.py
@@ -13,7 +13,7 @@ from collections.abc import Callable, Mapping
 from contextlib import AbstractContextManager, contextmanager
 from dataclasses import replace as dataclass_replace
 from datetime import UTC, datetime, timedelta
-from typing import Any, cast
+from typing import Any, ClassVar, cast
 from unittest.mock import ANY, MagicMock, patch
 
 import msgspec
@@ -1637,6 +1637,12 @@ class TestImporterWorker(unittest.TestCase):
             assert updated is not None
             result = updated.result
             assert isinstance(result, dict)
+            # Issue #1122: the live terminal commit must durably persist the
+            # scenario the failure-lane startup replay later reads back
+            # (``_replay_force_wrong_match_outcome``) — never assumed.
+            self.assertEqual(
+                result["post_commit_wrong_match_scenario"], "audio_corrupt",
+            )
             cleanup = result["cleanup"]
             assert isinstance(cleanup, dict)
             self.assertEqual(cleanup["outcome"], "deleted_operator_force_source")
@@ -2385,6 +2391,305 @@ class TestImporterWorker(unittest.TestCase):
         assert isinstance(cleanup, dict)
         self.assertTrue(cleanup["removed"])
 
+    def test_replay_force_wrong_match_outcome_reconstructs_every_field(
+        self,
+    ) -> None:
+        """Direct seam test: the replay reconstruction is exact (#1122).
+
+        The startup query already excludes every ``deferred=True`` row
+        from ever reaching ``_replay_force_wrong_match_outcome`` — so no
+        end-to-end pin can mutant-test this reconstruction in isolation.
+        This drives the helper directly against a real persisted
+        ``ImportJob`` to close that gap.
+        """
+        from scripts.importer import _replay_force_wrong_match_outcome
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=42))
+        job = db.enqueue_import_job(
+            IMPORT_JOB_FORCE,
+            request_id=42,
+            dedupe_key="replay-outcome-seam",
+            payload=force_import_payload(
+                download_log_id=1, failed_path="/tmp/replay-seam",
+            ),
+        )
+        db.mark_import_job_failed(
+            job.id,
+            error="Another import is already in progress",
+            result={
+                "success": False,
+                "message": "Another import is already in progress",
+                "deferred": True,
+                "code": None,
+                "post_commit_wrong_match_scenario": None,
+            },
+            message="Another import is already in progress",
+        )
+        stored = db.get_import_job(job.id)
+        assert stored is not None
+
+        outcome = _replay_force_wrong_match_outcome(stored)
+
+        self.assertEqual(
+            outcome.message, "Another import is already in progress",
+        )
+        self.assertIsNone(outcome.code)
+        self.assertTrue(outcome.deferred)
+        self.assertIsNone(outcome.post_commit_wrong_match_scenario)
+
+    def test_startup_replay_deletes_wrong_match_source_after_force_success_crash(
+        self,
+    ) -> None:
+        """Issue #1122: a crash between the terminal commit and the live
+        dismissal call still converges on the next startup replay — the row
+        is consumed and the source folder is gone.
+        """
+        from scripts import importer
+
+        db = FakePipelineDB()
+        root, source = _make_failed_import_source()
+        try:
+            with open(os.path.join(source, "01.mp3"), "wb") as handle:
+                handle.write(b"archival raw audio")
+            log_id = self._log_wrong_match(db, failed_path=source)
+            job = db.enqueue_import_job(
+                IMPORT_JOB_FORCE,
+                request_id=42,
+                dedupe_key=force_import_dedupe_key(log_id),
+                payload=force_import_payload(
+                    download_log_id=log_id,
+                    failed_path=source,
+                ),
+            )
+            # Simulates a crash right after the terminal commit: the job is
+            # COMPLETED but the live _dismiss_successful_force_import
+            # call never ran, so result carries no
+            # wrong_match_dismissal receipt.
+            db.mark_import_job_completed(
+                job.id,
+                result={
+                    "success": True, "message": "imported",
+                    "deferred": False, "code": None,
+                    "post_commit_wrong_match_scenario": None,
+                },
+                message="imported",
+            )
+
+            # Preconditions: the crash window is real.
+            self.assertTrue(os.path.isdir(source))
+            self.assertEqual(len(db.get_wrong_matches()), 1)
+
+            importer.recover_abandoned_running_jobs(db)
+
+            self.assertFalse(os.path.exists(source))
+            self.assertEqual(db.get_wrong_matches(), [])
+            converged = db.get_import_job(job.id)
+            assert converged is not None
+            dismissal = self._result(converged)["wrong_match_dismissal"]
+            assert isinstance(dismissal, dict)
+            self.assertTrue(dismissal["success"])
+            self.assertEqual(
+                dismissal["deleted_path"], os.path.abspath(source),
+            )
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    def test_startup_replay_deletes_audio_corrupt_source_after_force_failure_crash(
+        self,
+    ) -> None:
+        """Issue #1122 failure lane: same crash window, audio_corrupt.
+
+        The failure-lane receipt (cleanup) is missing after the crash;
+        replay must reach the SAME delete decision the live D3 path reaches.
+        """
+        from scripts import importer
+
+        db = FakePipelineDB()
+        root, source = _make_failed_import_source()
+        try:
+            with open(os.path.join(source, "01.mp3"), "wb") as handle:
+                handle.write(b"corrupt bytes")
+            log_id = self._log_wrong_match(db, failed_path=source)
+            job = db.enqueue_import_job(
+                IMPORT_JOB_FORCE,
+                request_id=42,
+                dedupe_key=force_import_dedupe_key(log_id),
+                payload=force_import_payload(
+                    download_log_id=log_id,
+                    failed_path=source,
+                ),
+            )
+            db.mark_import_job_failed(
+                job.id,
+                error="beets rejected: audio_corrupt",
+                result={
+                    "success": False, "message": "Rejected: audio_corrupt",
+                    "deferred": False, "code": None,
+                    "post_commit_wrong_match_scenario": "audio_corrupt",
+                },
+                message="Rejected: audio_corrupt",
+            )
+
+            self.assertTrue(os.path.isdir(source))
+            self.assertEqual(len(db.get_wrong_matches()), 1)
+
+            importer.recover_abandoned_running_jobs(db)
+
+            self.assertFalse(os.path.exists(source))
+            self.assertEqual(db.get_wrong_matches(), [])
+            converged = db.get_import_job(job.id)
+            assert converged is not None
+            cleanup = self._result(converged)["cleanup"]
+            assert isinstance(cleanup, dict)
+            self.assertEqual(cleanup["outcome"], "deleted_operator_force_source")
+            self.assertEqual(cleanup["deleted_path"], os.path.abspath(source))
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    def test_startup_replay_preserves_source_for_non_audio_corrupt_force_failure_crash(
+        self,
+    ) -> None:
+        """Must-still-work: an ordinary reject's crash window must not
+        delete the operator's quarantine source on replay — only
+        audio_corrupt ever does.
+        """
+        from scripts import importer
+
+        db = FakePipelineDB()
+        root, source = _make_failed_import_source()
+        try:
+            with open(os.path.join(source, "01.mp3"), "wb") as handle:
+                handle.write(b"legitimate audio")
+            log_id = self._log_wrong_match(db, failed_path=source)
+            job = db.enqueue_import_job(
+                IMPORT_JOB_FORCE,
+                request_id=42,
+                dedupe_key=force_import_dedupe_key(log_id),
+                payload=force_import_payload(
+                    download_log_id=log_id,
+                    failed_path=source,
+                ),
+            )
+            db.mark_import_job_failed(
+                job.id,
+                error="beets rejected: high_distance",
+                result={
+                    "success": False, "message": "Rejected: high_distance",
+                    "deferred": False, "code": None,
+                    "post_commit_wrong_match_scenario": "high_distance",
+                },
+                message="Rejected: high_distance",
+            )
+
+            importer.recover_abandoned_running_jobs(db)
+
+            self.assertTrue(os.path.isdir(source))
+            self.assertEqual(len(db.get_wrong_matches()), 1)
+            converged = db.get_import_job(job.id)
+            assert converged is not None
+            cleanup = self._result(converged)["cleanup"]
+            assert isinstance(cleanup, dict)
+            self.assertEqual(cleanup["outcome"], "preserved_operator_force_source")
+            self.assertTrue(cleanup["skipped"])
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    def test_startup_replay_never_runs_wrong_match_cleanup_for_requeue_failed(
+        self,
+    ) -> None:
+        """Must-still-work: requeue_failed never gets a wrong-match
+        cleanup decision, live or replayed — the requeue UPDATE itself
+        failing says nothing about the candidate (mirrors the live
+        process_claimed_job's own U2 comment).
+        """
+        from scripts import importer
+
+        db = FakePipelineDB()
+        root, source = _make_failed_import_source()
+        try:
+            with open(os.path.join(source, "01.mp3"), "wb") as handle:
+                handle.write(b"audio")
+            log_id = self._log_wrong_match(db, failed_path=source)
+            job = db.enqueue_import_job(
+                IMPORT_JOB_FORCE,
+                request_id=42,
+                dedupe_key=force_import_dedupe_key(log_id),
+                payload=force_import_payload(
+                    download_log_id=log_id,
+                    failed_path=source,
+                ),
+            )
+            db.mark_import_job_failed(
+                job.id,
+                error="requeue failed",
+                result={
+                    "success": False,
+                    "message": "requeue UPDATE failed: boom",
+                    "deferred": False,
+                    "code": DISPATCH_CODE_REQUEUE_FAILED,
+                },
+                message="requeue UPDATE failed: boom",
+            )
+
+            importer.recover_abandoned_running_jobs(db)
+
+            self.assertTrue(os.path.isdir(source))
+            self.assertEqual(len(db.get_wrong_matches()), 1)
+            converged = db.get_import_job(job.id)
+            assert converged is not None
+            self.assertNotIn("cleanup", self._result(converged))
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    def test_startup_replay_never_runs_wrong_match_cleanup_for_deferred_failure(
+        self,
+    ) -> None:
+        """Must-still-work: a ``deferred`` terminal failure (e.g. release-
+        lock contention) never gets a wrong-match cleanup decision, live
+        or replayed — ``_cleanup_failed_force_import``'s own first line
+        skips it live (mirrors ``test_deferred_force_import_preserves_
+        source_and_wrong_match`` above, extended across a startup replay).
+        """
+        from scripts import importer
+
+        db = FakePipelineDB()
+        root, source = _make_failed_import_source()
+        try:
+            with open(os.path.join(source, "01.mp3"), "wb") as handle:
+                handle.write(b"audio")
+            log_id = self._log_wrong_match(db, failed_path=source)
+            job = db.enqueue_import_job(
+                IMPORT_JOB_FORCE,
+                request_id=42,
+                dedupe_key=force_import_dedupe_key(log_id),
+                payload=force_import_payload(
+                    download_log_id=log_id,
+                    failed_path=source,
+                ),
+            )
+            db.mark_import_job_failed(
+                job.id,
+                error="Another import is already in progress",
+                result={
+                    "success": False,
+                    "message": "Another import is already in progress",
+                    "deferred": True,
+                    "code": None,
+                },
+                message="Another import is already in progress",
+            )
+
+            importer.recover_abandoned_running_jobs(db)
+
+            self.assertTrue(os.path.isdir(source))
+            self.assertEqual(len(db.get_wrong_matches()), 1)
+            converged = db.get_import_job(job.id)
+            assert converged is not None
+            self.assertNotIn("cleanup", self._result(converged))
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
     def test_importer_does_not_claim_job_waiting_for_preview(self):
         from scripts import importer
 
@@ -2951,6 +3256,11 @@ class TestImporterWorker(unittest.TestCase):
                 return []
 
             def list_terminal_force_action_cleanup_jobs(
+                self,
+            ) -> list[ImportJob]:
+                return []
+
+            def list_terminal_force_wrong_match_cleanup_jobs(
                 self,
             ) -> list[ImportJob]:
                 return []
@@ -9011,6 +9321,339 @@ def _completion_stub_execute_fn(
         )
 
     return execute
+
+
+# The five terminal-outcome classes a force job's wrong-match receipt can
+# reach (issue #1122). ``failed_requeue_failed`` and ``failed_deferred`` are
+# both "never adjudicated" classes, for different reasons: the live path
+# (``process_claimed_job``'s U2 comment) never even CALLS the wrong-match
+# cleanup decision for ``requeue_failed`` (the requeue UPDATE itself failed,
+# a DB transient, not a verdict about the candidate); for a ``deferred``
+# outcome (e.g. release-lock contention) the cleanup helper IS called live
+# but its own first line skips the decision immediately.
+_WRONG_MATCH_REPLAY_OUTCOMES: tuple[str, ...] = (
+    "completed",
+    "failed_audio_corrupt",
+    "failed_other_scenario",
+    "failed_requeue_failed",
+    "failed_deferred",
+)
+
+
+def _wrong_match_replay_terminal_result(
+    outcome: str,
+) -> tuple[str, dict[str, object], str]:
+    """Return (job status, ``_job_result``-shaped payload, error) for a class.
+
+    Mirrors exactly what the live terminal commit persists via
+    ``scripts.importer._job_result`` before the crash window opens — never
+    a shape the property invents.
+    """
+    if outcome == "completed":
+        return "completed", {
+            "success": True, "message": "imported", "deferred": False,
+            "code": None, "post_commit_wrong_match_scenario": None,
+        }, ""
+    if outcome == "failed_audio_corrupt":
+        return "failed", {
+            "success": False, "message": "Rejected: audio_corrupt",
+            "deferred": False, "code": None,
+            "post_commit_wrong_match_scenario": "audio_corrupt",
+        }, "beets rejected: audio_corrupt"
+    if outcome == "failed_other_scenario":
+        return "failed", {
+            "success": False, "message": "Rejected: high_distance",
+            "deferred": False, "code": None,
+            "post_commit_wrong_match_scenario": "high_distance",
+        }, "beets rejected: high_distance"
+    if outcome == "failed_requeue_failed":
+        return "failed", {
+            "success": False, "message": "requeue UPDATE failed: boom",
+            "deferred": False, "code": DISPATCH_CODE_REQUEUE_FAILED,
+        }, "requeue failed"
+    if outcome == "failed_deferred":
+        return "failed", {
+            "success": False,
+            "message": "Another import is already in progress",
+            "deferred": True, "code": None,
+        }, "Another import is already in progress"
+    raise AssertionError(f"unrecognised outcome {outcome!r}")
+
+
+def wrong_match_replay_violations(
+    *,
+    outcome: str,
+    source_existed_before_replay: bool,
+    source_exists_after_replay: bool,
+    wrong_match_visible_after_replay: bool,
+    receipt: dict[str, object] | None,
+) -> list[str]:
+    """Issue #1122's crash-window invariant, per terminal outcome class.
+
+    - ``completed`` (success lane, D7) and ``failed_audio_corrupt`` (failure
+      lane, D3): the source is gone and the row is consumed after replay —
+      regardless of whether it was already gone before replay started
+      (idempotent retry).
+    - ``failed_other_scenario``: replay must never change the source or the
+      row; the receipt records ``preserved_operator_force_source``.
+    - ``failed_requeue_failed`` and ``failed_deferred``: replay must never
+      write ANY receipt and must never touch the source or the row — the
+      live path never adjudicates the candidate for either (never calls
+      the cleanup decision for ``requeue_failed``; calls it but
+      short-circuits immediately for ``deferred``), and replay must not
+      either.
+
+    Accumulates every violated clause rather than stopping at the first, so
+    a world violating more than one clause cannot mask the others.
+    """
+    violations: list[str] = []
+    if outcome in ("completed", "failed_audio_corrupt"):
+        if source_exists_after_replay:
+            violations.append(
+                f"{outcome}: source must be deleted by replay"
+            )
+        if wrong_match_visible_after_replay:
+            violations.append(
+                f"{outcome}: wrong-match row must be consumed by replay"
+            )
+        if receipt is None:
+            violations.append(f"{outcome}: replay must record a receipt")
+    elif outcome == "failed_other_scenario":
+        if source_exists_after_replay != source_existed_before_replay:
+            violations.append(
+                "failed_other_scenario: replay must never touch the source"
+            )
+        if not wrong_match_visible_after_replay:
+            violations.append(
+                "failed_other_scenario: row must remain visible after replay"
+            )
+        if (
+            receipt is None
+            or receipt.get("outcome") != "preserved_operator_force_source"
+        ):
+            violations.append(
+                "failed_other_scenario: receipt must record preservation"
+            )
+    elif outcome in ("failed_requeue_failed", "failed_deferred"):
+        if receipt is not None:
+            violations.append(
+                f"{outcome}: replay must never record a receipt"
+            )
+        if source_exists_after_replay != source_existed_before_replay:
+            violations.append(
+                f"{outcome}: replay must never touch the source"
+            )
+        if not wrong_match_visible_after_replay:
+            violations.append(
+                f"{outcome}: replay must never touch the row"
+            )
+    else:
+        violations.append(f"unrecognised outcome {outcome!r}")
+    return violations
+
+
+class TestForceWrongMatchReceiptStartupReplayGenerated(unittest.TestCase):
+    """Generated: issue #1122's crash-window invariant over the outcome space.
+
+    Drives the REAL ``importer.recover_abandoned_running_jobs`` startup
+    sweep over every terminal outcome class a force job's wrong-match
+    receipt can reach, crossed with whether the source folder was already
+    removed before replay ever runs (the idempotent-retry sub-case the
+    deterministic pins above don't separately cover).
+    """
+
+    def _world(
+        self,
+        outcome: str,
+        *,
+        source_already_deleted: bool,
+    ) -> tuple[FakePipelineDB, str, ImportJob]:
+        db = FakePipelineDB()
+        root, source = _make_failed_import_source()
+        self.addCleanup(shutil.rmtree, root, ignore_errors=True)
+        with open(os.path.join(source, "01.mp3"), "wb") as handle:
+            handle.write(b"generated wrong-match audio")
+        db.seed_request(make_request_row(id=42, status="wanted"))
+        db.log_download(
+            42,
+            soulseek_username="alice",
+            outcome="rejected",
+            validation_result={
+                "scenario": "high_distance", "failed_path": source,
+            },
+        )
+        log_id = db.download_logs[-1].id
+        job = db.enqueue_import_job(
+            IMPORT_JOB_FORCE,
+            request_id=42,
+            dedupe_key=(
+                f"generated-wrong-match:{outcome}:{source_already_deleted}"
+            ),
+            payload=force_import_payload(
+                download_log_id=log_id, failed_path=source,
+            ),
+        )
+        status, result, error = _wrong_match_replay_terminal_result(outcome)
+        message = str(result["message"])
+        if status == "completed":
+            db.mark_import_job_completed(job.id, result=result, message=message)
+        else:
+            db.mark_import_job_failed(
+                job.id, error=error, result=result, message=message,
+            )
+        if source_already_deleted:
+            shutil.rmtree(source)
+        return db, source, job
+
+    @given(
+        outcome=st.sampled_from(_WRONG_MATCH_REPLAY_OUTCOMES),
+        source_already_deleted=st.booleans(),
+    )
+    def test_generated_startup_replay_reaches_the_live_decision(
+        self,
+        outcome: str,
+        source_already_deleted: bool,
+    ) -> None:
+        from scripts import importer
+
+        db, source, job = self._world(
+            outcome, source_already_deleted=source_already_deleted,
+        )
+        source_existed_before = os.path.isdir(source)
+
+        importer.recover_abandoned_running_jobs(db)
+
+        converged = db.get_import_job(job.id)
+        assert converged is not None
+        result = converged.result or {}
+        raw_receipt = (
+            result.get("wrong_match_dismissal")
+            if outcome == "completed" else result.get("cleanup")
+        )
+        receipt = raw_receipt if isinstance(raw_receipt, dict) else None
+        violations = wrong_match_replay_violations(
+            outcome=outcome,
+            source_existed_before_replay=source_existed_before,
+            source_exists_after_replay=os.path.exists(source),
+            wrong_match_visible_after_replay=bool(db.get_wrong_matches()),
+            receipt=receipt,
+        )
+        self.assertEqual(violations, [], violations)
+
+
+class TestWrongMatchReplayViolationsTripOnViolations(unittest.TestCase):
+    """Known-bad self-tests: each clause of the checker must trip alone.
+
+    Each row is (desc, outcome, source_existed_before_replay,
+    source_exists_after_replay, wrong_match_visible_after_replay, receipt,
+    expected_message) — explicit positional fields rather than a
+    ``dict[str, object]`` kwargs blob, so Pyright can verify every argument
+    against ``wrong_match_replay_violations``'s real parameter types.
+    """
+
+    CASES: ClassVar[
+        list[tuple[str, str, bool, bool, bool, dict[str, object] | None, str]]
+    ] = [
+        (
+            "completed source survives", "completed",
+            True, True, False, {"success": True},
+            "completed: source must be deleted by replay",
+        ),
+        (
+            "completed row still visible", "completed",
+            True, False, True, {"success": True},
+            "completed: wrong-match row must be consumed by replay",
+        ),
+        (
+            "completed missing receipt", "completed",
+            True, False, False, None,
+            "completed: replay must record a receipt",
+        ),
+        (
+            "audio_corrupt source survives", "failed_audio_corrupt",
+            True, True, False,
+            {"outcome": "deleted_operator_force_source"},
+            "failed_audio_corrupt: source must be deleted by replay",
+        ),
+        (
+            "audio_corrupt row still visible", "failed_audio_corrupt",
+            True, False, True,
+            {"outcome": "deleted_operator_force_source"},
+            "failed_audio_corrupt: wrong-match row must be consumed by replay",
+        ),
+        (
+            "audio_corrupt missing receipt", "failed_audio_corrupt",
+            True, False, False, None,
+            "failed_audio_corrupt: replay must record a receipt",
+        ),
+        (
+            "preserve touches source", "failed_other_scenario",
+            True, False, True,
+            {"outcome": "preserved_operator_force_source"},
+            "failed_other_scenario: replay must never touch the source",
+        ),
+        (
+            "preserve clears row", "failed_other_scenario",
+            True, True, False,
+            {"outcome": "preserved_operator_force_source"},
+            "failed_other_scenario: row must remain visible after replay",
+        ),
+        (
+            "preserve wrong receipt", "failed_other_scenario",
+            True, True, True,
+            {"outcome": "deleted_operator_force_source"},
+            "failed_other_scenario: receipt must record preservation",
+        ),
+        (
+            "requeue_failed writes a receipt", "failed_requeue_failed",
+            True, True, True, {"outcome": "anything"},
+            "failed_requeue_failed: replay must never record a receipt",
+        ),
+        (
+            "requeue_failed touches source", "failed_requeue_failed",
+            True, False, True, None,
+            "failed_requeue_failed: replay must never touch the source",
+        ),
+        (
+            "requeue_failed clears row", "failed_requeue_failed",
+            True, True, False, None,
+            "failed_requeue_failed: replay must never touch the row",
+        ),
+        (
+            "deferred writes a receipt", "failed_deferred",
+            True, True, True, {"outcome": "anything"},
+            "failed_deferred: replay must never record a receipt",
+        ),
+        (
+            "deferred touches source", "failed_deferred",
+            True, False, True, None,
+            "failed_deferred: replay must never touch the source",
+        ),
+        (
+            "deferred clears row", "failed_deferred",
+            True, True, False, None,
+            "failed_deferred: replay must never touch the row",
+        ),
+        (
+            "unrecognised outcome", "bogus",
+            True, True, True, None,
+            "unrecognised outcome 'bogus'",
+        ),
+    ]
+
+    def test_each_clause_trips_with_its_own_message(self) -> None:
+        for (
+            desc, outcome, before, after, visible, receipt, expected_message,
+        ) in self.CASES:
+            with self.subTest(desc=desc):
+                violations = wrong_match_replay_violations(
+                    outcome=outcome,
+                    source_existed_before_replay=before,
+                    source_exists_after_replay=after,
+                    wrong_match_visible_after_replay=visible,
+                    receipt=receipt,
+                )
+                self.assertIn(expected_message, violations)
 
 
 class TestForceJobFailuresAreRecordedNotParked(unittest.TestCase):

--- a/tests/test_import_queue.py
+++ b/tests/test_import_queue.py
@@ -2628,6 +2628,7 @@ class TestImporterWorker(unittest.TestCase):
                     "message": "requeue UPDATE failed: boom",
                     "deferred": False,
                     "code": DISPATCH_CODE_REQUEUE_FAILED,
+                    "post_commit_wrong_match_scenario": None,
                 },
                 message="requeue UPDATE failed: boom",
             )
@@ -2676,6 +2677,7 @@ class TestImporterWorker(unittest.TestCase):
                     "message": "Another import is already in progress",
                     "deferred": True,
                     "code": None,
+                    "post_commit_wrong_match_scenario": None,
                 },
                 message="Another import is already in progress",
             )
@@ -2689,6 +2691,232 @@ class TestImporterWorker(unittest.TestCase):
             self.assertNotIn("cleanup", self._result(converged))
         finally:
             shutil.rmtree(root, ignore_errors=True)
+
+    def test_startup_replay_retries_a_previously_failed_receipt_not_parks_it(
+        self,
+    ) -> None:
+        """Issue #1122 review MAJOR-1: a receipt PRESENT with
+        ``success: false`` (e.g. an EACCES-shaped ``path_unavailable``,
+        the #1063 shape) must be retried on the next startup, never
+        treated as done. A presence-only predicate (``NOT result ?
+        'wrong_match_dismissal'``) would park this row forever — the exact
+        duplicate-import park this PR exists to close, and a violation of
+        CLAUDE.md invariant 11.
+        """
+        from scripts import importer
+
+        db = FakePipelineDB()
+        root, source = _make_failed_import_source()
+        try:
+            with open(os.path.join(source, "01.mp3"), "wb") as handle:
+                handle.write(b"archival raw audio")
+            log_id = self._log_wrong_match(db, failed_path=source)
+            job = db.enqueue_import_job(
+                IMPORT_JOB_FORCE,
+                request_id=42,
+                dedupe_key=force_import_dedupe_key(log_id),
+                payload=force_import_payload(
+                    download_log_id=log_id,
+                    failed_path=source,
+                ),
+            )
+            # A receipt WAS already written by a prior replay attempt, but
+            # the cleanup itself failed (e.g. a transient EACCES) — the
+            # crash window this pin proves closed is "receipt present but
+            # unsuccessful", not "receipt entirely missing".
+            db.mark_import_job_completed(
+                job.id,
+                result={
+                    "success": True, "message": "imported",
+                    "deferred": False, "code": None,
+                    "post_commit_wrong_match_scenario": None,
+                    "wrong_match_dismissal": {
+                        "success": False, "download_log_id": log_id,
+                        "error": "path_unavailable: EACCES",
+                    },
+                },
+                message="imported",
+            )
+
+            # Precondition: the row still needs work.
+            self.assertTrue(os.path.isdir(source))
+            self.assertEqual(len(db.get_wrong_matches()), 1)
+
+            importer.recover_abandoned_running_jobs(db)
+
+            # Retried and this time succeeds — nothing in the fake
+            # actually blocks the real deletion, mirroring how a real
+            # transient EACCES would clear on a later attempt.
+            self.assertFalse(os.path.exists(source))
+            self.assertEqual(db.get_wrong_matches(), [])
+            converged = db.get_import_job(job.id)
+            assert converged is not None
+            dismissal = self._result(converged)["wrong_match_dismissal"]
+            assert isinstance(dismissal, dict)
+            self.assertTrue(dismissal["success"])
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    def test_startup_replay_never_touches_a_historical_row_without_the_era_marker(
+        self,
+    ) -> None:
+        """Issue #1122 review MAJOR-2/3: a completed force job whose
+        result predates the ``post_commit_wrong_match_scenario`` marker
+        (any pre-#1122 or otherwise non-adjudicating shape) must never be
+        selected by the startup sweep — a bare presence check would have
+        deleted its source. Measured live on doc2: 619 such rows at first
+        startup (477 completed, 142 failed), none of them actual
+        crash-window rows — the #1077 D10 sweep had already emptied those
+        quarantine roots 26 hours earlier, so a presence-only predicate
+        was harmless only by accident of timing.
+        """
+        from scripts import importer
+
+        db = FakePipelineDB()
+        root, source = _make_failed_import_source()
+        try:
+            with open(os.path.join(source, "01.mp3"), "wb") as handle:
+                handle.write(b"pre-feature completed force import")
+            log_id = self._log_wrong_match(db, failed_path=source)
+            job = db.enqueue_import_job(
+                IMPORT_JOB_FORCE,
+                request_id=42,
+                dedupe_key=force_import_dedupe_key(log_id),
+                payload=force_import_payload(
+                    download_log_id=log_id,
+                    failed_path=source,
+                ),
+            )
+            # No era marker at all: this row predates issue #1122's
+            # ``_job_result`` change.
+            db.mark_import_job_completed(
+                job.id, result={"success": True}, message="imported",
+            )
+
+            importer.recover_abandoned_running_jobs(db)
+
+            self.assertTrue(os.path.isdir(source))
+            self.assertEqual(len(db.get_wrong_matches()), 1)
+            converged = db.get_import_job(job.id)
+            assert converged is not None
+            self.assertNotIn(
+                "wrong_match_dismissal", self._result(converged),
+            )
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
+
+    def test_startup_replay_survives_one_raising_job_and_continues_the_sweep(
+        self,
+    ) -> None:
+        """Issue #1122 review MEDIUM-4: an unguarded exception in the
+        failure-lane cleanup helper must not crash the whole startup
+        sweep. Unlike ``_record_terminal_force_action_cleanup``'s callee
+        (fully exception-safe internally), ``_cleanup_failed_force_import``'s
+        ``audio_corrupt`` branch calls DB methods with no internal guard —
+        an escape there would otherwise propagate through
+        ``recover_abandoned_running_jobs`` into ``main()``, crash-looping
+        the whole importer under ``Restart=on-failure`` over one bad row.
+        """
+        from scripts import importer
+
+        db = FakePipelineDB()
+        root1, source1 = _make_failed_import_source()
+        root2, source2 = _make_failed_import_source()
+        try:
+            with open(os.path.join(source1, "01.mp3"), "wb") as handle:
+                handle.write(b"raising job source")
+            with open(os.path.join(source2, "01.mp3"), "wb") as handle:
+                handle.write(b"second job source")
+            log_id1 = self._log_wrong_match(
+                db, request_id=42, failed_path=source1,
+            )
+            job1 = db.enqueue_import_job(
+                IMPORT_JOB_FORCE,
+                request_id=42,
+                dedupe_key=force_import_dedupe_key(log_id1),
+                payload=force_import_payload(
+                    download_log_id=log_id1, failed_path=source1,
+                ),
+            )
+            db.mark_import_job_failed(
+                job1.id,
+                error="beets rejected: audio_corrupt",
+                result={
+                    "success": False, "message": "Rejected: audio_corrupt",
+                    "deferred": False, "code": None,
+                    "post_commit_wrong_match_scenario": "audio_corrupt",
+                },
+                message="Rejected: audio_corrupt",
+            )
+
+            log_id2 = self._log_wrong_match(
+                db, request_id=43, failed_path=source2,
+            )
+            job2 = db.enqueue_import_job(
+                IMPORT_JOB_FORCE,
+                request_id=43,
+                dedupe_key=force_import_dedupe_key(log_id2),
+                payload=force_import_payload(
+                    download_log_id=log_id2, failed_path=source2,
+                ),
+            )
+            db.mark_import_job_failed(
+                job2.id,
+                error="beets rejected: audio_corrupt",
+                result={
+                    "success": False, "message": "Rejected: audio_corrupt",
+                    "deferred": False, "code": None,
+                    "post_commit_wrong_match_scenario": "audio_corrupt",
+                },
+                message="Rejected: audio_corrupt",
+            )
+
+            real_get_entry = db.get_download_log_entry
+
+            def _raise_for_job1(log_id: int):
+                if log_id == log_id1:
+                    raise RuntimeError("DB connection dropped")
+                return real_get_entry(log_id)
+
+            with patch.object(
+                db, "get_download_log_entry", side_effect=_raise_for_job1,
+            ):
+                # Must not raise out of the sweep itself.
+                importer.recover_abandoned_running_jobs(db)
+
+            # job1: untouched, left exactly as it was for the next retry.
+            self.assertTrue(os.path.isdir(source1))
+            self.assertEqual(
+                len([
+                    row for row in db.get_wrong_matches()
+                    if row["download_log_id"] == log_id1
+                ]),
+                1,
+            )
+            stored_job1 = db.get_import_job(job1.id)
+            assert stored_job1 is not None
+            self.assertNotIn("cleanup", self._result(stored_job1))
+
+            # job2: still converged normally — one bad job does not stop
+            # the sweep from processing the rest.
+            self.assertFalse(os.path.exists(source2))
+            self.assertEqual(
+                len([
+                    row for row in db.get_wrong_matches()
+                    if row["download_log_id"] == log_id2
+                ]),
+                0,
+            )
+            stored_job2 = db.get_import_job(job2.id)
+            assert stored_job2 is not None
+            cleanup2 = self._result(stored_job2)["cleanup"]
+            assert isinstance(cleanup2, dict)
+            self.assertEqual(
+                cleanup2["outcome"], "deleted_operator_force_source",
+            )
+        finally:
+            shutil.rmtree(root1, ignore_errors=True)
+            shutil.rmtree(root2, ignore_errors=True)
 
     def test_importer_does_not_claim_job_waiting_for_preview(self):
         from scripts import importer
@@ -9339,44 +9567,73 @@ _WRONG_MATCH_REPLAY_OUTCOMES: tuple[str, ...] = (
     "failed_deferred",
 )
 
+# Issue #1122 review MAJOR-2/3: the review's live doc2 measurement found the
+# ORIGINAL predicate (presence-of-key, no era marker) selected 619 pre-feature
+# rows at first startup (477 completed, 142 failed) — zero of them actual
+# crash-window rows. These five classes are the non-adjudicating shapes that
+# must NEVER be selected/replayed after the era-marker fix, built via the
+# REAL producers where one currently exists (test-fidelity.md Rule C).
+_WRONG_MATCH_REPLAY_HISTORICAL_WORLDS: tuple[str, ...] = (
+    "historical_completed_no_marker",
+    "historical_executor_crash",
+    "historical_operator_cleanup",
+    "historical_preview_shape",
+    "historical_null_result",
+)
+
+_WRONG_MATCH_REPLAY_ALL_WORLDS: tuple[str, ...] = (
+    *_WRONG_MATCH_REPLAY_OUTCOMES,
+    *_WRONG_MATCH_REPLAY_HISTORICAL_WORLDS,
+)
+
+# Both the checker and the world builder share this membership set: every
+# outcome the live path never adjudicates, so replay must write no receipt
+# and touch neither the source nor the row.
+_NEVER_ADJUDICATED_OUTCOMES: tuple[str, ...] = (
+    "failed_requeue_failed",
+    "failed_deferred",
+    *_WRONG_MATCH_REPLAY_HISTORICAL_WORLDS,
+)
+
 
 def _wrong_match_replay_terminal_result(
     outcome: str,
 ) -> tuple[str, dict[str, object], str]:
     """Return (job status, ``_job_result``-shaped payload, error) for a class.
 
-    Mirrors exactly what the live terminal commit persists via
-    ``scripts.importer._job_result`` before the crash window opens — never
-    a shape the property invents.
+    Calls the REAL ``scripts.importer._job_result`` producer (issue #1122
+    review MINOR-5) instead of hand-typing the shape, so a change to
+    ``_job_result``'s own fields breaks this fixture — never silently
+    drifts from what the live terminal commit actually persists.
     """
+    from scripts.importer import _job_result
+
     if outcome == "completed":
-        return "completed", {
-            "success": True, "message": "imported", "deferred": False,
-            "code": None, "post_commit_wrong_match_scenario": None,
-        }, ""
+        return "completed", _job_result(DispatchOutcome(
+            success=True, message="imported",
+            post_commit_wrong_match_scenario=None,
+        )), ""
     if outcome == "failed_audio_corrupt":
-        return "failed", {
-            "success": False, "message": "Rejected: audio_corrupt",
-            "deferred": False, "code": None,
-            "post_commit_wrong_match_scenario": "audio_corrupt",
-        }, "beets rejected: audio_corrupt"
+        return "failed", _job_result(DispatchOutcome(
+            success=False, message="Rejected: audio_corrupt",
+            post_commit_wrong_match_scenario="audio_corrupt",
+        )), "beets rejected: audio_corrupt"
     if outcome == "failed_other_scenario":
-        return "failed", {
-            "success": False, "message": "Rejected: high_distance",
-            "deferred": False, "code": None,
-            "post_commit_wrong_match_scenario": "high_distance",
-        }, "beets rejected: high_distance"
+        return "failed", _job_result(DispatchOutcome(
+            success=False, message="Rejected: high_distance",
+            post_commit_wrong_match_scenario="high_distance",
+        )), "beets rejected: high_distance"
     if outcome == "failed_requeue_failed":
-        return "failed", {
-            "success": False, "message": "requeue UPDATE failed: boom",
-            "deferred": False, "code": DISPATCH_CODE_REQUEUE_FAILED,
-        }, "requeue failed"
+        return "failed", _job_result(DispatchOutcome(
+            success=False, message="requeue UPDATE failed: boom",
+            code=DISPATCH_CODE_REQUEUE_FAILED,
+        )), "requeue failed"
     if outcome == "failed_deferred":
-        return "failed", {
-            "success": False,
-            "message": "Another import is already in progress",
-            "deferred": True, "code": None,
-        }, "Another import is already in progress"
+        return "failed", _job_result(DispatchOutcome(
+            success=False,
+            message="Another import is already in progress",
+            deferred=True,
+        )), "Another import is already in progress"
     raise AssertionError(f"unrecognised outcome {outcome!r}")
 
 
@@ -9396,12 +9653,15 @@ def wrong_match_replay_violations(
       (idempotent retry).
     - ``failed_other_scenario``: replay must never change the source or the
       row; the receipt records ``preserved_operator_force_source``.
-    - ``failed_requeue_failed`` and ``failed_deferred``: replay must never
-      write ANY receipt and must never touch the source or the row — the
-      live path never adjudicates the candidate for either (never calls
-      the cleanup decision for ``requeue_failed``; calls it but
-      short-circuits immediately for ``deferred``), and replay must not
-      either.
+    - Every name in ``_NEVER_ADJUDICATED_OUTCOMES`` (``failed_requeue_failed``,
+      ``failed_deferred``, and the five ``historical_*`` classes): replay
+      must never write ANY receipt and must never touch the source or the
+      row. The live path never adjudicated the candidate for any of
+      these — either it never reaches the wrong-match decision at all
+      (``requeue_failed``, every historical/non-adjudicating shape lacking
+      the era marker) or it reaches the decision and short-circuits
+      immediately (``deferred``) — and replay must reach that identical
+      no-op, not fabricate a verdict.
 
     Accumulates every violated clause rather than stopping at the first, so
     a world violating more than one clause cannot mask the others.
@@ -9434,7 +9694,7 @@ def wrong_match_replay_violations(
             violations.append(
                 "failed_other_scenario: receipt must record preservation"
             )
-    elif outcome in ("failed_requeue_failed", "failed_deferred"):
+    elif outcome in _NEVER_ADJUDICATED_OUTCOMES:
         if receipt is not None:
             violations.append(
                 f"{outcome}: replay must never record a receipt"
@@ -9457,9 +9717,12 @@ class TestForceWrongMatchReceiptStartupReplayGenerated(unittest.TestCase):
 
     Drives the REAL ``importer.recover_abandoned_running_jobs`` startup
     sweep over every terminal outcome class a force job's wrong-match
-    receipt can reach, crossed with whether the source folder was already
-    removed before replay ever runs (the idempotent-retry sub-case the
-    deterministic pins above don't separately cover).
+    receipt can reach — the five adjudicating/no-op classes, crossed with
+    whether the source folder was already removed before replay ever runs
+    (the idempotent-retry sub-case the deterministic pins above don't
+    separately cover) — PLUS the five historical/non-adjudicating shapes
+    the review round (MAJOR-2/3) proved a presence-only predicate would
+    have selected and replayed against live production data.
     """
 
     def _world(
@@ -9493,20 +9756,75 @@ class TestForceWrongMatchReceiptStartupReplayGenerated(unittest.TestCase):
                 download_log_id=log_id, failed_path=source,
             ),
         )
-        status, result, error = _wrong_match_replay_terminal_result(outcome)
-        message = str(result["message"])
-        if status == "completed":
-            db.mark_import_job_completed(job.id, result=result, message=message)
-        else:
-            db.mark_import_job_failed(
-                job.id, error=error, result=result, message=message,
+
+        if outcome in _WRONG_MATCH_REPLAY_OUTCOMES:
+            status, result, error = _wrong_match_replay_terminal_result(
+                outcome,
             )
+            message = str(result["message"])
+            if status == "completed":
+                db.mark_import_job_completed(
+                    job.id, result=result, message=message,
+                )
+            else:
+                db.mark_import_job_failed(
+                    job.id, error=error, result=result, message=message,
+                )
+        elif outcome == "historical_completed_no_marker":
+            # Live-row evidence: 477 of the 619 pre-feature rows doc2
+            # measured were exactly this shape — a 'completed' force job
+            # from before ``_job_result`` ever wrote the era marker.
+            db.mark_import_job_completed(
+                job.id, result={"success": True}, message="imported",
+            )
+        elif outcome == "historical_executor_crash":
+            # The literal shape ``process_claimed_job``'s own top-level
+            # exception handler writes (``scripts/importer.py``, BEFORE
+            # ``_job_result`` is ever computed) — constructed directly
+            # rather than driving that call chain live, since doing so
+            # would need a new ``cast(Any, ...)`` escape hatch for one
+            # shape a deterministic pin in this same file
+            # (``test_crashed_force_job_is_failed_not_parked``) already
+            # exercises end-to-end through the real code path.
+            db.mark_import_job_failed(
+                job.id, error="RuntimeError: generated executor crash",
+                result={"success": False},
+            )
+        elif outcome == "historical_operator_cleanup":
+            # Real producer: the actual ``mark_import_job_failed`` DB
+            # method, called directly with no ``result`` kwarg — mirrors
+            # ``tests/test_wrong_matches_cleanup.py``'s own "operator
+            # cancelled" pattern for an ad hoc administrative
+            # terminalization outside the adjudicating decision path.
+            db.mark_import_job_failed(job.id, error="operator cancelled")
+        elif outcome == "historical_preview_shape":
+            # Live-row evidence (issue #1122 review MAJOR-3, doc2
+            # measurement): 130 of 142 pre-feature failed rows carried
+            # this shape. No CURRENT production code path writes it;
+            # registered as a HISTORICAL trigger per test-fidelity.md
+            # Rule C's escape hatch.
+            db.mark_import_job_failed(
+                job.id, error="preview lifecycle",
+                result={"preview": {"stale": True}},
+            )
+        elif outcome == "historical_null_result":
+            # A genuinely NULL ``result`` column has no public-API
+            # constructor — reach into the fake's own row store directly,
+            # mirroring the real-PG test's raw ``UPDATE ... result = NULL``.
+            db.mark_import_job_failed(job.id, error="unknown")
+            for row in db._import_jobs:
+                if row["id"] == job.id:
+                    row["result"] = None
+                    break
+        else:
+            raise AssertionError(f"unrecognised outcome {outcome!r}")
+
         if source_already_deleted:
             shutil.rmtree(source)
         return db, source, job
 
     @given(
-        outcome=st.sampled_from(_WRONG_MATCH_REPLAY_OUTCOMES),
+        outcome=st.sampled_from(_WRONG_MATCH_REPLAY_ALL_WORLDS),
         source_already_deleted=st.booleans(),
     )
     def test_generated_startup_replay_reaches_the_live_decision(
@@ -9526,9 +9844,11 @@ class TestForceWrongMatchReceiptStartupReplayGenerated(unittest.TestCase):
         converged = db.get_import_job(job.id)
         assert converged is not None
         result = converged.result or {}
+        raw_wrong_match_dismissal = result.get("wrong_match_dismissal")
+        raw_cleanup = result.get("cleanup")
         raw_receipt = (
-            result.get("wrong_match_dismissal")
-            if outcome == "completed" else result.get("cleanup")
+            raw_wrong_match_dismissal
+            if raw_wrong_match_dismissal is not None else raw_cleanup
         )
         receipt = raw_receipt if isinstance(raw_receipt, dict) else None
         violations = wrong_match_replay_violations(

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -1381,12 +1381,19 @@ class TestImportJobQueueAPI(unittest.TestCase):
     def test_list_terminal_force_wrong_match_cleanup_jobs_selects_missing_receipts(
         self,
     ) -> None:
-        """Issue #1122: the predicate names exactly the rows missing a receipt.
+        """Issue #1122: the predicate is a positive selection rule, not an
+        exclusion enumeration.
 
         Real-PG proof of the JSONB predicate in
         ``list_terminal_force_wrong_match_cleanup_jobs`` — the ``?``
-        key-existence operator and ``IS DISTINCT FROM`` NULL handling are
-        exactly the class of behavior a fake cannot validate.
+        key-existence operator, the ``#>>`` nested-success extraction, and
+        ``IS DISTINCT FROM`` NULL handling are exactly the class of
+        behavior a fake cannot validate. Covers the review-round
+        corrections: MAJOR-1 (success-keyed, not presence-keyed — a
+        receipt can be present with ``success: false``), MAJOR-2/3 (the
+        ``post_commit_wrong_match_scenario`` era-AND-lane marker excludes
+        every historical/non-adjudicating shape by construction, not by
+        naming each one).
         """
         from lib.import_queue import IMPORT_JOB_FORCE, force_import_payload
 
@@ -1401,7 +1408,9 @@ class TestImportJobQueueAPI(unittest.TestCase):
                 ),
             )
 
-        # Completed, receipt missing -> included.
+        # -- completed arm --------------------------------------------------
+
+        # Marker present, receipt entirely missing -> included.
         completed_missing = _force_job("completed-missing")
         self.db.mark_import_job_completed(
             completed_missing.id,
@@ -1412,18 +1421,38 @@ class TestImportJobQueueAPI(unittest.TestCase):
             message="done",
         )
 
-        # Completed, receipt already recorded -> excluded.
-        completed_done = _force_job("completed-done")
+        # Marker present, receipt present but success=false (e.g. entry
+        # not found, unsafe path, rmtree failure, EACCES) -> included:
+        # MAJOR-1's exact fix. A presence-only check would park this row.
+        completed_failed_receipt = _force_job("completed-failed-receipt")
         self.db.mark_import_job_completed(
-            completed_done.id,
+            completed_failed_receipt.id,
             result={
-                "success": True,
+                "success": True, "message": "done", "deferred": False,
+                "code": None, "post_commit_wrong_match_scenario": None,
+                "wrong_match_dismissal": {
+                    "success": False, "error": "path_unavailable: EACCES",
+                },
+            },
+            message="done",
+        )
+
+        # Marker present, receipt proven successful -> excluded.
+        completed_successful_receipt = _force_job("completed-successful-receipt")
+        self.db.mark_import_job_completed(
+            completed_successful_receipt.id,
+            result={
+                "success": True, "message": "done", "deferred": False,
+                "code": None, "post_commit_wrong_match_scenario": None,
                 "wrong_match_dismissal": {"success": True},
             },
             message="done",
         )
 
-        # Failed, receipt missing, ordinary code -> included.
+        # -- failed arm -------------------------------------------------
+
+        # Marker present, receipt entirely missing, ordinary code ->
+        # included.
         failed_missing = _force_job("failed-missing")
         self.db.mark_import_job_failed(
             failed_missing.id,
@@ -1436,8 +1465,44 @@ class TestImportJobQueueAPI(unittest.TestCase):
             message="rejected",
         )
 
-        # Failed, receipt missing, but ``requeue_failed`` — the live code
-        # never runs the wrong-match decision for this code -> excluded.
+        # Marker present, receipt present but success=false -> included
+        # (MAJOR-1, failure arm).
+        failed_failed_receipt = _force_job("failed-failed-receipt")
+        self.db.mark_import_job_failed(
+            failed_failed_receipt.id,
+            error="beets rejected: audio_corrupt",
+            result={
+                "success": False, "message": "rejected", "deferred": False,
+                "code": None,
+                "post_commit_wrong_match_scenario": "audio_corrupt",
+                "cleanup": {
+                    "success": False, "outcome": "deleted_operator_force_source",
+                    "error": "path_unavailable: EACCES",
+                },
+            },
+            message="rejected",
+        )
+
+        # Marker present, receipt proven successful -> excluded.
+        failed_successful_receipt = _force_job("failed-successful-receipt")
+        self.db.mark_import_job_failed(
+            failed_successful_receipt.id,
+            error="beets rejected",
+            result={
+                "success": False, "message": "rejected", "deferred": False,
+                "code": None,
+                "post_commit_wrong_match_scenario": "high_distance",
+                "cleanup": {
+                    "success": True,
+                    "outcome": "preserved_operator_force_source",
+                },
+            },
+            message="rejected",
+        )
+
+        # Marker present, receipt missing, but ``requeue_failed`` — the
+        # live code never runs the wrong-match decision for this code ->
+        # excluded.
         failed_requeue = _force_job("failed-requeue")
         self.db.mark_import_job_failed(
             failed_requeue.id,
@@ -1445,26 +1510,15 @@ class TestImportJobQueueAPI(unittest.TestCase):
             result={
                 "success": False, "message": "requeue UPDATE failed",
                 "deferred": False, "code": "requeue_failed",
+                "post_commit_wrong_match_scenario": None,
             },
             message="requeue UPDATE failed",
         )
 
-        # Failed, receipt already recorded -> excluded.
-        failed_done = _force_job("failed-done")
-        self.db.mark_import_job_failed(
-            failed_done.id,
-            error="beets rejected",
-            result={
-                "success": False,
-                "cleanup": {"outcome": "preserved_operator_force_source"},
-            },
-            message="rejected",
-        )
-
-        # Failed, receipt missing, but ``deferred`` — e.g. release-lock
-        # contention. The live cleanup helper IS called but its own first
-        # line skips the decision immediately, so no receipt ever lands;
-        # replay must not manufacture one -> excluded.
+        # Marker present, receipt missing, but ``deferred`` — e.g.
+        # release-lock contention. The live cleanup helper IS called but
+        # its own first line skips the decision immediately, so no
+        # receipt ever lands; replay must not manufacture one -> excluded.
         failed_deferred = _force_job("failed-deferred")
         self.db.mark_import_job_failed(
             failed_deferred.id,
@@ -1473,18 +1527,42 @@ class TestImportJobQueueAPI(unittest.TestCase):
                 "success": False,
                 "message": "Another import is already in progress",
                 "deferred": True, "code": None,
+                "post_commit_wrong_match_scenario": None,
             },
             message="Another import is already in progress",
         )
 
-        # Failed with a genuinely NULL ``result`` column (pre-#1122 shape,
-        # or any writer that never populated it) -> still included: a
-        # missing receipt is a missing receipt.
-        failed_null_result = _force_job("failed-null-result")
+        # -- historical / non-adjudicating shapes (MAJOR-2/3) ------------
+
+        # Completed, NO era marker at all (pre-#1122 shape) -> excluded
+        # forever by design, even though a bare presence check would have
+        # selected it.
+        historical_completed = _force_job("historical-completed-no-marker")
+        self.db.mark_import_job_completed(
+            historical_completed.id,
+            result={"success": True},
+            message="done",
+        )
+
+        # Failed, NO era marker (e.g. the executor-crash literal
+        # ``{"success": false}`` written before ``_job_result`` is ever
+        # computed, or any other historical/operator shape) -> excluded.
+        historical_failed = _force_job("historical-failed-no-marker")
+        self.db.mark_import_job_failed(
+            historical_failed.id,
+            error="RuntimeError: boom",
+            result={"success": False},
+            message="Executor crashed",
+        )
+
+        # Failed with a genuinely NULL ``result`` column -> excluded: no
+        # marker can be present in a NULL column, so this stays receiptless
+        # forever by the same rule, not a special case.
+        historical_null_result = _force_job("historical-null-result")
         self.db._execute(
             "UPDATE import_jobs SET status = 'failed', result = NULL "
             "WHERE id = %s",
-            (failed_null_result.id,),
+            (historical_null_result.id,),
         )
         self.db.conn.commit()
 
@@ -1493,12 +1571,16 @@ class TestImportJobQueueAPI(unittest.TestCase):
             for job in self.db.list_terminal_force_wrong_match_cleanup_jobs()
         }
         self.assertIn(completed_missing.id, selected)
-        self.assertNotIn(completed_done.id, selected)
-        self.assertNotIn(failed_deferred.id, selected)
+        self.assertIn(completed_failed_receipt.id, selected)
+        self.assertNotIn(completed_successful_receipt.id, selected)
         self.assertIn(failed_missing.id, selected)
+        self.assertIn(failed_failed_receipt.id, selected)
+        self.assertNotIn(failed_successful_receipt.id, selected)
         self.assertNotIn(failed_requeue.id, selected)
-        self.assertNotIn(failed_done.id, selected)
-        self.assertIn(failed_null_result.id, selected)
+        self.assertNotIn(failed_deferred.id, selected)
+        self.assertNotIn(historical_completed.id, selected)
+        self.assertNotIn(historical_failed.id, selected)
+        self.assertNotIn(historical_null_result.id, selected)
 
     def test_enqueue_youtube_import_is_allowed_by_pg_constraint(self):
         from lib.import_queue import (

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -1378,6 +1378,128 @@ class TestImportJobQueueAPI(unittest.TestCase):
         self.assertEqual(job.dedupe_key, dedupe)
         self.assertFalse(job.deduped)
 
+    def test_list_terminal_force_wrong_match_cleanup_jobs_selects_missing_receipts(
+        self,
+    ) -> None:
+        """Issue #1122: the predicate names exactly the rows missing a receipt.
+
+        Real-PG proof of the JSONB predicate in
+        ``list_terminal_force_wrong_match_cleanup_jobs`` — the ``?``
+        key-existence operator and ``IS DISTINCT FROM`` NULL handling are
+        exactly the class of behavior a fake cannot validate.
+        """
+        from lib.import_queue import IMPORT_JOB_FORCE, force_import_payload
+
+        def _force_job(suffix: str):
+            return self.db.enqueue_import_job(
+                IMPORT_JOB_FORCE,
+                request_id=self.req_id,
+                dedupe_key=f"force-wrong-match-predicate:{suffix}",
+                payload=force_import_payload(
+                    download_log_id=1,
+                    failed_path="/tmp/predicate-source",
+                ),
+            )
+
+        # Completed, receipt missing -> included.
+        completed_missing = _force_job("completed-missing")
+        self.db.mark_import_job_completed(
+            completed_missing.id,
+            result={
+                "success": True, "message": "done", "deferred": False,
+                "code": None, "post_commit_wrong_match_scenario": None,
+            },
+            message="done",
+        )
+
+        # Completed, receipt already recorded -> excluded.
+        completed_done = _force_job("completed-done")
+        self.db.mark_import_job_completed(
+            completed_done.id,
+            result={
+                "success": True,
+                "wrong_match_dismissal": {"success": True},
+            },
+            message="done",
+        )
+
+        # Failed, receipt missing, ordinary code -> included.
+        failed_missing = _force_job("failed-missing")
+        self.db.mark_import_job_failed(
+            failed_missing.id,
+            error="beets rejected: audio_corrupt",
+            result={
+                "success": False, "message": "rejected", "deferred": False,
+                "code": None,
+                "post_commit_wrong_match_scenario": "audio_corrupt",
+            },
+            message="rejected",
+        )
+
+        # Failed, receipt missing, but ``requeue_failed`` — the live code
+        # never runs the wrong-match decision for this code -> excluded.
+        failed_requeue = _force_job("failed-requeue")
+        self.db.mark_import_job_failed(
+            failed_requeue.id,
+            error="requeue failed",
+            result={
+                "success": False, "message": "requeue UPDATE failed",
+                "deferred": False, "code": "requeue_failed",
+            },
+            message="requeue UPDATE failed",
+        )
+
+        # Failed, receipt already recorded -> excluded.
+        failed_done = _force_job("failed-done")
+        self.db.mark_import_job_failed(
+            failed_done.id,
+            error="beets rejected",
+            result={
+                "success": False,
+                "cleanup": {"outcome": "preserved_operator_force_source"},
+            },
+            message="rejected",
+        )
+
+        # Failed, receipt missing, but ``deferred`` — e.g. release-lock
+        # contention. The live cleanup helper IS called but its own first
+        # line skips the decision immediately, so no receipt ever lands;
+        # replay must not manufacture one -> excluded.
+        failed_deferred = _force_job("failed-deferred")
+        self.db.mark_import_job_failed(
+            failed_deferred.id,
+            error="Another import is already in progress",
+            result={
+                "success": False,
+                "message": "Another import is already in progress",
+                "deferred": True, "code": None,
+            },
+            message="Another import is already in progress",
+        )
+
+        # Failed with a genuinely NULL ``result`` column (pre-#1122 shape,
+        # or any writer that never populated it) -> still included: a
+        # missing receipt is a missing receipt.
+        failed_null_result = _force_job("failed-null-result")
+        self.db._execute(
+            "UPDATE import_jobs SET status = 'failed', result = NULL "
+            "WHERE id = %s",
+            (failed_null_result.id,),
+        )
+        self.db.conn.commit()
+
+        selected = {
+            job.id
+            for job in self.db.list_terminal_force_wrong_match_cleanup_jobs()
+        }
+        self.assertIn(completed_missing.id, selected)
+        self.assertNotIn(completed_done.id, selected)
+        self.assertNotIn(failed_deferred.id, selected)
+        self.assertIn(failed_missing.id, selected)
+        self.assertNotIn(failed_requeue.id, selected)
+        self.assertNotIn(failed_done.id, selected)
+        self.assertIn(failed_null_result.id, selected)
+
     def test_enqueue_youtube_import_is_allowed_by_pg_constraint(self):
         from lib.import_queue import (
             IMPORT_JOB_YOUTUBE,


### PR DESCRIPTION
Part of #1122 (item 3, widened to both lanes). Non-closing: the issue closes after deploy + live verification.

## What

A crash between a force-import job's terminal commit and its wrong-match source handling previously left the world stuck forever: success lane — the completed import's Wrong Matches row stayed visible and force-importable (duplicate-import risk) with a folder that should have been deleted; failure lane — `_cleanup_failed_force_import` equally unreplayed. Post-#1077 D7 raised the stakes from pointer-clear to delete.

`list_terminal_force_wrong_match_cleanup_jobs` + a startup replay in `recover_abandoned_running_jobs` now close the window by replaying the exact live helpers, with the failure-lane `DispatchOutcome` reconstructed from JSONB (`result.post_commit_wrong_match_scenario`, persisted at every terminal commit by `_job_result`).

## Selection is positive, success-keyed, and era-bounded (review round 2)

- `result ? 'post_commit_wrong_match_scenario'` is a required arm — an era-AND-lane marker only `_job_result`'s adjudicating path writes (single-writer invariant, review-enforced, docstring'd). This excludes by construction every never-adjudicated class: preview-stage terminalization, executor-crash literals, operator terminalizations, and **all 619 pre-feature rows** the round-1 review measured as selected under a naive unbounded predicate (477 of them through the delete lane — harmless only because the #1077 D10 sweep had emptied those folders 26 hours earlier). Those historical rows stay receiptless forever by design: they never adjudicated, and replaying anything for them would fabricate a verdict.
- Both receipt arms key on **proven success** (`#>> '{...,success}' IS DISTINCT FROM 'true'`), not key presence — a failed cleanup (DB blip, EACCES probe) retries every startup instead of parking forever, matching the sibling `force_action_cleanup` replay's semantics. Preserve/skipped receipts carry success=true and correctly stop replay.
- `requeue_failed` and `deferred=true` remain excluded (they carry the marker but legitimately never produce a cleanup decision); a per-job exception guard makes a poisoned row log-and-continue instead of crash-looping the importer under Restart=on-failure.

Measured on live doc2 after the rewrite: the predicate selects **0 of 2,381** terminal force rows.

## Evidence

- Deterministic crash-window pins driving the real startup replay (decided outcome: row consumed + folder gone) for both lanes; generated property over a 10-world domain (5 adjudicated outcome classes × replay states + 5 historical/never-adjudicated shapes built via real producers or registered with live-row evidence), accumulating checker with a 16-case per-clause known-bad matrix.
- 18 planted mutants killed across three rounds, each isolated to its own site (predicate arms real-SQL and fake separately, marker arm, scenario persistence, deferred reconstruction, per-job guard).
- Real-PG predicate proof spanning every branch incl. NULL result; `FakePipelineDB` mirrors `->>`/`#>>` text semantics via `_jsonb_scalar_text`.
- Two independent review rounds; round 2 verified the full predicate truth table and marker reachability end-to-end through real persistence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)