### PR TITLE
fix(#1138): attribute resolve_current_releases rows by normalized id

### DIFF
--- a/lib/beets_db.py
+++ b/lib/beets_db.py
@@ -532,21 +532,37 @@ class BeetsDB:
         self,
         identities: list[ReleaseIdentity],
     ) -> dict[ReleaseIdentity, CurrentBeetsResolution]:
-        """Batch the same exact resolver contract without cardinality loss."""
+        """Batch the same exact resolver contract without cardinality loss.
+
+        SQL membership stays exact on the queried raw id. Python
+        attribution keys on ``normalize_release_id`` so a fetched row is
+        attached even when the caller handed a non-normalized identity.
+        """
 
         unique_identities = tuple(dict.fromkeys(identities))
         album_ids_by_identity: dict[ReleaseIdentity, set[int]] = {
             identity: set() for identity in unique_identities
         }
-        mb_by_release_id = {
-            identity.release_id: identity
-            for identity in unique_identities
-        }
-        discogs_by_release_id = {
-            identity.release_id: identity
+        mb_sql_ids = tuple(
+            identity.release_id for identity in unique_identities
+        )
+        mb_identities_by_normalized: dict[str, list[ReleaseIdentity]] = {}
+        for identity in unique_identities:
+            key = normalize_release_id(identity.release_id)
+            mb_identities_by_normalized.setdefault(key, []).append(identity)
+        discogs_sql_ids = tuple(
+            identity.release_id
             for identity in unique_identities
             if identity.source == "discogs"
-        }
+        )
+        discogs_identities_by_normalized: dict[str, list[ReleaseIdentity]] = {}
+        for identity in unique_identities:
+            if identity.source != "discogs":
+                continue
+            key = normalize_release_id(identity.release_id)
+            discogs_identities_by_normalized.setdefault(key, []).append(
+                identity,
+            )
 
         # One joined SELECT is the snapshot boundary. Beets can move an album
         # concurrently; separate album and item queries could otherwise return
@@ -568,8 +584,8 @@ class BeetsDB:
                 "SELECT release_id FROM wanted_discogs"
                 ") ORDER BY a.id, i.id",
                 (
-                    json.dumps(tuple(mb_by_release_id)),
-                    json.dumps(tuple(discogs_by_release_id)),
+                    json.dumps(mb_sql_ids),
+                    json.dumps(discogs_sql_ids),
                 ),
             ).fetchall()
             for (
@@ -591,17 +607,17 @@ class BeetsDB:
                 item_rows_by_album_id.setdefault(album_id, [])
 
                 mb_release_id = normalize_release_id(raw_mb_release_id)
-                mb_identity = mb_by_release_id.get(mb_release_id)
-                if mb_identity is not None:
+                for mb_identity in mb_identities_by_normalized.get(
+                    mb_release_id, (),
+                ):
                     album_ids_by_identity[mb_identity].add(album_id)
 
                 discogs_release_id = normalize_release_id(
                     raw_discogs_release_id,
                 )
-                discogs_identity = discogs_by_release_id.get(
-                    discogs_release_id,
-                )
-                if discogs_identity is not None:
+                for discogs_identity in discogs_identities_by_normalized.get(
+                    discogs_release_id, (),
+                ):
                     album_ids_by_identity[discogs_identity].add(album_id)
 
                 # UUID + numeric Discogs is a valid cross-source identity pair.

--- a/tests/test_beets_current_resolver_generated.py
+++ b/tests/test_beets_current_resolver_generated.py
@@ -173,6 +173,26 @@ class TestCurrentBeetsResolverPins(unittest.TestCase):
                     f"mb_albumid:{DISCOGS_TARGET}",
                 ))
 
+    def test_non_normalized_discogs_query_attributes_the_sql_hit(self) -> None:
+        """#1138 sibling — SQL CAST hits 12856590 for queried '012856590';
+        Python attribution must use the normalized key or the row is lost.
+        """
+
+        identity = ReleaseIdentity(
+            source="discogs", release_id=f"0{DISCOGS_TARGET}",
+        )
+        with BeetsWorld(REPO) as world:
+            snapshot = world.import_release(_release("discogs", tracks=1))
+            with BeetsDB(
+                str(world.library_db),
+                library_root=str(world.library_root),
+            ) as beets:
+                result = beets.resolve_current_release(identity)
+        self.assertIsInstance(result, CurrentBeetsUnique)
+        assert isinstance(result, CurrentBeetsUnique)
+        self.assertEqual(result.album_path, snapshot.album_path)
+        self.assertEqual(result.identity, identity)
+
     def test_each_discogs_layout_preserves_zero_and_two_match_cardinality(self) -> None:
         for legacy in (False, True):
             for cardinality in (0, 2):

