### PR TITLE
perf(#1131): trim disposable ephemeral-pg clusters' RAM/tmpfs footprint

### DIFF
--- a/lib/ephemeral_postgres.py
+++ b/lib/ephemeral_postgres.py
@@ -103,34 +103,49 @@ class EphemeralPostgres:
             "-c synchronous_commit=off",
             # wal_level=minimal cannot start with wal_senders > 0 — nothing
             # here streams, replicates, or does PITR, so replica-level WAL
-            # (the default) buys this cluster nothing. Beyond shrinking
-            # what's retained, minimal also lets Postgres skip WAL entirely
-            # for operations on a relation created or truncated in the SAME
-            # transaction — tests TRUNCATE between runs, so that path is hit
-            # constantly here.
+            # (the default) buys this cluster nothing and minimal drops
+            # some replica-only record content for free. NOT a measured WAL
+            # *volume* win: minimal's well-known same-transaction
+            # create/truncate WAL-skip never triggers here — `PipelineDB`
+            # runs autocommit=True (lib/pipeline_db/_core.py) and the test
+            # helper's TRUNCATE is its own statement, so it commits before
+            # any test writes a row and every later INSERT is a different
+            # transaction. 100% of this PR's measured pg_wal reduction (see
+            # the PR body) is the min/max_wal_size ceiling change below, not
+            # this setting.
             "-c wal_level=minimal",
             "-c max_wal_senders=0",
             # 2MB is the hard-enforced floor with 1MB WAL segments (initdb
             # --wal-segsize=1 below); measured empirically (issue #1131) —
             # postgres refuses to start below it. Pushed to the floor
-            # deliberately: a wider ceiling measured zero wall-time benefit
-            # on a 553-real-DB-test burst (both landed at ~14s) while
-            # costing an extra ~8MB of retained WAL for every doubling, so
-            # there is no knee to stop at short of the floor itself — the
-            # checkpoint churn this forces is CPU work against RAM, not disk
-            # I/O, and this cluster has nothing else to do with that CPU.
+            # deliberately: sweeping the same 553-real-DB-test burst across
+            # 2MB/4MB/8MB/16MB/64MB ceilings measured zero wall-time
+            # difference (all landed within 13.1s-14.9s, no trend) while
+            # post-run pg_wal tracked the ceiling itself roughly 1:1 (~4MB
+            # at 4MB, ~8MB at 8MB, ~16MB at 16MB) — so every doubling costs
+            # real retained WAL and there is no knee to stop at short of the
+            # floor itself. The checkpoint churn this forces is CPU work
+            # against RAM, not disk I/O, and this cluster has nothing else
+            # to do with that CPU.
             "-c min_wal_size=2MB",
             "-c max_wal_size=8MB",
-            # The much smaller max_wal_size above forces frequent
-            # checkpoints; both of these silence the resulting log spam
-            # ("checkpoint starting: wal" and "checkpoints are occurring too
-            # frequently") — that log lives in this same tmpdir on the same
-            # tmpfs, so left on it would claw back a meaningful slice of the
-            # WAL saving over a real worker's lifetime (measured: ~50KB of
-            # spam from ONE 553-test module before these were added, at
-            # zero cost since nothing here reads this cluster's checkpoint
-            # telemetry).
-            "-c checkpoint_warning=0",
+            # checkpoint_warning stays at its default: it is the one in-band
+            # signal that would tell an operator this cluster's own
+            # min_wal_size/max_wal_size ceiling has been pushed too small
+            # for some future heavier workload, and silencing it in the
+            # same commit that ships that tiny ceiling would blind exactly
+            # the diagnostic needed to notice. log_checkpoints=off is kept:
+            # unlike the warning, its "checkpoint starting"/"checkpoint
+            # complete" LOG lines carry no diagnostic value (routine
+            # per-checkpoint telemetry, not a signal anything is wrong), and
+            # the much smaller max_wal_size above makes checkpoints frequent
+            # enough that logging every one is real (if modest) tmpfs-
+            # resident log growth for no offsetting benefit: measured on
+            # ONE 553-test module with checkpoint_warning genuinely live,
+            # log_checkpoints=off keeps pg.log ~17KB above the stock-config
+            # baseline instead of ~50KB (both on) — nowhere near a
+            # "meaningful slice" of the pg_wal saving, as an earlier draft
+            # of this comment overstated, but a real and free reduction.
             "-c log_checkpoints=off",
             # Autovacuum exists to reclaim space and update planner stats
             # over a database's working lifetime. Nothing here has one:

--- a/lib/ephemeral_postgres.py
+++ b/lib/ephemeral_postgres.py
@@ -101,24 +101,65 @@ class EphemeralPostgres:
             "-c fsync=off",
             "-c full_page_writes=off",
             "-c synchronous_commit=off",
-            # Recycled-WAL-segment floor. The stock 80MB/1GB defaults size
-            # for sustained production write volume; shrinking both keeps
-            # pg_wal from ballooning under a busy test worker while staying
-            # well above the single-segment floor initdb --wal-segsize=1
-            # already established below.
-            "-c min_wal_size=32MB",
-            "-c max_wal_size=64MB",
+            # wal_level=minimal cannot start with wal_senders > 0 — nothing
+            # here streams, replicates, or does PITR, so replica-level WAL
+            # (the default) buys this cluster nothing. Beyond shrinking
+            # what's retained, minimal also lets Postgres skip WAL entirely
+            # for operations on a relation created or truncated in the SAME
+            # transaction — tests TRUNCATE between runs, so that path is hit
+            # constantly here.
+            "-c wal_level=minimal",
+            "-c max_wal_senders=0",
+            # 2MB is the hard-enforced floor with 1MB WAL segments (initdb
+            # --wal-segsize=1 below); measured empirically (issue #1131) —
+            # postgres refuses to start below it. Pushed to the floor
+            # deliberately: a wider ceiling measured zero wall-time benefit
+            # on a 553-real-DB-test burst (both landed at ~14s) while
+            # costing an extra ~8MB of retained WAL for every doubling, so
+            # there is no knee to stop at short of the floor itself — the
+            # checkpoint churn this forces is CPU work against RAM, not disk
+            # I/O, and this cluster has nothing else to do with that CPU.
+            "-c min_wal_size=2MB",
+            "-c max_wal_size=8MB",
+            # The much smaller max_wal_size above forces frequent
+            # checkpoints; both of these silence the resulting log spam
+            # ("checkpoint starting: wal" and "checkpoints are occurring too
+            # frequently") — that log lives in this same tmpdir on the same
+            # tmpfs, so left on it would claw back a meaningful slice of the
+            # WAL saving over a real worker's lifetime (measured: ~50KB of
+            # spam from ONE 553-test module before these were added, at
+            # zero cost since nothing here reads this cluster's checkpoint
+            # telemetry).
+            "-c checkpoint_warning=0",
+            "-c log_checkpoints=off",
             # Autovacuum exists to reclaim space and update planner stats
             # over a database's working lifetime. Nothing here has one:
             # tests TRUNCATE between runs (reclaiming space immediately,
             # unlike DELETE) and the whole cluster is destroyed in minutes.
             "-c autovacuum=off",
-            # One worker process owns this cluster; the busiest concurrent-
-            # connection tests in this repo top out around 2-3 threads
-            # sharing it. 20 keeps a comfortable multiple of that instead of
-            # reserving shared-memory bookkeeping (PGPROC slots, the lock
-            # table) for the stock 100.
-            "-c max_connections=20",
+            # NOT one connection at a time: scripts/run_world_model_burst.py
+            # runs ONE coordinator-owned EphemeralPostgres (this same class)
+            # with up to IN_PROCESS_JOB_CAP=30 concurrent child processes,
+            # each holding a connection to its own cloned database on this
+            # cluster, plus transient createdb/dropdb maintenance
+            # connections for every clone create/drop. 50 clears that cap
+            # with real headroom instead of the canonical suite's own
+            # handful-of-threads ceiling; the PGPROC/lock-table cost of 50
+            # vs. the stock 100 is trivial next to the WAL/shared_buffers
+            # savings above.
+            "-c max_connections=50",
+        )
+
+    @property
+    def _initdb_args(self) -> tuple[str, ...]:
+        return (
+            "initdb", "-D", str(self._datadir), "--no-locale", "-E", "UTF8",
+            "-A", "trust",
+            # Disposable cluster (see _server_options): skip initdb's own
+            # fsync of the freshly written catalog files, and shrink the
+            # WAL segment size to its 1MB floor so pg_wal starts (and
+            # stays) far below the 16MB-per-segment default footprint.
+            "--no-sync", "--wal-segsize=1",
         )
 
     def _failure_detail(self, error: subprocess.CalledProcessError) -> str:
