### PR TITLE
fix(#1130): barrier the drift-warning journal read on the admission line

### DIFF
--- a/nix/tests/module-vm.nix
+++ b/nix/tests/module-vm.nix
@@ -4920,6 +4920,19 @@ pkgs.testers.nixosTest {
         "systemctl show cratedigger-import-preview-worker.service "
         "-p InvocationID --value"
     ).strip()
+    # This unit is Type=simple, so systemd reports "active" the moment it
+    # execs -- before the Python interpreter has run the admission check at
+    # all. Reading the journal here samples a window the worker has not yet
+    # written to, which is why the exact-count assertions below flaked to 0
+    # on a slow (TCG-emulated) host while passing under KVM (#1130). The
+    # admission line is emitted AFTER every warning line
+    # (lib/beets_startup.py), so waiting for it proves both are present and
+    # keeps the counts exact rather than weakening them to ">= 1". Same
+    # barrier as the safe/recovered admission sites below.
+    machine.wait_until_succeeds(
+        f"journalctl _SYSTEMD_INVOCATION_ID={warning_invocation} -o cat "
+        "| grep -q 'Beets configuration admitted for preview'"
+    )
     warning_log = machine.succeed(
         f"journalctl _SYSTEMD_INVOCATION_ID={warning_invocation} -o cat"
     )


### PR DESCRIPTION
Closes #1130 (the flaky-assertion half; the runtime-budget/KVM half is tracked in #1131).

## Diagnosis

`cratedigger-import-preview-worker` is `Type=simple` (`nix/module.nix:2553`), so systemd reports the unit **active the instant it execs** — before the Python interpreter has run the Beets admission check at all.

The warning-drift scenario captured the `InvocationID` and read that invocation's journal *immediately* after `wait_for_unit`, sampling a window the worker had not yet written to:

```python
machine.wait_for_unit("cratedigger-import-preview-worker.service")
warning_invocation = ...
warning_log = machine.succeed(f"journalctl _SYSTEMD_INVOCATION_ID={warning_invocation} -o cat")
assert warning_log.count("Beets configuration warning [musicbrainz_endpoint_drift]") == 1
```

Under KVM the interpreter wins the race and the intervening round-trips absorb the gap. Under TCG (epimetheus, no `/dev/kvm`) Python startup is slow enough that the read lands first, so the count sees **0**.

This is a **latent race, not a TCG-specific bug** — emulation only widened the window. It is not a double-emission: `lib/beets_startup.py` logs exactly one line per warning and one admission line per startup.

## Fix

Add the same `wait_until_succeeds` barrier the two sibling admission sites in this very scenario already carry (`safe_invocation`, `recovered_invocation`) — this third one was simply missed.

Waiting on `"admitted for preview"` is sufficient for **both** assertions: `lib/beets_startup.py` logs every warning **before** the admission line, so the admission line's presence proves the drift warning is already in the journal.

That keeps both counts **exact** rather than weakening them to `>= 1` as the issue's suggested shape #2 proposed. The invariant is "drift is reported exactly once per startup", and an exact count still enforces it once the sampling race is removed — the timing proxy is what was wrong, not the count.

## Audit

All nine `_SYSTEMD_INVOCATION_ID` reads in this file were checked. This was the **only** one preceded by `wait_for_unit`. The other eight either wait for process exit (`systemctl is-failed`, so the stream is closed and drained) or already carry the barrier.

## Evidence

**moduleVm check, epimetheus, TCG: PASS (`nix build .#checks.x86_64-linux.moduleVm`, exit 0, test script finished in 2247.27s).**

The run directly measured the race window. The new barrier had to *wait 8.63 seconds* for the line the old code read with zero waiting:

```
machine: waiting for success: journalctl _SYSTEMD_INVOCATION_ID=1e5065fc... -o cat | grep -q 'Beets configuration admitted for preview'
machine # [ 1527.935155] cratedigger-import-preview-worker[19154]: ... Beets configuration admitted for preview
machine: (finished: ..., in 8.63 seconds)
```

An 8.63s gap between "systemd says active" and "the admission line exists" is exactly the window the old immediate read sampled.

Targeted gate on epimetheus (`bash scripts/test.sh tests.test_nix_module` — `tests/test_nix_module.py` parses this file): **6/6 phases PASSED** (js-syntax, js-unit, pyright, ruff, vulture, python).

🤖 Generated with [Claude Code](https://claude.com/claude-code)