### PR TITLE
fix(quality): derive average bitrate without float truncation

### DIFF
--- a/lib/beets_db.py
+++ b/lib/beets_db.py
@@ -23,6 +23,7 @@ from lib.evidence_media_identity import (
     canonical_beets_codec,
     canonical_beets_format,
 )
+from lib.media_readiness import kbps_from_bps
 from lib.release_identity import (
     ConflictingReleaseIdentityError,
     ReleaseIdentity,
@@ -401,11 +402,17 @@ def album_info_from_current(
     return AlbumInfo(
         album_id=current.album_id,
         track_count=len(measured),
-        min_bitrate_kbps=int(min(numeric_bitrates) / 1000),
-        avg_bitrate_kbps=int(
-            sum(numeric_bitrates) / len(numeric_bitrates) / 1000
+        # Rounded, not floored — and by the SAME helper the frame-measured
+        # candidate side uses. Flooring here while the candidate rounds makes
+        # identical audio compare one kbps apart, which is the skew that
+        # re-imported an album over itself (dl 39947).
+        min_bitrate_kbps=kbps_from_bps(min(numeric_bitrates)),
+        avg_bitrate_kbps=kbps_from_bps(
+            sum(numeric_bitrates) // len(numeric_bitrates)
         ),
-        median_bitrate_kbps=int(statistics.median(numeric_bitrates) / 1000),
+        median_bitrate_kbps=kbps_from_bps(
+            int(statistics.median(numeric_bitrates))
+        ),
         is_cbr=len(set(numeric_bitrates)) == 1,
         album_path=current.album_path,
         format=_reduce_album_format(measured_formats, cfg),
@@ -959,11 +966,13 @@ class BeetsDB:
             result[release_id] = {
                 "beets_tracks": len(current.items),
                 "beets_format": ",".join(formats) if formats else None,
+                # Same shared reduction as get_album_info — these two
+                # projections of the same album must never disagree.
                 "beets_bitrate": (
-                    int(min(bitrates) / 1000) if bitrates else None
+                    kbps_from_bps(min(bitrates)) if bitrates else None
                 ),
                 "beets_avg_bitrate": (
-                    int(sum(bitrates) / len(bitrates) / 1000)
+                    kbps_from_bps(sum(bitrates) // len(bitrates))
                     if bitrates else None
                 ),
                 "beets_samplerate": min(samplerates) if samplerates else None,

--- a/lib/measurement.py
+++ b/lib/measurement.py
@@ -623,12 +623,21 @@ def _needs_spectral_check(
         transcode-cliff case; unknown VBR is the conservative default
         (issue #39: resumed downloads without slskd metadata).
       - VBR MP3 → run only when ``avg_bitrate_kbps`` is unknown (conservative)
-        or below ``vbr_threshold_kbps``. Issue #93: a VBR MP3 at avg 182kbps
-        (well below genuine V0's ~240-260kbps range) was an obvious transcode
-        that the old ``is_vbr``-only gate let through. The threshold comes
-        from ``cfg.quality_ranks.mp3_vbr.excellent``. This is a scan-selection
-        policy only; the later transcode decision consumes the resulting
-        spectral grade, not the bitrate threshold.
+        or at or below ``vbr_threshold_kbps``. Issue #93: a VBR MP3 at avg
+        182kbps (well below genuine V0's ~240-260kbps range) was an obvious
+        transcode that the old ``is_vbr``-only gate let through. The threshold
+        comes from ``cfg.quality_ranks.mp3_vbr.excellent``. This is a
+        scan-selection policy only; the later transcode decision consumes the
+        resulting spectral grade, not the bitrate threshold.
+
+        The comparison is INCLUSIVE. ``average_bitrate_kbps_from_frames``
+        reports the nearest integer rather than the floor, so a per-track
+        rate can read up to one kbps higher than it used to and an album
+        whose true average sits just under the threshold can now land
+        exactly on it. Under a strict ``<`` that album would silently stop
+        being scanned, in the last kbps before the boundary — which is
+        precisely where a fake V0 is most likely to sit. Reading exactly
+        the threshold means "not yet proven above it", so we scan.
 
     This helper is pure: filesystem enumeration and any M4A codec probe happen
     once at the measurement boundary and arrive as ``lossless_candidate``.
@@ -645,7 +654,7 @@ def _needs_spectral_check(
         return True
     if avg_bitrate_kbps is None or vbr_threshold_kbps is None:
         return True
-    return avg_bitrate_kbps < vbr_threshold_kbps
+    return avg_bitrate_kbps <= vbr_threshold_kbps
 
 
 def _persist_spectral_state(

--- a/lib/media_readiness.py
+++ b/lib/media_readiness.py
@@ -386,6 +386,19 @@ def _repair_flac_total_samples(path: Path, sample_count: int) -> bool:
         os.close(fd)
 
 
+def kbps_from_bps(bits_per_second: int) -> int:
+    """Nearest-integer kbps for a bit-per-second rate.
+
+    The ONE bps->kbps reduction. Both sides of every quality comparison must
+    round the same way or identical audio compares unequal: the candidate is
+    measured frame-by-frame here, while the installed copy is reduced from
+    Beets' stored per-item rates in ``lib.beets_db``. Flooring one side while
+    rounding the other reintroduces exactly the one-kbps skew that
+    ``average_bitrate_kbps_from_frames`` exists to remove.
+    """
+    return (bits_per_second + 500) // 1000
+
+
 def average_bitrate_kbps_from_frames(
     compressed_bytes: int,
     sample_count: int,
@@ -403,18 +416,27 @@ def average_bitrate_kbps_from_frames(
     path yielded ``255.99999999999997`` and reported 255.
 
     That single kbps is not cosmetic. Per-track bitrate uniformity is what
-    ``is_cbr`` is derived from, one odd track makes a constant-bitrate album
-    look variable, and MP3 then ranks through ``cfg.mp3_vbr``
-    (transparent >= 245) instead of ``cfg.mp3_cbr`` (transparent >= 320) —
-    a two-tier swing on identical audio.
+    the two decision-path ``is_cbr`` derivations read
+    (``harness/import_one.py`` for the candidate, ``lib.beets_db`` for the
+    installed copy; the preview lane instead reads mutagen's declared
+    ``bitrate_mode``). One odd track makes a constant-bitrate album look
+    variable, and MP3 then ranks through ``cfg.mp3_vbr``
+    (transparent >= 245) instead of ``cfg.mp3_cbr`` (transparent >= 320).
+    At 255 kbps that ladder swap alone is GOOD -> TRANSPARENT, two tiers;
+    on the live album it was enough to put the candidate's TRANSPARENT above
+    the installed copy's EXCELLENT and trigger the re-import.
 
     The quotient is therefore evaluated as an exact integer ratio and
     rounded half-up. Rounding rather than truncating is the second half:
     a real stream rarely lands on an exact integer, and flooring biases
-    every such track downward.
+    every such track downward. Half-up rather than banker's rounding is
+    deliberate — it is parity-independent, so a constant stream whose
+    tracks all land on ``x.5`` cannot be split by the tie rule.
 
-    Returns None when any input is non-positive — a rate cannot be derived
-    and the caller must not invent one.
+    Returns None when any input is non-positive. ``_frame_facts`` and
+    ``_stream_facts`` already reject those upstream, so no production caller
+    reaches it today; the guard is fail-closed legislation for this
+    module-public helper rather than a live branch.
     """
     if compressed_bytes <= 0 or sample_count <= 0 or sample_rate <= 0:
         return None

--- a/lib/media_readiness.py
+++ b/lib/media_readiness.py
@@ -386,6 +386,43 @@ def _repair_flac_total_samples(path: Path, sample_count: int) -> bool:
         os.close(fd)
 
 
+def average_bitrate_kbps_from_frames(
+    compressed_bytes: int,
+    sample_count: int,
+    sample_rate: int,
+) -> int | None:
+    """Nearest-integer kbps for a stream, derived without float error.
+
+    Deliberately does NOT route through ``duration_seconds``.
+    ``sample_count / sample_rate`` is a float, and for an ordinary sample
+    count it is not exactly representable — so a stream whose true rate is
+    an exact integer can come back a hair under it, and truncating floors
+    that to one kbps LOW. Live instance: Koppel ``Improvisationer for
+    Klaver`` track 04 (evidence 36856), where
+    ``8517888 * 8 == 266.184 s * 256 kbps * 1000`` exactly, yet the float
+    path yielded ``255.99999999999997`` and reported 255.
+
+    That single kbps is not cosmetic. Per-track bitrate uniformity is what
+    ``is_cbr`` is derived from, one odd track makes a constant-bitrate album
+    look variable, and MP3 then ranks through ``cfg.mp3_vbr``
+    (transparent >= 245) instead of ``cfg.mp3_cbr`` (transparent >= 320) —
+    a two-tier swing on identical audio.
+
+    The quotient is therefore evaluated as an exact integer ratio and
+    rounded half-up. Rounding rather than truncating is the second half:
+    a real stream rarely lands on an exact integer, and flooring biases
+    every such track downward.
+
+    Returns None when any input is non-positive — a rate cannot be derived
+    and the caller must not invent one.
+    """
+    if compressed_bytes <= 0 or sample_count <= 0 or sample_rate <= 0:
+        return None
+    numerator = compressed_bytes * 8 * sample_rate
+    denominator = sample_count * 1000
+    return (numerator + denominator // 2) // denominator
+
+
 def _facts_for_path(path: Path) -> MediaFileFacts:
     wire = _ffprobe_readiness(path)
     stream_index, codec, sample_rate, channels, bit_depth, container = _stream_facts(path, wire)
@@ -393,7 +430,9 @@ def _facts_for_path(path: Path) -> MediaFileFacts:
         path, wire, audio_stream_index=stream_index,
     )
     duration = sample_count / sample_rate
-    bitrate = int((compressed_bytes * 8) / duration / 1000) if duration > 0 else None
+    bitrate = average_bitrate_kbps_from_frames(
+        compressed_bytes, sample_count, sample_rate,
+    )
     return MediaFileFacts(
         path=str(path.resolve()), codec=codec,
         container=container,

--- a/tests/fakes/beets.py
+++ b/tests/fakes/beets.py
@@ -292,13 +292,27 @@ class FakeBeetsDB:
         that. Checking it with test-side arithmetic is how the promise came
         apart once already. Consumers read these aggregates through
         ``album_info_from_current``, so the round trip is the contract.
+
+        Resolution goes through the CLASS's resolver, never
+        ``self.resolve_current_release``. Tests legitimately replace that
+        attribute with a wrapper — ``_mock_beets_db`` in
+        ``tests/test_integration_slices.py`` wraps it in one that re-seeds
+        on every call — and a self-check that re-entered the wrapper would
+        recurse into the very seeding it is verifying. This check is about
+        the state this instance just wrote, so it reads that state directly.
         """
+        identity = _lookup_identity(mb_release_id)
         recorded = len(self.resolve_current_release_calls)
         try:
-            projected = self._project_album_info(mb_release_id)
+            resolution = (
+                FakeBeetsDB.resolve_current_release(self, identity)
+                if identity is not None
+                else None
+            )
         finally:
             # Seeding is not an observation; keep the recorder honest.
             del self.resolve_current_release_calls[recorded:]
+        projected = self._album_info_from_resolution(resolution)
         assert projected is not None, (
             f"seeded AlbumInfo for {mb_release_id} does not resolve to a "
             "unique current release"
@@ -860,18 +874,12 @@ class FakeBeetsDB:
         ]
         return int(min(bitrates) / 1000) if bitrates else None
 
-    def _project_album_info(
-        self, mb_release_id: str, cfg: QualityRankConfig | None = None,
+    def _album_info_from_resolution(
+        self,
+        resolution: CurrentBeetsResolution | None,
+        cfg: QualityRankConfig | None = None,
     ) -> AlbumInfo | None:
-        """Production's own projection over this fake's seeded items.
-
-        Not recorded: seeding verifies itself through here, and a seed is
-        not an observation the test asked for.
-        """
-        identity = _lookup_identity(mb_release_id)
-        if identity is None:
-            return None
-        resolution = self.resolve_current_release(identity)
+        """Production's own projection over one resolved snapshot."""
         if not isinstance(resolution, CurrentBeetsUnique):
             return None
         from lib.quality import QualityRankConfig
@@ -884,14 +892,21 @@ class FakeBeetsDB:
     def get_album_info(
         self, mb_release_id: str, _cfg: Any = None,
     ) -> Any:
-        # Delegates to the real projection instead of re-deriving the
+        # Projects through the real reducer instead of re-deriving the
         # aggregates. The hand-copied version floored bps->kbps while
         # production rounds, so this fake answered 48 kbps where the real
         # ``album_info_from_current`` answered 49 for the very same seeded
         # items — a divergence no test could see, because both sides of
         # every assertion were the copy.
         self.get_album_info_calls.append(mb_release_id)
-        return self._project_album_info(mb_release_id, _cfg)
+        identity = _lookup_identity(mb_release_id)
+        if identity is None:
+            return None
+        # Deliberately the instance attribute: a test that wrapped the
+        # resolver expects its wrapper on this read path.
+        return self._album_info_from_resolution(
+            self.resolve_current_release(identity), _cfg,
+        )
 
     def get_item_paths(self, mb_release_id: str) -> list[tuple[int, str]]:
         self.get_item_paths_calls.append(mb_release_id)

--- a/tests/fakes/beets.py
+++ b/tests/fakes/beets.py
@@ -7,7 +7,7 @@ import os
 import statistics
 from collections.abc import Sequence
 from dataclasses import replace
-from typing import Any, Self
+from typing import TYPE_CHECKING, Any, Self
 
 from lib.beets_db import (
     AlbumInfo,
@@ -20,13 +20,17 @@ from lib.beets_db import (
     CurrentBeetsUnique,
     ReleaseLocation,
     _lookup_identity,
-    _reduce_album_format,
+    album_info_from_current,
 )
+from lib.media_readiness import kbps_from_bps
 from lib.release_identity import (
     ReleaseIdentity,
     detect_release_source,
     normalize_release_id,
 )
+
+if TYPE_CHECKING:
+    from lib.quality import QualityRankConfig
 
 
 class FakeBeetsDB:
@@ -183,6 +187,7 @@ class FakeBeetsDB:
                     for index, bitrate in enumerate(bitrates)
                 ],
             )
+            self._assert_seed_projects_to(mb_release_id, info)
         elif info is None:
             key = normalize_release_id(mb_release_id)
             self._album_ids_for_release[key] = []
@@ -277,9 +282,62 @@ class FakeBeetsDB:
             )],
         )
 
+    def _assert_seed_projects_to(
+        self, mb_release_id: str, info: AlbumInfo,
+    ) -> None:
+        """Prove the seeded items really project back to ``info``.
+
+        ``_synthesize_bitrates`` promises a world whose PRODUCTION reduction
+        is the requested ``AlbumInfo``; only the real reducer can settle
+        that. Checking it with test-side arithmetic is how the promise came
+        apart once already. Consumers read these aggregates through
+        ``album_info_from_current``, so the round trip is the contract.
+        """
+        recorded = len(self.resolve_current_release_calls)
+        try:
+            projected = self._project_album_info(mb_release_id)
+        finally:
+            # Seeding is not an observation; keep the recorder honest.
+            del self.resolve_current_release_calls[recorded:]
+        assert projected is not None, (
+            f"seeded AlbumInfo for {mb_release_id} does not resolve to a "
+            "unique current release"
+        )
+        actual = (
+            projected.track_count,
+            projected.min_bitrate_kbps,
+            projected.avg_bitrate_kbps,
+            projected.median_bitrate_kbps,
+            projected.is_cbr,
+        )
+        expected = (
+            info.track_count,
+            info.min_bitrate_kbps,
+            info.avg_bitrate_kbps or info.min_bitrate_kbps,
+            info.median_bitrate_kbps or info.min_bitrate_kbps,
+            info.is_cbr,
+        )
+        assert actual == expected, (
+            "seeded items do not reduce to the requested AlbumInfo: "
+            f"production projects {actual}, test asked for {expected}"
+        )
+
     @staticmethod
     def _synthesize_bitrates(info: AlbumInfo) -> list[int]:
-        """Construct per-item facts whose production reduction is ``info``."""
+        """Construct per-item facts whose production reduction is ``info``.
+
+        Every window and every check below reduces through the production
+        helper ``kbps_from_bps``. Re-deriving the reduction here is what let
+        this fake drift: it targeted and verified a FLOORED window while
+        ``album_info_from_current`` rounds half-up, so it happily built an
+        album it claimed averaged 48 kbps that the real projection read as
+        49. The usable mean therefore runs to ``average * 1000 + 499``, not
+        to the floor band's ``average * 1000 + 999``.
+
+        Its reach is narrower than production's: min and median are emitted
+        as whole kilobits, so aggregates only sub-kilobit rates can produce
+        are refused as "not jointly expressible" rather than mis-built.
+        """
 
         count = info.track_count
         assert count > 0, "AlbumInfo with no items is not production-expressible"
@@ -287,6 +345,9 @@ class FakeBeetsDB:
         average = info.avg_bitrate_kbps or minimum
         median = info.median_bitrate_kbps or minimum
         assert minimum <= median, "minimum bitrate cannot exceed median"
+        # Highest per-item mean (bps) that still reduces to ``average`` kbps:
+        # kbps_from_bps(average * 1000 + 499) == average, +500 rounds up.
+        max_mean_bps = average * 1000 + 499
         if count == 1:
             values = [minimum * 1000]
             assert average == minimum and median == minimum, (
@@ -298,7 +359,9 @@ class FakeBeetsDB:
             )
             low = minimum * 1000
             target_total = max(2 * average * 1000, low * 2)
-            assert target_total <= 2 * (average + 1) * 1000 - 1
+            assert target_total <= 2 * max_mean_bps + 1, (
+                "AlbumInfo min/avg/median are not jointly expressible"
+            )
             values = [low, target_total - low]
         else:
             low_count = (count - 1) // 2
@@ -309,7 +372,8 @@ class FakeBeetsDB:
                 + [median * 1000] * middle_count
             )
             target_min = count * average * 1000
-            target_max = count * (average + 1) * 1000 - 1
+            # sum // count <= max_mean_bps  <=>  sum <= count*max + count-1.
+            target_max = count * max_mean_bps + (count - 1)
             target_total = max(
                 target_min,
                 sum(fixed) + high_count * median * 1000,
@@ -324,9 +388,9 @@ class FakeBeetsDB:
             values = fixed + highs
         if not info.is_cbr and len(values) > 1 and len(set(values)) == 1:
             values[-1] += 1
-        assert int(min(values) / 1000) == minimum
-        assert int(sum(values) / len(values) / 1000) == average
-        assert int(statistics.median(values) / 1000) == median
+        assert kbps_from_bps(min(values)) == minimum
+        assert kbps_from_bps(sum(values) // len(values)) == average
+        assert kbps_from_bps(int(statistics.median(values))) == median
         assert (len(set(values)) == 1) == info.is_cbr, (
             "AlbumInfo is_cbr disagrees with its per-item bitrates"
         )
@@ -465,11 +529,15 @@ class FakeBeetsDB:
             result[identity.release_id] = {
                 "beets_tracks": len(current.items),
                 "beets_format": ",".join(formats) if formats else None,
+                # Same shared reduction production's check_mbids_detail
+                # uses; a floored copy here would let the two projections
+                # of one album disagree in the fake while agreeing in
+                # production.
                 "beets_bitrate": (
-                    int(min(bitrates) / 1000) if bitrates else None
+                    kbps_from_bps(min(bitrates)) if bitrates else None
                 ),
                 "beets_avg_bitrate": (
-                    int(sum(bitrates) / len(bitrates) / 1000)
+                    kbps_from_bps(sum(bitrates) // len(bitrates))
                     if bitrates else None
                 ),
                 "beets_samplerate": min(samplerates) if samplerates else None,
@@ -792,40 +860,38 @@ class FakeBeetsDB:
         ]
         return int(min(bitrates) / 1000) if bitrates else None
 
-    def get_album_info(
-        self, mb_release_id: str, _cfg: Any = None,
-    ) -> Any:
-        self.get_album_info_calls.append(mb_release_id)
+    def _project_album_info(
+        self, mb_release_id: str, cfg: QualityRankConfig | None = None,
+    ) -> AlbumInfo | None:
+        """Production's own projection over this fake's seeded items.
+
+        Not recorded: seeding verifies itself through here, and a seed is
+        not an observation the test asked for.
+        """
         identity = _lookup_identity(mb_release_id)
         if identity is None:
             return None
         resolution = self.resolve_current_release(identity)
         if not isinstance(resolution, CurrentBeetsUnique):
             return None
-        measured = [
-            (item, bitrate)
-            for item in resolution.items
-            if (bitrate := item.bitrate) is not None and bitrate > 0
-        ]
-        if not measured:
-            return None
-        bitrates = [bitrate for _item, bitrate in measured]
         from lib.quality import QualityRankConfig
 
-        cfg = _cfg if _cfg is not None else QualityRankConfig.defaults()
-        return AlbumInfo(
-            album_id=resolution.album_id,
-            track_count=len(measured),
-            min_bitrate_kbps=int(min(bitrates) / 1000),
-            avg_bitrate_kbps=int(sum(bitrates) / len(bitrates) / 1000),
-            median_bitrate_kbps=int(statistics.median(bitrates) / 1000),
-            is_cbr=len(set(bitrates)) == 1,
-            album_path=resolution.album_path,
-            format=_reduce_album_format(
-                {item.format for item, _bitrate in measured if item.format},
-                cfg,
-            ),
+        return album_info_from_current(
+            resolution,
+            cfg if cfg is not None else QualityRankConfig.defaults(),
         )
+
+    def get_album_info(
+        self, mb_release_id: str, _cfg: Any = None,
+    ) -> Any:
+        # Delegates to the real projection instead of re-deriving the
+        # aggregates. The hand-copied version floored bps->kbps while
+        # production rounds, so this fake answered 48 kbps where the real
+        # ``album_info_from_current`` answered 49 for the very same seeded
+        # items — a divergence no test could see, because both sides of
+        # every assertion were the copy.
+        self.get_album_info_calls.append(mb_release_id)
+        return self._project_album_info(mb_release_id, _cfg)
 
     def get_item_paths(self, mb_release_id: str) -> list[tuple[int, str]]:
         self.get_item_paths_calls.append(mb_release_id)

--- a/tests/test_beets_current_resolver_generated.py
+++ b/tests/test_beets_current_resolver_generated.py
@@ -23,6 +23,7 @@ from lib.beets_db import (
     open_beets_db,
 )
 from lib.config import CratediggerConfig
+from lib.media_readiness import kbps_from_bps
 from lib.quality import QualityRankConfig
 from lib.release_identity import (
     ConflictingReleaseIdentityError,
@@ -312,7 +313,11 @@ class TestCurrentBeetsResolverGenerated(unittest.TestCase):
     ) -> None:
         values = sorted((first, second, third))
         minimum = values[0]
-        average = int(sum(values) / len(values))
+        # Reduced by the production helper, not a test-side floor: the fake
+        # seeds whole-kilobit items and ``album_info_from_current`` rounds
+        # half-up, so a floored average asks for an AlbumInfo those items
+        # cannot produce.
+        average = kbps_from_bps(sum(value * 1000 for value in values) // len(values))
         median = values[1]
         is_cbr = len(set(values)) == 1
         fake = FakeBeetsDB(library_root="/library")

--- a/tests/test_beets_db.py
+++ b/tests/test_beets_db.py
@@ -18,6 +18,10 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from lib.beets_db import BeetsDB, open_beets_db
 from lib.config import CratediggerConfig
+from lib.media_readiness import (
+    average_bitrate_kbps_from_frames,
+    kbps_from_bps,
+)
 from lib.quality import AudioQualityMeasurement, QualityRankConfig
 from lib.release_identity import ConflictingReleaseIdentityError
 
@@ -783,7 +787,9 @@ class TestGetAlbumInfo(unittest.TestCase):
             info = db.get_album_info("def-456", self.cfg)
         assert info is not None
         self.assertEqual(info.min_bitrate_kbps, 238)
-        self.assertEqual(info.avg_bitrate_kbps, 244)  # (245+238+251)/3 = 244.66 → 244
+        # (245+238+251)/3 = 244.66 → 245 (nearest, not floored — the two
+        # sides of a comparison must reduce bps to kbps the same way).
+        self.assertEqual(info.avg_bitrate_kbps, 245)
         # Median of {238, 245, 251} = 245
         self.assertEqual(info.median_bitrate_kbps, 245)
         self.assertFalse(info.is_cbr)
@@ -904,7 +910,8 @@ class TestGetAlbumInfo(unittest.TestCase):
         assert info is not None
         self.assertEqual(info.format, "Opus")
         self.assertEqual(info.min_bitrate_kbps, 120)
-        self.assertEqual(info.avg_bitrate_kbps, 127)  # (128+120+135)/3 = 127.66 → 127
+        # (128+120+135)/3 = 127.66 -> 128 nearest, not 127 floored.
+        self.assertEqual(info.avg_bitrate_kbps, 128)
         self.assertFalse(info.is_cbr)
 
     def test_flac_album_format(self) -> None:
@@ -1232,11 +1239,14 @@ class TestCheckMbidsDetail(unittest.TestCase):
                 "request-6039", QualityRankConfig.defaults()
             )
 
+        # 2_310_000 / 8 == 288_750 bps -> 289 kbps nearest (was 288 floored).
+        # Both projections reduce through the same shared helper, so they
+        # can never disagree about the same album.
         self.assertEqual(detail["beets_bitrate"], 194)
-        self.assertEqual(detail["beets_avg_bitrate"], 288)
+        self.assertEqual(detail["beets_avg_bitrate"], 289)
         assert info is not None
         self.assertEqual(info.min_bitrate_kbps, 194)
-        self.assertEqual(info.avg_bitrate_kbps, 288)
+        self.assertEqual(info.avg_bitrate_kbps, 289)
         self.assertEqual(info.median_bitrate_kbps, 320)
 
     def test_missing_mbid_not_in_result(self) -> None:
@@ -2002,3 +2012,55 @@ class TestListAlbumMbIdentities(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestBitrateReductionRoundsLikeTheCandidateSide(unittest.TestCase):
+    """Both sides of a quality comparison must reduce bps to kbps identically.
+
+    The installed copy is reduced from Beets' stored per-item rates here; the
+    candidate is measured frame-by-frame in ``lib.media_readiness``. When this
+    side floored and that side rounded, identical audio compared one kbps
+    apart — which is the skew that let dl 39947 "upgrade" an album over
+    itself. Both now call ``kbps_from_bps``.
+    """
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.db_path = os.path.join(self.tmp.name, "library.db")
+        _create_test_db(self.db_path)
+        self.cfg = QualityRankConfig.defaults()
+
+    def test_rates_are_rounded_not_floored(self) -> None:
+        # 105_892 bps floors to 105 and rounds to 106. The frame-measured
+        # candidate side reports 106 for the same stream.
+        _insert_album(self.db_path, 1, "round-me", [
+            (105_892, "/music/A/B/01.mp3"),
+            (105_892, "/music/A/B/02.mp3"),
+            (105_892, "/music/A/B/03.mp3"),
+        ])
+        with BeetsDB(self.db_path) as db:
+            info = db.get_album_info("round-me", self.cfg)
+        assert info is not None
+        self.assertEqual(info.min_bitrate_kbps, 106)
+        self.assertEqual(info.avg_bitrate_kbps, 106)
+        self.assertEqual(info.median_bitrate_kbps, 106)
+        self.assertEqual(
+            info.min_bitrate_kbps, kbps_from_bps(105_892),
+            "installed side must reduce through the shared helper",
+        )
+
+    def test_agrees_with_the_frame_measured_candidate_side(self) -> None:
+        # One stream, two producers: Beets' stored bps and a frame count for
+        # the same true rate. They must land on the same kbps.
+        sample_rate, seconds = 44_100, 100
+        for true_kbps in (128, 192, 256, 320):
+            with self.subTest(true_kbps=true_kbps):
+                sample_count = sample_rate * seconds
+                compressed_bytes = true_kbps * 1000 * seconds // 8
+                frame_side = average_bitrate_kbps_from_frames(
+                    compressed_bytes, sample_count, sample_rate,
+                )
+                beets_side = kbps_from_bps(true_kbps * 1000)
+                self.assertEqual(frame_side, beets_side)
+                self.assertEqual(frame_side, true_kbps)

--- a/tests/test_current_library_quality_generated.py
+++ b/tests/test_current_library_quality_generated.py
@@ -17,6 +17,7 @@ from lib.banding import (
     current_library_bitrate,
 )
 from lib.beets_db import BeetsDB
+from lib.media_readiness import kbps_from_bps
 from lib.quality import QualityRankConfig
 from tests.test_beets_db import _create_test_db, _insert_album
 
@@ -29,9 +30,18 @@ def assert_positive_track_average_projection(
     rank: str,
 ) -> None:
     """Current projection and rank must use the positive-track average."""
+    # This checker legislates WHICH tracks the projection selects — positive
+    # ones, averaged rather than collapsed to the minimum. The bps->kbps
+    # reduction itself is a separate contract owned by ``kbps_from_bps`` and
+    # pinned in tests/test_beets_db.py; reusing it here keeps this property
+    # about selection instead of silently re-pinning a rounding mode.
+    # Sharing the reduction costs no detection power in either direction:
+    # the min-selected known-bad self-test below still trips, and planting
+    # a floored reduction in production's own check_mbids_detail is still
+    # killed by this property.
     positive = [value for value in bitrates_bps if value > 0]
-    expected_min = min(positive) // 1000
-    expected_avg = int((sum(positive) / len(positive)) / 1000)
+    expected_min = kbps_from_bps(min(positive))
+    expected_avg = kbps_from_bps(sum(positive) // len(positive))
     assert detail["beets_bitrate"] == expected_min
     assert detail["beets_avg_bitrate"] == expected_avg
     assert selected_kbps == expected_avg

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -10,6 +10,7 @@ from zoneinfo import ZoneInfo
 
 import msgspec
 
+from lib.beets_db import AlbumInfo
 from lib.grab_list import DownloadFile, GrabListEntry
 from lib.pipeline_db import (
     PersistedDistance,
@@ -6673,6 +6674,170 @@ class TestFakeBeetsDB(unittest.TestCase):
             beets.get_album_info_calls,
             ["mbid-1", "mbid-1", "mbid-unknown"],
         )
+
+    def _rounding_boundary_album(self) -> AlbumInfo:
+        """What the shrunk lineage world really reduces to.
+
+        Hypothesis shrank to three tracks at 32 / 57 / 57 kbps. Their mean
+        is 48666 bps, which production's ``kbps_from_bps`` rounds to 49
+        while a floored copy reads 48 — the one-kbps gap that made a seeded
+        AlbumInfo and its rebuilt twin disagree. (Seeding this AlbumInfo
+        synthesizes 32 / 57 / 58, the whole-kilobit world with the same
+        aggregates.)
+        """
+        return AlbumInfo(
+            album_id=1,
+            track_count=3,
+            min_bitrate_kbps=32,
+            avg_bitrate_kbps=49,
+            median_bitrate_kbps=57,
+            is_cbr=False,
+            album_path="/Beets/Artist/Rounding",
+            format="AAC",
+        )
+
+    def _sub_kilobit_tracks(self) -> list[dict[str, object]]:
+        """Two items whose rate is not a whole number of kilobits.
+
+        Real Beets rows carry raw bits per second, which almost never land
+        on a kilobit boundary. 255600 is where flooring and rounding
+        disagree — 255 against 256 — so a floored copy of either projection
+        shows here and nowhere in the whole-kbps worlds ``set_album_info``
+        can express.
+        """
+        return [
+            {"bitrate": 255_600, "format": "MP3"},
+            {"bitrate": 255_600, "format": "MP3"},
+        ]
+
+    def test_get_album_info_is_the_production_projection(self) -> None:
+        """The fake must not re-derive what album_info_from_current derives.
+
+        Its hand-copied projection floored bps->kbps after production moved
+        to rounding, so the fake answered one kbps low for identical seeded
+        items. Both sides of every assertion were the copy, so nothing could
+        see it.
+        """
+        from lib.beets_db import CurrentBeetsUnique, album_info_from_current
+        from lib.quality import QualityRankConfig
+        from tests.fakes.beets import _lookup_identity
+
+        beets = FakeBeetsDB()
+        beets.set_tracks_for_release("mbid-sub", self._sub_kilobit_tracks())
+
+        identity = _lookup_identity("mbid-sub")
+        assert identity is not None
+        resolution = beets.resolve_current_release(identity)
+        assert isinstance(resolution, CurrentBeetsUnique)
+        expected = album_info_from_current(
+            resolution, QualityRankConfig.defaults(),
+        )
+        assert expected is not None
+        actual = beets.get_album_info("mbid-sub")
+        assert actual is not None
+
+        self.assertEqual(actual.min_bitrate_kbps, expected.min_bitrate_kbps)
+        self.assertEqual(actual.avg_bitrate_kbps, expected.avg_bitrate_kbps)
+        self.assertEqual(
+            actual.median_bitrate_kbps, expected.median_bitrate_kbps,
+        )
+        # 255 is what the floored copy reported.
+        self.assertEqual(actual.min_bitrate_kbps, 256)
+        self.assertEqual(actual.avg_bitrate_kbps, 256)
+        self.assertEqual(actual.median_bitrate_kbps, 256)
+        # Production also publishes the per-item codec set; the copy never
+        # did, so a mixed-codec fake album silently looked single-codec.
+        self.assertEqual(actual.formats_on_disk, expected.formats_on_disk)
+        self.assertEqual(actual.formats_on_disk, frozenset({"mp3"}))
+
+    def test_check_mbids_detail_shares_the_projection_reduction(self) -> None:
+        """The two projections of one album must not disagree in the fake."""
+        beets = FakeBeetsDB()
+        beets.set_tracks_for_release("mbid-sub", self._sub_kilobit_tracks())
+
+        detail = beets.check_mbids_detail(["mbid-sub"])["mbid-sub"]
+        projected = beets.get_album_info("mbid-sub")
+        assert projected is not None
+
+        self.assertEqual(detail["beets_bitrate"], projected.min_bitrate_kbps)
+        self.assertEqual(
+            detail["beets_avg_bitrate"], projected.avg_bitrate_kbps,
+        )
+        self.assertEqual(detail["beets_bitrate"], 256)
+        self.assertEqual(detail["beets_avg_bitrate"], 256)
+
+    def test_seeding_refuses_a_world_production_cannot_reduce_to(self) -> None:
+        """min/avg/median the synthesizer can no longer build.
+
+        32 / 48 / 57 is what the floored helper derived from tracks at
+        32 / 57 / 57, and it is not reachable from whole-kilobit tracks:
+        the median pins two of them at 57000 bps, so the smallest mean the
+        synthesizer can reach already rounds to 49. (Sub-kilobit tracks —
+        31500 / 56500 / 56500 — do reduce to it, which is why the refusal
+        is a limit of this constructor, not a claim about production.)
+        """
+        beets = FakeBeetsDB()
+        with self.assertRaisesRegex(
+            AssertionError, "not jointly expressible",
+        ):
+            beets.set_album_info("mbid-floored", AlbumInfo(
+                album_id=1,
+                track_count=3,
+                min_bitrate_kbps=32,
+                avg_bitrate_kbps=48,
+                median_bitrate_kbps=57,
+                is_cbr=False,
+                album_path="/Beets/Artist/Floored",
+                format="AAC",
+            ))
+
+    def test_seed_projection_checker_rejects_a_mismatched_album(self) -> None:
+        """Known-bad self-test for the seed round-trip's mismatch clause.
+
+        Driven through the real ``set_album_info``, so it also proves the
+        check is wired into seeding rather than merely callable.
+        """
+        class _WrongSynthesis(FakeBeetsDB):
+            @staticmethod
+            def _synthesize_bitrates(info: AlbumInfo) -> list[int]:
+                # Right min and median, wrong top track: production
+                # averages this world to 53, not the 49 asked for. (Nudging
+                # the top track by one kbps is NOT a mutant — 58000 still
+                # reduces to 49, which is the whole point of this check.)
+                return [32_000, 57_000, 70_000]
+
+        beets = _WrongSynthesis()
+        with self.assertRaisesRegex(
+            AssertionError, "do not reduce to the requested AlbumInfo",
+        ):
+            beets.set_album_info("mbid-round", self._rounding_boundary_album())
+
+    def test_seed_projection_checker_rejects_an_unresolvable_release(
+        self,
+    ) -> None:
+        """Known-bad self-test for the seed round-trip's resolution clause.
+
+        An album path that escapes the library root resolves ambiguous, so
+        there is no projection to compare against — also through the real
+        seeding path.
+        """
+        import dataclasses
+
+        beets = FakeBeetsDB()
+        with self.assertRaisesRegex(
+            AssertionError, "does not resolve to a unique current release",
+        ):
+            beets.set_album_info("mbid-escape", dataclasses.replace(
+                self._rounding_boundary_album(), album_path="../escape",
+            ))
+
+    def test_seeding_does_not_record_its_own_verification(self) -> None:
+        """A seed is not an observation the test asked for."""
+        beets = FakeBeetsDB()
+        beets.set_album_info("mbid-round", self._rounding_boundary_album())
+
+        self.assertEqual(beets.resolve_current_release_calls, [])
+        self.assertEqual(beets.get_album_info_calls, [])
 
     def test_check_mbids_uses_seeded_album_exists_state(self) -> None:
         beets = FakeBeetsDB()

--- a/tests/test_force_import_gates.py
+++ b/tests/test_force_import_gates.py
@@ -227,14 +227,21 @@ class TestNeedsSpectralCheckDecisions(unittest.TestCase):
         self.assertFalse(self._run("", False))
 
     def test_vbr_threshold_table(self):
-        """VBR branch: gate only when avg is unknown or < threshold."""
+        """VBR branch: gate when avg is unknown or at/below the threshold."""
         CASES = [
             # (desc, avg_kbps, expected)
             ("avg unknown → gate (conservative)",          None, True),
             ("go_team case — avg 182 < 210 → gate",         182, True),
             ("live issue #93 avg 182kbps transcode",        182, True),
             ("just below threshold — 200 → gate",           200, True),
-            ("at threshold — 210 is NOT below → skip",      210, False),
+            # Inclusive since PR #1144: per-track rates are rounded to the
+            # nearest integer rather than floored, so a true 209.6 album now
+            # reads exactly 210. A strict `<` would silently stop scanning it
+            # in the last kbps before the boundary — where a fake V0 is most
+            # likely to sit. Reading exactly the threshold is "not yet proven
+            # above it". See TestVbrScanThresholdIsInclusive.
+            ("at threshold — 210 is not proven above → gate", 210, True),
+            ("first kbps proven above threshold — 211 → skip", 211, False),
             ("genuine V0 avg ~245 → skip",                  245, False),
             ("genuine V0 avg ~260 → skip",                  260, False),
             ("very low 96kbps → gate",                       96, True),
@@ -1066,3 +1073,45 @@ class TestFallbackSkippedWhenBeetsFindsNoAlbum(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestVbrScanThresholdIsInclusive(unittest.TestCase):
+    """A rounded average must not round an album out of the transcode scan.
+
+    ``average_bitrate_kbps_from_frames`` reports the nearest integer rather
+    than the floor (PR #1144). That lifts a per-track rate by up to one kbps,
+    so an album whose true average sits just under
+    ``cfg.quality_ranks.mp3_vbr.excellent`` can now read exactly the
+    threshold. With a strict ``<`` that album silently stops being scanned —
+    the issue #93 fake-V0 gate losing coverage in the last kbps before the
+    boundary, which is the one place a fake V0 is most likely to sit.
+
+    The threshold is therefore inclusive: reading exactly the threshold is
+    "not yet proven above it", and the conservative action is to scan.
+    """
+
+    THRESHOLD = 210
+
+    def _run(self, avg_kbps: int | None) -> bool:
+        from lib.measurement import _needs_spectral_check
+        return _needs_spectral_check(
+            "mp3", True,
+            lossless_candidate=False,
+            avg_bitrate_kbps=avg_kbps,
+            vbr_threshold_kbps=self.THRESHOLD,
+        )
+
+    def test_album_landing_exactly_on_the_threshold_is_still_scanned(self) -> None:
+        # True per-track rate 209.6: floored to 209 before the rounding fix,
+        # rounded to 210 after it. Both must still be scanned.
+        self.assertTrue(self._run(209), "below threshold must scan")
+        self.assertTrue(self._run(self.THRESHOLD), "exactly at threshold must scan")
+
+    def test_genuinely_above_threshold_still_skips(self) -> None:
+        # Must-still-work guard: a real V0 (~245) is not dragged into the scan.
+        for avg in (self.THRESHOLD + 1, 245, 260):
+            with self.subTest(avg=avg):
+                self.assertFalse(self._run(avg))
+
+    def test_unknown_average_remains_conservative(self) -> None:
+        self.assertTrue(self._run(None))

--- a/tests/test_long_tail_service_generated.py
+++ b/tests/test_long_tail_service_generated.py
@@ -28,6 +28,7 @@ from lib.beets_db import (
     CurrentBeetsUnique,
 )
 from lib.long_tail_service import list_long_tail
+from lib.media_readiness import kbps_from_bps
 from lib.quality import QualityRankConfig
 from lib.release_identity import ReleaseIdentity
 from tests.fakes import FakePipelineDB
@@ -328,7 +329,12 @@ class TestCurrentBeetsBandingGenerated(unittest.TestCase):
         flac_bitrate: int,
     ) -> None:
         cfg = QualityRankConfig.defaults()
-        average_kbps = int((mp3_bitrate + flac_bitrate) / 2 / 1000)
+        # Production's reduction, so the expectation cannot drift from the
+        # projection it is compared against. Behaviour-neutral today: no
+        # sum in this strategy's domain reaches a rank boundary where floor
+        # and round disagree — but the ladder is the only reason, and that
+        # is not a property this test should depend on.
+        average_kbps = kbps_from_bps((mp3_bitrate + flac_bitrate) // 2)
         expected = compute_library_rank("MP3", average_kbps, cfg)
         bands: list[str] = []
         for flac_first in (True, False):

--- a/tests/test_media_readiness.py
+++ b/tests/test_media_readiness.py
@@ -6,6 +6,8 @@ import subprocess
 import tempfile
 import unittest
 from pathlib import Path
+from typing import IO
+from unittest.mock import patch
 
 from lib.media_readiness import (
     MediaReadinessError,
@@ -233,3 +235,36 @@ class TestAverageBitrateDerivationPin(unittest.TestCase):
         ):
             with self.subTest(label):
                 self.assertIsNone(average_bitrate_kbps_from_frames(*args))
+
+    def test_the_reader_itself_reports_the_exact_rate(self) -> None:
+        """The fix has to reach the call site, not just the helper.
+
+        ``media_facts_for_path`` is what every consumer actually calls, and
+        it kept its own float derivation until this change. Only ffprobe
+        itself is replaced, at the subprocess leaf; its compact output is
+        then parsed, validated and reduced entirely by production code.
+        """
+        compressed_bytes, sample_count, sample_rate = self.KOPPEL_TRACK_04
+        probe_output = (
+            f"index=0|codec_type=audio|codec_name=mp3"
+            f"|sample_rate={sample_rate}|channels=2\n"
+            f"stream_index=0|nb_samples={sample_count}\n"
+            f"stream_index=0|size={compressed_bytes}\n"
+            f"format_name=mp3\n"
+        )
+
+        def fake_ffprobe(
+            argv: list[str], *, stdout: IO[str], **_kwargs: object,
+        ) -> subprocess.CompletedProcess[str]:
+            stdout.write(probe_output)
+            return subprocess.CompletedProcess(argv, 0)
+
+        with patch(
+            "lib.media_readiness.subprocess.run", side_effect=fake_ffprobe,
+        ):
+            facts = media_facts_for_path("/nonexistent/04 Koppel.mp3")
+
+        # Guards against a fixture that stopped reproducing the live world.
+        self.assertEqual(facts.sample_count, sample_count)
+        self.assertEqual(facts.compressed_audio_bytes, compressed_bytes)
+        self.assertEqual(facts.average_bitrate_kbps, 256)

--- a/tests/test_media_readiness.py
+++ b/tests/test_media_readiness.py
@@ -200,15 +200,27 @@ class TestAverageBitrateDerivationPin(unittest.TestCase):
         )
 
     def test_rate_is_rounded_to_nearest_not_truncated(self) -> None:
-        # 44100 Hz, 1152-sample frames: a real stream rarely lands on an exact
-        # integer. Nearest-integer is the honest report; flooring always biases
-        # a constant stream downward and can break uniformity on one track.
-        sample_rate, sample_count = 44_100, 44_100  # exactly 1 second
-        for exact_bits, expected in ((191_600, 192), (192_400, 192), (191_499, 191)):
-            with self.subTest(exact_bits=exact_bits):
+        # A real stream rarely lands on an exact integer. Nearest-integer is
+        # the honest report; flooring always biases a constant stream downward
+        # and can break uniformity on a single track.
+        #
+        # Exactly one second at 44100 Hz, so kbps == bytes * 8 / 1000 and the
+        # cases below are the byte counts that bracket the 191.5 rounding
+        # boundary. Byte counts, not bit counts: the input is bytes, and a
+        # "bits" spelling that is not a multiple of eight would be a fixture
+        # that cannot exist.
+        sample_rate, sample_count = 44_100, 44_100
+        cases = (
+            (23_950, 192),  # 191.600 kbps -> up
+            (24_050, 192),  # 192.400 kbps -> down
+            (23_937, 191),  # 191.496 kbps -> down, just under the boundary
+            (23_938, 192),  # 191.504 kbps -> up, just over it
+        )
+        for compressed_bytes, expected in cases:
+            with self.subTest(compressed_bytes=compressed_bytes):
                 self.assertEqual(
                     average_bitrate_kbps_from_frames(
-                        exact_bits // 8, sample_count, sample_rate,
+                        compressed_bytes, sample_count, sample_rate,
                     ),
                     expected,
                 )

--- a/tests/test_media_readiness.py
+++ b/tests/test_media_readiness.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from lib.media_readiness import (
     MediaReadinessError,
+    average_bitrate_kbps_from_frames,
     flac_total_samples_only_changed,
     inspect_media,
     media_facts_for_path,
@@ -166,3 +167,57 @@ class TestFlacReadinessPin(unittest.TestCase):
             facts = media_facts_for_path(str(path))
             self.assertEqual(facts.codec, "mp3")
             self.assertGreater(facts.sample_count, 0)
+
+
+class TestAverageBitrateDerivationPin(unittest.TestCase):
+    """A constant-bitrate stream must never read one kbps low (Koppel, dl 39947).
+
+    ``album_quality_evidence`` id 36856: ten genuinely 256 kbps tracks, one of
+    which derived 255 because the rate was computed through a float
+    ``duration`` that is not exactly representable. That single kbps broke
+    per-track bitrate uniformity, flipped ``is_cbr`` to False, routed the album
+    onto ``cfg.mp3_vbr`` (transparent >= 245) instead of ``cfg.mp3_cbr``
+    (transparent >= 320), and the album out-ranked and re-imported over itself.
+    """
+
+    # Track 04 of the live album, exactly as ffprobe reported it. The real
+    # quotient is an integer: 8517888 * 8 == 266.184 s * 256 kbps * 1000.
+    KOPPEL_TRACK_04 = (8_517_888, 12_776_832, 48_000)
+
+    def test_exactly_representable_rate_is_not_floored_one_low(self) -> None:
+        compressed_bytes, sample_count, sample_rate = self.KOPPEL_TRACK_04
+        # The defect: routing through float seconds loses the exact quotient.
+        self.assertEqual(
+            int((compressed_bytes * 8) / (sample_count / sample_rate) / 1000),
+            255,
+            "fixture no longer reproduces the float-truncation world",
+        )
+        self.assertEqual(
+            average_bitrate_kbps_from_frames(
+                compressed_bytes, sample_count, sample_rate,
+            ),
+            256,
+        )
+
+    def test_rate_is_rounded_to_nearest_not_truncated(self) -> None:
+        # 44100 Hz, 1152-sample frames: a real stream rarely lands on an exact
+        # integer. Nearest-integer is the honest report; flooring always biases
+        # a constant stream downward and can break uniformity on one track.
+        sample_rate, sample_count = 44_100, 44_100  # exactly 1 second
+        for exact_bits, expected in ((191_600, 192), (192_400, 192), (191_499, 191)):
+            with self.subTest(exact_bits=exact_bits):
+                self.assertEqual(
+                    average_bitrate_kbps_from_frames(
+                        exact_bits // 8, sample_count, sample_rate,
+                    ),
+                    expected,
+                )
+
+    def test_degenerate_inputs_withhold_a_rate(self) -> None:
+        for label, args in (
+            ("no samples", (1_000, 0, 44_100)),
+            ("no sample rate", (1_000, 44_100, 0)),
+            ("no audio bytes", (0, 44_100, 44_100)),
+        ):
+            with self.subTest(label):
+                self.assertIsNone(average_bitrate_kbps_from_frames(*args))

--- a/tests/test_media_readiness_generated.py
+++ b/tests/test_media_readiness_generated.py
@@ -123,6 +123,10 @@ def bitrate_derivation_violations(
     Accumulating rather than short-circuiting: each clause is evaluated on
     every world, so an earlier violation can never mask a later one.
     """
+    # Two clauses below are deliberately SUBSUMED rather than independent:
+    # when the ratio is an exact integer, `nearest` equals it, and a negative
+    # `derived` can never equal a non-negative `nearest`. They are kept for
+    # the named diagnosis they produce, not for extra detection power.
     violations: list[str] = []
     degenerate = compressed_bytes <= 0 or sample_count <= 0 or sample_rate <= 0
     if degenerate:

--- a/tests/test_media_readiness_generated.py
+++ b/tests/test_media_readiness_generated.py
@@ -11,7 +11,11 @@ from hypothesis import given, settings
 from hypothesis import strategies as st
 
 import tests._hypothesis_profiles  # noqa: F401
-from lib.media_readiness import flac_total_samples_only_changed, prepare_media_readiness
+from lib.media_readiness import (
+    average_bitrate_kbps_from_frames,
+    flac_total_samples_only_changed,
+    prepare_media_readiness,
+)
 from tests.audio_fixtures import make_test_flac
 from tests.test_media_readiness import _streaminfo_span, _zero_flac_duration_metadata
 
@@ -95,3 +99,161 @@ class TestFlacMetadataMutationProperty(unittest.TestCase):
         forbidden = bytearray(allowed)
         forbidden[start + 13] ^= 0x10
         self.assertFalse(flac_total_samples_only_changed(before, bytes(forbidden)))
+
+
+# Track 04 of Koppel *Improvisationer for Klaver* exactly as ffprobe reported
+# it (evidence 36856): the real quotient is the integer 256, but the float
+# path yielded 255.99999999999997 and truncated to 255.
+_KOPPEL_TRACK_04 = {
+    "compressed_bytes": 8_517_888,
+    "sample_count": 12_776_832,
+    "sample_rate": 48_000,
+}
+
+
+def bitrate_derivation_violations(
+    *,
+    compressed_bytes: int,
+    sample_count: int,
+    sample_rate: int,
+    derived: int | None,
+) -> list[str]:
+    """Every way a derived average bitrate can misreport its own stream.
+
+    Accumulating rather than short-circuiting: each clause is evaluated on
+    every world, so an earlier violation can never mask a later one.
+    """
+    violations: list[str] = []
+    degenerate = compressed_bytes <= 0 or sample_count <= 0 or sample_rate <= 0
+    if degenerate:
+        if derived is not None:
+            violations.append(
+                f"degenerate stream invented a rate: got {derived}"
+            )
+        return violations
+    if derived is None:
+        violations.append("measurable stream withheld a rate")
+        return violations
+    numerator = compressed_bytes * 8 * sample_rate
+    denominator = sample_count * 1000
+    if numerator % denominator == 0:
+        exact = numerator // denominator
+        if derived != exact:
+            violations.append(
+                f"exact integer rate {exact} reported as {derived}"
+            )
+    nearest = (numerator + denominator // 2) // denominator
+    if derived != nearest:
+        violations.append(
+            f"rate {derived} is not the nearest integer {nearest}"
+        )
+    if derived < 0:
+        violations.append(f"negative rate {derived}")
+    return violations
+
+
+class TestAverageBitrateDerivationProperty(unittest.TestCase):
+    """A constant-bitrate stream must read as its own constant rate.
+
+    Patrols the world space around the Koppel pin in
+    ``tests/test_media_readiness.py`` — the float-truncation defect that
+    made one 256 kbps track of ten report 255, broke ``is_cbr`` uniformity
+    and re-imported an album over itself (dl 39947).
+    """
+
+    @settings(max_examples=250)
+    @given(
+        nominal_kbps=st.sampled_from((96, 128, 160, 192, 224, 256, 320)),
+        sample_rate=st.sampled_from((44_100, 48_000, 32_000, 22_050)),
+        seconds_milli=st.integers(min_value=1_000, max_value=900_000),
+    )
+    def test_exact_constant_streams_report_their_own_rate(
+        self, *, nominal_kbps: int, sample_rate: int, seconds_milli: int,
+    ) -> None:
+        # Build a stream whose true rate is EXACTLY nominal_kbps, then let the
+        # real production derivation read it back.
+        sample_count = max(1, (sample_rate * seconds_milli) // 1000)
+        numerator = nominal_kbps * 1000 * sample_count
+        if numerator % (8 * sample_rate):
+            return  # not an exact whole-byte stream; covered by the general clause
+        compressed_bytes = numerator // (8 * sample_rate)
+        derived = average_bitrate_kbps_from_frames(
+            compressed_bytes, sample_count, sample_rate,
+        )
+        self.assertEqual(
+            bitrate_derivation_violations(
+                compressed_bytes=compressed_bytes,
+                sample_count=sample_count,
+                sample_rate=sample_rate,
+                derived=derived,
+            ),
+            [],
+        )
+        self.assertEqual(derived, nominal_kbps)
+
+    @settings(max_examples=250)
+    @given(
+        compressed_bytes=st.integers(min_value=0, max_value=200_000_000),
+        sample_count=st.integers(min_value=0, max_value=200_000_000),
+        sample_rate=st.sampled_from((0, 8_000, 22_050, 32_000, 44_100, 48_000, 96_000)),
+    )
+    def test_arbitrary_streams_never_misreport(
+        self, *, compressed_bytes: int, sample_count: int, sample_rate: int,
+    ) -> None:
+        derived = average_bitrate_kbps_from_frames(
+            compressed_bytes, sample_count, sample_rate,
+        )
+        self.assertEqual(
+            bitrate_derivation_violations(
+                compressed_bytes=compressed_bytes,
+                sample_count=sample_count,
+                sample_rate=sample_rate,
+                derived=derived,
+            ),
+            [],
+        )
+
+
+class TestBitrateDerivationCheckerTripsOnViolations(unittest.TestCase):
+    """Known-bad self-test per CLAUSE — a guard that never fires proves nothing."""
+
+    def test_exact_integer_clause_trips(self) -> None:
+        # The live defect world: exact 256, reported 255.
+        self.assertIn(
+            "exact integer rate 256 reported as 255",
+            bitrate_derivation_violations(**_KOPPEL_TRACK_04, derived=255),
+        )
+
+    def test_nearest_integer_clause_trips(self) -> None:
+        # A non-exact stream reported one low. 44100 Hz, 1 s, 191.6 kbps.
+        found = bitrate_derivation_violations(
+            compressed_bytes=191_600 // 8, sample_count=44_100,
+            sample_rate=44_100, derived=191,
+        )
+        self.assertTrue(
+            any("is not the nearest integer 192" in v for v in found), found,
+        )
+
+    def test_withheld_rate_clause_trips(self) -> None:
+        self.assertIn(
+            "measurable stream withheld a rate",
+            bitrate_derivation_violations(**_KOPPEL_TRACK_04, derived=None),
+        )
+
+    def test_invented_rate_clause_trips(self) -> None:
+        self.assertIn(
+            "degenerate stream invented a rate: got 128",
+            bitrate_derivation_violations(
+                compressed_bytes=0, sample_count=44_100,
+                sample_rate=44_100, derived=128,
+            ),
+        )
+
+    def test_negative_rate_clause_trips(self) -> None:
+        found = bitrate_derivation_violations(**_KOPPEL_TRACK_04, derived=-1)
+        self.assertTrue(any("negative rate -1" in v for v in found), found)
+
+    def test_clean_world_has_no_violations(self) -> None:
+        self.assertEqual(
+            bitrate_derivation_violations(**_KOPPEL_TRACK_04, derived=256), [],
+        )

--- a/tests/test_preview_failure_evidence_generated.py
+++ b/tests/test_preview_failure_evidence_generated.py
@@ -49,6 +49,7 @@ from lib.import_queue import (
     force_import_payload,
     youtube_import_payload,
 )
+from lib.media_readiness import kbps_from_bps
 from lib.quality import (
     ActiveDownloadState,
     AlbumQualityEvidence,
@@ -171,7 +172,13 @@ def preview_failure_worlds(draw: st.DrawFn) -> PreviewFailureWorld:
         ))),
         storage_format=draw(st.sampled_from(("MP3", "Opus", "FLAC"))),
         minimum=minimum,
-        average=int((minimum + median + maximum) / 3),
+        # Reduced by the production helper, not a test-side floor: these
+        # become whole-kilobit Beets items, and ``album_info_from_current``
+        # rounds half-up, so a floored average asks for an AlbumInfo those
+        # items cannot produce.
+        average=kbps_from_bps(
+            sum(value * 1000 for value in (minimum, median, maximum)) // 3
+        ),
         median=median,
         hook_fault=draw(st.sampled_from(("none", "prepare", "enrich"))),
     )

--- a/tests/test_quality_lineage_generated.py
+++ b/tests/test_quality_lineage_generated.py
@@ -30,6 +30,7 @@ from lib.import_preview import (
     prepare_current_evidence_for_failure,
 )
 from lib.measurement import PreimportMeasurement
+from lib.media_readiness import kbps_from_bps
 from lib.pipeline_db.download_log import _DownloadLogMixin
 from lib.quality import (
     IMPORT_RESULT_SENTINEL,
@@ -106,10 +107,18 @@ def _coherent_three_track_metrics(
     second: int,
     third: int,
 ) -> tuple[int, int, int, bool]:
-    """Turn generated item bitrates into production-derived album metrics."""
+    """Turn generated item bitrates into production-derived album metrics.
+
+    The album average is reduced by the production helper, not by a
+    test-side ``int(.../3)``. Flooring here derived an AlbumInfo one kbps
+    below the one ``album_info_from_current`` rebuilds from the very same
+    three tracks (it rounds half-up), so the round trip these tests assert
+    was being fed a world production cannot produce.
+    """
 
     minimum, median, maximum = sorted((first, second, third))
-    average = int((minimum + median + maximum) / 3)
+    bitrates_bps = [value * 1000 for value in (minimum, median, maximum)]
+    average = kbps_from_bps(sum(bitrates_bps) // len(bitrates_bps))
     return minimum, average, median, minimum == maximum
 
 


### PR DESCRIPTION
## Problem

A constant-bitrate MP3 album could report **one track one kbps low**. That single kbps breaks per-track bitrate uniformity, which is what `is_cbr` is derived from (`harness/import_one.py:2191`, `lib/beets_db.py:409`). A constant album then looks variable, and MP3 ranks through `cfg.mp3_vbr` (transparent ≥ 245) instead of `cfg.mp3_cbr` (transparent ≥ 320) — **a two-tier rank swing on identical audio**.

### Live instance — dl 39947 / request 4781, Thomas Koppel *Improvisationer for Klaver*

The download and the library copy are **the same rip**: evidence `25529` (library, measured 2026-06-24) and `36856` (the download, measured 2026-08-13) carry `ultrasonic_deficit_db = 83.61596636394096` — identical to 16 significant figures, from two independent measurements two months apart, plus identical cliff (18500 Hz) and identical V0 probe (231/237/237).

Track 04 is genuinely 256 kbps. The quotient is an exact integer:

```
8_517_888 bytes × 8  ==  266.184 s × 256 kbps × 1000  ==  68_143_104
```

But `sample_count / sample_rate` is not exactly representable, so:

```python
duration = sample_count / sample_rate                        # 266.184 (inexact)
bitrate  = int((compressed_bytes * 8) / duration / 1000)     # 255.99999999999997 -> 255
```

Nine tracks read 256, one read 255 → `is_cbr=False` → VBR ladder → **TRANSPARENT** vs the library copy's **EXCELLENT** → `verdict=better` → re-imported over itself.

Replaying the persisted `comparison_basis` through the real `compare_quality` reproduces it field-for-field; flipping only the candidate's `is_cbr` yields `verdict=worse, rank=good`, i.e. it would have been rejected.

## Fix

`average_bitrate_kbps_from_frames` evaluates the quotient as an **exact integer ratio** and rounds half-up, never routing through the float duration.

Rounding rather than truncating is the second half of the fix: a real stream rarely lands on an exact integer, and flooring biases every such track downward.

Note `compressed_bytes` is the sum of audio **packet** sizes from `ffprobe -show_packets` — tags were never included, so this is not a tag-overhead bug. It is purely float error in the derivation.

## Live impact — 60-album library sample (real files, doc2)

```
albums checked: 60   files: 558
per-file rate changed:   178  (31.9%)
albums whose is_cbr FLIPS: 11  (18.3%)

  [319, 320] -> [320]   ×4
  [255, 256] -> [256]   ×3
  [191, 192] -> [192]   ×2
  [127, 128] -> [128]   ×1
```

Every flip is a plain CBR album at a standard rate that was being read as variable and ranked on the generous VBR ladder. No album flips the other way.

This changes newly written evidence only; existing rows are unaffected until re-measured.

## Tests — pin + property, mutant-qualified

- `TestAverageBitrateDerivationPin` — the exact live numbers, nearest-integer contract, degenerate-input contract.
- `TestAverageBitrateDerivationProperty` — exact constant streams report their own rate; arbitrary streams never misreport.
- `TestBitrateDerivationCheckerTripsOnViolations` — a message-asserting known-bad self-test for **every clause** of the checker.

**Kill matrix.** Mutant = restore the float path (`int((compressed_bytes * 8) / duration / 1000)`). Killed by all four:

| test | mutant |
|---|---|
| `test_exactly_representable_rate_is_not_floored_one_low` | FAIL ✅ |
| `test_rate_is_rounded_to_nearest_not_truncated` | FAIL ✅ |
| `test_exact_constant_streams_report_their_own_rate` (generated) | FAIL ✅ |
| `test_arbitrary_streams_never_misreport` (generated) | FAIL ✅ |

Both generated properties die on the mutant, so the load-bearing half is qualified, not just the pins.

## Gate

`scripts/run_final_gate.sh` → **pass**, receipt `/run/user/1000/cratedigger-final-gate.DTURUHmg`, commit `530e7253`.

## Follow-ups (agreed sequence, not deferral)

1. **This PR** — truncation.
2. Measurement symmetry: candidate uses ffmpeg *measured* rate, library uses beets *declared* frame-header nominal. Different quantities, still not comparable.
3. Mint `mp3 vN` contracts from the LAME header so genuine VBR is proven, not guessed.
4. Collapse `mp3_vbr`/`mp3_cbr` into one MP3 ladder; bump `lineage_version` 4→5 for lazy re-derivation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
