### PR TITLE
perf(tests): cut deploy-pin fake-shim subprocess cost (#1131)

### DIFF
--- a/tests/fakes/deploy_pin.py
+++ b/tests/fakes/deploy_pin.py
@@ -8,32 +8,60 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
-_FAKE_COMMAND = r'''#!/usr/bin/env python3
+_FAKE_COMMAND = r'''#!/usr/bin/env -S python3 -S
 import fcntl
 import json
 import os
-import shutil
-import signal
 import sys
 import time
-from pathlib import Path
 
-state_path = Path(os.environ["DEPLOY_PIN_FAKE_STATE"])
-state_lock = state_path.with_suffix(".lock").open("a+", encoding="utf-8")
+# SIGTERM's POSIX signal number, hardcoded to avoid importing `signal` on
+# every one of the ~28 subprocess spawns per script run (tests/fakes/deploy_pin.py
+# profiling, issue #1131): the `signal` module costs real per-process import
+# time and this fake never needs anything from it beyond this one constant.
+SIGTERM = 15
+
+state_path = os.environ["DEPLOY_PIN_FAKE_STATE"]
+lock_path = os.path.splitext(state_path)[0] + ".lock"
+state_lock = open(lock_path, "a+", encoding="utf-8")
 fcntl.flock(state_lock, fcntl.LOCK_EX)
-state = json.loads(state_path.read_text(encoding="utf-8"))
-command = Path(sys.argv[0]).name
+with open(state_path, encoding="utf-8") as _f:
+    state = json.loads(_f.read())
+command = os.path.basename(sys.argv[0])
 raw_args = sys.argv[1:]
 
 
 def save():
-    state_path.write_text(json.dumps(state, sort_keys=True), encoding="utf-8")
+    with open(state_path, "w", encoding="utf-8") as _f:
+        _f.write(json.dumps(state, sort_keys=True))
 
 
 def fail(message):
     print(message, file=sys.stderr)
     save()
     raise SystemExit(1)
+
+
+def rmtree(path):
+    """Best-effort recursive delete, matching shutil.rmtree(ignore_errors=True)
+    for the plain worktree directories this fake ever creates (no symlinks,
+    no cross-device edge cases) -- avoids importing `shutil` per call."""
+    if not os.path.isdir(path) or os.path.islink(path):
+        try:
+            os.remove(path)
+        except OSError:
+            pass
+        return
+    try:
+        entries = os.listdir(path)
+    except OSError:
+        return
+    for name in entries:
+        rmtree(os.path.join(path, name))
+    try:
+        os.rmdir(path)
+    except OSError:
+        pass
 
 
 def lock_payload(revision):
@@ -96,17 +124,16 @@ if command == "nix":
     state["events"].append(["nix", *raw_args])
     save()
     time.sleep(state.get("nix_delay_seconds", 0))
-    state = json.loads(state_path.read_text(encoding="utf-8"))
+    with open(state_path, encoding="utf-8") as _f:
+        state = json.loads(_f.read())
     if state.get("fault") == "nix":
         fail("fake nix update failed")
     if raw_args != ["flake", "update", "cratedigger-src"]:
         fail(f"unexpected nix argv: {raw_args!r}")
     if state["remote_move_on_nix"]:
         move_live_remote()
-    Path.cwd().joinpath("flake.lock").write_text(
-        lock_payload(os.environ["DEPLOY_PIN_FAKE_TARGET"]),
-        encoding="utf-8",
-    )
+    with open(os.path.join(os.getcwd(), "flake.lock"), "w", encoding="utf-8") as _f:
+        _f.write(lock_payload(os.environ["DEPLOY_PIN_FAKE_TARGET"]))
     save()
     raise SystemExit(0)
 
@@ -114,9 +141,9 @@ if command != "git":
     fail(f"unexpected fake command: {command}")
 
 args = list(raw_args)
-cwd = Path.cwd()
+cwd = os.getcwd()
 if args[:1] == ["-C"]:
-    cwd = Path(args[1])
+    cwd = args[1]
     args = args[2:]
 
 if args[:1] == ["fetch"]:
@@ -155,7 +182,7 @@ elif args[:3] == ["rev-parse", "--verify", "--quiet"]:
             and value in state["commits"]
         ):
             save()