@@ -171,16 +212,7 @@ class EphemeralPostgres:
             # unattended gate.
             self._socket_tmpdir = Path(tempfile.mkdtemp(prefix="cdpg-", dir="/tmp"))
             subprocess.run(
-                [
-                    "initdb", "-D", str(self._datadir), "--no-locale", "-E", "UTF8",
-                    "-A", "trust",
-                    # Disposable cluster (see _server_options): skip initdb's
-                    # own fsync of the freshly written catalog files, and
-                    # shrink the WAL segment size to its 1MB floor so pg_wal
-                    # starts (and stays) far below the 16MB-per-segment
-                    # default footprint.
-                    "--no-sync", "--wal-segsize=1",
-                ],
+                self._initdb_args,
                 capture_output=True,
                 check=True,
             )

--- a/lib/ephemeral_postgres.py
+++ b/lib/ephemeral_postgres.py
@@ -72,6 +72,12 @@ class EphemeralPostgres:
 
     @property
     def _server_options(self) -> tuple[str, ...]:
+        # This cluster is disposable: its data is destroyed at teardown (or
+        # on the next reboot if teardown never runs) and it is used by
+        # exactly one test worker process. Every setting below trades a
+        # production durability/scalability guarantee this world does not
+        # need for less RAM and less tmpfs — do NOT copy this list into a
+        # production or long-lived Postgres config.
         return (
             f"-k {self._socket_dir}",
             "-c listen_addresses=''",
@@ -80,6 +86,39 @@ class EphemeralPostgres:
             # instead of relying on the five-minute production default.
             "-c checkpoint_timeout=30s",
             "-c checkpoint_completion_target=0.1",
+            # 128MB (the stock default) is sized for a real workload's
+            # buffer pool; a throwaway schema exercised by one worker at a
+            # time never approaches it. This is the single biggest real-RAM
+            # lever available (issue #1131) — it does not touch tmpfs bytes,
+            # since shared_buffers is anonymous shared memory, not a file
+            # under the data directory.
+            "-c shared_buffers=16MB",
+            # No crash recovery is ever performed on this cluster — it is
+            # deleted outright on any failure (EphemeralPostgres._cleanup)
+            # rather than restarted against its data directory. Durability
+            # and torn-page protection exist to survive a crash; skipping
+            # them here is safe by construction, not merely acceptable.
+            "-c fsync=off",
+            "-c full_page_writes=off",
+            "-c synchronous_commit=off",
+            # Recycled-WAL-segment floor. The stock 80MB/1GB defaults size
+            # for sustained production write volume; shrinking both keeps
+            # pg_wal from ballooning under a busy test worker while staying
+            # well above the single-segment floor initdb --wal-segsize=1
+            # already established below.
+            "-c min_wal_size=32MB",
+            "-c max_wal_size=64MB",
+            # Autovacuum exists to reclaim space and update planner stats
+            # over a database's working lifetime. Nothing here has one:
+            # tests TRUNCATE between runs (reclaiming space immediately,
+            # unlike DELETE) and the whole cluster is destroyed in minutes.
+            "-c autovacuum=off",
+            # One worker process owns this cluster; the busiest concurrent-
+            # connection tests in this repo top out around 2-3 threads
+            # sharing it. 20 keeps a comfortable multiple of that instead of
+            # reserving shared-memory bookkeeping (PGPROC slots, the lock
+            # table) for the stock 100.
+            "-c max_connections=20",
         )
 
     def _failure_detail(self, error: subprocess.CalledProcessError) -> str:
@@ -135,6 +174,12 @@ class EphemeralPostgres:
                 [
                     "initdb", "-D", str(self._datadir), "--no-locale", "-E", "UTF8",
                     "-A", "trust",
+                    # Disposable cluster (see _server_options): skip initdb's
+                    # own fsync of the freshly written catalog files, and
+                    # shrink the WAL segment size to its 1MB floor so pg_wal
+                    # starts (and stays) far below the 16MB-per-segment
+                    # default footprint.
+                    "--no-sync", "--wal-segsize=1",
                 ],
                 capture_output=True,
                 check=True,

