### PR TITLE
docs(#1143): per-diff-site kill matrix, not a per-PR summary

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -188,7 +188,10 @@ Any type that **crosses JSON** — harness stdout, an HTTP response, a JSONB blo
   `tests/test_verdict_tiers_generated.py` is the pattern:
   `proof_verdict_from_evidence` and `proof_verdict_from_facts` agree, then
   `web.classify.proof_gate_projection` receives the aliases the browser's
-  render path really gets. PR #973 proved why: the faulty lineage-gated input
+  render path really gets. The adapter is the function production actually
+  calls to read or write the value — not a sibling that happens to answer
+  a similar question (``_matching_album_ids`` is not
+  ``resolve_current_releases``). PR #973 proved why: the faulty lineage-gated input
   shape occurred on 26,503 live rows, but `storage_format` covered it, so the
   measured live verdict impact was zero; a generated counterexample proved the
   potential divergence while the common library functions remained in lockstep.
@@ -710,6 +713,8 @@ Before writing any new code, decide which test types you owe and what infrastruc
 
 Routes are the strictest gate: `TestRouteContractAudit` will fail at test time if you add a route to `web/routes/` without classifying it. This is intentional — it prevents shipping endpoints the frontend can rely on without contract coverage.
 
+**Before writing a test, answer:** *What one-line change to production would make this test fail? If the answer is a function this test does not call, the test patrols a bystander.* That question catches agree-by-construction and wrong-reader pins at authoring time (issue #1143).
+
 ## Test Taxonomy
 
 Four categories of tests. Each has different rules for what's acceptable. **All four categories already have established patterns and shared infrastructure in this repo — use them. Do not invent parallel approaches.**
@@ -839,3 +844,4 @@ rationale; never allowlist a pure decision.
 - Non-trivial work goes on a feature branch with a PR (e.g. `feat/cooldowns`, `fix/spectral-race`)
 - PRs are merged via GitHub **Create a merge commit** (not Rebase-and-merge, not Squash-and-merge). This keeps the PR attached to mainline history while preserving the individual commits, so write them well.
 - Deploy and verify live after merging
+- **Kill matrix is per-diff-site, not per-PR** (issue #1143). The PR body names every new or changed assertion, checker clause, and constant, and for each, the exact one-line production mutation that makes it fail. A row that cannot name one is the finding. A mutant that kills test A does not qualify test B. A summary "planted a mutant, confirmed RED" is not a matrix.

--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -191,7 +191,8 @@ Any type that **crosses JSON** — harness stdout, an HTTP response, a JSONB blo
   render path really gets. The adapter is the function production actually
   calls to read or write the value — not a sibling that happens to answer
   a similar question (``_matching_album_ids`` is not
-  ``resolve_current_releases``). PR #973 proved why: the faulty lineage-gated input
+  ``resolve_current_releases``). PR #973 proved why the shared-library
+  stop is insufficient: the faulty lineage-gated input
   shape occurred on 26,503 live rows, but `storage_format` covered it, so the
   measured live verdict impact was zero; a generated counterexample proved the
   potential divergence while the common library functions remained in lockstep.
@@ -243,7 +244,8 @@ Any type that **crosses JSON** — harness stdout, an HTTP response, a JSONB blo
   `fuzz` is not killed for gating purposes — pin that world as an
   `@example` and re-measure. **Standing scope:** a PR adding or changing a
   checker clause audits that checker's clauses as part of the change, and
-  records the kill matrix in the PR. The audit examines test
+  fills the per-diff-site kill matrix in
+  `.github/pull_request_template.md`. The audit examines test
   machinery, so its artifacts are deterministic-only, and its evidence is a
   named world plus a killed mutant — never a scanner inferring reachability
   from source (issue #1094). Procedure: `docs/generated-testing.md`
@@ -255,13 +257,16 @@ Any type that **crosses JSON** — harness stdout, an HTTP response, a JSONB blo
   property's claimed coverage) and run the relevant tests against each. A
   surviving mutant is either a missing invariant (add it) or an entropy
   budget miss (pin the decisive world as an `@example`). The driver is an
-  operator/agent one-shot — never committed (`scope.md`); record the kill
-  matrix in the issue/PR. Canonical run: issue #548, 2026-07-08 — 13
-  mutants, incl. reverting fix `6cf26a4`, led to PR #555. **When you
-  inject at all, cover every site the diff adds, named individually — a
-  killed mutant at one site does not qualify any other** (the "Agree by
-  construction" rule above, generalized from claimed adapters to diff
-  sites). Lesson (#1110): the implementer reported reverting each fix and
+  operator/agent one-shot — never committed (`scope.md`). Record the kill
+  matrix as one row per diff site, not one summary per PR:
+
+  | Site (assertion / clause / constant) | One-line mutant | Test that goes RED | Result |
+  | --- | --- | --- | --- |
+
+  Fill that table in `.github/pull_request_template.md`. A mutant that
+  kills test A does not qualify test B. Canonical run: issue #548,
+  2026-07-08 — 13 mutants, incl. reverting fix `6cf26a4`, led to PR #555.
+  Lesson (#1110): the implementer reported reverting each fix and
   watching its own pin go red — true only of `renderConvergeControls`;
   mutants at the three `deleteWrongMatchGroup` restore paths and at
   `removeWrongMatchEntry` survived every JS assertion, and one recreated
@@ -844,4 +849,4 @@ rationale; never allowlist a pure decision.
 - Non-trivial work goes on a feature branch with a PR (e.g. `feat/cooldowns`, `fix/spectral-race`)
 - PRs are merged via GitHub **Create a merge commit** (not Rebase-and-merge, not Squash-and-merge). This keeps the PR attached to mainline history while preserving the individual commits, so write them well.
 - Deploy and verify live after merging
-- **Kill matrix is per-diff-site, not per-PR** (issue #1143). The PR body names every new or changed assertion, checker clause, and constant, and for each, the exact one-line production mutation that makes it fail. A row that cannot name one is the finding. A mutant that kills test A does not qualify test B. A summary "planted a mutant, confirmed RED" is not a matrix.
+- PR body follows `.github/pull_request_template.md`. The kill matrix is per diff site (assertion / clause / constant → one-line mutant → test that goes RED). A summary is not a matrix.

--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -842,6 +842,9 @@ rationale; never allowlist a pure decision.
   new false claim can hide. Earned four times in one batch (#1101,
   #1102, #1107, #1110); in each, the false claim was caught only by the
   next independent read, never by the round that wrote it.
+- Independent review plants at least two mutants at the named subject of
+  each new or changed test, not only at sites the author's kill matrix
+  already lists (issue #1143 / #1155).
 - Fix everything it finds before committing. This is not optional.
 
 ## Commits & PRs

--- a/.claude/rules/test-fidelity.md
+++ b/.claude/rules/test-fidelity.md
@@ -31,6 +31,8 @@ def test_upsert_round_trip_preserves_every_field(self):
 
 **When a test fakes an external dependency that has a documented exception contract, the failure-case fake MUST use the real exception classes the production code can encounter. Do not return `None` (or any synthetic stand-in) where the real adapter raises.**
 
+A fake must also mirror *when* the real edge fails, not only what it raises. An operator-facing claim about process behaviour owes a real-subprocess test. A fake that fails earlier than the real producer can manufacture a passing test for a false claim (a write-failing stdout fake vs a block-buffered pipe that raises EPIPE at shutdown).
+
 External dependencies in scope:
 - `web/mb.py::get_release` and `get_release_group_releases` — raises `urllib.error.HTTPError` on 404, `urllib.error.URLError` on transport failure
 - `web/discogs.py::get_release` and `get_master_releases` — same exception shape plus `requests.HTTPError` paths

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Summary
+
+<!-- What changed and why. Keep issue references non-closing until deploy/live proof, unless this PR is docs-only. -->
+
+## Kill matrix (per diff site, not per PR)
+
+Every new or changed assertion, checker clause, and constant gets its own row. A mutant that kills row A does not qualify row B. "Planted a mutant, confirmed RED" is not a matrix. A row that cannot name a one-line production mutation is the finding.
+
+| Site (assertion / clause / constant) | One-line production mutant | Test that must go RED | Result |
+| --- | --- | --- | --- |
+| | | | |
+
+## Reviewer
+
+Plant at least two mutants yourself at sites the matrix names. Do not only check the author's table.
+
+## Risk
+
+<!-- Blast radius. What this does not change. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@ Every new or changed assertion, checker clause, and constant gets its own row. A
 
 ## Reviewer
 
-Plant at least two mutants yourself at sites the matrix names. Do not only check the author's table.
+Plant at least two mutants yourself. Aim at the named subject of each new or changed test, not only at sites the author's table already lists. A matrix that cites a scheduling mutant for a kill-both-phases test is the #1155 shape.
 
 ## Risk
 

--- a/docs/generated-testing.md
+++ b/docs/generated-testing.md
@@ -775,8 +775,9 @@ fuzz entropy** = the deterministic suite budget misses the decisive world, so
 pin it as an `@example`; **survived both tiers** = either a missing invariant
 (add it, with a known-bad self-test) or a world the strategies rarely make
 decisive (again, pin the decisive world). The mutation driver is an
-operator/agent one-shot — never committed (`.claude/rules/scope.md`); record
-the kill matrix in the issue/PR.
+operator/agent one-shot — never committed (`.claude/rules/scope.md`); fill
+the per-diff-site kill matrix in `.github/pull_request_template.md`. A
+summary "planted a mutant, confirmed RED" is not a matrix.
 
 Canonical run (issue #548, 2026-07-08): 13 mutants — including reverting
 fix `6cf26a4`, which the generated lifecycle property killed independently

--- a/tests/_docs_reference_audit.py
+++ b/tests/_docs_reference_audit.py
@@ -12,6 +12,7 @@ REMOVAL_STABLE_REPO_ROOTS = frozenset({
     ".agents",
     ".claude",
     ".codex",
+    ".github",
     "docs",
     "examples",
     "harness",


### PR DESCRIPTION
## Summary

Rules already required a kill matrix. A one-line "planted a mutant, confirmed RED" still satisfied them, which is how #1155 and #1151 shipped. This adds the actual PR-body form and points the already-loaded rules at it.

Fixes #1143

## Kill matrix (per diff site, not per PR)

| Site (assertion / clause / constant) | One-line production mutant | Test that must go RED | Result |
| --- | --- | --- | --- |
| `.github` unregistered in `REMOVAL_STABLE_REPO_ROOTS` | delete the `.github` frozenset entry | `test_tracked_top_level_surfaces_are_registered` | RED without the register |
| living-doc path `.github/pull_request_template.md` | delete the template file | `test_repo_paths_and_path_symbols_resolve` | RED (stale path in code-quality.md) |
| New Work Checklist authoring question | delete that paragraph | none — process prose | n/a; a missing row here is the #1143 finding |
| Rule B timing sentence | delete `test-fidelity.md` timing paragraph | none — process prose | n/a |

## Reviewer

Plant at least two mutants yourself. Aim at the named subject of each new or changed test, not only at sites the author's table already lists.

## Risk

Low. Docs/rules only. No production code. No mutation-testing runner. No deploy.