### PR TITLE
perf(#1131): stub the AAC-lattice DSP leaf in manifest-purity generated tests

### DIFF
--- a/tests/test_preview_manifest_generated.py
+++ b/tests/test_preview_manifest_generated.py
@@ -259,23 +259,54 @@ def _materialize_canonical_album(
     return db, ctx, album, staged_album
 
 
-def _stub_aac_lattice(_path: str) -> AacLatticeCapture:
-    """No-op stand-in for the real AAC-lattice frame-DSP.
+def _stub_aac_lattice(path: str) -> AacLatticeCapture:
+    """Fast per-track stand-in wired through the REAL per-album recording
+    loop, not a flat replacement of the whole capture.
+
+    ``measure_album_aac_lattice`` (``lib/aac_lattice.py``) exposes
+    ``analyze_fn`` as its own sanctioned kwarg-DI seam for exactly this —
+    its docstring: "lets the generated fault-isolation property drive this
+    real recording loop over a generated fault space without paying for
+    ffmpeg per example." Using it here keeps the real ``album_audio_files``
+    walk of the canonical directory, the real per-file recording loop, and
+    the real ``AacLatticeCapture.from_tracks`` aggregation inside the
+    composition — only ``analyze_track``'s expensive leg (subprocess ffmpeg
+    decode + MDCT/FFT, tens of seconds of CPU per track) is replaced by
+    ``_fixed_analysis``. That is higher fidelity than a flat empty capture:
+    every manifest this module builds has >=1 audio file, and production
+    always returns one scored row per file it finds — a flat
+    ``AacLatticeCapture()`` is the shape production only returns for an
+    album with NO audio files, which this module never builds.
 
     ``measure_and_persist_candidate_evidence`` defaults
     ``aac_lattice_measure_fn`` to the real ``measure_aac_lattice`` (issue
-    #829 PR-A), which decodes every candidate track via a subprocess and
-    runs MDCT/FFT analysis on it — tens of seconds of real CPU per call,
-    on manifests this module builds purely to exercise file *presence*,
-    never audio *content*. It is capture-only for every assertion this
-    module makes: manifest purity, action-file-handoff safety, and
-    rematerialize/dispatch outcomes all key on which files exist under
-    the canonical directory, never on ``AlbumQualityEvidence.aac_lattice``
-    — this is the same sanctioned kwarg-DI seam already used for
-    ``spectral_detail_analyzer`` below, injecting the well-formed "measured
-    nothing" capture instead of the expensive default.
+    #829 PR-A). No assertion in this module reads the resulting
+    ``AlbumQualityEvidence.aac_lattice`` VALUE — but it is not entirely off
+    the assertion path either: ``_write_preview_spectral_evidence_file``
+    folds ``AacLatticeCapture.validation_errors()`` into its own
+    ``storage_validation_errors()`` gate, so a MALFORMED capture would
+    break today's ``assert len(handoffs) == 1`` below. The accurate claim
+    is narrower than "capture-only": only the lattice's well-formedness is
+    load-bearing here, never its content. What this module genuinely never
+    exercises is the DECISION leg — ``full_pipeline_decision_from_evidence``
+    reads a candidate's lattice as a promotion gate
+    (``lib/quality/pipeline.py``), and production does carry a fresh
+    lattice into the quality-evidence action-file payload and on to
+    ``harness/import_one.py``'s ``aac_lattice_proof_leg`` — but what severs
+    that here is the PRE-EXISTING ``run_import_fn`` stub below
+    (``_capture_action_file_handoff``), not any preview/importer split.
     """
-    return AacLatticeCapture()
+    from lib.aac_lattice import AacLatticeAnalysis, measure_album_aac_lattice
+
+    def _fixed_analysis(_track_path: str) -> AacLatticeAnalysis:
+        """A fast, well-formed per-track score — same shape as a real
+        scored track (bounded offset, finite z/proba) — standing in for
+        ``analyze_track``'s real decode+DSP."""
+        return AacLatticeAnalysis(
+            offset=347, z=4.72, proba=0.5, sample_rate=44100, channels=2,
+        )
+
+    return measure_album_aac_lattice(path, analyze_fn=_fixed_analysis)
 
 
 def _stub_import_one_run() -> ImportOneRun:
@@ -317,8 +348,13 @@ def _run_owned_preview_action(
 ) -> tuple[ImportPreviewResult, PreviewActionFileHandoff]:
     """Drive the REAL preview fact-gathering (the #859 fire site) against a
     real owned canonical album. ``_write_preview_spectral_evidence_file``
-    runs unmocked — only the harness subprocess and the beets exact-release
-    lookup (both legitimate external-edge seams) are stubbed."""
+    runs unmocked. Every kwarg-DI seam passed to
+    ``measure_and_persist_candidate_evidence`` below stands in for a
+    legitimate external edge, never this module's own manifest-purity
+    logic: the harness subprocess (``run_import_fn``), the beets
+    exact-release lookup (``existing_spectral_resolver``), and both
+    spectral detectors (``spectral_detail_analyzer``,
+    ``aac_lattice_measure_fn``)."""
     run = _stub_import_one_run()
     handoffs: list[PreviewActionFileHandoff] = []
     if db.get_import_job(import_job_id) is None:

--- a/tests/test_preview_manifest_generated.py
+++ b/tests/test_preview_manifest_generated.py
@@ -84,6 +84,7 @@ from lib.import_preview import (
 from lib.measurement import ExistingSpectralAuditLookup
 from lib.processing_paths import canonical_folder_for_row, processing_albums_dir
 from lib.quality import (
+    AacLatticeCapture,
     AudioQualityMeasurement,
     ImportResult,
     SpectralAnalysisDetail,
@@ -258,6 +259,25 @@ def _materialize_canonical_album(
     return db, ctx, album, staged_album
 
 
+def _stub_aac_lattice(_path: str) -> AacLatticeCapture:
+    """No-op stand-in for the real AAC-lattice frame-DSP.
+
+    ``measure_and_persist_candidate_evidence`` defaults
+    ``aac_lattice_measure_fn`` to the real ``measure_aac_lattice`` (issue
+    #829 PR-A), which decodes every candidate track via a subprocess and
+    runs MDCT/FFT analysis on it — tens of seconds of real CPU per call,
+    on manifests this module builds purely to exercise file *presence*,
+    never audio *content*. It is capture-only for every assertion this
+    module makes: manifest purity, action-file-handoff safety, and
+    rematerialize/dispatch outcomes all key on which files exist under
+    the canonical directory, never on ``AlbumQualityEvidence.aac_lattice``
+    — this is the same sanctioned kwarg-DI seam already used for
+    ``spectral_detail_analyzer`` below, injecting the well-formed "measured
+    nothing" capture instead of the expensive default.
+    """
+    return AacLatticeCapture()
+
+
 def _stub_import_one_run() -> ImportOneRun:
     """A minimal, valid harness result — the harness subprocess itself is
     the sanctioned ``run_import_fn`` kwarg-DI seam (never the sidecar
@@ -339,6 +359,7 @@ def _run_owned_preview_action(
                 attempted=True, grade="genuine", bitrate_kbps=1000,
                 spectral_measurement_version=SPECTRAL_MEASUREMENT_VERSION,
             ),
+            aac_lattice_measure_fn=_stub_aac_lattice,
         )
     assert len(handoffs) == 1, "lossless preview must hand off one action file"
     return result, handoffs[0]


### PR DESCRIPTION
## Summary

Issue #1131 (test-suite optimization) named `tests.test_deploy_pin_generated`
and `tests.test_preview_manifest_generated` as the two joint-slowest
canonical-suite Python targets after two sibling PRs remove unrelated poles.
This PR profiles both (not guesses), fixes the one genuinely hoistable/
removable hotspot it found, and documents why the other module's cost is
NOT reducible within this PR's ownership boundary.

**Updated after review round 1** (see PR comments for the full response):
the fix now uses a higher-fidelity stub, two docstrings had wrong rationales
corrected, and the before/after numbers below are like-for-like.

## Profiling — what I found (not what the issue assumed)

**`test_preview_manifest_generated.py`** — the issue's write-up guessed
"real PostgreSQL." It actually uses `FakePipelineDB`/`FakeBeetsDB` (no
PostgreSQL at all) and real filesystem manifests, which is correct and
untouched. `cProfile` on the two Hypothesis-relevant classes found the
real hotspot:

| Class | Before | Dominant frame (cProfile cumtime) |
|---|---|---|
| `TestPreviewSidecarManifestPurityPin` (1 test, real audio) | 17.3s | `measure_aac_lattice` → `detect_aac` → `band_counts`/numpy FFT/MDCT: **15.1s (87%)** |
| `TestPreviewManifestPurityProperty` (1 property, finite 128-mask domain) | 34.4s | `measure_aac_lattice` → `_decode_to_float_wav` (subprocess decode, 585 calls): **23.2s (68%)** |

Both call `measure_and_persist_candidate_evidence` (`lib/import_preview.py`),
whose `aac_lattice_measure_fn` kwarg **defaults to the real
`measure_aac_lattice`** (issue #829 PR-A). This module's invariant is
canonical-manifest *file* purity (#859); no assertion in this module reads
the resulting `AlbumQualityEvidence.aac_lattice` **value** — but it is not
entirely off the assertion path: `_write_preview_spectral_evidence_file`
(`lib/import_preview.py`) folds `AacLatticeCapture.validation_errors()` into
its own `storage_validation_errors()` gate (`lib/quality/evidence_types.py`),
so a malformed capture would break `assert len(handoffs) == 1` today. The
accurate claim is narrower than "capture-only": only well-formedness is
load-bearing here, never content. What this module genuinely never
exercises is the *decision* leg — `full_pipeline_decision_from_evidence`
reads a candidate's lattice as a promotion gate (`lib/quality/pipeline.py`),
and production **does** carry a fresh lattice into the quality-evidence
action-file payload and on to `harness/import_one.py`'s
`aac_lattice_proof_leg` (:2466) — what severs that composition here is the
**pre-existing** `run_import_fn` stub (`_capture_action_file_handoff`), not
a preview/importer split. All of this is verified against the real call
chain, not asserted from a docstring.

The fix: drive the **real** `measure_album_aac_lattice` per-album recording
loop (`lib/aac_lattice.py:721` — real `album_audio_files` walk + real
`AacLatticeCapture.from_tracks` aggregation) through its own sanctioned
`analyze_fn` kwarg-DI seam, replacing only the expensive per-track leg
(`analyze_track`'s ffmpeg decode + MDCT/FFT) with a fast, well-formed
`_fixed_analysis`. This is higher-fidelity than a flat `AacLatticeCapture()`:
every manifest this module builds has ≥1 audio file, and production always
returns one scored row per file found — a flat empty capture is the shape
production only returns for an album with **no** audio files, which this
module never builds (`.claude/rules/test-fidelity.md` Rule B territory).
Isolation: `_stub_aac_lattice`/`_fixed_analysis` are pure functions with no
shared mutable state — nothing to couple examples through. The
`lib.aac_lattice` import (pulls in numpy) is deferred inside
`_stub_aac_lattice`, mirroring both `lib.measurement`'s own documented
lazy-import rationale and the existing `tests/test_integration_slices.py`
precedent for this exact seam — measured at ~0.12s once (numpy was not
otherwise transitively loaded by this file's import graph), paid only by
the two classes that call it, negligible against the ~30s saved.

Remaining cost in `TestPreviewManifestPurityProperty` (now ~8.5s) is real
`ffprobe` calls scaling with the Hypothesis-varied file count per example —
genuine, coverage-relevant work (media-readiness normalization touching the
same files the manifest-purity invariant checks), left untouched per the
issue's own permitted "genuinely varies per example, leave it alone"
outcome.

**`test_deploy_pin_generated.py`** — the issue's write-up guessed "real git
repositories (and signing)." It actually drives `scripts/pin_nixosconfig.sh`
against `tests/fakes/deploy_pin.py::FakeDeployPinCommands`, a fully-faked
git/nix/hostname shim (no real git process, no real signing — the
`gpgsig` block is literal fixture text). Profiling:

- `FakeDeployPinCommands.__init__` (writes 3 tiny shim scripts): **0.2ms** —
  already negligible, no hoist needed.
- One `fake.run(SCRIPT)` call spawns **~28 real subprocesses** (git/nix/
  hostname invocations the bash script makes internally) and costs **~0.85s**.
- The two slow Hypothesis-decorated tests each call `fake.run()` **twice per
  example** (inject a fault, then retry) — that's the retry-safety property
  itself, not redundant setup; reducing it would weaken the invariant.

The per-subprocess-call overhead lives entirely inside
`tests/fakes/deploy_pin.py`, which is **shared with `tests/test_deploy_pin_script.py`**
(a sibling deterministic test file, not part of this PR's mandate) — not
"exclusively theirs" per this PR's explicit scope boundary
("you own only the two test modules and anything they import that is
exclusively theirs... another change owns the scheduler"). I left it
untouched rather than risk scope creep or blast radius into a file another
PR/agent may be working; `tests/test_deploy_pin_generated.py` itself has no
in-scope hoistable setup — every unit of its cost is either free (the fake's
`__init__`) or a real, per-example-varying script invocation that composes
the actual invariant under test. **This is a deliberate "cannot hoist within
scope, here is why" outcome**, as the issue explicitly permits.

## Coverage contract — proof

- No `max_examples`, `deadline`, profile tier, `@example` pin, checker
  clause, or strategy changed anywhere in either module. All changes are in
  `tests/test_preview_manifest_generated.py`: one stub function rewritten to
  drive a real production recording loop with a fast per-track leg, and two
  docstrings corrected.
- Isolation: `_stub_aac_lattice`/`_fixed_analysis` are pure functions with no
  shared/mutable fixture state — nothing to couple examples through.
- Depth: ran a burst scoped to just these two modules under the `fuzz`
  profile (`nix-shell --run "python3 scripts/run_fuzz_tests.py
  tests.test_deploy_pin_generated tests.test_preview_manifest_generated"`)
  — **25/25 tests green, `DEPTH 3 properties measured, 0 shallow (space
  exhausted below budget), 0 discarding at least 10% of their examples`**.
  `test_preview_manifest_generated` (whole module) ran in ~13.6s under the
  *expanded* fuzz-profile example budget.
- `bash scripts/test.sh tests.test_deploy_pin_generated` and
  `bash scripts/test.sh tests.test_preview_manifest_generated` (each run
  once, foreground, full 6-phase targeted bundle incl. Pyright/Ruff/Vulture/
  JS): both **PASSED**.

## Measured before/after — like-for-like

Plain `nix-shell --run "python3 -m unittest tests.test_preview_manifest_generated -v"`,
no profiler overhead, whole module (10 tests), both sides measured the same
way on this host:

| | Before (original main) | After (this PR) |
|---|---|---|
| Whole `test_preview_manifest_generated` module | **42.8s** | **9.1s** |

That's **-79%**, consistent with the reviewer's independent reproduction
(40.9s → 12.6s, -69%) within host variance. Per-class breakdown (cProfile,
carries profiling overhead, useful for relative attribution not absolute
timing): `TestPreviewSidecarManifestPurityPin` 17.3s → 1.7s;
`TestPreviewManifestPurityProperty` 34.4s → 8.5s.

`test_deploy_pin_generated` is unchanged (no in-scope hoist found, see above).

## Test plan

- [x] `nix-shell --run "python3 -m unittest tests.test_preview_manifest_generated -v"` — 10/10 green (9.1s)
- [x] `nix-shell --run "pyright tests/test_preview_manifest_generated.py --threads 4"` — 0 errors
- [x] `nix-shell --run "bash scripts/run_ruff.sh tests/test_preview_manifest_generated.py"` — clean
- [x] Scoped fuzz burst (`fuzz` profile) over both modules — 25/25 green, 0 shallow properties, 0 discarding
- [x] `bash scripts/test.sh tests.test_deploy_pin_generated` — PASSED (6/6 phases)
- [x] `bash scripts/test.sh tests.test_preview_manifest_generated` — PASSED (6/6 phases)
- [x] `git status` in the shared checkout confirmed untouched (worktree-only diff)

Not merging — leaving for review per repo convention.