--- a/tests/test_ephemeral_pg.py
+++ b/tests/test_ephemeral_pg.py
@@ -71,6 +71,14 @@ class TestEphemeralPostgresIsolation(unittest.TestCase):
                 "-c listen_addresses=''",
                 "-c checkpoint_timeout=30s",
                 "-c checkpoint_completion_target=0.1",
+                "-c shared_buffers=16MB",
+                "-c fsync=off",
+                "-c full_page_writes=off",
+                "-c synchronous_commit=off",
+                "-c min_wal_size=32MB",
+                "-c max_wal_size=64MB",
+                "-c autovacuum=off",
+                "-c max_connections=20",
             ),
         )
 
@@ -83,6 +91,40 @@ class TestEphemeralPostgresIsolation(unittest.TestCase):
                     "current_setting('checkpoint_completion_target')"
                 )
                 self.assertEqual(cursor.fetchone(), ("30s", "0.1"))
+
+    def test_live_cluster_applies_the_disposable_diet_settings(self) -> None:
+        """Issue #1131: every RAM/tmpfs trim actually takes effect live.
+
+        `_server_options` is a seam-level pin on the argv shape; this proves
+        PostgreSQL itself accepted and applied every setting rather than
+        silently falling back to a stock default on a typo or a rejected
+        value.
+        """
+        with EphemeralPostgres() as pg:
+            assert pg.dsn is not None
+            with psycopg2.connect(pg.dsn) as connection, connection.cursor() as cursor:
+                cursor.execute(
+                    "SELECT current_setting('shared_buffers'), "
+                    "current_setting('fsync'), "
+                    "current_setting('full_page_writes'), "
+                    "current_setting('synchronous_commit'), "
+                    "current_setting('min_wal_size'), "
+                    "current_setting('max_wal_size'), "
+                    "current_setting('autovacuum'), "
+                    "current_setting('max_connections')"
+                )
+                self.assertEqual(
+                    cursor.fetchone(),
+                    ("16MB", "off", "off", "off", "32MB", "64MB", "off", "20"),
+                )
+
+    def test_initdb_shrinks_the_wal_segment_size_to_its_floor(self) -> None:
+        """--wal-segsize=1 is initdb-time, so pin it directly (issue #1131)."""
+        with EphemeralPostgres() as pg:
+            assert pg.dsn is not None
+            with psycopg2.connect(pg.dsn) as connection, connection.cursor() as cursor:
+                cursor.execute("SHOW wal_segment_size")
+                self.assertEqual(cursor.fetchone(), ("1MB",))
 
     def test_long_tmpdir_keeps_socket_path_below_postgres_limit(self) -> None:
         with tempfile.TemporaryDirectory(dir="/tmp") as root:

--- a/tests/test_ephemeral_pg.py
+++ b/tests/test_ephemeral_pg.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import subprocess
 import tempfile
+import threading
 import unittest
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -65,20 +66,57 @@ class TestEphemeralPostgresIsolation(unittest.TestCase):
         pg._socket_tmpdir = Path("/tmp/cdpg-checkpoint-contract")
 
         self.assertEqual(
-            pg._server_options,
+            pg._server_options[:4],
             (
                 "-k /tmp/cdpg-checkpoint-contract",
                 "-c listen_addresses=''",
                 "-c checkpoint_timeout=30s",
                 "-c checkpoint_completion_target=0.1",
+            ),
+        )
+
+    def test_server_options_include_the_disposable_diet_settings(self) -> None:
+        """Issue #1131: argv-pins the RAM/tmpfs trims, split out from the
+        checkpoint/delayed-unlink pin above so each test's name matches what
+        it actually asserts."""
+        pg = EphemeralPostgres()
+        pg._socket_tmpdir = Path("/tmp/cdpg-diet-contract")
+
+        self.assertEqual(
+            pg._server_options[4:],
+            (
                 "-c shared_buffers=16MB",
                 "-c fsync=off",
                 "-c full_page_writes=off",
                 "-c synchronous_commit=off",
-                "-c min_wal_size=32MB",
-                "-c max_wal_size=64MB",
+                "-c wal_level=minimal",
+                "-c max_wal_senders=0",
+                "-c min_wal_size=2MB",
+                "-c max_wal_size=8MB",
+                "-c checkpoint_warning=0",
+                "-c log_checkpoints=off",
                 "-c autovacuum=off",
-                "-c max_connections=20",
+                "-c max_connections=50",
+            ),
+        )
+
+    def test_initdb_args_skip_fsync_and_shrink_wal_segments(self) -> None:
+        """Issue #1131: mirrors the `_server_options` seam pin above.
+
+        Before this test, nothing asserted `initdb`'s argv at all — the only
+        existing initdb test patches `subprocess.run` wholesale with a
+        `CalledProcessError` side effect and never inspects the call args —
+        so `--no-sync`/`--wal-segsize=1` could be deleted without failing
+        anything.
+        """
+        pg = EphemeralPostgres()
+        pg.tmpdir = Path("/tmp/cdpg-initdb-contract")
+
+        self.assertEqual(
+            pg._initdb_args,
+            (
+                "initdb", "-D", "/tmp/cdpg-initdb-contract/data", "--no-locale",
+                "-E", "UTF8", "-A", "trust", "--no-sync", "--wal-segsize=1",
             ),
         )
 
@@ -108,14 +146,21 @@ class TestEphemeralPostgresIsolation(unittest.TestCase):
                     "current_setting('fsync'), "
                     "current_setting('full_page_writes'), "
                     "current_setting('synchronous_commit'), "
+                    "current_setting('wal_level'), "
+                    "current_setting('max_wal_senders'), "
                     "current_setting('min_wal_size'), "
                     "current_setting('max_wal_size'), "
+                    "current_setting('checkpoint_warning'), "
+                    "current_setting('log_checkpoints'), "
                     "current_setting('autovacuum'), "
                     "current_setting('max_connections')"
                 )
                 self.assertEqual(
                     cursor.fetchone(),
-                    ("16MB", "off", "off", "off", "32MB", "64MB", "off", "20"),
+                    (
+                        "16MB", "off", "off", "off", "minimal", "0", "2MB", "8MB",
+                        "0", "off", "off", "50",
+                    ),
                 )
 
     def test_initdb_shrinks_the_wal_segment_size_to_its_floor(self) -> None:
@@ -156,3 +201,41 @@ class TestEphemeralPostgresIsolation(unittest.TestCase):
             databases = tuple(executor.map(start_query_stop, range(4)))
 
         self.assertEqual(databases, ("cratedigger_test",) * 4)
+
+    def test_admits_more_than_the_world_model_burst_cap_concurrently(self) -> None:
+        """Issue #1131: max_connections must clear more than the canonical
+        suite's own handful of threads.
+
+        scripts/run_world_model_burst.py runs ONE coordinator-owned cluster
+        (this same `EphemeralPostgres`) with up to `IN_PROCESS_JOB_CAP` (30)
+        concurrent child processes, each holding a connection to its own
+        cloned database on that cluster, plus transient createdb/dropdb
+        maintenance connections for every clone create/drop. Deliberately
+        not importing that constant — scripts/run_world_model_burst.py
+        imports this module, so importing it back would be circular — but
+        the number below must stay above it: a too-low max_connections
+        fails closed with "sorry, too many clients already", which a
+        Barrier forces every successful connection to prove did not happen
+        by holding them all open simultaneously before releasing any.
+        """
+        concurrent_connections = 32  # > IN_PROCESS_JOB_CAP (30) in that script
+
+        with EphemeralPostgres() as pg:
+            assert pg.dsn is not None
+            barrier = threading.Barrier(concurrent_connections)
+            errors: list[BaseException] = []
+
+            def connect_and_hold(_: int) -> None:
+                try:
+                    with psycopg2.connect(pg.dsn) as connection:
+                        barrier.wait(timeout=10)
+                        with connection.cursor() as cursor:
+                            cursor.execute("SELECT 1")
+                            cursor.fetchone()
+                except BaseException as error:  # noqa: BLE001 - proving admission
+                    errors.append(error)
+
+            with ThreadPoolExecutor(max_workers=concurrent_connections) as executor:
+                list(executor.map(connect_and_hold, range(concurrent_connections)))
+
+        self.assertEqual(errors, [])

--- a/tests/test_ephemeral_pg.py
+++ b/tests/test_ephemeral_pg.py
@@ -13,6 +13,16 @@ from unittest.mock import patch
 import psycopg2
 
 from lib.ephemeral_postgres import EphemeralPostgres, EphemeralPostgresError
+from scripts.run_world_model_burst import IN_PROCESS_JOB_CAP
+
+
+def _server_option_int(options: tuple[str, ...], name: str) -> int:
+    """Read an integer ``-c name=value`` out of ``_server_options``."""
+    prefix = f"-c {name}="
+    for option in options:
+        if option.startswith(prefix):
+            return int(option.removeprefix(prefix))
+    raise AssertionError(f"{name!r} not found in server options: {options!r}")
 
 
 class TestEphemeralPostgresFailures(unittest.TestCase):
@@ -61,15 +71,29 @@ class TestEphemeralPostgresFailures(unittest.TestCase):
 
 
 class TestEphemeralPostgresIsolation(unittest.TestCase):
+    def test_server_options_open_with_the_private_socket_and_local_listener(
+        self,
+    ) -> None:
+        """Issue #1131 review round 2 (F7): split out from the checkpoint
+        pin below — this test's name now matches exactly what it asserts."""
+        pg = EphemeralPostgres()
+        pg._socket_tmpdir = Path("/tmp/cdpg-socket-contract")
+
+        self.assertEqual(
+            pg._server_options[:2],
+            (
+                "-k /tmp/cdpg-socket-contract",
+                "-c listen_addresses=''",
+            ),
+        )
+
     def test_server_options_bound_delayed_relation_unlink_lifetime(self) -> None:
         pg = EphemeralPostgres()
         pg._socket_tmpdir = Path("/tmp/cdpg-checkpoint-contract")
 
         self.assertEqual(
-            pg._server_options[:4],
+            pg._server_options[2:4],
             (
-                "-k /tmp/cdpg-checkpoint-contract",
-                "-c listen_addresses=''",
                 "-c checkpoint_timeout=30s",
                 "-c checkpoint_completion_target=0.1",
             ),
@@ -77,8 +101,8 @@ class TestEphemeralPostgresIsolation(unittest.TestCase):
 
     def test_server_options_include_the_disposable_diet_settings(self) -> None:
         """Issue #1131: argv-pins the RAM/tmpfs trims, split out from the
-        checkpoint/delayed-unlink pin above so each test's name matches what
-        it actually asserts."""
+        socket/checkpoint pins above so each test's name matches what it
+        actually asserts."""
         pg = EphemeralPostgres()
         pg._socket_tmpdir = Path("/tmp/cdpg-diet-contract")
 
@@ -93,12 +117,24 @@ class TestEphemeralPostgresIsolation(unittest.TestCase):
                 "-c max_wal_senders=0",
                 "-c min_wal_size=2MB",
                 "-c max_wal_size=8MB",
-                "-c checkpoint_warning=0",
                 "-c log_checkpoints=off",
                 "-c autovacuum=off",
                 "-c max_connections=50",
             ),
         )
+
+    def test_max_connections_exceeds_the_world_model_burst_job_cap(self) -> None:
+        """Issue #1131 review round 2 (F2): the genuinely load-bearing
+        invariant, pinned statically against the REAL imported
+        `IN_PROCESS_JOB_CAP` — not a hand-copied number — so raising that
+        cap flips this pin without a live cluster, threads, or timing.
+        """
+        pg = EphemeralPostgres()
+        pg._socket_tmpdir = Path("/tmp/cdpg-max-connections-contract")
+
+        max_connections = _server_option_int(pg._server_options, "max_connections")
+
+        self.assertGreater(max_connections, IN_PROCESS_JOB_CAP)
 
     def test_initdb_args_skip_fsync_and_shrink_wal_segments(self) -> None:
         """Issue #1131: mirrors the `_server_options` seam pin above.
@@ -150,7 +186,6 @@ class TestEphemeralPostgresIsolation(unittest.TestCase):
                     "current_setting('max_wal_senders'), "
                     "current_setting('min_wal_size'), "
                     "current_setting('max_wal_size'), "
-                    "current_setting('checkpoint_warning'), "
                     "current_setting('log_checkpoints'), "
                     "current_setting('autovacuum'), "
                     "current_setting('max_connections')"
@@ -159,7 +194,7 @@ class TestEphemeralPostgresIsolation(unittest.TestCase):
                     cursor.fetchone(),
                     (
                         "16MB", "off", "off", "off", "minimal", "0", "2MB", "8MB",
-                        "0", "off", "off", "50",
+                        "off", "off", "50",
                     ),
                 )
 