-            os.kill(os.getppid(), signal.SIGTERM)
+            os.kill(os.getppid(), SIGTERM)
             time.sleep(0.1)
             raise SystemExit(143)
         print(value)
@@ -180,25 +207,24 @@ elif args[:2] == ["rev-parse", "--verify"]:
         and value in state["commits"]
     ):
         save()
-        os.kill(os.getppid(), signal.SIGTERM)
+        os.kill(os.getppid(), SIGTERM)
         time.sleep(0.1)
         raise SystemExit(143)
     print(value)
 elif args[:3] == ["worktree", "add", "--detach"]:
-    worktree = Path(args[3])
+    worktree = args[3]
     revision = args[4]
     commit = captured_object(revision)
     if commit is None:
         fail(f"worktree revision was not captured: {revision}")
     if state["remote_move_on_worktree_add"]:
         move_live_remote()
-    worktree.mkdir(parents=True)
-    worktree.joinpath("flake.lock").write_text(
-        lock_payload(commit["target"]), encoding="utf-8"
-    )
-    state["worktree"] = str(worktree)
+    os.makedirs(worktree)
+    with open(os.path.join(worktree, "flake.lock"), "w", encoding="utf-8") as _f:
+        _f.write(lock_payload(commit["target"]))
+    state["worktree"] = worktree
     state["worktree_base"] = revision
-    state["events"].append(["worktree-add", str(worktree), revision])
+    state["events"].append(["worktree-add", worktree, revision])
 elif args == ["status", "--porcelain"]:
     print(" M flake.lock")
 elif args == ["add", "flake.lock"]:
@@ -209,9 +235,8 @@ elif args[:2] == ["symbolic-ref", "HEAD"]:
 elif args[:2] == ["commit", "-m"]:
     state["commit_count"] += 1
     revision = f'{0xC000 + state["commit_count"]:040x}'
-    target = json.loads(cwd.joinpath("flake.lock").read_text(
-        encoding="utf-8"
-    ))["nodes"]["cratedigger-src"]["locked"]["rev"]
+    with open(os.path.join(cwd, "flake.lock"), encoding="utf-8") as _f:
+        target = json.loads(_f.read())["nodes"]["cratedigger-src"]["locked"]["rev"]
     state["commits"][revision] = {
         "parent": state["worktree_base"],
         "target": target,
@@ -239,7 +264,7 @@ elif args == ["rev-parse", "HEAD"]:
         "invalid_signature_signal_after_commit",
     }:
         save()
-        os.kill(os.getppid(), signal.SIGTERM)
+        os.kill(os.getppid(), SIGTERM)
         time.sleep(0.1)
         raise SystemExit(143)
     print(state["worktree_head"])
@@ -360,11 +385,11 @@ elif args[:1] == ["ls-remote"] and args[-1] == "refs/heads/master":
         move_live_remote()
     print(f'{state["remote_rev"]}\trefs/heads/master')
 elif args[:2] == ["worktree", "remove"]:
-    worktree = Path(args[-1])
-    state["events"].append(["worktree-remove", str(worktree)])
+    worktree = args[-1]
+    state["events"].append(["worktree-remove", worktree])
     if state.get("fault") == "cleanup":
         fail("fake worktree cleanup failed")
-    shutil.rmtree(worktree, ignore_errors=True)
+    rmtree(worktree)
     state["worktree"] = None
 else:
     fail(f"unexpected git argv in {cwd}: {args!r}")

