### PR TITLE
perf(#1131): collapse test_nix_module's redundant nix evals, fix VM guest cores

### DIFF
--- a/nix/tests/module-vm.nix
+++ b/nix/tests/module-vm.nix
@@ -1055,6 +1055,11 @@ pkgs.testers.nixosTest {
     # default tmpfs-backed writable overlay because the test queries closures
     # with nix-store, which maintains store bookkeeping while it runs.
     virtualisation.memorySize = 2048;
+    # The guest core count has no explicit default in this file, so it was
+    # silently inheriting the qemu-vm module's default of 1 (issue #1131) —
+    # serializing PostgreSQL, nginx, ~10 switch-to-configuration calls, and 2
+    # reboots onto one emulated core. Give it real parallelism.
+    virtualisation.cores = 4;
     virtualisation.useNixStoreImage = true;
     virtualisation.writableStore = true;
   };

--- a/scripts/run_python_tests.py
+++ b/scripts/run_python_tests.py
@@ -73,13 +73,20 @@ AUDITED_FRONTLOAD_MODULES = frozenset({"tests.test_nix_module"})
 #: — a cache only pays off when every one of its consumers runs in the same
 #: worker PROCESS. method_batch splits methods across separate processes by
 #: TEST COUNT, blind to cost, and a naive full unshard (this issue's own
-#: round 1) serializes every merged world onto ONE target. Measured
+#: round 1) serializes every merged world onto ONE target instead. Measured
 #: (round 2 review, quiet 30-core host): main's own method_batch worst case
 #: is 61.6s; a full unshard is 118.3s (+92%); this module's own
 #: HOTSPOT_ISOLATED_METHODS carve-out below restores a 2-target floor level
-#: with main (~65s) while still merging the redundant preamble each
-#: `nix eval` used to pay independently (total eval CPU 100.8s vs main's
-#: 126.6s).
+#: with main (~61-65s), not better. The CPU merging saves is modest — on
+#: the order of a few seconds, bounded by the sub-1s shared preamble each
+#: eliminated `nix eval` call no longer pays, NOT the gap between each
+#: world's SOLO measured time and one combined run. The real payoff is
+#: capping this module at AT MOST TWO concurrent heavy nix-eval
+#: subprocesses instead of up to five under main's own scheme: a
+#: worker-count sweep on main shows this module's pole inflating hard with
+#: concurrency (88.0s at 8 workers, 122.7s at 12, 147.7s at 16, 152.3s at
+#: 20), so bounding its own concurrency is what makes raising the suite's
+#: worker count affordable — the next lever on this issue, not this PR.
 HOTSPOT_SHARD_POLICIES = {
     "tests.test_beets_destructive_configs_generated": "method_batch",
     "tests.test_deploy_pin_generated": "method_batch",
@@ -652,6 +659,17 @@ def hotspot_targets(
     refactored (a rename or removal) without updating this table, and
     fails closed rather than silently dropping coverage.
     """
+    # Same module-membership check shard_test_ids performs. Without a
+    # granularity, the remainder target is built directly (not handed to
+    # shard_test_ids), so this function must enforce it itself — otherwise
+    # a foreign test ID slipped into test_ids would be silently bundled
+    # into the remainder target instead of rejected.
+    prefix = f"{module.name}."
+    foreign = [test_id for test_id in test_ids if not test_id.startswith(prefix)]
+    if foreign:
+        raise ValueError(
+            f"test ID {foreign[0]} does not belong to module {module.name}"
+        )
     unknown = isolated - set(test_ids)
     if unknown:
         raise ValueError(

--- a/scripts/run_python_tests.py
+++ b/scripts/run_python_tests.py
@@ -66,11 +66,23 @@ WORLD_MODEL_MODULE = "tests.world_model.state_machine"
 # Method profiling showed the dominant Nix evaluation was otherwise admitted
 # late enough to become the deterministic suite's tail.
 AUDITED_FRONTLOAD_MODULES = frozenset({"tests.test_nix_module"})
+#: tests.test_nix_module (issue #1131) is NOT method_batch here on purpose.
+#: Its handful of expensive nix-eval tests share ONE evaluated JSON blob via
+#: a module-level ``functools.cache`` (``_shared_module_worlds`` in the test
+#: module) — that cache only pays off when every consumer runs in the same
+#: worker PROCESS. method_batch splits methods across separate processes by
+#: TEST COUNT, blind to cost: it could (and, measured, did) land more than
+#: one multi-second, multi-GB nix-eval method in the same batch, or run
+#: several of them concurrently at higher worker counts, which is what drove
+#: the shared test RAM root to 96%. Left unsharded, the module is one
+#: frontloaded target with at most one such subprocess live at a time;
+#: measured whole-module wall time (nix-shell warm, single process) dropped
+#: from a ~142.7s serial sum of six separate nix-eval subprocess calls to
+#: ~103.6s for one merged evaluation plus every other test in the module.
 HOTSPOT_SHARD_POLICIES = {
     "tests.test_beets_destructive_configs_generated": "method_batch",
     "tests.test_deploy_pin_generated": "method_batch",
     "tests.test_deploy_pin_script": "method_batch",
-    "tests.test_nix_module": "method_batch",
     "tests.test_pipeline_db": "class_batch",
 }
 HOTSPOT_CLASS_BATCHES = 8

--- a/scripts/run_python_tests.py
+++ b/scripts/run_python_tests.py
@@ -67,18 +67,19 @@ WORLD_MODEL_MODULE = "tests.world_model.state_machine"
 # late enough to become the deterministic suite's tail.
 AUDITED_FRONTLOAD_MODULES = frozenset({"tests.test_nix_module"})
 #: tests.test_nix_module (issue #1131) is NOT method_batch here on purpose.
-#: Its handful of expensive nix-eval tests share ONE evaluated JSON blob via
-#: a module-level ``functools.cache`` (``_shared_module_worlds`` in the test
-#: module) — that cache only pays off when every consumer runs in the same
+#: Its nix-eval tests are cost-grouped into two ``functools``-free,
+#: exception-memoizing cached helpers in the test module
+#: (``_shared_module_worlds_web_auth_matrix`` / ``_shared_module_worlds_rest``)
+#: — a cache only pays off when every one of its consumers runs in the same
 #: worker PROCESS. method_batch splits methods across separate processes by
-#: TEST COUNT, blind to cost: it could (and, measured, did) land more than
-#: one multi-second, multi-GB nix-eval method in the same batch, or run
-#: several of them concurrently at higher worker counts, which is what drove
-#: the shared test RAM root to 96%. Left unsharded, the module is one
-#: frontloaded target with at most one such subprocess live at a time;
-#: measured whole-module wall time (nix-shell warm, single process) dropped
-#: from a ~142.7s serial sum of six separate nix-eval subprocess calls to
-#: ~103.6s for one merged evaluation plus every other test in the module.
+#: TEST COUNT, blind to cost, and a naive full unshard (this issue's own
+#: round 1) serializes every merged world onto ONE target. Measured
+#: (round 2 review, quiet 30-core host): main's own method_batch worst case
+#: is 61.6s; a full unshard is 118.3s (+92%); this module's own
+#: HOTSPOT_ISOLATED_METHODS carve-out below restores a 2-target floor level
+#: with main (~65s) while still merging the redundant preamble each
+#: `nix eval` used to pay independently (total eval CPU 100.8s vs main's
+#: 126.6s).
 HOTSPOT_SHARD_POLICIES = {
     "tests.test_beets_destructive_configs_generated": "method_batch",
     "tests.test_deploy_pin_generated": "method_batch",
@@ -87,6 +88,24 @@ HOTSPOT_SHARD_POLICIES = {
 }
 HOTSPOT_CLASS_BATCHES = 8
 HOTSPOT_METHOD_BATCHES = 12
+#: Issue #1131 review round 2: exact test IDs that must run as their OWN
+#: singleton target, isolated from the rest of their module. Unlike
+#: HOTSPOT_SHARD_POLICIES (a generic, cost-BLIND split balanced by test
+#: count), this is a manually audited, cost-AWARE carve-out — the named
+#: test is this module's single most expensive nix-eval consumer, and its
+#: own cached helper (see ``_shared_module_worlds_web_auth_matrix`` in
+#: ``tests/test_nix_module.py``) is scoped so this target pays for exactly
+#: the nix eval it needs, never a bundled neighbour's. A module named here
+#: with no ``HOTSPOT_SHARD_POLICIES`` entry bundles every OTHER discovered
+#: test into one remainder target (see ``hotspot_targets``).
+HOTSPOT_ISOLATED_METHODS: Mapping[str, frozenset[str]] = {
+    "tests.test_nix_module": frozenset({
+        (
+            "tests.test_nix_module.TestWebAuthenticationModuleContract."
+            "test_basic_and_insecure_mode_matrix_is_evaluated"
+        ),
+    }),
+}
 
 #: Hypothesis' ``stopped-because`` reason when a strategy space ran out of
 #: distinct worlds before the example budget ran out
@@ -614,21 +633,76 @@ def assert_exact_target_coverage(
         raise ValueError(f"test target belongs to the wrong module: {module.name}")
 
 
+def hotspot_targets(
+    module: TestModule,
+    test_ids: Sequence[str],
+    *,
+    granularity: str | None,
+    isolated: frozenset[str] = frozenset(),
+) -> tuple[TestTarget, ...]:
+    """Carve ``isolated`` test IDs into singleton targets, then shard the rest.
+
+    Isolation (``HOTSPOT_ISOLATED_METHODS``) and ``method_batch``/
+    ``class_batch`` granularity (``HOTSPOT_SHARD_POLICIES``) are
+    orthogonal: an isolated ID always gets its own target, applied before
+    any batching of what remains. With no ``granularity``, the remainder
+    becomes one bundled target rather than one per remaining test — the
+    shape ``tests.test_nix_module`` uses (see its module docstring). An
+    isolated ID absent from the discovered set means the module was
+    refactored (a rename or removal) without updating this table, and
+    fails closed rather than silently dropping coverage.
+    """
+    unknown = isolated - set(test_ids)
+    if unknown:
+        raise ValueError(
+            f"unknown isolated test id(s) for {module.name}: {sorted(unknown)}"
+        )
+    isolated_targets = tuple(
+        TestTarget(module, test_id, (test_id,), load_names=(test_id,))
+        for test_id in sorted(isolated)
+    )
+    remainder = tuple(test_id for test_id in test_ids if test_id not in isolated)
+    if not remainder:
+        targets = isolated_targets
+    elif granularity is None:
+        targets = isolated_targets + (
+            TestTarget(
+                module,
+                f"{module.name}::remainder",
+                remainder,
+                load_names=remainder,
+            ),
+        )
+    else:
+        targets = isolated_targets + shard_test_ids(
+            module, remainder, granularity=granularity
+        )
+    assert_exact_target_coverage(module, test_ids, targets)
+    return targets
+
+
 def build_test_targets(
     schedule: Sequence[TestModule],
     listed_test_ids: Mapping[str, Sequence[str]],
+    *,
+    isolated_methods: Mapping[str, frozenset[str]] = HOTSPOT_ISOLATED_METHODS,
 ) -> tuple[TestTarget, ...]:
     """Expand only audited hotspots, leaving every other module isolated."""
     targets: list[TestTarget] = []
     for module in schedule:
         granularity = HOTSPOT_SHARD_POLICIES.get(module.name)
-        if granularity is None:
+        isolated = isolated_methods.get(module.name, frozenset())
+        if granularity is None and not isolated:
             targets.append(TestTarget(module, module.name))
             continue
         test_ids = listed_test_ids.get(module.name)
         if test_ids is None:
             raise ValueError(f"missing discovery manifest for hotspot {module.name}")
-        targets.extend(shard_test_ids(module, test_ids, granularity=granularity))
+        targets.extend(
+            hotspot_targets(
+                module, test_ids, granularity=granularity, isolated=isolated
+            )
+        )
     return tuple(targets)
 
 
@@ -638,6 +712,9 @@ def select_test_targets(
     *,
     listed_test_ids: Mapping[str, Sequence[str]] | None = None,
     hotspot_policies: Mapping[str, str] = HOTSPOT_SHARD_POLICIES,
+    hotspot_isolated_methods: Mapping[
+        str, frozenset[str]
+    ] = HOTSPOT_ISOLATED_METHODS,
 ) -> tuple[TestTarget, ...]:
     """Resolve unittest selectors while retaining canonical module isolation."""
     plan = tuple(selectors)
@@ -670,7 +747,8 @@ def select_test_targets(
     for module in selected_modules:
         if module.name in exact_modules:
             granularity = hotspot_policies.get(module.name)
-            if granularity is None:
+            isolated = hotspot_isolated_methods.get(module.name, frozenset())
+            if granularity is None and not isolated:
                 targets.append(TestTarget(module, module.name))
                 continue
             test_ids = manifests.get(module.name)
@@ -679,7 +757,9 @@ def select_test_targets(
                     f"missing discovery manifest for hotspot {module.name}"
                 )
             targets.extend(
-                shard_test_ids(module, test_ids, granularity=granularity)
+                hotspot_targets(
+                    module, test_ids, granularity=granularity, isolated=isolated
+                )
             )
             continue
         seen: set[str] = set()
@@ -1353,15 +1433,14 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"No Python tests found under {start}", file=sys.stderr)
         return 2
     modules = complete_test_modules(discovered, top)
+    hotspot_module_names = HOTSPOT_SHARD_POLICIES.keys() | HOTSPOT_ISOLATED_METHODS.keys()
     selected_hotspots = {
-        selector
-        for selector in args.test
-        if selector in HOTSPOT_SHARD_POLICIES
+        selector for selector in args.test if selector in hotspot_module_names
     }
     hotspot_names = (
         selected_hotspots
         if args.test
-        else HOTSPOT_SHARD_POLICIES.keys() & {module.name for module in modules}
+        else hotspot_module_names & {module.name for module in modules}
     )
     listed_test_ids = {
         module_name: list_module_test_ids(module_name, top)
@@ -1385,7 +1464,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         f"({os.cpu_count() or 1} host CPUs)"
     )
     sharded_target_count = sum(
-        target.module.name in HOTSPOT_SHARD_POLICIES for target in schedule
+        target.module.name in hotspot_module_names for target in schedule
     )
     print(
         f"Queue: {len(schedule)} targets "

--- a/tests/test_nix_module.py
+++ b/tests/test_nix_module.py
@@ -26,6 +26,7 @@ failure depends on Nix option assertion evaluation.
 
 from __future__ import annotations
 
+import functools
 import json
 import re
 import subprocess
@@ -129,20 +130,50 @@ class TestDecisionDifferentialWrapperContract(unittest.TestCase):
         self.assertIn("decisionDifferential", text[text.index("environment.systemPackages"):])
 
 
-class TestDefaultHeadlessComposition(unittest.TestCase):
-    """The exported module keeps the direct CLI usable without the web."""
+@functools.cache
+def _shared_module_worlds() -> dict[str, object]:
+    """One ``nix eval`` for every consumer that reads assertions/options only.
 
-    def test_exported_module_installs_cli_without_web_units_or_sockets(
-        self,
-    ) -> None:
-        expression = r'''
+    ``TestDefaultHeadlessComposition``, three of
+    ``TestWebAuthenticationModuleContract``'s nix-eval tests, and both of
+    ``TestExternalBeetsRuntimeCapability``'s nix-eval tests each used to pay
+    for an independent ``builtins.getFlake`` + ``import nixpkgs`` +
+    ``import ./nix/beets.nix`` preamble (measured: ~0.24s alone — cheap) and
+    then their own full NixOS module-tree evaluation per world (measured:
+    the real cost, ~1.3-2.3s per ``lib.nixosSystem`` call). Method-batch
+    sharding (issue #1131) balances by TEST COUNT, not cost, so it could land
+    several of these multi-second, multi-GB ``nix eval`` subprocesses in the
+    same batch by chance, or — at higher worker counts — run several of them
+    truly concurrently. That concurrency, not the redundant preamble, is what
+    drove the shared test RAM root to 96% utilization and made raising
+    worker count a regression instead of a speedup.
+
+    This merges every world these five tests need into ONE expression,
+    evaluated at most once per test PROCESS (``functools.cache``): every
+    world here only ever reads ``.config.assertions`` or plain option/service
+    values, never forces ``.system.build.toplevel``, so none of them can
+    raise or ``abort`` mid-evaluation and take the others down with it.
+    ``test_injected_basic_path_cannot_render_toplevel`` is the one nix-eval
+    test in this module that DOES force ``.system.build.toplevel``,
+    specifically to observe the hard assertion ``abort`` (non-zero exit,
+    stderr text) that path triggers — merging it here would let that one
+    deliberately-failing world abort the whole shared evaluation for every
+    other consumer, so it keeps its own independent ``nix eval`` call.
+
+    Callers index their own top-level key out of the returned dict; nothing
+    downstream of this helper changed shape or assertions.
+    """
+    expression = r'''
+      let
+        f = builtins.getFlake (toString ./.);
+        lib = f.inputs.nixpkgs.lib;
+        modulePkgs = import f.inputs.nixpkgs {
+          system = builtins.currentSystem;
+        };
+        beetsPackage = import ./nix/beets.nix { pkgs = modulePkgs; };
+      in {
+        headlessComposition =
           let
-            f = builtins.getFlake (toString ./.);
-            modulePkgs = import f.inputs.nixpkgs {
-              system = builtins.currentSystem;
-            };
-            beetsPackage = import ./nix/beets.nix { pkgs = modulePkgs; };
-            lib = f.inputs.nixpkgs.lib;
             system = lib.nixosSystem {
               system = builtins.currentSystem;
               modules = [
@@ -166,7 +197,7 @@ class TestDefaultHeadlessComposition(unittest.TestCase):
                 })
               ];
             };
-          in builtins.toJSON {
+          in {
             webEnabled = system.config.services.cratedigger.web.enable;
             systemPackages =
               map lib.getName system.config.environment.systemPackages;
@@ -178,36 +209,10 @@ class TestDefaultHeadlessComposition(unittest.TestCase):
               builtins.filter
                 (name: lib.hasPrefix "cratedigger" name)
                 (builtins.attrNames system.config.systemd.sockets);
-          }
-        '''
-        result = subprocess.run(
-            ["nix", "eval", "--raw", "--impure", "--expr", expression],
-            cwd=REPO_ROOT,
-            capture_output=True,
-            check=False,
-            text=True,
-        )
-        self.assertEqual(result.returncode, 0, result.stderr)
-        composition = json.loads(result.stdout)
-        self.assertFalse(composition["webEnabled"])
-        self.assertIn("pipeline-cli", composition["systemPackages"])
-        self.assertIn("decision-differential", composition["systemPackages"])
-        self.assertFalse(composition["hasWebService"])
-        self.assertEqual(composition["cratediggerSockets"], [])
+          };
 
-
-class TestWebAuthenticationModuleContract(unittest.TestCase):
-    """The enabled web surface has one fail-closed module-owned perimeter."""
-
-    def test_basic_and_insecure_mode_matrix_is_evaluated(self) -> None:
-        expression = r'''
+        webAuthMatrix =
           let
-            f = builtins.getFlake (toString ./.);
-            lib = f.inputs.nixpkgs.lib;
-            modulePkgs = import f.inputs.nixpkgs {
-              system = builtins.currentSystem;
-            };
-            beetsPackage = import ./nix/beets.nix { pkgs = modulePkgs; };
             evaluate = extra:
               let
                 system = lib.nixosSystem {
@@ -583,17 +588,382 @@ class TestWebAuthenticationModuleContract(unittest.TestCase):
               };
               systemd.services.nginx.restartIfChanged = lib.mkForce false;
             };
-          }
-        '''
-        result = subprocess.run(
-            ["nix", "eval", "--impure", "--json", "--expr", expression],
-            cwd=REPO_ROOT,
-            capture_output=True,
-            check=False,
-            text=True,
-        )
-        self.assertEqual(result.returncode, 0, result.stderr)
-        worlds = json.loads(result.stdout)
+          };
+
+        mergedGateway =
+          let
+            render = enableIPv6: basicAuthFile: externalAuth:
+              let
+                system = lib.nixosSystem {
+                  system = builtins.currentSystem;
+                  modules = [
+                    f.nixosModules.default
+                    ({ ... }: {
+                      networking.enableIPv6 = enableIPv6;
+                      services.cratedigger = {
+                        enable = true;
+                        src = ./.;
+                        user = "cratedigger";
+                        group = "cratedigger";
+                        slskd.apiKeyFile = "/run/secrets/slskd-key";
+                        slskd.downloadDir = "/srv/slskd";
+                        pipelineDb.createLocally = true;
+                        beets.runtime = {
+                          package = beetsPackage;
+                          configDir = "/etc/beets";
+                          expectedLibrary = "/srv/beets/beets-library.db";
+                          expectedDirectory = "/srv/music";
+                          expectedStateFile = "/var/lib/beets/state.pickle";
+                          expectedSecretInclude = "/run/secrets/beets.yaml";
+                        };
+                        web = ({
+                          enable = true;
+                          hostName = "music.example.test";
+                          enableInsecure =
+                            basicAuthFile == null && !externalAuth;
+                          inherit externalAuth;
+                        } // lib.optionalAttrs (basicAuthFile != null) {
+                          inherit basicAuthFile;
+                        });
+                      };
+                      services.nginx.virtualHosts.cratedigger-auth-gateway
+                        .locations."/merged-probe" = {
+                          proxyPass =
+                            "http://unix:/run/cratedigger-web/web.sock:";
+                          recommendedProxySettings = false;
+                        };
+                    })
+                  ];
+                };
+                gateway =
+                  system.config.services.nginx.virtualHosts.cratedigger-auth-gateway;
+                reject =
+                  system.config.services.nginx.virtualHosts.cratedigger-auth-reject;
+                socket = system.config.systemd.sockets.cratedigger-web;
+                webService =
+                  system.config.systemd.services.cratedigger-web;
+                nginxService = system.config.systemd.services.nginx;
+              in {
+                failures = map (assertion: assertion.message)
+                  (builtins.filter
+                    (assertion:
+                      !assertion.assertion
+                      && lib.hasPrefix
+                        "services.cratedigger.web"
+                        assertion.message)
+                    system.config.assertions);
+                listen = map (item: {
+                  inherit (item) addr port;
+                }) gateway.listen;
+                hostName = gateway.serverName;
+                gatewayExtra = gateway.extraConfig;
+                gatewayPolicy =
+                  system.config.environment.etc
+                    ."cratedigger/web-gateway-policy".text;
+                basicAuthFile = gateway.basicAuthFile;
+                rootBasicAuthFile = gateway.locations."/".basicAuthFile;
+                mergedBasicAuthFile =
+                  gateway.locations."/merged-probe".basicAuthFile;
+                proxyPass = gateway.locations."/".proxyPass;
+                healthProxy = gateway.locations."= /healthz".proxyPass;
+                healthExtra = gateway.locations."= /healthz".extraConfig;
+                rejectDefault = reject.default;
+                rejectConfig = reject.locations."/".extraConfig;
+                socketListen = socket.listenStreams;
+                socketGroup = socket.socketConfig.SocketGroup;
+                socketMode = socket.socketConfig.SocketMode;
+                webAfter = webService.after;
+                webRequires = webService.requires;
+                webGroups = webService.serviceConfig.SupplementaryGroups;
+                webUser = webService.serviceConfig.User;
+                webGroup = webService.serviceConfig.Group;
+                webStartPre = webService.serviceConfig.ExecStartPre;
+                nginxEnableReload =
+                  system.config.services.nginx.enableReload;
+                nginxRestartIfChanged = nginxService.restartIfChanged;
+                nginxAfter = nginxService.after;
+                nginxWants = nginxService.wants;
+                nginxRequires = nginxService.requires;
+                nginxUnit =
+                  system.config.systemd.units."nginx.service".text;
+                nginxGroups = nginxService.serviceConfig.SupplementaryGroups;
+                nginxUser = nginxService.serviceConfig.User;
+                nginxGroup = nginxService.serviceConfig.Group;
+                nginxUserGroups =
+                  system.config.users.users.${system.config.services.nginx.user}.extraGroups;
+                applicationUserGroups =
+                  system.config.users.users.cratedigger.extraGroups;
+                startPre = nginxService.serviceConfig.ExecStartPre;
+                reload = nginxService.serviceConfig.ExecReload;
+              };
+          in {
+            dualStack =
+              render true "/run/secrets/cratedigger.htpasswd" false;
+            ipv4Only =
+              render false "/run/secrets/cratedigger.htpasswd" false;
+            insecureRecovery = render false null false;
+            alternateBasic =
+              render false "/run/secrets/cratedigger-alternate.htpasswd" false;
+            externalMode = render false null true;
+          };
+
+        beetsCapability =
+          let
+            ambientPkgs = modulePkgs // {
+              python3 = modulePkgs.python311;
+              python3Packages = modulePkgs.python311Packages;
+            };
+            ambientBeetsPackage = import ./nix/beets.nix {
+              pkgs = ambientPkgs;
+            };
+            runtime = {
+              package = beetsPackage;
+              configDir = "/etc/beets";
+              expectedLibrary = "/srv/beets/beets-library.db";
+              expectedDirectory = "/srv/music";
+              expectedStateFile = "/var/lib/beets/state.pickle";
+              expectedSecretInclude = "/run/secrets/beets.yaml";
+              readinessUnits = [];
+            };
+            failures = candidate:
+              let system = lib.nixosSystem {
+                system = builtins.currentSystem;
+                modules = [
+                  f.nixosModules.default
+                  ({ ... }: {
+                    services.cratedigger = {
+                      enable = true;
+                      src = ./.;
+                      packageSet = modulePkgs;
+                      slskd.apiKeyFile = "/run/secrets/slskd-key";
+                      slskd.downloadDir = "/srv/slskd";
+                      pipelineDb.createLocally = true;
+                      beets.runtime = candidate;
+                      beets.validation = {
+                        stagingDir = "/srv/incoming";
+                        trackingFile = "/srv/incoming/tracking.jsonl";
+                      };
+                    };
+                  })
+                ];
+              }; in map (assertion: assertion.message)
+                (builtins.filter
+                  (assertion:
+                    !assertion.assertion
+                    && lib.hasPrefix
+                      "services.cratedigger.beets.runtime"
+                      assertion.message)
+                  system.config.assertions);
+            disabled = lib.nixosSystem {
+              system = builtins.currentSystem;
+              modules = [ f.nixosModules.default ];
+            };
+            identityFailures = user: group:
+              let system = lib.nixosSystem {
+                system = builtins.currentSystem;
+                modules = [
+                  f.nixosModules.default
+                  ({ ... }: {
+                    services.cratedigger = {
+                      enable = true;
+                      src = ./.;
+                      packageSet = modulePkgs;
+                      inherit user group;
+                      slskd.apiKeyFile = "/run/secrets/slskd-key";
+                      slskd.downloadDir = "/srv/slskd";
+                      pipelineDb.createLocally = true;
+                      beets.runtime = runtime;
+                      beets.validation = {
+                        stagingDir = "/srv/incoming";
+                        trackingFile = "/srv/incoming/tracking.jsonl";
+                      };
+                    };
+                  })
+                ];
+              }; in map (assertion: assertion.message)
+                (builtins.filter
+                  (assertion:
+                    !assertion.assertion
+                    && lib.hasPrefix "services.cratedigger"
+                      assertion.message)
+                  system.config.assertions);
+            defaultIdentity = let system = lib.nixosSystem {
+              system = builtins.currentSystem;
+              modules = [
+                f.nixosModules.default
+                ({ ... }: {
+                  services.cratedigger = {
+                    enable = true;
+                    src = ./.;
+                    packageSet = modulePkgs;
+                    slskd.apiKeyFile = "/run/secrets/slskd-key";
+                    slskd.downloadDir = "/srv/slskd";
+                    pipelineDb.createLocally = true;
+                    beets.runtime = runtime;
+                    beets.validation = {
+                      stagingDir = "/srv/incoming";
+                      trackingFile = "/srv/incoming/tracking.jsonl";
+                    };
+                  };
+                })
+              ];
+            }; in {
+              user = system.config.services.cratedigger.user;
+              group = system.config.services.cratedigger.group;
+              serviceUser = system.config.systemd.services.cratedigger.serviceConfig.User;
+              serviceGroup = system.config.systemd.services.cratedigger.serviceConfig.Group;
+            };
+          in {
+            valid = failures runtime;
+            missing = builtins.listToAttrs (map (field: {
+              name = field;
+              value = failures (builtins.removeAttrs runtime [ field ]);
+            }) [
+              "package" "configDir" "expectedLibrary" "expectedDirectory"
+              "expectedStateFile" "expectedSecretInclude"
+            ]);
+            incompatiblePackage = failures (runtime // {
+              package = beetsPackage // { pythonModule = null; };
+            });
+            ambientPackageMismatch = {
+              distinct =
+                ambientBeetsPackage.pythonModule != modulePkgs.python3;
+              failures = failures (runtime // {
+                package = ambientBeetsPackage;
+              });
+            };
+            invalidPaths = {
+              configDir = failures (runtime // { configDir = "etc/beets"; });
+              expectedLibrary = failures (runtime // {
+                expectedLibrary = "/srv/beets/../beets-library.db";
+              });
+              expectedDirectory = failures (runtime // {
+                expectedDirectory = "/srv//music";
+              });
+              expectedStateFile = failures (runtime // {
+                expectedStateFile = "var/lib/beets/state.pickle";
+              });
+              expectedSecretInclude = failures (runtime // {
+                expectedSecretInclude = "/run/secrets/./beets.yaml";
+              });
+            };
+            rootPaths = {
+              configDir = failures (runtime // { configDir = "/"; });
+              expectedDirectory = failures (runtime // {
+                expectedDirectory = "/";
+              });
+              expectedLibrary = failures (runtime // {
+                expectedLibrary = "/beets-library.db";
+              });
+            };
+            rootIdentity = identityFailures "root" "root";
+            numericIdentity = identityFailures "0" "0";
+            inherit defaultIdentity;
+            disabled = {
+              assertions = builtins.filter
+                (assertion:
+                  !assertion.assertion
+                  && lib.hasPrefix
+                    "services.cratedigger"
+                    assertion.message)
+                disabled.config.assertions;
+              services = builtins.filter
+                (name: lib.hasPrefix "cratedigger" name)
+                (builtins.attrNames disabled.config.systemd.services);
+            };
+          };
+
+        beetsReadiness =
+          let
+            system = lib.nixosSystem {
+              system = builtins.currentSystem;
+              modules = [
+                f.nixosModules.default
+                ({ ... }: {
+                  services.cratedigger = {
+                    enable = true;
+                    src = ./.;
+                    packageSet = modulePkgs;
+                    slskd.apiKeyFile = "/run/secrets/slskd-key";
+                    slskd.downloadDir = "/srv/slskd";
+                    pipelineDb.createLocally = true;
+                    web = {
+                      enable = true;
+                      hostName = "music.example.test";
+                      enableInsecure = true;
+                    };
+                    beets.runtime = {
+                      package = beetsPackage;
+                      configDir = "/etc/beets";
+                      expectedLibrary = "/srv/beets/beets-library.db";
+                      expectedDirectory = "/srv/music";
+                      expectedStateFile = "/var/lib/beets/state.pickle";
+                      expectedSecretInclude = "/run/secrets/beets.yaml";
+                      readinessUnits = [
+                        "beets-config-ready.service"
+                        "beets-secret-ready.service"
+                      ];
+                    };
+                    beets.validation = {
+                      stagingDir = "/srv/incoming";
+                      trackingFile = "/srv/incoming/tracking.jsonl";
+                    };
+                  };
+                })
+              ];
+            };
+            unit = name: let value = system.config.systemd.services.${name}; in {
+              after = value.after;
+              wants = value.wants;
+              requires = value.requires;
+              bindReadOnlyPaths = value.serviceConfig.BindReadOnlyPaths or [];
+              bindPaths = value.serviceConfig.BindPaths or [];
+              readWritePaths = value.serviceConfig.ReadWritePaths or [];
+            };
+          in {
+            main = unit "cratedigger";
+            importer = unit "cratedigger-importer";
+            preview = unit "cratedigger-import-preview-worker";
+            web = unit "cratedigger-web";
+          };
+      }
+    '''
+    result = subprocess.run(
+        ["nix", "eval", "--impure", "--json", "--expr", expression],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise AssertionError(result.stderr)
+    value = json.loads(result.stdout)
+    if not isinstance(value, dict):
+        raise TypeError(value)
+    return value
+
+
+class TestDefaultHeadlessComposition(unittest.TestCase):
+    """The exported module keeps the direct CLI usable without the web."""
+
+    def test_exported_module_installs_cli_without_web_units_or_sockets(
+        self,
+    ) -> None:
+        composition = _shared_module_worlds()["headlessComposition"]
+        assert isinstance(composition, dict)
+        self.assertFalse(composition["webEnabled"])
+        self.assertIn("pipeline-cli", composition["systemPackages"])
+        self.assertIn("decision-differential", composition["systemPackages"])
+        self.assertFalse(composition["hasWebService"])
+        self.assertEqual(composition["cratediggerSockets"], [])
+
+
+class TestWebAuthenticationModuleContract(unittest.TestCase):
+    """The enabled web surface has one fail-closed module-owned perimeter."""
+
+    def test_basic_and_insecure_mode_matrix_is_evaluated(self) -> None:
+        worlds = _shared_module_worlds()["webAuthMatrix"]
+        assert isinstance(worlds, dict)
         self.assertTrue(
             any("exactly one" in message for message in worlds["missing"])
         )
@@ -814,138 +1184,8 @@ class TestWebAuthenticationModuleContract(unittest.TestCase):
         self.assertIn("nginx-token-safe segments", result.stderr)
 
     def test_merged_basic_gateway_values_are_exact(self) -> None:
-        expression = r'''
-          let
-            f = builtins.getFlake (toString ./.);
-            lib = f.inputs.nixpkgs.lib;
-            modulePkgs = import f.inputs.nixpkgs {
-              system = builtins.currentSystem;
-            };
-            beetsPackage = import ./nix/beets.nix { pkgs = modulePkgs; };
-            render = enableIPv6: basicAuthFile: externalAuth:
-              let
-                system = lib.nixosSystem {
-                  system = builtins.currentSystem;
-                  modules = [
-                    f.nixosModules.default
-                    ({ ... }: {
-                      networking.enableIPv6 = enableIPv6;
-                      services.cratedigger = {
-                        enable = true;
-                        src = ./.;
-                        user = "cratedigger";
-                        group = "cratedigger";
-                        slskd.apiKeyFile = "/run/secrets/slskd-key";
-                        slskd.downloadDir = "/srv/slskd";
-                        pipelineDb.createLocally = true;
-                        beets.runtime = {
-                          package = beetsPackage;
-                          configDir = "/etc/beets";
-                          expectedLibrary = "/srv/beets/beets-library.db";
-                          expectedDirectory = "/srv/music";
-                          expectedStateFile = "/var/lib/beets/state.pickle";
-                          expectedSecretInclude = "/run/secrets/beets.yaml";
-                        };
-                        web = ({
-                          enable = true;
-                          hostName = "music.example.test";
-                          enableInsecure =
-                            basicAuthFile == null && !externalAuth;
-                          inherit externalAuth;
-                        } // lib.optionalAttrs (basicAuthFile != null) {
-                          inherit basicAuthFile;
-                        });
-                      };
-                      services.nginx.virtualHosts.cratedigger-auth-gateway
-                        .locations."/merged-probe" = {
-                          proxyPass =
-                            "http://unix:/run/cratedigger-web/web.sock:";
-                          recommendedProxySettings = false;
-                        };
-                    })
-                  ];
-                };
-                gateway =
-                  system.config.services.nginx.virtualHosts.cratedigger-auth-gateway;
-                reject =
-                  system.config.services.nginx.virtualHosts.cratedigger-auth-reject;
-                socket = system.config.systemd.sockets.cratedigger-web;
-                webService =
-                  system.config.systemd.services.cratedigger-web;
-                nginxService = system.config.systemd.services.nginx;
-              in {
-                failures = map (assertion: assertion.message)
-                  (builtins.filter
-                    (assertion:
-                      !assertion.assertion
-                      && lib.hasPrefix
-                        "services.cratedigger.web"
-                        assertion.message)
-                    system.config.assertions);
-                listen = map (item: {
-                  inherit (item) addr port;
-                }) gateway.listen;
-                hostName = gateway.serverName;
-                gatewayExtra = gateway.extraConfig;
-                gatewayPolicy =
-                  system.config.environment.etc
-                    ."cratedigger/web-gateway-policy".text;
-                basicAuthFile = gateway.basicAuthFile;
-                rootBasicAuthFile = gateway.locations."/".basicAuthFile;
-                mergedBasicAuthFile =
-                  gateway.locations."/merged-probe".basicAuthFile;
-                proxyPass = gateway.locations."/".proxyPass;
-                healthProxy = gateway.locations."= /healthz".proxyPass;
-                healthExtra = gateway.locations."= /healthz".extraConfig;
-                rejectDefault = reject.default;
-                rejectConfig = reject.locations."/".extraConfig;
-                socketListen = socket.listenStreams;
-                socketGroup = socket.socketConfig.SocketGroup;
-                socketMode = socket.socketConfig.SocketMode;
-                webAfter = webService.after;
-                webRequires = webService.requires;
-                webGroups = webService.serviceConfig.SupplementaryGroups;
-                webUser = webService.serviceConfig.User;
-                webGroup = webService.serviceConfig.Group;
-                webStartPre = webService.serviceConfig.ExecStartPre;
-                nginxEnableReload =
-                  system.config.services.nginx.enableReload;
-                nginxRestartIfChanged = nginxService.restartIfChanged;
-                nginxAfter = nginxService.after;
-                nginxWants = nginxService.wants;
-                nginxRequires = nginxService.requires;
-                nginxUnit =
-                  system.config.systemd.units."nginx.service".text;
-                nginxGroups = nginxService.serviceConfig.SupplementaryGroups;
-                nginxUser = nginxService.serviceConfig.User;
-                nginxGroup = nginxService.serviceConfig.Group;
-                nginxUserGroups =
-                  system.config.users.users.${system.config.services.nginx.user}.extraGroups;
-                applicationUserGroups =
-                  system.config.users.users.cratedigger.extraGroups;
-                startPre = nginxService.serviceConfig.ExecStartPre;
-                reload = nginxService.serviceConfig.ExecReload;
-              };
-          in {
-            dualStack =
-              render true "/run/secrets/cratedigger.htpasswd" false;
-            ipv4Only =
-              render false "/run/secrets/cratedigger.htpasswd" false;
-            insecureRecovery = render false null false;
-            alternateBasic =
-              render false "/run/secrets/cratedigger-alternate.htpasswd" false;
-            externalMode = render false null true;
-          }
-        '''
-        result = subprocess.run(
-            ["nix", "eval", "--impure", "--json", "--expr", expression],
-            cwd=REPO_ROOT,
-            capture_output=True,
-            check=False,
-            text=True,
-        )
-        self.assertEqual(result.returncode, 0, result.stderr)
-        worlds = json.loads(result.stdout)
+        worlds = _shared_module_worlds()["mergedGateway"]
+        assert isinstance(worlds, dict)
         dual = worlds["dualStack"]
         ipv4 = worlds["ipv4Only"]
         insecure = worlds["insecureRecovery"]
@@ -1415,6 +1655,19 @@ class TestModuleVmPerformanceContract(unittest.TestCase):
         self.assertIn("virtualisation.useNixStoreImage = true;", text)
         self.assertIn("virtualisation.writableStore = true;", text)
 
+    def test_guest_declares_more_than_one_core(self) -> None:
+        """Issue #1131: an unset ``virtualisation.cores`` silently inherits
+        the qemu-vm module's guest default of 1, serializing PostgreSQL,
+        nginx, ~10 switch-to-configuration calls, and 2 reboots onto one
+        emulated core. Pin an explicit, deliberately-chosen core count so it
+        can't regress back to the implicit default unnoticed.
+        """
+        text = MODULE_VM_NIX.read_text(encoding="utf-8")
+        match = re.search(r"virtualisation\.cores\s*=\s*(\d+)\s*;", text)
+        self.assertIsNotNone(match, "virtualisation.cores must be set explicitly")
+        assert match is not None
+        self.assertGreater(int(match.group(1)), 1)
+
 
 class TestImporterServiceContract(unittest.TestCase):
     def test_importer_wrapper_and_service_are_defined(self) -> None:
@@ -1564,22 +1817,6 @@ class TestExternalBeetsRuntimeCapability(unittest.TestCase):
     )
 
     @staticmethod
-    def _nix_eval_json(expression: str) -> dict[str, object]:
-        result = subprocess.run(
-            ["nix", "eval", "--impure", "--json", "--expr", expression],
-            cwd=REPO_ROOT,
-            capture_output=True,
-            check=False,
-            text=True,
-        )
-        if result.returncode != 0:
-            raise AssertionError(result.stderr)
-        value = json.loads(result.stdout)
-        if not isinstance(value, dict):
-            raise TypeError(value)
-        return value
-
-    @staticmethod
     def _string_list(value: object) -> list[str]:
         if not isinstance(value, list):
             raise TypeError(value)
@@ -1589,178 +1826,8 @@ class TestExternalBeetsRuntimeCapability(unittest.TestCase):
         return strings
 
     def test_capability_assertions_cover_happy_missing_invalid_and_disabled(self) -> None:
-        worlds = self._nix_eval_json(r'''
-          let
-            f = builtins.getFlake (toString ./.);
-            lib = f.inputs.nixpkgs.lib;
-            modulePkgs = import f.inputs.nixpkgs {
-              system = builtins.currentSystem;
-            };
-            beetsPackage = import ./nix/beets.nix { pkgs = modulePkgs; };
-            ambientPkgs = modulePkgs // {
-              python3 = modulePkgs.python311;
-              python3Packages = modulePkgs.python311Packages;
-            };
-            ambientBeetsPackage = import ./nix/beets.nix {
-              pkgs = ambientPkgs;
-            };
-            runtime = {
-              package = beetsPackage;
-              configDir = "/etc/beets";
-              expectedLibrary = "/srv/beets/beets-library.db";
-              expectedDirectory = "/srv/music";
-              expectedStateFile = "/var/lib/beets/state.pickle";
-              expectedSecretInclude = "/run/secrets/beets.yaml";
-              readinessUnits = [];
-            };
-            failures = candidate:
-              let system = lib.nixosSystem {
-                system = builtins.currentSystem;
-                modules = [
-                  f.nixosModules.default
-                  ({ ... }: {
-                    services.cratedigger = {
-                      enable = true;
-                      src = ./.;
-                      packageSet = modulePkgs;
-                      slskd.apiKeyFile = "/run/secrets/slskd-key";
-                      slskd.downloadDir = "/srv/slskd";
-                      pipelineDb.createLocally = true;
-                      beets.runtime = candidate;
-                      beets.validation = {
-                        stagingDir = "/srv/incoming";
-                        trackingFile = "/srv/incoming/tracking.jsonl";
-                      };
-                    };
-                  })
-                ];
-              }; in map (assertion: assertion.message)
-                (builtins.filter
-                  (assertion:
-                    !assertion.assertion
-                    && lib.hasPrefix
-                      "services.cratedigger.beets.runtime"
-                      assertion.message)
-                  system.config.assertions);
-            disabled = lib.nixosSystem {
-              system = builtins.currentSystem;
-              modules = [ f.nixosModules.default ];
-            };
-            identityFailures = user: group:
-              let system = lib.nixosSystem {
-                system = builtins.currentSystem;
-                modules = [
-                  f.nixosModules.default
-                  ({ ... }: {
-                    services.cratedigger = {
-                      enable = true;
-                      src = ./.;
-                      packageSet = modulePkgs;
-                      inherit user group;
-                      slskd.apiKeyFile = "/run/secrets/slskd-key";
-                      slskd.downloadDir = "/srv/slskd";
-                      pipelineDb.createLocally = true;
-                      beets.runtime = runtime;
-                      beets.validation = {
-                        stagingDir = "/srv/incoming";
-                        trackingFile = "/srv/incoming/tracking.jsonl";
-                      };
-                    };
-                  })
-                ];
-              }; in map (assertion: assertion.message)
-                (builtins.filter
-                  (assertion:
-                    !assertion.assertion
-                    && lib.hasPrefix "services.cratedigger"
-                      assertion.message)
-                  system.config.assertions);
-            defaultIdentity = let system = lib.nixosSystem {
-              system = builtins.currentSystem;
-              modules = [
-                f.nixosModules.default
-                ({ ... }: {
-                  services.cratedigger = {
-                    enable = true;
-                    src = ./.;
-                    packageSet = modulePkgs;
-                    slskd.apiKeyFile = "/run/secrets/slskd-key";
-                    slskd.downloadDir = "/srv/slskd";
-                    pipelineDb.createLocally = true;
-                    beets.runtime = runtime;
-                    beets.validation = {
-                      stagingDir = "/srv/incoming";
-                      trackingFile = "/srv/incoming/tracking.jsonl";
-                    };
-                  };
-                })
-              ];
-            }; in {
-              user = system.config.services.cratedigger.user;
-              group = system.config.services.cratedigger.group;
-              serviceUser = system.config.systemd.services.cratedigger.serviceConfig.User;
-              serviceGroup = system.config.systemd.services.cratedigger.serviceConfig.Group;
-            };
-          in {
-            valid = failures runtime;
-            missing = builtins.listToAttrs (map (field: {
-              name = field;
-              value = failures (builtins.removeAttrs runtime [ field ]);
-            }) [
-              "package" "configDir" "expectedLibrary" "expectedDirectory"
-              "expectedStateFile" "expectedSecretInclude"
-            ]);
-            incompatiblePackage = failures (runtime // {
-              package = beetsPackage // { pythonModule = null; };
-            });
-            ambientPackageMismatch = {
-              distinct =
-                ambientBeetsPackage.pythonModule != modulePkgs.python3;
-              failures = failures (runtime // {
-                package = ambientBeetsPackage;
-              });
-            };
-            invalidPaths = {
-              configDir = failures (runtime // { configDir = "etc/beets"; });
-              expectedLibrary = failures (runtime // {
-                expectedLibrary = "/srv/beets/../beets-library.db";
-              });
-              expectedDirectory = failures (runtime // {
-                expectedDirectory = "/srv//music";
-              });
-              expectedStateFile = failures (runtime // {
-                expectedStateFile = "var/lib/beets/state.pickle";
-              });
-              expectedSecretInclude = failures (runtime // {
-                expectedSecretInclude = "/run/secrets/./beets.yaml";
-              });
-            };
-            rootPaths = {
-              configDir = failures (runtime // { configDir = "/"; });
-              expectedDirectory = failures (runtime // {
-                expectedDirectory = "/";
-              });
-              expectedLibrary = failures (runtime // {
-                expectedLibrary = "/beets-library.db";
-              });
-            };
-            rootIdentity = identityFailures "root" "root";
-            numericIdentity = identityFailures "0" "0";
-            inherit defaultIdentity;
-            disabled = {
-              assertions = builtins.filter
-                (assertion:
-                  !assertion.assertion
-                  && lib.hasPrefix
-                    "services.cratedigger"
-                    assertion.message)
-                disabled.config.assertions;
-              services = builtins.filter
-                (name: lib.hasPrefix "cratedigger" name)
-                (builtins.attrNames disabled.config.systemd.services);
-            };
-          }
-        ''')
+        worlds = _shared_module_worlds()["beetsCapability"]
+        assert isinstance(worlds, dict)
         self.assertEqual(worlds["valid"], [])
         missing = worlds["missing"]
         assert isinstance(missing, dict)
@@ -1841,66 +1908,8 @@ class TestExternalBeetsRuntimeCapability(unittest.TestCase):
         self.assertEqual(worlds["disabled"], {"assertions": [], "services": []})
 
     def test_readiness_and_role_state_capabilities_evaluate(self) -> None:
-        units = self._nix_eval_json(r'''
-          let
-            f = builtins.getFlake (toString ./.);
-            lib = f.inputs.nixpkgs.lib;
-            modulePkgs = import f.inputs.nixpkgs {
-              system = builtins.currentSystem;
-            };
-            beetsPackage = import ./nix/beets.nix { pkgs = modulePkgs; };
-            system = lib.nixosSystem {
-              system = builtins.currentSystem;
-              modules = [
-                f.nixosModules.default
-                ({ ... }: {
-                  services.cratedigger = {
-                    enable = true;
-                    src = ./.;
-                    packageSet = modulePkgs;
-                    slskd.apiKeyFile = "/run/secrets/slskd-key";
-                    slskd.downloadDir = "/srv/slskd";
-                    pipelineDb.createLocally = true;
-                    web = {
-                      enable = true;
-                      hostName = "music.example.test";
-                      enableInsecure = true;
-                    };
-                    beets.runtime = {
-                      package = beetsPackage;
-                      configDir = "/etc/beets";
-                      expectedLibrary = "/srv/beets/beets-library.db";
-                      expectedDirectory = "/srv/music";
-                      expectedStateFile = "/var/lib/beets/state.pickle";
-                      expectedSecretInclude = "/run/secrets/beets.yaml";
-                      readinessUnits = [
-                        "beets-config-ready.service"
-                        "beets-secret-ready.service"
-                      ];
-                    };
-                    beets.validation = {
-                      stagingDir = "/srv/incoming";
-                      trackingFile = "/srv/incoming/tracking.jsonl";
-                    };
-                  };
-                })
-              ];
-            };
-            unit = name: let value = system.config.systemd.services.${name}; in {
-              after = value.after;
-              wants = value.wants;
-              requires = value.requires;
-              bindReadOnlyPaths = value.serviceConfig.BindReadOnlyPaths or [];
-              bindPaths = value.serviceConfig.BindPaths or [];
-              readWritePaths = value.serviceConfig.ReadWritePaths or [];
-            };
-          in {
-            main = unit "cratedigger";
-            importer = unit "cratedigger-importer";
-            preview = unit "cratedigger-import-preview-worker";
-            web = unit "cratedigger-web";
-          }
-        ''')
+        units = _shared_module_worlds()["beetsReadiness"]
+        assert isinstance(units, dict)
         readiness = {
             "beets-config-ready.service",
             "beets-secret-ready.service",

--- a/tests/test_nix_module.py
+++ b/tests/test_nix_module.py
@@ -130,20 +130,22 @@ class TestDecisionDifferentialWrapperContract(unittest.TestCase):
 
 
 #: Issue #1131 review round 2: exception-memoizing cache for the two
-#: cost-grouped nix evaluations below, keyed by an arbitrary string tag.
+#: cost-grouped nix evaluations below, keyed by the EXPRESSION itself
+#: (never a hand-written tag — a stale or mismatched tag would silently
+#: return one expression's cached value for a different one).
 #: ``functools.cache`` does not memoize a raised exception — on a real
 #: module regression every consumer of a failing evaluation would
 #: independently re-pay the full ``nix eval`` just to report the same
 #: failure. Memoizing the exception too means a real regression costs one
 #: nix eval to detect, not one per consumer.
-_NIX_EVAL_CACHE: dict[str, dict[str, object] | BaseException] = {}
+_NIX_EVAL_CACHE: dict[str, dict[str, object] | Exception] = {}
 
 
-def _cached_nix_eval_json(cache_key: str, expression: str) -> dict[str, object]:
-    """Run one ``nix eval --json`` at most once per process per cache key."""
-    cached = _NIX_EVAL_CACHE.get(cache_key)
+def _cached_nix_eval_json(expression: str) -> dict[str, object]:
+    """Run one ``nix eval --json`` at most once per process per expression."""
+    cached = _NIX_EVAL_CACHE.get(expression)
     if cached is not None:
-        if isinstance(cached, BaseException):
+        if isinstance(cached, Exception):
             raise cached
         return cached
     try:
@@ -159,10 +161,13 @@ def _cached_nix_eval_json(cache_key: str, expression: str) -> dict[str, object]:
         value = json.loads(result.stdout)
         if not isinstance(value, dict):
             raise TypeError(value)
-    except BaseException as exc:
-        _NIX_EVAL_CACHE[cache_key] = exc
+    except Exception as exc:
+        # Not `except BaseException`: a Ctrl-C or SystemExit must propagate
+        # normally, never get memoized and instantly re-raised at every
+        # later consumer for the rest of the process.
+        _NIX_EVAL_CACHE[expression] = exc
         raise
-    _NIX_EVAL_CACHE[cache_key] = value
+    _NIX_EVAL_CACHE[expression] = value
     return value
 
 
@@ -172,17 +177,30 @@ def _shared_module_worlds_web_auth_matrix() -> dict[str, object]:
     Issue #1131 review round 2: measured per-world costs are wildly uneven
     (``headlessComposition`` 0.80s, ``beetsReadiness`` 3.46s,
     ``mergedGateway`` 18.67s, ``beetsCapability`` 38.28s, ``webAuthMatrix``
-    65.44s — the pole). Merging every world into ONE evaluation and running
-    the whole module unsharded serializes ALL of that onto a single target
-    and pushes the module's critical-path contribution from main's own
-    61.6s (its worst `method_batch` bin-packing) to 118.3s — a regression,
-    not a fix; that full-unshard attempt is what round 1 of this review
-    reverted. Splitting the merge by cost and restoring a 2-target shard —
-    this world isolated, the other four bundled in
-    ``_shared_module_worlds_rest`` — keeps the floor level with main
-    (~65s vs ~61.6s) while still cutting total nix-eval CPU work (~100.8s
-    measured vs main's ~126.6s) by sharing this evaluation's own preamble
-    across its 39 internal worlds in one process.
+    65.44s — the pole). Running the whole module unsharded (this issue's
+    own round 1) serializes every merged world onto ONE target and pushes
+    the module's critical-path contribution from main's own 61.6s (its
+    worst `method_batch` bin-packing) to 118.3s — a regression, not a fix.
+
+    The CPU saved by merging evaluations is modest, NOT the headline
+    reason for this split: the shared preamble (``getFlake`` + ``import
+    nixpkgs`` + ``import ./nix/beets.nix``) measured at well under 1s
+    forced standalone, so eliminating N-1 redundant preambles is bounded
+    above by roughly N-1 seconds, not by the sum of each eval's SOLO wall
+    time (which double-counts nixpkgs-import work every eval pays whether
+    merged or not). The real reason to split by cost rather than merge
+    everything or run one unsharded target: main's own `method_batch`
+    sharding can (and, this module's own shard simulation shows, does)
+    land more than one of these multi-GB nix-eval methods in the same
+    12-way batch, and a worker-count sweep on main shows this module's
+    pole inflating hard with concurrency (88.0s at 8 workers, 122.7s at
+    12, 147.7s at 16, 152.3s at 20). Isolating this one world caps this
+    module at AT MOST TWO concurrent
+    heavy nix-eval subprocesses (this function's, plus
+    ``_shared_module_worlds_rest``'s), down from up to five under main's
+    own scheme — which is what would make raising the suite's worker
+    count affordable, the next lever on this issue. Floor: level with
+    main's own 61.6s (~61-65s measured), not better.
 
     See ``HOTSPOT_ISOLATED_METHODS`` in ``scripts/run_python_tests.py`` for
     the scheduler half of this split: the whole point is defeated if this
@@ -579,7 +597,7 @@ def _shared_module_worlds_web_auth_matrix() -> dict[str, object]:
           };
       }
     '''
-    return _cached_nix_eval_json("web_auth_matrix", expression)
+    return _cached_nix_eval_json(expression)
 
 
 def _shared_module_worlds_rest() -> dict[str, object]:
@@ -587,16 +605,21 @@ def _shared_module_worlds_rest() -> dict[str, object]:
 
     Issue #1131 review round 2: ``headlessComposition`` (0.80s),
     ``mergedGateway`` (18.67s), ``beetsCapability`` (38.28s), and
-    ``beetsReadiness`` (3.46s) sum to ~61s — close enough to
+    ``beetsReadiness`` (3.46s) sum to ~61s solo — close enough to
     ``webAuthMatrix``'s own 65.44s (see
     ``_shared_module_worlds_web_auth_matrix``) that bundling them into one
     target keeps the module's two-target floor level with main's own
-    worst-case bin-packed batch (61.6s), while still merging away the
-    redundant ``getFlake`` + ``import nixpkgs`` + ``import ./nix/beets.nix``
-    preamble each of these four used to pay independently. Every world here
-    only ever reads ``.config.assertions`` or plain option/service values,
-    never forces ``.system.build.toplevel``, so none of them can raise
-    mid-evaluation and take the others down with it.
+    worst-case bin-packed batch (~61.6s), not better. Merging these four
+    also eliminates 3 of the 4 redundant ``getFlake`` + ``import nixpkgs``
+    + ``import ./nix/beets.nix`` preambles they used to pay independently
+    — each measured at well under 1s standalone, so the CPU this merge
+    actually saves is on the order of a few seconds, not the difference
+    between the four solo totals and one combined run (those totals
+    double-count nixpkgs-import work every eval pays regardless of
+    merging). Every world here only ever reads ``.config.assertions`` or
+    plain option/service values, never forces ``.system.build.toplevel``,
+    so none of them can raise mid-evaluation and take the others down
+    with it.
 
     ``test_injected_basic_path_cannot_render_toplevel`` DOES force
     ``.system.build.toplevel`` to observe the resulting Nix assertion
@@ -993,7 +1016,7 @@ def _shared_module_worlds_rest() -> dict[str, object]:
           };
       }
     '''
-    return _cached_nix_eval_json("rest", expression)
+    return _cached_nix_eval_json(expression)
 
 
 class TestDefaultHeadlessComposition(unittest.TestCase):
@@ -1716,10 +1739,11 @@ class TestModuleVmPerformanceContract(unittest.TestCase):
         through ``nix build .#checks.x86_64-linux.moduleVm`` under KVM
         (4:33 wall vs 5:34 at the old default of 1) rather than a loose
         ``> 1`` bound — a future edit to e.g. 2 cores would pass a `> 1`
-        check without ever being verified under the real VM check, and
-        raising guest cores is known to be able to surface latent timing
-        races (issue #1130's own precedent), so a value change here is a
-        deliberate, re-verified decision, not a silent drift.
+        check without ever being verified under the real VM check. Guest
+        core count changes guest scheduling/timing, which can in principle
+        surface a latent race in a test that happens to be sensitive to
+        it, so a value change here should be a deliberate, re-verified
+        decision under the real VM check, not a silent drift.
         """
         text = MODULE_VM_NIX.read_text(encoding="utf-8")
         match = re.search(r"virtualisation\.cores\s*=\s*(\d+)\s*;", text)

--- a/tests/test_nix_module.py
+++ b/tests/test_nix_module.py
@@ -26,7 +26,6 @@ failure depends on Nix option assertion evaluation.
 
 from __future__ import annotations
 
-import functools
 import json
 import re
 import subprocess
@@ -130,38 +129,66 @@ class TestDecisionDifferentialWrapperContract(unittest.TestCase):
         self.assertIn("decisionDifferential", text[text.index("environment.systemPackages"):])
 
 
-@functools.cache
-def _shared_module_worlds() -> dict[str, object]:
-    """One ``nix eval`` for every consumer that reads assertions/options only.
+#: Issue #1131 review round 2: exception-memoizing cache for the two
+#: cost-grouped nix evaluations below, keyed by an arbitrary string tag.
+#: ``functools.cache`` does not memoize a raised exception — on a real
+#: module regression every consumer of a failing evaluation would
+#: independently re-pay the full ``nix eval`` just to report the same
+#: failure. Memoizing the exception too means a real regression costs one
+#: nix eval to detect, not one per consumer.
+_NIX_EVAL_CACHE: dict[str, dict[str, object] | BaseException] = {}
 
-    ``TestDefaultHeadlessComposition``, three of
-    ``TestWebAuthenticationModuleContract``'s nix-eval tests, and both of
-    ``TestExternalBeetsRuntimeCapability``'s nix-eval tests each used to pay
-    for an independent ``builtins.getFlake`` + ``import nixpkgs`` +
-    ``import ./nix/beets.nix`` preamble (measured: ~0.24s alone — cheap) and
-    then their own full NixOS module-tree evaluation per world (measured:
-    the real cost, ~1.3-2.3s per ``lib.nixosSystem`` call). Method-batch
-    sharding (issue #1131) balances by TEST COUNT, not cost, so it could land
-    several of these multi-second, multi-GB ``nix eval`` subprocesses in the
-    same batch by chance, or — at higher worker counts — run several of them
-    truly concurrently. That concurrency, not the redundant preamble, is what
-    drove the shared test RAM root to 96% utilization and made raising
-    worker count a regression instead of a speedup.
 
-    This merges every world these five tests need into ONE expression,
-    evaluated at most once per test PROCESS (``functools.cache``): every
-    world here only ever reads ``.config.assertions`` or plain option/service
-    values, never forces ``.system.build.toplevel``, so none of them can
-    raise or ``abort`` mid-evaluation and take the others down with it.
-    ``test_injected_basic_path_cannot_render_toplevel`` is the one nix-eval
-    test in this module that DOES force ``.system.build.toplevel``,
-    specifically to observe the hard assertion ``abort`` (non-zero exit,
-    stderr text) that path triggers — merging it here would let that one
-    deliberately-failing world abort the whole shared evaluation for every
-    other consumer, so it keeps its own independent ``nix eval`` call.
+def _cached_nix_eval_json(cache_key: str, expression: str) -> dict[str, object]:
+    """Run one ``nix eval --json`` at most once per process per cache key."""
+    cached = _NIX_EVAL_CACHE.get(cache_key)
+    if cached is not None:
+        if isinstance(cached, BaseException):
+            raise cached
+        return cached
+    try:
+        result = subprocess.run(
+            ["nix", "eval", "--impure", "--json", "--expr", expression],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise AssertionError(result.stderr)
+        value = json.loads(result.stdout)
+        if not isinstance(value, dict):
+            raise TypeError(value)
+    except BaseException as exc:
+        _NIX_EVAL_CACHE[cache_key] = exc
+        raise
+    _NIX_EVAL_CACHE[cache_key] = value
+    return value
 
-    Callers index their own top-level key out of the returned dict; nothing
-    downstream of this helper changed shape or assertions.
+
+def _shared_module_worlds_web_auth_matrix() -> dict[str, object]:
+    """The ``webAuthMatrix`` nix eval — this module's single heaviest world.
+
+    Issue #1131 review round 2: measured per-world costs are wildly uneven
+    (``headlessComposition`` 0.80s, ``beetsReadiness`` 3.46s,
+    ``mergedGateway`` 18.67s, ``beetsCapability`` 38.28s, ``webAuthMatrix``
+    65.44s — the pole). Merging every world into ONE evaluation and running
+    the whole module unsharded serializes ALL of that onto a single target
+    and pushes the module's critical-path contribution from main's own
+    61.6s (its worst `method_batch` bin-packing) to 118.3s — a regression,
+    not a fix; that full-unshard attempt is what round 1 of this review
+    reverted. Splitting the merge by cost and restoring a 2-target shard —
+    this world isolated, the other four bundled in
+    ``_shared_module_worlds_rest`` — keeps the floor level with main
+    (~65s vs ~61.6s) while still cutting total nix-eval CPU work (~100.8s
+    measured vs main's ~126.6s) by sharing this evaluation's own preamble
+    across its 39 internal worlds in one process.
+
+    See ``HOTSPOT_ISOLATED_METHODS`` in ``scripts/run_python_tests.py`` for
+    the scheduler half of this split: the whole point is defeated if this
+    function's sole consumer ever runs in a different worker process than
+    intended, so it is carved into its OWN singleton target rather than
+    left to generic count-balanced batching.
     """
     expression = r'''
       let
@@ -172,45 +199,6 @@ def _shared_module_worlds() -> dict[str, object]:
         };
         beetsPackage = import ./nix/beets.nix { pkgs = modulePkgs; };
       in {
-        headlessComposition =
-          let
-            system = lib.nixosSystem {
-              system = builtins.currentSystem;
-              modules = [
-                f.nixosModules.default
-                ({ ... }: {
-                  services.cratedigger = {
-                    enable = true;
-                    src = ./.;
-                    slskd.apiKeyFile = "/run/secrets/slskd-key";
-                    slskd.downloadDir = "/srv/slskd";
-                    pipelineDb.createLocally = true;
-                    beets.runtime = {
-                      package = beetsPackage;
-                      configDir = "/etc/beets";
-                      expectedLibrary = "/srv/beets/beets-library.db";
-                      expectedDirectory = "/srv/music";
-                      expectedStateFile = "/var/lib/beets/state.pickle";
-                      expectedSecretInclude = "/run/secrets/beets.yaml";
-                    };
-                  };
-                })
-              ];
-            };
-          in {
-            webEnabled = system.config.services.cratedigger.web.enable;
-            systemPackages =
-              map lib.getName system.config.environment.systemPackages;
-            hasWebService =
-              builtins.hasAttr
-                "cratedigger-web"
-                system.config.systemd.services;
-            cratediggerSockets =
-              builtins.filter
-                (name: lib.hasPrefix "cratedigger" name)
-                (builtins.attrNames system.config.systemd.sockets);
-          };
-
         webAuthMatrix =
           let
             evaluate = extra:
@@ -589,6 +577,83 @@ def _shared_module_worlds() -> dict[str, object]:
               systemd.services.nginx.restartIfChanged = lib.mkForce false;
             };
           };
+      }
+    '''
+    return _cached_nix_eval_json("web_auth_matrix", expression)
+
+
+def _shared_module_worlds_rest() -> dict[str, object]:
+    """The other four nix-eval worlds this module's tests still merge.
+
+    Issue #1131 review round 2: ``headlessComposition`` (0.80s),
+    ``mergedGateway`` (18.67s), ``beetsCapability`` (38.28s), and
+    ``beetsReadiness`` (3.46s) sum to ~61s — close enough to
+    ``webAuthMatrix``'s own 65.44s (see
+    ``_shared_module_worlds_web_auth_matrix``) that bundling them into one
+    target keeps the module's two-target floor level with main's own
+    worst-case bin-packed batch (61.6s), while still merging away the
+    redundant ``getFlake`` + ``import nixpkgs`` + ``import ./nix/beets.nix``
+    preamble each of these four used to pay independently. Every world here
+    only ever reads ``.config.assertions`` or plain option/service values,
+    never forces ``.system.build.toplevel``, so none of them can raise
+    mid-evaluation and take the others down with it.
+
+    ``test_injected_basic_path_cannot_render_toplevel`` DOES force
+    ``.system.build.toplevel`` to observe the resulting Nix assertion
+    failure — that failure is a catchable ``throw`` (``builtins.tryEval``
+    returns ``{"success": false}`` in ~5.1s measured), not an uncatchable
+    ``abort``, but ``tryEval`` discards the failure's message and the test
+    asserts on the EXACT stderr text (``"nginx-token-safe segments"``).
+    Merging it here would lose the one thing the test needs, so it keeps
+    its own independent ``nix eval`` call regardless of catchability.
+    """
+    expression = r'''
+      let
+        f = builtins.getFlake (toString ./.);
+        lib = f.inputs.nixpkgs.lib;
+        modulePkgs = import f.inputs.nixpkgs {
+          system = builtins.currentSystem;
+        };
+        beetsPackage = import ./nix/beets.nix { pkgs = modulePkgs; };
+      in {
+        headlessComposition =
+          let
+            system = lib.nixosSystem {
+              system = builtins.currentSystem;
+              modules = [
+                f.nixosModules.default
+                ({ ... }: {
+                  services.cratedigger = {
+                    enable = true;
+                    src = ./.;
+                    slskd.apiKeyFile = "/run/secrets/slskd-key";
+                    slskd.downloadDir = "/srv/slskd";
+                    pipelineDb.createLocally = true;
+                    beets.runtime = {
+                      package = beetsPackage;
+                      configDir = "/etc/beets";
+                      expectedLibrary = "/srv/beets/beets-library.db";
+                      expectedDirectory = "/srv/music";
+                      expectedStateFile = "/var/lib/beets/state.pickle";
+                      expectedSecretInclude = "/run/secrets/beets.yaml";
+                    };
+                  };
+                })
+              ];
+            };
+          in {
+            webEnabled = system.config.services.cratedigger.web.enable;
+            systemPackages =
+              map lib.getName system.config.environment.systemPackages;
+            hasWebService =
+              builtins.hasAttr
+                "cratedigger-web"
+                system.config.systemd.services;
+            cratediggerSockets =
+              builtins.filter
+                (name: lib.hasPrefix "cratedigger" name)
+                (builtins.attrNames system.config.systemd.sockets);
+          };
 
         mergedGateway =
           let
@@ -928,19 +993,7 @@ def _shared_module_worlds() -> dict[str, object]:
           };
       }
     '''
-    result = subprocess.run(
-        ["nix", "eval", "--impure", "--json", "--expr", expression],
-        cwd=REPO_ROOT,
-        capture_output=True,
-        check=False,
-        text=True,
-    )
-    if result.returncode != 0:
-        raise AssertionError(result.stderr)
-    value = json.loads(result.stdout)
-    if not isinstance(value, dict):
-        raise TypeError(value)
-    return value
+    return _cached_nix_eval_json("rest", expression)
 
 
 class TestDefaultHeadlessComposition(unittest.TestCase):
@@ -949,7 +1002,7 @@ class TestDefaultHeadlessComposition(unittest.TestCase):
     def test_exported_module_installs_cli_without_web_units_or_sockets(
         self,
     ) -> None:
-        composition = _shared_module_worlds()["headlessComposition"]
+        composition = _shared_module_worlds_rest()["headlessComposition"]
         assert isinstance(composition, dict)
         self.assertFalse(composition["webEnabled"])
         self.assertIn("pipeline-cli", composition["systemPackages"])
@@ -962,7 +1015,7 @@ class TestWebAuthenticationModuleContract(unittest.TestCase):
     """The enabled web surface has one fail-closed module-owned perimeter."""
 
     def test_basic_and_insecure_mode_matrix_is_evaluated(self) -> None:
-        worlds = _shared_module_worlds()["webAuthMatrix"]
+        worlds = _shared_module_worlds_web_auth_matrix()["webAuthMatrix"]
         assert isinstance(worlds, dict)
         self.assertTrue(
             any("exactly one" in message for message in worlds["missing"])
@@ -1184,7 +1237,7 @@ class TestWebAuthenticationModuleContract(unittest.TestCase):
         self.assertIn("nginx-token-safe segments", result.stderr)
 
     def test_merged_basic_gateway_values_are_exact(self) -> None:
-        worlds = _shared_module_worlds()["mergedGateway"]
+        worlds = _shared_module_worlds_rest()["mergedGateway"]
         assert isinstance(worlds, dict)
         dual = worlds["dualStack"]
         ipv4 = worlds["ipv4Only"]
@@ -1655,18 +1708,24 @@ class TestModuleVmPerformanceContract(unittest.TestCase):
         self.assertIn("virtualisation.useNixStoreImage = true;", text)
         self.assertIn("virtualisation.writableStore = true;", text)
 
-    def test_guest_declares_more_than_one_core(self) -> None:
+    def test_guest_declares_the_verified_core_count(self) -> None:
         """Issue #1131: an unset ``virtualisation.cores`` silently inherits
         the qemu-vm module's guest default of 1, serializing PostgreSQL,
         nginx, ~10 switch-to-configuration calls, and 2 reboots onto one
-        emulated core. Pin an explicit, deliberately-chosen core count so it
-        can't regress back to the implicit default unnoticed.
+        emulated core. Pinned to the EXACT value that was actually run
+        through ``nix build .#checks.x86_64-linux.moduleVm`` under KVM
+        (4:33 wall vs 5:34 at the old default of 1) rather than a loose
+        ``> 1`` bound — a future edit to e.g. 2 cores would pass a `> 1`
+        check without ever being verified under the real VM check, and
+        raising guest cores is known to be able to surface latent timing
+        races (issue #1130's own precedent), so a value change here is a
+        deliberate, re-verified decision, not a silent drift.
         """
         text = MODULE_VM_NIX.read_text(encoding="utf-8")
         match = re.search(r"virtualisation\.cores\s*=\s*(\d+)\s*;", text)
         self.assertIsNotNone(match, "virtualisation.cores must be set explicitly")
         assert match is not None
-        self.assertGreater(int(match.group(1)), 1)
+        self.assertEqual(int(match.group(1)), 4)
 
 
 class TestImporterServiceContract(unittest.TestCase):
@@ -1826,7 +1885,7 @@ class TestExternalBeetsRuntimeCapability(unittest.TestCase):
         return strings
 
     def test_capability_assertions_cover_happy_missing_invalid_and_disabled(self) -> None:
-        worlds = _shared_module_worlds()["beetsCapability"]
+        worlds = _shared_module_worlds_rest()["beetsCapability"]
         assert isinstance(worlds, dict)
         self.assertEqual(worlds["valid"], [])
         missing = worlds["missing"]
@@ -1908,7 +1967,7 @@ class TestExternalBeetsRuntimeCapability(unittest.TestCase):
         self.assertEqual(worlds["disabled"], {"assertions": [], "services": []})
 
     def test_readiness_and_role_state_capabilities_evaluate(self) -> None:
-        units = _shared_module_worlds()["beetsReadiness"]
+        units = _shared_module_worlds_rest()["beetsReadiness"]
         assert isinstance(units, dict)
         readiness = {
             "beets-config-ready.service",

--- a/tests/test_parallel_test_runner.py
+++ b/tests/test_parallel_test_runner.py
@@ -27,6 +27,7 @@ from scripts.run_fuzz_tests import (
 )
 from scripts.run_python_tests import (
     AUDITED_FRONTLOAD_MODULES,
+    HOTSPOT_ISOLATED_METHODS,
     HOTSPOT_SHARD_POLICIES,
     HYPOTHESIS_CASE_STATUSES,
     STRATEGY_SPACE_EXHAUSTED,
@@ -49,8 +50,10 @@ from scripts.run_python_tests import (
     assert_exact_schedule,
     assert_exact_target_coverage,
     assert_hypothesis_deadlines_disabled,
+    build_test_targets,
     complete_test_modules,
     discover_test_modules,
+    hotspot_targets,
     hypothesis_example_budgets,
     list_module_test_ids,
     recommended_worker_count,
@@ -505,14 +508,17 @@ class TestModuleScheduling(unittest.TestCase):
             frozenset({"tests.test_nix_module"}),
         )
         # tests.test_nix_module is frontloaded but deliberately NOT
-        # method_batch-sharded (issue #1131): its nix-eval tests share one
-        # evaluated JSON blob behind a module-level functools.cache, which
-        # only pays off when every consumer stays in the same worker
-        # process. Splitting it across method-batch processes would defeat
-        # the cache and, at higher worker counts, run several multi-GB nix
-        # eval subprocesses concurrently — the exact contention that drove
-        # the shared test RAM root to 96%.
-        self.assertNotIn("tests.test_nix_module", HOTSPOT_SHARD_POLICIES)
+        # method_batch-sharded (issue #1131 review round 2): its nix-eval
+        # tests are cost-grouped into two exception-memoizing cached
+        # helpers, which only pay off when every one of a group's
+        # consumers runs in the same worker process. A blind method_batch
+        # split could land the module's two heaviest nix-eval methods in
+        # one batch; a naive full unshard (this issue's own round 1)
+        # serializes every merged world onto one target instead
+        # (measured: main's own worst-case bin-packed batch is 61.6s, a
+        # full unshard is 118.3s). HOTSPOT_ISOLATED_METHODS below is the
+        # narrower fix: carve the single heaviest consumer into its own
+        # target, bundle everything else into one remainder target.
         self.assertEqual(
             HOTSPOT_SHARD_POLICIES,
             {
@@ -522,6 +528,35 @@ class TestModuleScheduling(unittest.TestCase):
                 "tests.test_pipeline_db": "class_batch",
             },
         )
+        self.assertEqual(
+            HOTSPOT_ISOLATED_METHODS,
+            {
+                "tests.test_nix_module": frozenset({
+                    (
+                        "tests.test_nix_module.TestWebAuthenticationModuleContract."
+                        "test_basic_and_insecure_mode_matrix_is_evaluated"
+                    ),
+                }),
+            },
+        )
+
+    def test_isolated_method_ids_are_real_discovered_tests(self) -> None:
+        """Rule C-adjacent: an isolated ID that drifted (renamed/removed)
+        must fail the suite closed, not silently stop isolating anything.
+        """
+        for module_name, isolated in HOTSPOT_ISOLATED_METHODS.items():
+            discovered = {
+                test.id()
+                for test in _iter_test_cases(
+                    unittest.defaultTestLoader.loadTestsFromName(module_name)
+                )
+            }
+            missing = isolated - discovered
+            self.assertEqual(
+                missing,
+                set(),
+                f"{module_name}: isolated test id(s) no longer exist: {missing}",
+            )
 
     def test_class_batching_is_exact_and_bounds_repeated_imports(self) -> None:
         module = TestModule("tests.test_hotspot", Path("/test_hotspot.py"), 90)
@@ -556,6 +591,98 @@ class TestModuleScheduling(unittest.TestCase):
             test_ids,
         )
 
+    def test_isolated_method_gets_its_own_target_and_bundles_the_remainder(
+        self,
+    ) -> None:
+        module = TestModule("tests.test_hotspot", Path("/test_hotspot.py"), 90)
+        test_ids = (
+            "tests.test_hotspot.TestCases.test_cheap_one",
+            "tests.test_hotspot.TestCases.test_cheap_two",
+            "tests.test_hotspot.TestCases.test_expensive",
+        )
+        isolated = frozenset({"tests.test_hotspot.TestCases.test_expensive"})
+
+        targets = hotspot_targets(
+            module, test_ids, granularity=None, isolated=isolated
+        )
+
+        assert_exact_target_coverage(module, test_ids, targets)
+        self.assertEqual(len(targets), 2)
+        isolated_target = next(
+            t for t in targets if t.expected_test_ids == (
+                "tests.test_hotspot.TestCases.test_expensive",
+            )
+        )
+        self.assertEqual(
+            isolated_target.test_name,
+            "tests.test_hotspot.TestCases.test_expensive",
+        )
+        self.assertEqual(
+            isolated_target.load_names,
+            ("tests.test_hotspot.TestCases.test_expensive",),
+        )
+        remainder_target = next(t for t in targets if t is not isolated_target)
+        self.assertEqual(
+            set(remainder_target.expected_test_ids),
+            {
+                "tests.test_hotspot.TestCases.test_cheap_one",
+                "tests.test_hotspot.TestCases.test_cheap_two",
+            },
+        )
+        self.assertEqual(remainder_target.load_names, remainder_target.expected_test_ids)
+
+    def test_isolation_composes_with_granularity_on_the_remainder(self) -> None:
+        module = TestModule("tests.test_hotspot", Path("/test_hotspot.py"), 90)
+        test_ids = (
+            "tests.test_hotspot.TestCases.test_cheap_one",
+            "tests.test_hotspot.TestCases.test_cheap_two",
+            "tests.test_hotspot.TestCases.test_expensive",
+        )
+        isolated = frozenset({"tests.test_hotspot.TestCases.test_expensive"})
+
+        targets = hotspot_targets(
+            module, test_ids, granularity="method", isolated=isolated
+        )
+
+        assert_exact_target_coverage(module, test_ids, targets)
+        # Isolation carves one target off; "method" then shards the other
+        # two into one target EACH — three targets total, not two.
+        self.assertEqual(len(targets), 3)
+
+    def test_hotspot_targets_rejects_an_unknown_isolated_id(self) -> None:
+        """Known-bad self-test: an isolated ID that drifted out of the
+        discovered set must fail closed, never silently drop coverage.
+        """
+        module = TestModule("tests.test_hotspot", Path("/test_hotspot.py"), 90)
+        test_ids = ("tests.test_hotspot.TestCases.test_one",)
+        isolated = frozenset({"tests.test_hotspot.TestCases.test_renamed"})
+
+        with self.assertRaisesRegex(ValueError, "unknown isolated test id"):
+            hotspot_targets(module, test_ids, granularity=None, isolated=isolated)
+
+    def test_build_test_targets_applies_isolated_methods(self) -> None:
+        module = TestModule("tests.test_hotspot", Path("/test_hotspot.py"), 90)
+        test_ids = (
+            "tests.test_hotspot.TestCases.test_cheap",
+            "tests.test_hotspot.TestCases.test_expensive",
+        )
+        isolated = frozenset({"tests.test_hotspot.TestCases.test_expensive"})
+
+        targets = build_test_targets(
+            (module,),
+            {module.name: test_ids},
+            isolated_methods={module.name: isolated},
+        )
+
+        assert_exact_target_coverage(module, test_ids, targets)
+        self.assertEqual(
+            {target.test_name for target in targets},
+            {
+                "tests.test_hotspot.TestCases.test_expensive",
+                "tests.test_hotspot::remainder",
+            },
+        )
+
     def test_selected_module_keeps_the_canonical_hotspot_sharding(self) -> None:
         module = TestModule("tests.test_hotspot", Path("/test_hotspot.py"), 90)
         test_ids = (
@@ -571,6 +698,32 @@ class TestModuleScheduling(unittest.TestCase):
         )
 
         self.assertEqual(tuple(target.test_name for target in targets), test_ids)
+
+    def test_selected_module_applies_isolated_methods_with_no_shard_policy(
+        self,
+    ) -> None:
+        module = TestModule("tests.test_hotspot", Path("/test_hotspot.py"), 90)
+        test_ids = (
+            "tests.test_hotspot.TestCases.test_cheap",
+            "tests.test_hotspot.TestCases.test_expensive",
+        )
+        isolated = frozenset({"tests.test_hotspot.TestCases.test_expensive"})
+
+        targets = select_test_targets(
+            (module,),
+            (module.name,),
+            listed_test_ids={module.name: test_ids},
+            hotspot_policies={},
+            hotspot_isolated_methods={module.name: isolated},
+        )
+
+        self.assertEqual(
+            {target.test_name for target in targets},
+            {
+                "tests.test_hotspot.TestCases.test_expensive",
+                "tests.test_hotspot::remainder",
+            },
+        )
 
     def test_selected_method_runs_only_that_exact_unittest_name(self) -> None:
         module = TestModule("tests.test_alpha", Path("/test_alpha.py"), 10)

--- a/tests/test_parallel_test_runner.py
+++ b/tests/test_parallel_test_runner.py
@@ -512,13 +512,19 @@ class TestModuleScheduling(unittest.TestCase):
         # tests are cost-grouped into two exception-memoizing cached
         # helpers, which only pay off when every one of a group's
         # consumers runs in the same worker process. A blind method_batch
-        # split could land the module's two heaviest nix-eval methods in
-        # one batch; a naive full unshard (this issue's own round 1)
-        # serializes every merged world onto one target instead
-        # (measured: main's own worst-case bin-packed batch is 61.6s, a
-        # full unshard is 118.3s). HOTSPOT_ISOLATED_METHODS below is the
-        # narrower fix: carve the single heaviest consumer into its own
-        # target, bundle everything else into one remainder target.
+        # split could land more than one of the module's heavy nix-eval
+        # methods in one batch (up to 5, main's own scheme); a naive full
+        # unshard (this issue's own round 1) serializes every merged world
+        # onto one target instead (measured: main's own worst-case
+        # bin-packed batch is 61.6s, a full unshard is 118.3s).
+        # HOTSPOT_ISOLATED_METHODS below is the narrower fix: carve the
+        # single heaviest consumer into its own target, bundle everything
+        # else into one remainder target — floor level with main (not
+        # better), at most TWO concurrent heavy nix-eval subprocesses
+        # instead of up to five, which is what makes raising the suite's
+        # worker count affordable (main's own worker-count sweep shows
+        # this module's pole inflating hard with concurrency: 88.0s at 8
+        # workers, 122.7s at 12, 147.7s at 16, 152.3s at 20).
         self.assertEqual(
             HOTSPOT_SHARD_POLICIES,
             {
@@ -541,8 +547,14 @@ class TestModuleScheduling(unittest.TestCase):
         )
 
     def test_isolated_method_ids_are_real_discovered_tests(self) -> None:
-        """Rule C-adjacent: an isolated ID that drifted (renamed/removed)
-        must fail the suite closed, not silently stop isolating anything.
+        """Dev-loop drift signal, not a suite-level guard: hotspot_targets'
+        own runtime check (an isolated ID missing from the real discovery
+        manifest) already fails the suite closed during scheduling, before
+        this test would ever run in a normal `scripts/test.sh` or
+        `run_tests.sh` invocation. This pin exists so a direct
+        `unittest tests.test_parallel_test_runner` run (or an isolated
+        rerun of just this test) also catches a renamed/removed isolated
+        test id quickly, without needing a full scheduling pass.
         """
         for module_name, isolated in HOTSPOT_ISOLATED_METHODS.items():
             discovered = {
@@ -645,9 +657,24 @@ class TestModuleScheduling(unittest.TestCase):
         )
 
         assert_exact_target_coverage(module, test_ids, targets)
-        # Isolation carves one target off; "method" then shards the other
-        # two into one target EACH — three targets total, not two.
         self.assertEqual(len(targets), 3)
+        # A bare target COUNT can't distinguish this from isolation being
+        # disabled entirely: "method" granularity already puts every test
+        # in its own target, so 1 isolated + 2 method shards and 3 plain
+        # method shards both total 3 targets with the same expected_test_ids.
+        # The real discriminator is load_names: hotspot_targets sets it
+        # explicitly for the isolated singleton, while shard_test_ids's
+        # own plain (non-batch) branch leaves it empty (falls back to
+        # test_name at load time) — so under isolation-disabled, the
+        # target covering the "expensive" ID would have load_names == ().
+        isolated_target = next(
+            t for t in targets
+            if t.expected_test_ids == ("tests.test_hotspot.TestCases.test_expensive",)
+        )
+        self.assertEqual(isolated_target.load_names, isolated_target.expected_test_ids)
+        for other in targets:
+            if other is not isolated_target:
+                self.assertEqual(other.load_names, ())
 
     def test_hotspot_targets_rejects_an_unknown_isolated_id(self) -> None:
         """Known-bad self-test: an isolated ID that drifted out of the

--- a/tests/test_parallel_test_runner.py
+++ b/tests/test_parallel_test_runner.py
@@ -503,13 +503,21 @@ class TestModuleScheduling(unittest.TestCase):
             AUDITED_FRONTLOAD_MODULES,
             frozenset({"tests.test_nix_module"}),
         )
+        # tests.test_nix_module is frontloaded but deliberately NOT
+        # method_batch-sharded (issue #1131): its nix-eval tests share one
+        # evaluated JSON blob behind a module-level functools.cache, which
+        # only pays off when every consumer stays in the same worker
+        # process. Splitting it across method-batch processes would defeat
+        # the cache and, at higher worker counts, run several multi-GB nix
+        # eval subprocesses concurrently — the exact contention that drove
+        # the shared test RAM root to 96%.
+        self.assertNotIn("tests.test_nix_module", HOTSPOT_SHARD_POLICIES)
         self.assertEqual(
             HOTSPOT_SHARD_POLICIES,
             {
                 "tests.test_beets_destructive_configs_generated": "method_batch",
                 "tests.test_deploy_pin_generated": "method_batch",
                 "tests.test_deploy_pin_script": "method_batch",
-                "tests.test_nix_module": "method_batch",
                 "tests.test_pipeline_db": "class_batch",
             },
         )

--- a/tests/test_targeted_test_selection.py
+++ b/tests/test_targeted_test_selection.py
@@ -201,13 +201,27 @@ class TestTargetedTestSelection(unittest.TestCase):
                     changed_paths=(relative,),
                     repo_root=REPO_ROOT,
                 )
-                # hotspot_policies={}: this pin only proves every selector
-                # resolves to a real discovered module (issue #1081's actual
-                # concern) — hotspot method/class sharding is a separate,
+                # hotspot_policies={} / hotspot_isolated_methods={}: this pin
+                # only proves every selector resolves to a real discovered
+                # module (issue #1081's actual concern) — hotspot
+                # method/class sharding AND the cost-aware isolation
+                # carve-out (issue #1131 review round 2) are a separate,
                 # already-covered concern (tests.test_parallel_test_runner)
                 # that needs an expensive discovery-manifest subprocess per
-                # hotspot module, irrelevant here.
-                select_test_targets(modules, selection, hotspot_policies={})
+                # hotspot module, irrelevant here. Passing only
+                # hotspot_policies={} is NOT enough on its own:
+                # select_test_targets defaults hotspot_isolated_methods to
+                # the real HOTSPOT_ISOLATED_METHODS registry, so a selector
+                # resolving to tests.test_nix_module would still route
+                # through hotspot_targets (isolation is non-empty even
+                # with an empty shard policy) and raise "missing discovery
+                # manifest" here, since no listed_test_ids was supplied.
+                select_test_targets(
+                    modules,
+                    selection,
+                    hotspot_policies={},
+                    hotspot_isolated_methods={},
+                )
 
     def test_shared_fakes_map_to_their_real_consumers_not_only_test_fakes(
         self,


### PR DESCRIPTION
## Summary — round 3 (two blocking fixes + N1-N10)

**Round 2 verification: the scheduling machinery is proven correct end to end.** The reviewer computed real plans with the real functions and a real discovery manifest — both `build_test_targets` and `select_test_targets` produce byte-identical 2-target plans (isolated ID + 47-test remainder = 48 discovered, no drops/dups/inventions). It ran an isolated+remainder pair through the real `_run_test_target` end to end, confirming the order-sensitive `expected_test_ids` contract holds with the new 47-element `load_names`. 7 of 8 planted mutants killed, both entry points independently covered. The cache is sound including tracebacks (round 2 shape), the `throw`-not-`abort` correction is right, the split preserves the round-1-verified merge byte-identically, and the branch merges cleanly with main.

## B1 (blocking, fixed): a new test couldn't fail for the property it named

`test_isolation_composes_with_granularity_on_the_remainder` asserted only `len(targets) == 3`. That count can't distinguish "1 isolated + 2 method shards" from "3 plain method shards with isolation disabled" — with `method` granularity, every test already lands in its own target regardless of isolation, so the target SET is identical either way. Proven: with isolation entirely disabled (mutant M1), the old assertion still passed.

Fixed to assert the actual discriminator: `load_names`. `hotspot_targets` sets it explicitly for the isolated singleton (`load_names=(test_id,)`); `shard_test_ids`'s own plain non-batch branch leaves it empty (`load_names=()`, falls back to `test_name` at load time). Verified against the same M1-style mutant (isolation forced off): the old assertion still passes, the new one now fails with `() != ('tests.test_hotspot.TestCases.test_expensive',)`.

## B2 (blocking, fixed): the "~26s CPU saved" claim was false

It had propagated into four places (both docstrings in `tests/test_nix_module.py`, the scheduler comment in `scripts/run_python_tests.py`, the scheduler test comment in `tests/test_parallel_test_runner.py`, and this PR's own prior body/commit text). The per-world cost table is SOLO totals, not marginals: the shared preamble (`getFlake` + `import nixpkgs` + `import ./nix/beets.nix`) measured well under 1s standalone, and a complete standalone `headlessComposition` eval (preamble plus a full `lib.nixosSystem` plus assertions) measured 1s across three runs, matching the table's own 0.80s. So eliminating N-1 redundant preambles saves roughly N-1 seconds, not the gap between the sum of solo totals and one combined run — round 1's 5→1 merge saves ≤~4s; round 2's 4→1 `rest` merge saves ≤~3s. All four sites rewritten to state this honestly.

**The quiet-host number.** Canonical suite on epimetheus, back to back, same host, nothing else running: main (`2c4a4951`, incl. #1147/#1150/#1148/#1152) python phase **191.1s**; this branch (`8f899604`) python phase **199.1s**. Single runs, so +8s is within run-to-run noise — not a regression, but not a wall-clock win either.

## The honest case for merging this

Not CPU savings — those are ~3s, not ~26s. Not floor improvement — main's own worst-case `method_batch` bin-packing already floors at **61.6s**; this PR's 2-target split (isolate the 65.44s `webAuthMatrix` pole, bundle the other four worlds at ~61s) lands at **~61-65s**, floor PARITY, not better. (A fully-unsharded module, this issue's own round 1, floors at **118.3s** — a real regression, reverted.)

**The actual value is concurrency-boundedness.** A worker-count sweep on main shows this module's own critical-path contribution inflating hard as suite concurrency rises: **88.0s at 8 workers → 122.7s at 12 → 147.7s at 16 → 152.3s at 20.** Main's `method_batch` sharding can put up to 5 of this module's heavy nix-eval methods in flight at once at higher worker counts; this PR's cost-grouped isolation caps that at AT MOST 2 (the isolated `webAuthMatrix` target plus the bundled `rest` target), regardless of how many workers the suite runs overall. That is what makes raising the suite's worker count affordable — the next and largest remaining lever on issue #1131, not something this PR claims to deliver itself.

## N1-N10, addressed

- **N1:** `select_test_targets`'s new `hotspot_isolated_methods` kwarg defaults to the real `HOTSPOT_ISOLATED_METHODS` registry, so `tests/test_targeted_test_selection.py:210`'s `hotspot_policies={}` escape hatch was only half-effective — verified it would raise `ValueError: missing discovery manifest for hotspot tests.test_nix_module` if a selector ever resolved to the bare module name (passes today only by accident of the walk never producing that exact selector). Now passes `hotspot_isolated_methods={}` too, with the comment updated to explain why both are needed.
- **N2:** corrected "never running more than one heavy nix-eval subprocess... at a time" to "at most two, down from up to five" everywhere.
- **N3:** "7 new deterministic tests" corrected to 6 (55 → 61 collected in `tests/test_parallel_test_runner.py`).
- **N4:** docstrings and the scheduler comment now consistently say the floor is **~61-65s, parity with main's 61.6s** — not better, not worse — replacing the earlier inconsistent "worse than main" vs "better than main" framing.
- **N5:** `_cached_nix_eval_json` now keys on the expression itself, not a hand-written string tag — a mismatched tag could otherwise silently return one expression's cached value for a different one. Latent with today's two call sites; closed now regardless.
- **N6:** `except BaseException` → `except Exception` in the cache — a Ctrl-C/SystemExit no longer gets memoized and instantly re-raised at every later consumer.
- **N7:** `hotspot_targets`'s `granularity is None` path now performs the same module-prefix membership check `shard_test_ids` does (it was skipped because that path builds its remainder target directly, bypassing `shard_test_ids` entirely) — a foreign test ID is rejected instead of silently bundled. Unreachable today; now closed regardless.
- **N8:** softened the #1130 citation in the VM-cores pin's docstring — #1130 was a TCG-vs-KVM timing difference surfacing a count-sensitive assertion, not a core-count change. The caution about guest-timing sensitivity stands on its own without the stretched citation.
- **N9:** #1144 (`fix(quality): derive average bitrate without float truncation`) is NOT a #1131 sibling — it's an unrelated fix that happened to land on main during this review and was pulled in by the routine merge-forward. Not claimed as a sibling anywhere in this body.
- **N10:** clarified `test_isolated_method_ids_are_real_discovered_tests`'s docstring: it's a dev-loop drift signal (a direct `unittest` run catches a renamed/removed isolated ID fast), not a suite-level guard — `hotspot_targets`'s own runtime check already fails the suite closed during scheduling before this test would ever run in a normal `scripts/test.sh` or `run_tests.sh` invocation.

## Test plan

- [x] `nix-shell --run "python3 -m unittest tests.test_nix_module -v"` — 48/48 pass
- [x] `nix-shell --run "python3 -m unittest tests.test_parallel_test_runner -v"` — 61/61 pass
- [x] `nix-shell --run "python3 -m unittest tests.test_targeted_test_selection -v"` — 21/21 pass
- [x] `bash scripts/test.sh tests.test_nix_module` — 6/6 phases pass (js-syntax, js-unit, pyright, ruff, vulture, python 58.8s 0 failures)
- [x] Whole-repo Pyright + production-strict Pyright — both 0 errors
- [x] `nix build .#checks.x86_64-linux.moduleVm` — PASS under KVM (4:33 wall vs 5:34 at 1 core), run by the reviewer
- [x] B1 mutant kill verified directly (isolation-disabled mutant: old assertion passes, new assertion fails as expected)
- [x] Quiet-host `run_tests.sh` base-vs-branch python-phase wall time — captured by the coordinator (main 191.1s, branch 199.1s, within run-to-run noise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)