@@ -170,6 +205,18 @@ class TestEphemeralPostgresIsolation(unittest.TestCase):
             with psycopg2.connect(pg.dsn) as connection, connection.cursor() as cursor:
                 cursor.execute("SHOW wal_segment_size")
                 self.assertEqual(cursor.fetchone(), ("1MB",))
+
+    def test_live_cluster_keeps_checkpoint_warning_at_its_default(self) -> None:
+        """Issue #1131 review round 2 (F5): checkpoint_warning is
+        deliberately NOT silenced — it is the one in-band signal that would
+        tell an operator this cluster's own min_wal_size/max_wal_size
+        ceiling has been pushed too small for some future workload, and
+        this proves it is genuinely live, not accidentally still 0."""
+        with EphemeralPostgres() as pg:
+            assert pg.dsn is not None
+            with psycopg2.connect(pg.dsn) as connection, connection.cursor() as cursor:
+                cursor.execute("SHOW checkpoint_warning")
+                self.assertEqual(cursor.fetchone(), ("30s",))
 
     def test_long_tmpdir_keeps_socket_path_below_postgres_limit(self) -> None:
         with tempfile.TemporaryDirectory(dir="/tmp") as root:
@@ -203,22 +250,32 @@ class TestEphemeralPostgresIsolation(unittest.TestCase):
         self.assertEqual(databases, ("cratedigger_test",) * 4)
 
     def test_admits_more_than_the_world_model_burst_cap_concurrently(self) -> None:
-        """Issue #1131: max_connections must clear more than the canonical
-        suite's own handful of threads.
+        """Issue #1131: end-to-end companion to the static
+        `test_max_connections_exceeds_the_world_model_burst_job_cap` pin
+        above — proves a real cluster actually admits that many real
+        connections, not just that the arithmetic works out.
 
         scripts/run_world_model_burst.py runs ONE coordinator-owned cluster
-        (this same `EphemeralPostgres`) with up to `IN_PROCESS_JOB_CAP` (30)
+        (this same `EphemeralPostgres`) with up to `IN_PROCESS_JOB_CAP`
         concurrent child processes, each holding a connection to its own
         cloned database on that cluster, plus transient createdb/dropdb