--- a/tests/test_beets_retag_generated.py
+++ b/tests/test_beets_retag_generated.py
@@ -663,31 +663,16 @@ MB_ALBUMID_STORAGE_SHAPES: tuple[MbAlbumidStorageShape, ...] = (
 MB_ALBUMID_STORAGE_SHAPE_STRATEGY = st.sampled_from(MB_ALBUMID_STORAGE_SHAPES)
 
 def _queried_identity(case: str) -> ReleaseIdentity:
-    """The QUERIED identity's own case (#1093 review round 3, F1 secondary
-    finding; round-3-of-round-3 N-3 — this is a plain two-literal helper,
-    not a Hypothesis strategy: nothing in this module draws a case at
-    random, so no ``st.sampled_from`` object sits over it).
+    """The QUERIED identity's own case.
 
-    ``case="exact"`` — the ONLY case the fuzzed property below draws, and
-    the ONLY case reachable in production. Verified, not merely asserted:
-    EVERY ``ReleaseIdentity`` that reaches
+    ``case="exact"`` is the only case reachable in production: every
+    ``ReleaseIdentity`` that reaches
     :func:`lib.beets_retag.retag_merged_album` is built via
-    ``ReleaseIdentity.from_id`` (traced through both call sites in
-    ``lib/download_validation.py`` — ``old_identity =
-    ReleaseIdentity.from_id(normalize_release_id(stored_release_id))`` and
-    ``new_identity = ReleaseIdentity.from_id(survivor)``), and ``from_id``
-    normalizes (lowercases UUIDs) internally.
+    ``ReleaseIdentity.from_id``, which lowercases UUIDs.
 
-    ``case="upper"`` is called directly, ONCE, by
-    :class:`TestKnownUnreachableQueriedIdentityCaseDivergence` below — the
-    one combination NOT reachable this way — proving the boundary
-    empirically rather than asserting it, per the "state the invariant
-    explicitly" branch of the review finding: widening the FUZZED property
-    to draw it would patrol a genuine, but currently unreachable,
-    pre-existing defect in ``resolve_current_releases`` itself (its SQL
-    comparison and Python-side re-key disagree on which side to normalize)
-    — a defect in a WIDELY shared method well beyond the retag module's
-    scope, not something to silently absorb into #1093.
+    ``case="upper"`` is still drawn by the generated property and the
+    #1138 pin — production cannot construct it, but
+    ``resolve_current_releases`` must attribute a SQL-fetched row anyway.
     """
     release_id = MERGED if case == "exact" else MERGED.upper()
     return ReleaseIdentity(source="musicbrainz", release_id=release_id)
@@ -816,63 +801,38 @@ class TestQueryAndGuardConvergeOnStorageShape(unittest.TestCase):
     """
 
     @settings(deadline=None)
-    @given(shape=MB_ALBUMID_STORAGE_SHAPE_STRATEGY)
+    @given(
+        shape=MB_ALBUMID_STORAGE_SHAPE_STRATEGY,
+        identity_case=st.sampled_from(("exact", "upper")),
+    )
     def test_query_and_guard_agree_on_every_storage_shape(
-        self, shape: MbAlbumidStorageShape,
+        self, shape: MbAlbumidStorageShape, identity_case: str,
     ) -> None:
-        """Queries with ``identity_case="exact"`` — the ONLY case reachable
-        in production (see :func:`_queried_identity`). The ``"upper"``
-        case is exercised separately, deterministically, in
-        :class:`TestKnownUnreachableQueriedIdentityCaseDivergence`."""
         library_db, album_id, library_root = _mb_albumid_convergence_world()
         _write_mb_albumid(library_db, album_id, shape.value)
-        identity = _queried_identity("exact")
+        identity = _queried_identity(identity_case)
 
         guard_matches = _guard_matches(library_db, library_root, identity)
         query_matches = _query_matches(library_db, album_id, identity)
 
         check_query_and_guard_agree_on_storage_shape(
-            guard_matches=guard_matches, query_matches=query_matches,
-            shape=shape, identity_case="exact",
+            guard_matches=guard_matches,
+            query_matches=query_matches,
+            shape=shape,
+            identity_case=identity_case,
         )
 
 
-class TestKnownUnreachableQueriedIdentityCaseDivergence(unittest.TestCase):
-    """#1093 review round 3, F1 secondary finding — the ONE combination
-    excluded from the fuzzed property above, driven for real rather than
-    left silently untested.
+class TestPreviouslyDivergentQueriedIdentityCaseConverges(unittest.TestCase):
+    """#1138 — the one 11×2 cell that used to disagree now agrees.
 
-    Algebraically: ``resolve_current_releases`` matches a row iff its SQL
-    WHERE clause (exact, case-sensitive comparison against the RAW queried
-    ``identity.release_id``) selects it AND the Python-side re-key
-    (``normalize_release_id(stored_value)`` looked up in a dict keyed by
-    that SAME raw ``identity.release_id``) also finds it. The retag
-    query's ``MatchQuery`` matches a row iff the SQL comparison alone
-    selects it. The two mechanisms therefore diverge EXACTLY when
-    ``stored_value == identity.release_id`` (so the query matches, and the
-    guard's SQL half matches too) but
-    ``normalize_release_id(stored_value) != identity.release_id`` (so the
-    guard's Python-side re-key misses) — which, since the two are already
-    equal, reduces to: ``identity.release_id`` is not already in its own
-    normalized form. Every OTHER storage shape in
-    ``MB_ALBUMID_STORAGE_SHAPES`` either does not equal the ``"upper"``
-    identity at all, or (for ``"exact"``) is already normalized, so this
-    is PROVABLY the only divergent point in the whole 11-shape × 2-case
-    grid — not a sampled coincidence.
-
-    This is a genuine, PRE-EXISTING defect in ``resolve_current_releases``
-    itself (its SQL comparison and its Python-side re-key disagree about
-    which side of the comparison gets normalized) — unrelated to
-    #1093's actual scope (unifying the retag query's OWN selection
-    mechanism with the guard's) and reachable only through a queried
-    identity that ``ReleaseIdentity.from_id`` — the sole constructor for
-    every identity that reaches :func:`lib.beets_retag.retag_merged_album`
-    in production — can never produce. Fixing ``resolve_current_releases``
-    itself is out of scope here: it is a widely shared method with many
-    consumers beyond the retag module that this PR has not audited.
+    Queried identity is UPPER (unreachable via ``ReleaseIdentity.from_id``).
+    Stored ``mb_albumid`` is the same uppercase text. SQL fetches the row;
+    the Python re-key must attribute it. The retag ``MatchQuery`` already
+    matched. Both sides must report a hit.
     """
 
-    def test_a_matching_but_non_normalized_identity_diverges(self) -> None:
+    def test_matching_non_normalized_identity_converges(self) -> None:
         shape = next(
             s for s in MB_ALBUMID_STORAGE_SHAPES if s.label == "case_upper"
         )
@@ -883,18 +843,15 @@ class TestKnownUnreachableQueriedIdentityCaseDivergence(unittest.TestCase):
         guard_matches = _guard_matches(library_db, library_root, identity)
         query_matches = _query_matches(library_db, album_id, identity)
 
-        self.assertFalse(
+        self.assertTrue(
             guard_matches,
-            "resolve_current_releases's Python-side re-key normalizes the "
-            "stored value but looks it up in a dict keyed by the RAW "
-            "queried identity, so a same-case-but-not-normalized match "
-            "misses — this assertion is the known defect, not a bug in "
-            "this test",
+            "SQL fetched the uppercase row; Python attribution must "
+            "attach it to the queried identity",
         )
         self.assertTrue(
             query_matches,
             "the retag query's MatchQuery does a single exact SQL "
-            "comparison with no re-key step, so it DOES match here",
+            "comparison, so it matches the same-case stored value",
         )
 
 


### PR DESCRIPTION
## Bug Description

`BeetsDB.resolve_current_releases` fetched rows with exact SQL on the raw queried id, then re-keyed with `normalize_release_id(stored)` against a dict keyed by that same raw id. One cell diverged: stored uppercase × queried uppercase. SQL hit, Python missed, the public API reported missing. The retag `MatchQuery` hit.

Fixes #1138

## Root Cause

The two halves of one method disagreed about which side of the comparison is normalized. Production callers go through `ReleaseIdentity.from_id` and cannot construct the cell today, but this is the sole current-library membership authority — any future non-normalized caller inherited the split silently.

Issue prose polarity is inverted vs the empirical pin: the guard missed and the query hit, not the other way around. The suggested SQL-side normalize would have kept that pin divergent and risked breaking the #1093 exact-equality contract with `retag_album_query`.

## Fix

- SQL `IN` lists stay on the raw queried `identity.release_id` (no `LOWER`/`TRIM`, no extra normalized values)
- Python attribution maps are keyed by `normalize_release_id(queried)`; lookup is `normalize_release_id(stored)`
- Same change on the Discogs map (leading-zero sibling)
- Returned dict keys remain the caller-supplied `ReleaseIdentity` objects

## How to Verify

1. `nix-shell --run "python3 -m unittest tests.test_beets_retag_generated.TestPreviouslyDivergentQueriedIdentityCaseConverges -v"` — was RED on the old lookup, GREEN after
2. Sabotage: restore raw-keyed `.get`, pin fails; restore fix, pin passes
3. Widened 11×2 property draws `identity_case ∈ {exact, upper}`
4. Discogs pin: queried `012856590` against stored `12856590` resolves unique

## Test Plan

- [x] Converted the known-divergence pin to a convergence assertion (RED then GREEN)
- [x] Widened the generated #1093 property to both query cases
- [x] Discogs leading-zero sibling pin
- [x] Sabotage run proved the pin bites
- [x] Targeted bundle green: `bash scripts/test.sh tests.test_beets_retag_generated tests.test_beets_current_resolver_generated` (js-syntax, js-unit, pyright, ruff, vulture, python)

## Risk Assessment

Low — reachable production callers already normalize via `from_id`. Exact × `case_upper` still misses on both guard and retag query (#1093 preserved). No deploy needed to close the issue.

Independent grok-4.6 review: no B, no N. Residuals accepted (mixed-raw batch leak unreachable via `from_id`; legacy Discogs + padded query is a SQL miss, not this split).