### PR TITLE
fix(#1142): bind the Beets state file read-only for the census oneshot

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -2535,6 +2535,17 @@ in {
         Type = "oneshot";
         User = cfg.user;
         Group = cfg.group;
+        # #1142: the runner calls enforce_beets_startup(role="web") like
+        # cratedigger-web/cratedigger-import-preview-worker, so it owes the
+        # same read-only state-file bind those observer-role units use
+        # (beetsObserverReadOnlyPaths) — otherwise the host-writable
+        # cratedigger-ops group permission on state.pickle trips the
+        # startup contract's state_writable_by_reader check. No
+        # ProtectSystem/ReadWritePaths sandbox: unlike the CD-SEC-04 units
+        # above, this oneshot accepts no untrusted network/media input, and
+        # it still needs plain host write access to publish its snapshot
+        # into cfg.stateDir.
+        BindReadOnlyPaths = beetsObserverReadOnlyPaths;
         ExecStart = "${retagDivergenceCensusPkg}/bin/cratedigger-retag-census";
         WorkingDirectory = cfg.stateDir;
         # A measured live unbounded whole-library scan (~93,700 files)

--- a/tests/test_nix_module.py
+++ b/tests/test_nix_module.py
@@ -1014,6 +1014,7 @@ def _shared_module_worlds_rest() -> dict[str, object]:
             importer = unit "cratedigger-importer";
             preview = unit "cratedigger-import-preview-worker";
             web = unit "cratedigger-web";
+            census = unit "cratedigger-retag-census";
           };
       }
     '''
@@ -2015,7 +2016,11 @@ class TestExternalBeetsRuntimeCapability(unittest.TestCase):
             }
             typed_units[role] = unit
             self.assertLessEqual(readiness, set(unit["after"]), role)
-            if role == "main":
+            if role in ("main", "census"):
+                # Both are timer-driven, restartIfChanged=false oneshots
+                # (CLAUDE.md's migration-hold rationale): they intentionally
+                # use wants+after, never requires, so the readiness units'
+                # own restart-on-deploy never SIGTERMs a mid-flight run.
                 self.assertLessEqual(readiness, set(unit["wants"]), role)
                 self.assertTrue(
                     readiness.isdisjoint(unit["requires"]),
@@ -2025,7 +2030,11 @@ class TestExternalBeetsRuntimeCapability(unittest.TestCase):
                 self.assertLessEqual(readiness, set(unit["requires"]), role)
             self.assertNotIn("/etc/beets", unit["readWritePaths"], role)
         state = "/var/lib/beets/state.pickle"
-        for role in ("main", "preview", "web"):
+        for role in ("main", "preview", "web", "census"):
+            # #1142: the census oneshot calls enforce_beets_startup(role="web")
+            # and must bind the state file read-only exactly like the other
+            # web-role/observer callers, or the host-writable group
+            # permission trips state_writable_by_reader at startup.
             self.assertIn(f"-{state}", typed_units[role]["bindReadOnlyPaths"], role)
             self.assertNotIn(state, typed_units[role]["bindPaths"], role)
         self.assertIn(f"-{state}", typed_units["importer"]["bindPaths"])
@@ -2035,7 +2044,7 @@ class TestExternalBeetsRuntimeCapability(unittest.TestCase):
             self.assertIn("-/srv/beets", typed_units[role]["readWritePaths"], role)
         self.assertIn("-/srv/music", typed_units["main"]["bindReadOnlyPaths"])
         self.assertIn("-/srv/beets", typed_units["main"]["bindReadOnlyPaths"])
-        for role in ("main", "preview"):
+        for role in ("main", "preview", "census"):
             self.assertNotIn("/srv/music", typed_units[role]["readWritePaths"], role)
             self.assertNotIn("/srv/beets", typed_units[role]["readWritePaths"], role)
         text = MODULE_NIX.read_text(encoding="utf-8")
@@ -2407,6 +2416,16 @@ class TestRetagDivergenceCensusServiceShape(unittest.TestCase):
 
     def test_timer_is_wanted_by_timers_target(self) -> None:
         self.assertIn('wantedBy = ["timers.target"];', self.timer_block)
+
+    def test_service_binds_the_beets_state_file_read_only(self) -> None:
+        """The runner calls enforce_beets_startup(role="web"); it owes the
+        same beetsObserverReadOnlyPaths bind as the other web-role/observer
+        callers (see the real-eval assertion in
+        TestExternalBeetsRuntimeCapability.test_readiness_and_role_state_capabilities_evaluate
+        for the rendered-path proof, not just this source-text check)."""
+        self.assertIn(
+            "BindReadOnlyPaths = beetsObserverReadOnlyPaths;", self.service_block,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes the live deployment blocker discovered while activating #1142: `cratedigger-retag-census.service` ran the web-role Beets startup contract without the web-role read-only state-file bind, so it safely exited before scanning.

Adds the existing shared `beetsObserverReadOnlyPaths` to only the census service. It does not alter host file ownership, permissions, or broad service hardening.

## Verification

- RED: rendered Nix fixture showed census `BindReadOnlyPaths = []` and failed the state-file assertion.
- GREEN: rendered service binds `-/etc/beets` and `-/var/lib/beets/state.pickle` read-only.
- `tests.test_nix_module`: 57/57 pass.
- `bash scripts/test.sh tests.test_nix_module`: all six phases green.
- `nix build .#checks.x86_64-linux.moduleVm`: passed; VM test script completed in 294.83s.
- Independent Claude Opus review: no B/N findings.

## Kill matrix (per diff site, not per PR)

| Assertion / clause | One-line mutant | Test that goes RED | Result |
| --- | --- | --- | --- |
| Census web-role readonly state binding | remove `BindReadOnlyPaths = beetsObserverReadOnlyPaths` | rendered `beetsReadiness.census` state-file membership assertion | RED → restored GREEN |

## Reviewer

Plant at least two mutants yourself, including removal of the census bind and a wrong/missing state-file path.