-        maintenance connections for every clone create/drop. Deliberately
-        not importing that constant — scripts/run_world_model_burst.py
-        imports this module, so importing it back would be circular — but
-        the number below must stay above it: a too-low max_connections
-        fails closed with "sorry, too many clients already", which a
-        Barrier forces every successful connection to prove did not happen
-        by holding them all open simultaneously before releasing any.
+        maintenance connections for every clone create/drop. The count
+        below is derived from the real imported constant (round 2 review
+        F2: an earlier version hardcoded 32 behind a false "circular
+        import" excuse — scripts/run_world_model_burst.py never imports
+        this test module, so importing it here is safe and
+        tests/test_world_model_coordinator.py already does).
+
+        `barrier.wait` is a deadlock guard, not the assertion (round 2
+        review F4): a genuine per-connection failure calls `barrier.abort()`
+        so every OTHER waiting thread fails fast instead of silently
+        timing out and reporting a `BrokenBarrierError` that looks like a
+        scheduling delay. The timeout itself is generous — this repo's own
+        shared test host is documented to run under real load — so a slow
+        but eventually-successful connection is never mistaken for a
+        rejected one.
         """
-        concurrent_connections = 32  # > IN_PROCESS_JOB_CAP (30) in that script
+        concurrent_connections = IN_PROCESS_JOB_CAP + 2
 
         with EphemeralPostgres() as pg:
             assert pg.dsn is not None
@@ -228,12 +285,13 @@ class TestEphemeralPostgresIsolation(unittest.TestCase):
             def connect_and_hold(_: int) -> None:
                 try:
                     with psycopg2.connect(pg.dsn) as connection:
-                        barrier.wait(timeout=10)
+                        barrier.wait(timeout=60)
                         with connection.cursor() as cursor:
                             cursor.execute("SELECT 1")
                             cursor.fetchone()
                 except BaseException as error:  # noqa: BLE001 - proving admission
                     errors.append(error)
+                    barrier.abort()
 
             with ThreadPoolExecutor(max_workers=concurrent_connections) as executor:
                 list(executor.map(connect_and_hold, range(concurrent_connections)))


### PR DESCRIPTION
## Summary

Each canonical-suite worker that touches the DB starts its own disposable
PostgreSQL cluster on the RAM-backed tmpfs (`lib/ephemeral_postgres.py`,
`tests/conftest.py`). The cluster ran with near-stock Postgres defaults
(128MB `shared_buffers`, 16MB WAL segments, 80MB/1GB WAL floor/ceiling,
`fsync`/`full_page_writes`/`synchronous_commit` all on, `autovacuum` on,
`max_connections=100`) even though it is destroyed minutes later, is owned
by exactly one process the whole time, and never survives a crash (a
failed start deletes the whole tree rather than recovering it —
`EphemeralPostgres._cleanup`).

Measured on doc1 (`/run/user/1000`, 3.2GB tmpfs): at 12 workers (the
current `DEFAULT_MAX_WORKERS` cap) the suite peaks at 1405MB of tmpfs; a
manual 24-worker run peaks at 3148MB of 3277MB — 96% full — and starts
failing, including the repo's own headroom classifier correctly reporting
genuine exhaustion.

This PR trims the cluster to what a throwaway test DB durably needs, with
each setting commented in place so nobody mistakes the list for a
production-shaped config. **Three review rounds are folded in below** (see
"Review corrections" — a blocking connection-cap regression, a follow-up
WAL-size pass the operator asked for directly, and that pass's own two new
false claims).

## What changed and why (kept vs rejected)

Kept — all measurably pay and are safe because the data is worthless after
the run and there is no crash-recovery path:
- `shared_buffers=16MB` (from 128MB default) — biggest real-RAM lever;
  doesn't touch tmpfs bytes (it's anonymous shared memory, not a datadir
  file), but matters directly for the operator's "both normal RAM and
  tmpfs" goal.
- `fsync=off`, `full_page_writes=off`, `synchronous_commit=off` — no crash
  recovery is ever attempted against this cluster's data directory, so the
  durability/torn-page guarantees these buy are unused.
- `wal_level=minimal` + `max_wal_senders=0` (must be set together —
  `minimal` refuses to start with senders > 0) — nothing here streams,
  replicates, or does PITR, so `replica`-level WAL buys this cluster
  nothing, and `minimal` drops some replica-only record content for free.
  **Not a measured WAL-volume win** (see "Review corrections" F1): its
  well-known same-transaction create/truncate WAL-skip never triggers
  here, because `PipelineDB` runs `autocommit=True` and the test helper's
  `TRUNCATE` is its own statement — it commits before any test writes a
  row, so every later `INSERT` is a different transaction.
- `min_wal_size=2MB` / `max_wal_size=8MB` (from 80MB/1GB) — 2MB is the
  hard-enforced floor with 1MB WAL segments. **100% of this PR's measured
  pg_wal reduction is this setting**, not `wal_level`.
- `log_checkpoints=off` — the much smaller `max_wal_size` forces frequent
  checkpoints; this silences the resulting routine per-checkpoint LOG
  spam, which carries no diagnostic value and lives on the same tmpfs as
  the WAL it's saving.
- `checkpoint_warning` — **deliberately left at its default** (see
  "Review corrections" F5): it is the one in-band signal that would
  surface this cluster's own WAL ceiling being too small for a future
  heavier workload; silencing it would blind exactly the diagnostic
  needed to notice.
- `autovacuum=off` — tests `TRUNCATE` between runs (reclaims space
  immediately, unlike `DELETE`), so autovacuum's usual job is largely moot
  here; measured identical `base/` bytes with it off.
- `max_connections=50` (from the stock 100, and from an incorrectly-shipped
  20 — see "Review corrections" F2) — comfortably clears
  `scripts/run_world_model_burst.py`'s `IN_PROCESS_JOB_CAP` with headroom
  for its transient maintenance connections.
- `initdb --no-sync` — skips fsync during cluster creation; free given the
  data's disposability.
- `initdb --wal-segsize=1` — shrinks the WAL segment size to its 1MB floor
  (from the 16MB default), which is where most of the *idle-state* tmpfs
  saving comes from, and is also the floor that makes `min_wal_size=2MB`
  (two segments) reachable at all.

Considered and left alone: `checkpoint_timeout=30s` /
`checkpoint_completion_target=0.1` were already tuned in a prior PR for
the same reason (bounding deferred-unlink lifetime after `TRUNCATE`) and
are out of scope here.

## Measured before/after (doc1, `/run/user/1000` tmpfs, Postgres 18.4)

Per-cluster datadir bytes, via `du -sb` on a live cluster's data directory,
driven through the real `EphemeralPostgres`/`apply_migrations` production
code path:

| State | main (stock) | This branch (final) | Δ |
|---|---|---|---|
| Fresh cluster, pre-migrate | 48,378,006 B (46.1MB) | 39,989,702 B (38.1MB) | -8,388,304 B (**-17.34%**) |
| Fresh cluster, post-migrate (idle) | 50,685,254 B (48.3MB) | 42,296,950 B (40.3MB) | -8,388,304 B (**-16.55%**) |
| Post-run: full `tests.test_pipeline_db` (553 real-DB tests, heaviest single DB module) | 122,979,655 B (117.3MB) | 47,498,870 B (45.3MB) | -75,480,785 B (**-61.38%**) |
| `pg_wal` after that run | 83,886,080 B (80MB — old `min_wal_size` floor) | 8,388,608 B (8MB — new `max_wal_size` ceiling) | -75,497,472 B (**-90.0%**) — 100% attributable to the min/max_wal_size ceiling change; `wal_level=minimal` contributes nothing measurable here (see F1 below) |
| `base/` after that run | 38,457,756 B | 38,457,756 B (byte-identical) | 0 — confirms `autovacuum=off` didn't cause bloat for this workload |
| `pg.log` after that run | 79,586 B | 96,937 B (0 "occurring too frequently" lines suppressed — `checkpoint_warning` stayed live and fired 84 times, correctly, as designed) | +17,351 B — real but small; `log_checkpoints=off` alone keeps this ~33KB lower than leaving it on (129,728 B measured with both `checkpoint_warning` and `log_checkpoints` at their defaults) |
| Summed process RSS (postmaster + backends, `/proc/<pid>/status` `VmRSS`, double-counts shared pages — a proxy, not a clean per-cluster number) | 102,240 KB | 93,868 KB | -8,372 KB (**-8.19%**) |
| Wall time, that 553-test run | ~13-15s (repeated) | ~13-16s (repeated) | no measurable difference — see "WAL floor" below |

Idle-state savings (both rows) come almost entirely from `--wal-segsize=1`:
pg_wal 16MB → 8MB at that point, every other subdirectory byte-identical.
The realistic-workload row's much larger shrinkage is the `min_wal_size`/
`max_wal_size` ceiling change alone.

### Wall-time cost of the tiny WAL ceiling — measured, not assumed

A `max_wal_size` this small forces very frequent checkpoints. On real disk
that's a bad trade; on tmpfs the write is RAM-speed, so it's mostly CPU.
Measured directly: running the same 553-test module against `max_wal_size`
at 64MB, 16MB, 8MB (shipped), 4MB, and 2MB (the absolute floor,
`min_wal_size == max_wal_size`) all landed within **13.1s-14.9s** —
noise-level variation, no trend. `pg_wal` tracked the ceiling itself
roughly 1:1 (~4MB at 4MB, ~8MB at 8MB, ~16MB at 16MB — not a fixed
increment per doubling, proportional to the ceiling), shrinking all the
way to the floor with zero observed wall-time cost in this single-process
probe. Shipped at the operator-specified `2MB/8MB` rather than the bare
`2MB/2MB` floor: the remaining gap is under 5MB/cluster and untested at
the real 30-way-concurrent scale `scripts/run_world_model_burst.py`
generates (addressed separately below — F3).

### Projected saving at 12 and 24 concurrent clusters

This is a projection, not a rerun of the full canonical suite (explicitly
out of scope for this PR — the orchestrator owns that gate), and it rests
on two stated assumptions that are not independently verified:

1. **The measured `-61.38%` transfers to the aggregate.** It comes from the
   single heaviest real-DB module (`tests.test_pipeline_db`), whose
   baseline footprint (117.3MB) happens to sit close to the operator's
   measured 12-worker per-cluster average (1405MB / 12 ≈ 117.1MB) — a
   coincidence used here as a proxy, not proof that a real worker's
   aggregate footprint across many files behaves the same way. The
   dominant new mechanism (the 8MB WAL ceiling) is at least structurally
   favorable to this extrapolation — any worker whose peak WAL churn would
   have grown large under the old 1GB ceiling now clamps to the same tiny
   ~8MB regardless of workload size — but that is a directional argument,
   not a measurement.
2. **The tmpfs total is assumed to be entirely datadir bytes.** The
   projection applies the percentage to the operator's measured *total*
   tmpfs peak (1405MB / 3148MB), which also holds scratch directories,
   check bundles, and other per-test tmp state alongside the ephemeral PG
   clusters. This projection implicitly treats that other usage as zero or
   as scaling identically — neither is verified.

With those assumptions stated plainly:

- **12 workers:** 1405MB → ≈542MB (saves ≈863MB)
- **24 workers:** 3148MB → ≈1215MB (saves ≈1933MB)

## Interaction with the headroom machinery (not changed here)

Checked but deliberately left untouched, per the issue's own scoping:
`scripts/run_test_suite.py::_check_suite_headroom` /
`_default_min_headroom_bytes` (`CRATEDIGGER_TEST_RAM_MIN_BYTES`, default
1 GiB) and `scripts/test_tmpfs.sh`'s matching shell-entry guard. Also
confirmed the current worker cap: `scripts/run_python_tests.py`'s
`DEFAULT_MAX_WORKERS = 12` — the operator's "24 workers" figure was a
manual override past that cap, not the shipped default. This PR's saving
creates the headroom a future PR would need to safely raise
`DEFAULT_MAX_WORKERS`, but does not raise it, and does not touch either
headroom threshold — that's explicitly scoped to a later PR.

## Review corrections (three rounds folded in, not follow-ups)

### Round 2 → round 3: the WAL-minimization pass's own two new false claims

The verification review of the `max_connections=50` + WAL-minimal commit
found no functional regression (independently verified against a real PG
18.4 cluster and every consumer in the tree — no replication slots, no
`pg_basebackup`, no logical decoding, no WAL archiving anywhere;
`createdb --template` works under `wal_level=minimal`; every measurement-
table figure checked out), but found the same class of defect the
previous round had just fixed: a confident, plausible, unevidenced
mechanism claim.

- **F1 BLOCKING (fixed) — the `wal_level=minimal` rationale was false.**
  The comment and commit message claimed `minimal`'s same-transaction
  create/truncate WAL-skip is "hit constantly" by this repo's
  TRUNCATE-between-tests pattern. It is never hit: `PipelineDB` runs
  `autocommit=True` (`lib/pipeline_db/_core.py`) and `make_db()`
  (`tests/test_pipeline_db.py`) issues `TRUNCATE … CASCADE` as its own
  statement, which commits before any test writes a row — every later
  `INSERT` is a different transaction. The review independently measured
  this on a real cluster with the exact shipped options, 20k rows:
  autocommit-separated TRUNCATE-then-INSERT = 2,644 kB WAL;
  TRUNCATE+INSERT in one transaction = 500 kB — 5.3×, and this repo never
  reaches the cheap side. Kept the setting (harmless, drops some
  replica-only record content) but rewrote
  the comment, and the measurement table above now attributes 100% of the
  measured `pg_wal` reduction to the `min_wal_size`/`max_wal_size` ceiling
  change, none to `wal_level`.
- **F2 (fixed) — the concurrency pin's threshold was hardcoded behind a
  false reason.** The pin's docstring claimed importing
  `IN_PROCESS_JOB_CAP` from `scripts/run_world_model_burst.py` would be
  circular. It is not: that script never imports this test module, and
  `tests/test_world_model_coordinator.py` already imports 17 names from it
  at module level. The false reason was load-bearing — it justified
  hardcoding `32  # > IN_PROCESS_JOB_CAP (30)`, the exact number the pin
  exists to track, so raising `IN_PROCESS_JOB_CAP` to 40 would have left
  the pin green while the real regression came back. Fixed: import the
  real constant. Added a new static pin,
  `test_max_connections_exceeds_the_world_model_burst_job_cap`
  (`assertGreater(max_connections, IN_PROCESS_JOB_CAP)`, no cluster,
  threads, or timing), and derived the dynamic pin's connection count from
  the same import. **Verified the exact scenario F2 named**: monkeypatched
  `IN_PROCESS_JOB_CAP = 55` (above the shipped `max_connections=50`) and
  the static pin failed immediately (`50 not greater than 55`) with no
  code change needed to detect it.
- **F3 (addressed — ran the burst on the final tree) — no 30-way evidence
  for the final WAL settings.** The only 30-way proof in the previous
  commit was the `max_connections` RED/GREEN, but the WAL pass landed in
  the same commit at the OLD 32MB/64MB WAL values still in place at the
  time of that burst run — the one regime the 553-test sweep doesn't
  cover (30 clone DBs writing into one cluster-wide 8MB ceiling under one
  checkpointer, each of 50 targets running `createdb --template` of a
  ~40MB migrated template) was never actually exercised. Re-ran the real
  burst at its real nightly defaults (`examples=25, steps=100`, matching
  `scripts/daily_flake_update.sh`) on the true final tree: **`ALL GREEN in
  41.1s (50 targets)`** — faster than the earlier (pre-WAL-minimal) GREEN
  run (46.8s), though that's plausibly host-load noise rather than a
  causal effect and is reported as measured, not explained.
- **F4 (fixed) — the barrier pin could go spuriously red.**
  `barrier.wait(timeout=10)` is wall-clock synchronization inside the
  canonical suite, on a host this repo has already recorded dying under
  load (`BrokenProcessPool` at load ~46, per `.claude/rules/code-quality.md`
  § "Admission control on the shared test RAM root"). A slow-but-eventually-
  successful 32nd connection, or an executor unable to spawn a thread under
  memory pressure, would have manufactured 31 more `BrokenBarrierError`
  entries that read as "connection admission failed" when the cause was
  scheduling. Fixed: `barrier.abort()` on the connect-failure path, so a
  genuine rejection resolves fast (measured: the RED reproduction below
  completed in 0.49s, not a 10s or 60s hang) instead of stalling every
  other thread; the timeout itself moved to 60s as a pure deadlock guard,
  never the assertion.
- **F5 (fixed — kept live, corrected the rationale) — the instrument that
  would report F3 was silenced by an off-by-~1.5-orders-of-magnitude
  justification.** `checkpoint_warning=0` was justified as avoiding a
  "meaningful slice" of the saving; measured, the log-spam cost was ~50KB
  against 75,480,785 B saved — 0.07%. Worse, `checkpoint_warning` is the
  ONLY in-band signal that would tell an operator this PR's own WAL
  ceiling is too small for some future heavier workload, and it was
  silenced in the same commit that shipped that ceiling. Fixed: restored
  to its default (proven live with a new test,
  `test_live_cluster_keeps_checkpoint_warning_at_its_default`, `SHOW
  checkpoint_warning` = `30s`). `log_checkpoints=off` is kept — unlike the
  warning it carries no diagnostic value, and measured precisely for the
  combination actually shipped (`checkpoint_warning` live,
  `log_checkpoints` off): pg.log lands ~17KB above the stock-config
  baseline instead of ~50KB with both on.
- **F6 (fixed) — a wrong test count in the previous PR body.** It said "8
  original `test_ephemeral_pg` tests plus 5 new ones"; `main` actually has
  6, this branch collects 14 (8 new, after this round's additional 3: the
  split socket/listener pin, the static `max_connections` invariant, and
  the `checkpoint_warning` live-default proof). Corrected in the Test Plan
  below.
- **F7 (fixed) — correction #5 (from round 1→2) was two-thirds done.**
  `test_server_options_bound_delayed_relation_unlink_lifetime` still
  asserted `-k <socket>` and `-c listen_addresses=''` under a name about
  checkpoints. Split further:
  `test_server_options_open_with_the_private_socket_and_local_listener`
  now owns the first two entries; the checkpoint pin owns only the
  checkpoint-related two.
- **F8 (fixed) — the projection's unstated assumptions.** Documented
  explicitly in the "Projected saving" section above: the datadir-only
  percentage applied to the operator's TOTAL tmpfs peak assumes zero (or
  identically-scaling) other scratch/bundle/per-test tmp usage on that
  same tmpfs, and the single-module-to-12-worker-average match is used as
  a proxy, not proof.

Self-review of this round specifically re-read every sentence attributing
a measured saving to a named mechanism (per the review's own instruction)
and found two more imprecisions before they shipped: the
`min_wal_size`/`max_wal_size` comment's "~8MB per doubling" was only true
for one specific step (pg_wal tracks the ceiling roughly 1:1, not a fixed
increment — corrected in the code); and an earlier draft of the
`log_checkpoints` comment reused the "~50KB" figure from the wrong
setting combination (both silenced vs. only `log_checkpoints` off) — also
corrected before this commit, with the real measured number (~17KB) now
in both the code comment and the table above.

### Round 1 → round 2 (unchanged from the prior update, summarized)

1. **BLOCKING (fixed) — `max_connections=20` broke the world-model
   burst.** `scripts/run_world_model_burst.py` runs ONE coordinator-owned
   `EphemeralPostgres` with up to `IN_PROCESS_JOB_CAP` concurrent child
   processes each holding a connection to its own cloned database, plus
   transient maintenance connections. Raised to 50; proven RED/GREEN both
   at the pin and, end to end, at the real burst script's real nightly
   defaults (RED: `FATAL: sorry, too many clients already`, aborted after
   49.2s with 43/50 targets done; GREEN: all targets complete).
2. **Fixed — initdb argv seam pin.** `--no-sync`/`--wal-segsize=1` were
   previously unseamed (the only prior `initdb` test never inspected
   argv). Extracted `_initdb_args` as a property mirroring the existing
   `_server_options` seam and pinned it directly.
3. **Fixed — PR-body arithmetic.** The pre-migrate delta was mislabeled as
   the post-migrate figure.
4. **Fixed — an unevidenced `full_page_writes=off` WAL-volume claim,**
   dropped; the round-1 `pg_wal` numbers were entirely explained by the
   `min_wal_size`/`max_wal_size` ceiling, with `base/` byte-identical.
5. **Fixed — split the drifted `_server_options` pin** (completed fully in
   this round — see F7 above).

## Test plan

- [x] `nix-shell --run "python3 -m unittest tests.test_ephemeral_pg tests.test_migrator tests.test_parallel_test_runner -v"` —
      237 tests, all green. `tests.test_ephemeral_pg` alone: `main` has 6
      tests, this branch has 14 (8 new — the socket/listener split, the
      diet-settings pin, the initdb-argv seam pin, the initdb WAL-segment-
      floor live check, the static `max_connections`-exceeds-
      `IN_PROCESS_JOB_CAP` pin, the live WAL-minimal/`max_connections=50`
      assertion, the live `checkpoint_warning`-stays-default proof, and the
      concurrent-connection admission pin). `test_a_real_worker_exception_is_classified_by_live_measured_headroom`
      (in `test_parallel_test_runner`) still passes, proving the headroom
      classifier reports ample real headroom on a normal host.
- [x] RED/GREEN proof for `max_connections`, at both the static and
      dynamic pins and at the real `scripts/run_world_model_burst.py`
      consumer at its real nightly defaults (see "Review corrections"
      above for the exact transcripts, including the F2-specific
      `IN_PROCESS_JOB_CAP = 55` monkeypatch proof).
- [x] `nix-shell --run "pyright lib/ephemeral_postgres.py tests/test_ephemeral_pg.py"` — 0 errors.
- [x] `nix-shell --run "bash scripts/run_ruff.sh"` — clean.
- [x] `bash scripts/test.sh tests.test_ephemeral_pg` — 6/6 phases passed
      (js-syntax, js-unit, pyright, ruff, vulture, python), run three
      times (once per round), no queueing any time.

Per `.claude/rules/code-quality.md` § "Never property-test the test
machinery": this is test infrastructure, so it intentionally ships with
exact deterministic pins only — no Hypothesis property, no pin+property
pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
