### PR TITLE
perf(#1131): drop redundant nested nix-shell in decision-corpus-export test

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -381,18 +381,23 @@ an inherited process-environment setting, so a NESTED `nix-shell` a test
 spawns as its own subprocess also inherits it from the enclosing suite and
 skips the same refusal — deliberately, since the enclosing `run_suite`
 already owns headroom enforcement for the whole run and a nested shell
-re-imposing its own would be redundant, not protective. (`tests/test_
-decision_corpus_export.py` used to be this case, nesting six such
+re-imposing its own would be redundant, not protective. (`tests/test_decision_corpus_export.py` used to be this case, nesting six such
 subprocesses per run to invoke a copied `scripts/decision_differential.py`
 against historical base-ref archives; issue #1131 removed the nesting
 entirely — `sys.executable` was already the enclosing shell's own
 interpreter with an identical `PYTHONPATH`, so re-entering `nix-shell` paid
 a full Nix evaluation per call for zero additional capability. The six
-calls now invoke `sys.executable` directly, so nothing currently exercises
-this inherited-skip path — the mechanism remains in `scripts/test_tmpfs.sh`
-for the next test that legitimately needs to nest.) Only a genuinely
-interactive `nix-shell` entry, started outside any suite run, never has this
-var set and keeps its entry guard.
+calls now invoke `sys.executable` directly, so no test currently spawns a
+NESTED `nix-shell` — but this is not dead machinery: the top-level
+free-bytes skip itself is taken on EVERY suite run launched by
+`scripts/test.sh`, `scripts/run_final_gate.sh`, and
+`scripts/daily_flake_update.sh`, and is pinned by
+`tests/test_test_tmpfs.py::test_suite_owns_headroom_skips_only_the_free_bytes_refusal`.
+Only the nested-shell-inherits-the-var form has no current example — the
+mechanism remains in `scripts/test_tmpfs.sh` for the next test that
+legitimately needs to nest.) Only a genuinely interactive `nix-shell` entry,
+started outside any suite run, never has this var set and keeps its entry
+guard.
 
 Once admitted, `run_suite` best-effort reaps scratch directories nothing can
 still be writing (`reap_stale_check_bundles`, prefix set

--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -378,13 +378,21 @@ launching it as an unattended, contention-prone automation.
 
 It is NOT only interactive entries that differ: the var is
 an inherited process-environment setting, so a NESTED `nix-shell` a test
-spawns as its own subprocess (`tests/test_decision_corpus_export.py` does
-this) also inherits it from the enclosing suite and skips the same
-refusal — deliberately, since the enclosing `run_suite` already owns
-headroom enforcement for the whole run and a nested shell re-imposing its
-own would be redundant, not protective. Only a genuinely interactive
-`nix-shell` entry, started outside any suite run, never has this var set and
-keeps its entry guard.
+spawns as its own subprocess also inherits it from the enclosing suite and
+skips the same refusal — deliberately, since the enclosing `run_suite`
+already owns headroom enforcement for the whole run and a nested shell
+re-imposing its own would be redundant, not protective. (`tests/test_
+decision_corpus_export.py` used to be this case, nesting six such
+subprocesses per run to invoke a copied `scripts/decision_differential.py`
+against historical base-ref archives; issue #1131 removed the nesting
+entirely — `sys.executable` was already the enclosing shell's own
+interpreter with an identical `PYTHONPATH`, so re-entering `nix-shell` paid
+a full Nix evaluation per call for zero additional capability. The six
+calls now invoke `sys.executable` directly, so nothing currently exercises
+this inherited-skip path — the mechanism remains in `scripts/test_tmpfs.sh`
+for the next test that legitimately needs to nest.) Only a genuinely
+interactive `nix-shell` entry, started outside any suite run, never has this
+var set and keeps its entry guard.
 
 Once admitted, `run_suite` best-effort reaps scratch directories nothing can
 still be writing (`reap_stale_check_bundles`, prefix set

--- a/scripts/test_tmpfs.sh
+++ b/scripts/test_tmpfs.sh
@@ -79,12 +79,22 @@ setup_cratedigger_test_tmpfs() {
     # message instead of queueing on the lock (issue #1111 review M2) — this
     # setup still runs in full otherwise; only the free-bytes refusal defers.
     # This is inherited process environment, not an entry-time flag: a
-    # NESTED nix-shell a test spawns as its own subprocess (e.g.
-    # tests/test_decision_corpus_export.py) also inherits it from the
-    # enclosing suite and skips the same refusal — deliberately, since the
-    # enclosing run_suite() already owns headroom enforcement for the whole
-    # run. Only a genuinely interactive nix-shell entry, started outside any
-    # suite run, never has this set and keeps its own entry guard.
+    # NESTED nix-shell a test spawns as its own subprocess also inherits it
+    # from the enclosing suite and skips the same refusal — deliberately,
+    # since the enclosing run_suite() already owns headroom enforcement for
+    # the whole run. No test currently nests a nix-shell this way —
+    # tests/test_decision_corpus_export.py used to nest six such calls;
+    # issue #1131 removed the nesting since the already-active interpreter
+    # needed no re-entry. This is the SAME `if` check either way, so it is
+    # not dormant: it still runs, and skips, on every suite invocation
+    # started by scripts/test.sh, scripts/run_final_gate.sh, and
+    # scripts/daily_flake_update.sh, which all set this var before their
+    # own top-level nix-shell entry. Only the NESTED case — one shell
+    # spawning another as its own subprocess and inheriting the var that
+    # way — currently has no live example; nothing here needs to change
+    # for the next test that legitimately needs it. Only a genuinely
+    # interactive nix-shell entry, started outside any suite run, never has
+    # this set and keeps its own entry guard.
     if [[ "${CRATEDIGGER_SUITE_OWNS_HEADROOM:-}" != "1" ]]; then
         available_bytes="$(
             df -B1 --output=avail "$parent" | tail -n 1 | tr -d '[:space:]'

--- a/tests/test_decision_corpus_export.py
+++ b/tests/test_decision_corpus_export.py
@@ -1205,7 +1205,7 @@ class TestDecisionCorpusExport(unittest.TestCase):
                     script,
                 )
                 completed = subprocess.run(
-                    ["nix-shell", "--run", f"{sys.executable} {script} --help"],
+                    [sys.executable, str(script), "--help"],
                     check=False,
                     capture_output=True,
                     text=True,
@@ -1226,11 +1226,7 @@ class TestDecisionCorpusExport(unittest.TestCase):
                         *(("--counterfactual",) if counterfactual else ()),
                     )
                     completed = subprocess.run(
-                        [
-                            "nix-shell",
-                            "--run",
-                            " ".join((sys.executable, str(script), *args)),
-                        ],
+                        [sys.executable, str(script), *args],
                         check=False,
                         capture_output=True,
                         text=True,

--- a/tests/test_parallel_test_runner.py
+++ b/tests/test_parallel_test_runner.py
@@ -166,8 +166,8 @@ class TestWorkerCrashClassification(unittest.TestCase):
         configured 1 GiB startup floor (CRATEDIGGER_TEST_RAM_MIN_BYTES) —
         real exhaustion the suite would refuse to even start under — but
         was ABOVE the old internal _MIN_VALID_TEMP_HEADROOM_BYTES (64 MiB),
-        so it used to read as an ordinary worker failure. tests/test_
-        decision_corpus_export.py's now-removed nested nix-shell
+        so it used to read as an ordinary worker failure.
+        tests/test_decision_corpus_export.py's now-removed nested nix-shell
         subprocesses (issue #1131) used to genuinely fail in exactly this
         band mid-run.
         """

--- a/tests/test_parallel_test_runner.py
+++ b/tests/test_parallel_test_runner.py
@@ -167,8 +167,9 @@ class TestWorkerCrashClassification(unittest.TestCase):
         real exhaustion the suite would refuse to even start under — but
         was ABOVE the old internal _MIN_VALID_TEMP_HEADROOM_BYTES (64 MiB),
         so it used to read as an ordinary worker failure. tests/test_
-        decision_corpus_export.py's nested nix-shell subprocesses genuinely
-        fail in exactly this band mid-run.
+        decision_corpus_export.py's now-removed nested nix-shell
+        subprocesses (issue #1131) used to genuinely fail in exactly this
+        band mid-run.
         """
         original = os.environ.pop("CRATEDIGGER_TEST_RAM_MIN_BYTES", None)
         try:


### PR DESCRIPTION
## Summary

`tests/test_decision_corpus_export.py::TestDecisionCorpusExport::test_exact_base_archive_can_help_and_decide_with_the_copied_script` wrapped every `sys.executable` invocation in `nix-shell --run "..."`, six times per run (one `--help` + two `decide` calls, per each of two base-ref archives). `sys.executable` is already the interpreter of the nix-shell the test itself is running inside, so each nested call paid a full Nix evaluation (~7-8s) just to re-derive the shell.nix already active, for zero additional capability.

**Verified the premise empirically before changing anything** (not asserted from reading the diff, per this repo's test-fidelity rules):
- Ran a throwaway comparison from inside the active `nix-shell`: `sys.executable` direct invocation vs. the same command re-wrapped in `nix-shell --run`. `PYTHONPATH` was byte-identical between the two (same interpreter, same baked-in site-packages). `PATH` in the nested case was the exact same nix-store entries, just duplicated — no new tool became reachable.
- Confirmed `decide`/`--help` touch no external PATH tool: `decide_row`/`decide_corpus` run `full_pipeline_decision_from_evidence` over already-persisted evidence — pure Python, no subprocess/sox/ffmpeg calls.
- The nested `nix-shell` resolves the CURRENT tree's `shell.nix` regardless of which historical base-ref's copy of `scripts/decision_differential.py` is being executed, so it never bought isolation from the base tree either.

Opus-reviewed and independently re-confirmed the same three facts (base tree still executes under the canonical worker's injected PYTHONPATH, PYTHONPATH byte-identical outer vs. nested, no assertion/matrix entry weakened).

**The premise held — this is a straightforward redundant-nesting removal**, not a narrowing of what the test proves. Both `subprocess.run` calls now invoke `[sys.executable, str(script), ...]` directly as a real argv list (also closing a latent shell-quoting hazard from the old `" ".join(...)` shell-string form). Every assertion (`--help` returncode 0, `decide` returncode 0 + decoded JSON `decision_error is None` + CD-rip classifier check) and the full two-entry `base_ref` matrix are unchanged.

Checked the stated neighbourhood (`tests/test_render_differential*.py`, `tests/test_decision_differential*.py`) for the same shape — none of their `subprocess.run` calls wrap `nix-shell`; they already invoke `sys.executable` directly.

## Measured (isolated `nix-shell --run "python3 -m unittest ..."`, same machine, before vs. after, otherwise identical command)

| | before | after |
|---|---|---|
| whole file (23 tests), reported test time | 50.762s | 6.339s |
| whole file, wall time (`time`) | 52.110s | 7.340s |
| the one slow test alone, reported test time | 42.414s | 2.142s |
| the one slow test alone, wall time (`time`) | 43.496s | 3.193s |

## Docs freshness

Removing the nesting made **three** existing claims false. Review round 1 caught two and missed the third (found by grepping the artifact `decision_corpus_export` rather than any identifier, per `code-quality.md` § "Search prose by the artifact, not only by the identifier") — all three, plus the round-1 correction's own broken markdown code span and one ambiguous sentence, are fixed in this PR:

- `.claude/rules/code-quality.md` § "Test execution, evidence, and hooks" named this test as the live example of a nested `nix-shell` inheriting `CRATEDIGGER_SUITE_OWNS_HEADROOM` from the enclosing suite. Reworded to past tense with the #1131 removal noted. Also disambiguated: "nothing currently exercises this inherited-skip path" was true only of the NESTED form — the top-level free-bytes skip itself is taken on every suite run launched by `scripts/test.sh`, `scripts/run_final_gate.sh`, and `scripts/daily_flake_update.sh`, and is pinned by `tests/test_test_tmpfs.py::test_suite_owns_headroom_skips_only_the_free_bytes_refusal`; an agent reading the old wording could have concluded that branch was dead and deleted it. Also fixed an inline code span split across a line break (rendered as `` tests/test_ decision_corpus_export.py `` — a nonexistent path — and defeated a future `grep` for the real filename).
- `scripts/test_tmpfs.sh:80-92` — the actual source the corrected `code-quality.md` paragraph points readers to (`the mechanism remains in scripts/test_tmpfs.sh`) — still carried the identical present-tense claim naming this test as a live nesting example, contradicting the just-corrected pointer. Reworded to past tense; also fixed the same filename-split-across-lines issue found here.
- `tests/test_parallel_test_runner.py`'s docstring for `test_default_floor_is_the_configured_one_gib_minimum_not_64mib` claimed these subprocesses "genuinely fail" in the 64MiB-100MiB headroom band, present tense. Now reads past tense; also fixed the same filename-split-across-lines issue.

## Scope notes

- This is test infrastructure — deterministic-only per `code-quality.md` § "Never property-test the test machinery". No Hypothesis/generated pin+property pair added or owed.
- No production code touched. No test behaviour changed in this round — prose only.

## Test plan

- [x] Isolated run before change: `nix-shell --run "python3 -m unittest tests.test_decision_corpus_export -v"` — 23 passed, 50.762s
- [x] Isolated run after change: same command — 23 passed, 6.339s
- [x] `bash scripts/test.sh tests.test_decision_corpus_export` — 6/6 phases passed (js-syntax, js-unit, pyright, ruff, vulture, python — 30 selectors incl. the changed `tests.test_parallel_test_runner` and generated/audit siblings), 0 failures
- [x] Confirmed no other file in `tests/test_render_differential*.py` / `tests/test_decision_differential*.py` has the same redundant-nesting shape
- [x] Re-ran `grep -rn decision_corpus_export .` and `grep -rln "test_decision_corpus_export\.py"` after the prose corrections — every remaining hit is either accurate/unrelated (the epi memory note, the `docs/generated-testing.md` table row) or now on one grep-able line

🤖 Generated with [Claude Code](https://claude.com/claude-code)