--- a/tests/fakes/deploy_pin.py
+++ b/tests/fakes/deploy_pin.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 _FAKE_COMMAND = r'''#!/usr/bin/env -S python3 -S
+# -S skips `site` import for faster startup: this shim must stay stdlib-only.
 import fcntl
 import json
 import os
@@ -43,9 +44,15 @@ def fail(message):
 
 
 def rmtree(path):
-    """Best-effort recursive delete, matching shutil.rmtree(ignore_errors=True)
-    for the plain worktree directories this fake ever creates (no symlinks,
-    no cross-device edge cases) -- avoids importing `shutil` per call."""
+    """Best-effort recursive delete -- avoids importing `shutil` per call.
+    Matches shutil.rmtree(ignore_errors=True) for a real directory or a
+    missing path, the only two shapes this fake ever produces (it only
+    ever deletes a plain directory it itself created via os.makedirs()).
+    Diverges for a non-directory root: shutil's ignore_errors=True leaves
+    a file/symlink root untouched, this unlinks that one entry instead --
+    unreachable here, but not identical, so said plainly rather than
+    claimed away. It never follows a symlink out of the tree: a symlinked
+    child is unlinked, never descended into."""
     if not os.path.isdir(path) or os.path.islink(path):
         try:
             os.remove(path)


### PR DESCRIPTION
## Summary

`tests.test_deploy_pin_generated` was the slowest target in the canonical Python phase (~95-100s for the file). Both `tests/test_deploy_pin_generated.py` and `tests/test_deploy_pin_script.py` run the real `scripts/pin_nixosconfig.sh` via subprocess (that's the actual contract under test), and that script itself execs ~28 fake `git`/`nix`/`hostname` commands per run — `tests/fakes/deploy_pin.py::_FAKE_COMMAND` is a fully-faked shim (no real git/signing involved). The generated property calls `fake.run(SCRIPT)` twice per Hypothesis example (first run + retry), so the 28-subprocess cost is paid twice per example.

Re-profiled and confirmed the handover's diagnosis: no real git/network/signing anywhere, and each fake-command invocation was paying full `python3` interpreter startup **plus** `pathlib`/`shutil`/`signal` import cost it never actually used. Direct measurement of import cost alone (nix-shell, `-S` flag):

| imports | ms/call |
|---|---|
| bare `pass` | ~13-16 |
| `pass -S` (skip site init) | ~8-11 |
| `+json` | +9.5 |
| `+pathlib` | +12 |
| `+shutil` | +9 |
| `+fcntl` | +1 |
| `+signal` | +3 |

`pathlib` and `shutil` alone were ~21ms of avoidable per-call cost the fake's own logic never needed (it only ever touches `flake.lock` inside a directory it created itself, and deletes a directory it created itself).

## What changed

`tests/fakes/deploy_pin.py::_FAKE_COMMAND` (the shared fake shim, used by **both** consumers):
- Shebang `#!/usr/bin/env python3` → `#!/usr/bin/env -S python3 -S` (skips `site` module init; the fake only ever imports stdlib). Documented the constraint this creates at the shebang itself (`_FAKE_COMMAND` now carries a one-line comment: "this shim must stay stdlib-only").
- Dropped `from pathlib import Path` — every `Path`/`.joinpath`/`.mkdir`/`.write_text`/`.read_text` call site replaced with the equivalent `os.path.join` + plain `open()`/`os.makedirs()`. Scoped claim, not a general one: `str(Path(x))` is not byte-identical to `x` in general (`/a//b`→`/a/b`, trailing slashes collapse, `./a/b`→`a/b`), but it IS identical for the absolute clean paths the script actually passes here, and nothing in the suite asserts the general case — inert for the real inputs, not universally byte-identical.
- Dropped `import shutil` — `shutil.rmtree(worktree, ignore_errors=True)` replaced with a small hand-rolled recursive delete (`rmtree()`). See "Per-command equivalence argument" below for the measured (not assumed) divergence between the two.
- Dropped `import signal` — `signal.SIGTERM` replaced with the hardcoded POSIX constant `15` (this suite only runs on Linux).
- Kept `fcntl`, `json`, `os`, `sys`, `time` (all load-bearing: state locking, state serialization, `os.kill`/`os.getppid()` for the signal-fault-injection scenarios, `time.sleep`).

**Known siblings, not touched by this PR:** `tests/fakes/daily_flake_update.py:11` and `tests/fakes/deploy_cycle.py:11` carry the identical old pattern (`#!/usr/bin/env python3` + `pathlib` + `with_suffix(...).open(...)`). Neither is a measured hotspot, so left alone — noting them here for the #1131 ledger in case a future pass wants the same treatment.

**No control-flow, branch condition, error message, exit code, or signal-timing behavior changed.** Every event-log entry, CAS check, and state field is written in the exact same order with the exact same values as before — this is purely an import/interpreter-startup cost cut, not a logic change.

## Measured before/after

Quiet 16-thread host, `nix-shell` throughout.

| what | before | after | delta |
|---|---|---|---|
| single `fake.run(SCRIPT)` (5-run avg) | 0.85s | 0.61s | -27% |
| `tests.test_deploy_pin_script` (32 tests) | 48.3s | 33.1s | -31% |
| `tests.test_deploy_pin_generated` (15 tests) | 94.1s | 60.4s | -36% |
| `test_retry_never_silently_creates_a_second_signed_pin` alone (35 Hypothesis examples) | 47.4s | 34.4s | -27% |

`cProfile` on the biggest test confirms 100% of the remaining wall time is in `select.poll` waiting on the real subprocess tree (i.e. genuine script-execution time, no leftover Python-side inefficiency in the test code itself).

## Per-consumer treatment

`tests/fakes/deploy_pin.py` is shared, so both consumers get faster automatically from the same change:
- **`tests/test_deploy_pin_script.py`** keeps driving the real `scripts/pin_nixosconfig.sh` via a real subprocess, unchanged — that IS the contract under test (quoting, trap handling, `flock`, exit codes of the real shell script).
- **`tests/test_deploy_pin_generated.py`** also still drives the real script via real subprocess (it's a generated patrol of the real deploy-pin state machine, not a parallel reimplementation) — just against a cheaper fake.

## Per-command equivalence argument (test-fidelity.md Rule B)

None of these commands are external boundaries with a documented exception contract (git/nix/hostname behavior here is entirely our own fake, not a third-party adapter), so Rule B's "mirror the real adapter's exception contract" doesn't directly apply — but the same spirit (don't let the fake diverge from what it claims to simulate) does. For each site touched:

- **`Path.cwd()` / `Path(args[1])` / `cwd.joinpath(...)`** → `os.getcwd()` / plain string / `os.path.join(...)`: the stored/compared value was always a plain string on the state side already. `cwd` is not *only* used to build a file path, though — it's also interpolated into the operator-facing `fail(f"unexpected git argv in {cwd}: {args!r}")` error. Both `Path` and the plain string render identically in an f-string for every real input this fake ever produces, so the conclusion (no observable difference) still holds — the earlier claim just gave the wrong reason.
- **`worktree.mkdir(parents=True)`** → `os.makedirs(worktree)`: identical semantics (creates all missing parents, raises `FileExistsError` if the leaf exists — neither passes `exist_ok`).
- **`worktree.joinpath("flake.lock").write_text(...)`** / **`cwd.joinpath("flake.lock").read_text(...)`** → explicit `open(...).write(...)` / `open(...).read()`: byte-identical I/O, same encoding.
- **`shutil.rmtree(worktree, ignore_errors=True)`** → hand-rolled `rmtree()`: **measured, not assumed.** Ran both across regular file / symlink-to-file / symlink-to-dir / broken symlink / real dir / missing path. They match for a real directory and a missing path — the only two shapes this fake ever produces, since `worktree` is always a directory it created itself via `os.makedirs`. For a non-directory root they diverge: `shutil.rmtree(ignore_errors=True)` raises internally and swallows the error, leaving the entry untouched, while the hand-rolled version unlinks just that one entry (never following a symlink out of the tree — a symlinked child is unlinked, not descended into). Concretely: a regular file survives under the old code, gets deleted under the new one; a symlink (to a file or a directory) has its link unlinked under the new code while its target always survives either way; a broken symlink survives under the old code, gets deleted under the new one. This divergence is unreachable in this fake (the root is always a directory it created), but it is a real divergence, not "identical," and the docstring at `rmtree()`'s definition now says so plainly instead of overclaiming "no symlinks, no cross-device edge cases." A side effect worth calling out: this also removes a latent footgun the old code carried. `Path("")` is `PosixPath('.')`, so `shutil.rmtree(Path(args[-1]), ignore_errors=True)` with an empty `args[-1]` would have recursively deleted the process's own CWD; the new code turns that same input into a swallowed `FileNotFoundError` instead — strictly safer.
- **`signal.SIGTERM`** → `15`: POSIX-standard constant, this suite is Linux-only (nix-shell/NixOS).
- **`-S`**: only stdlib imports cross the shebang (`fcntl`, `json`, `os`, `sys`, `time`), so `site` is genuinely unneeded; `sys.path[0]`/`sys.argv[0]` are unaffected by `-S`; `env -S` is supported by the GNU coreutils in this nix-shell; and if `-S` or `env -S` were ever unsupported on some future host, the shebang would fail loudly (exit 125/127) inside the script's own `set -euo pipefail`, not silently succeed with wrong behavior.

Equivalence is proven two ways, not asserted from reading the diff:
1. **The existing extensive test suite**, unchanged: all 32 deterministic tests in `test_deploy_pin_script.py` and all 15 tests (deterministic known-bad checkers + 4 generated properties) in `test_deploy_pin_generated.py` pass against the new shim, including every fault-injection scenario (`signal_after_commit`, `signal_after_pending_commit`, `invalid_signature_signal_after_commit`, `cleanup`, `push`, `post_commit_*`, etc.) that exercises exactly the code paths this diff touched.
2. **Independent reviewer verification against the real script**, not the diff: patched `_FAKE_COMMAND` back to the pre-PR shim and ran 13 worlds (clean run, nix/push/signature/cleanup/post-commit/signal faults, divergent-receipt seeding, retry legs, worktree-add remote move) through the real `scripts/pin_nixosconfig.sh`, comparing returncode + stdout + stderr + the full normalized state JSON (`events`, `argv_calls`, `commits`, refs) old shim vs. new shim. Result: **DIFFERENCES: NONE**, 18.7s → 13.4s across the 13 worlds.

## Considered and declined: persistent socket server

The task brief pointed at `tests.node_jsonl_worker.NodeJsonlWorker` (one long-lived worker instead of one process per example) as the pattern to consider. Investigated a persistent-server design: a background thread inside the test process serving `git`/`nix`/`hostname` invocations over a TCP loopback socket, with the ~28-call-per-run cost reduced to thin socket clients.

Measured the client-side import floor directly before committing to the rewrite:

| client import set | ms/call |
|---|---|
| `os+sys+socket+json+time -S` (JSON-over-socket client) | ~18.2 |
| `fcntl+json+os+sys+time -S` (this PR's trimmed one-shot design) | ~16.9 |
| `os+sys+socket+time -S` (hand-rolled non-JSON protocol) | ~13.4 |

A JSON-over-socket client is not faster than the already-trimmed one-shot design — `json`'s import cost (~9.5ms) is unavoidable either way (needed for the state file in the one-shot design, or for the wire protocol in the socket design), and `socket`'s import cost is comparable to what `fcntl` + direct state-file I/O already costs. The only way to beat the current floor is a hand-rolled non-JSON wire protocol, which trades a real (if bounded) win for genuine protocol-design and cross-thread/cross-process equivalence risk on a security-shaped boundary (signed-commit and pin-receipt correctness). Per `code-quality.md`'s "stop when added protocol/scheduler complexity outweighs the measured wall-time return," declined the rewrite and stopped at the import-trim level, which already delivers a solid, low-risk, fully-measured 27-36% reduction with zero control-flow changes.

## Coverage contract

- No Hypothesis `max_examples`, `deadline`, or profile tier changed.
- No property, invariant-checker clause, or `@example` edge pin deleted or weakened.
- No plausibility filter added.
- No generated property converted to a deterministic test.
- `tests/test_deploy_pin_generated.py` still drives the real `scripts/pin_nixosconfig.sh` through real `subprocess.run`/`subprocess.Popen` — same production artifact under test as before.

## Test plan

- [x] `nix-shell --run "python3 -m unittest tests.test_deploy_pin_script -v"` — 32/32 pass
- [x] `nix-shell --run "python3 -m unittest tests.test_deploy_pin_generated -v"` — 15/15 pass
- [x] `bash scripts/test.sh tests.test_deploy_pin_generated` — 6/6 phases pass (js-syntax, js-unit, pyright, ruff, vulture, python)
- [x] `bash scripts/test.sh tests.test_deploy_pin_script` — 6/6 phases pass
- [x] Scoped fuzz burst: `nix-shell --run "python3 scripts/run_fuzz_tests.py tests.test_deploy_pin_generated"` — ALL GREEN, 2 properties measured, 0 shallow, 0 discarding
- [x] Verified no other files dirtied in the worktree; verified the shared checkout at `/home/abl030/cratedigger` was never touched

Not merging — leaving for review per instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
