### PR TITLE
fix(tests): make the daily gate green — sun_path ceiling, an escaping segment, and a version-flipping type-ignore

### DIFF
--- a/docs/solutions/testing/daily-gate-runs-a-different-environment.md
+++ b/docs/solutions/testing/daily-gate-runs-a-different-environment.md
@@ -1,0 +1,128 @@
+---
+title: "The daily gate is a different environment — fixtures that encode local path or version budgets fail only there"
+date: 2026-08-15
+category: testing
+problem_type: environment-drift
+component: testing
+tags:
+  - testing
+  - daily-gate
+  - fixtures
+  - af-unix
+  - pyright
+  - nixpkgs-unstable
+related_solutions:
+  - docs/solutions/testing/idealized-destructive-tests-missed-the-beets-runtime-envelope.md
+---
+
+# The daily gate is a different environment — fixtures that encode local path or version budgets fail only there
+
+## Context
+
+The 2026-08-15 `cratedigger-daily-checks` run failed two of five stages while
+the identical tree was green on every developer run:
+
+```
+FAIL deterministic full suite (exit 1)
+PASS stable Nix and Beets-release checks
+PASS world-model burst
+FAIL generated fuzz burst (exit 1)
+PASS mirror-harness smoke
+```
+
+Three defects. One was ordinary entropy — the fuzz burst generated
+`inside_segment=".."` into a world whose premise was "inside the library
+root", and `check_library_root_containment` correctly reported the escape a
+local run had simply never generated. The other two are the subject of this
+document: neither is reachable from a local `scripts/test.sh` or
+`scripts/run_tests.sh` at any depth or example count, because what differs is
+not the code and not the entropy. It is the environment.
+
+## What differs, exactly
+
+`modules/nixos/ci/cratedigger-daily-checks.nix` sets
+`XDG_RUNTIME_DIR = /run/cratedigger-daily-checks/scratch`, and
+`scripts/test_tmpfs.sh` roots the suite's `TMPDIR` under it. Compare:
+
+| Run | Suite `TMPDIR` | Length |
+| --- | --- | --- |
+| interactive | `/run/user/1000/cratedigger-tests.XXXXXX` | 39 |
+| daily gate | `/run/cratedigger-daily-checks/scratch/cratedigger-tests.XXXXXX` | 62 |
+
+Every generated world is built 23 bytes deeper than it is locally. The daily
+gate also runs `nix flake update nixpkgs` before the suite, so its Python,
+pyright, and every library are a moving target the repository lock does not
+pin — that is the entire point of the gate.
+
+## Defect 1 — 23 bytes overran `sun_path`
+
+Socket worlds were planted with `socket.socket(AF_UNIX).bind(path)`. `bind`
+enforces `sun_path`'s ~107-byte ceiling, which has nothing to do with the
+filesystem's own limits: the same path is a perfectly legal file. A socket
+planted inside a generated album folder
+(`<tmp>/failed_imports/Album/00 track.flac`) fit locally and overran on the
+gate, so 3 deterministic IDs and 24 fuzz shards died with `OSError: AF_UNIX
+path too long`.
+
+This was the class's third recurrence. The previous two were patched
+per-site by shortening one leaf name — which weakened the world (a generated
+leaf name is often the thing under test) and only moved the ceiling.
+
+The fix is `tests/helpers.py::make_socket_file`, which plants the same
+`S_ISSOCK` inode with `os.mknod(path, stat.S_IFSOCK | 0o600)`: no path
+ceiling, no descriptor to keep alive, and `open` still answers ENXIO exactly
+as it does for a bound socket — the only property these worlds assert. An
+unprivileged caller may create a socket or a FIFO; only device nodes need
+`CAP_MKNOD`. A test that needs a real LISTENER still binds a real socket.
+
+## Defect 2 — a suppression comment that flips with the library version
+
+`tests/test_audio_hash.py` carried
+`from mutagen.id3 import ID3, TIT2  # type: ignore[import-untyped]`.
+`mutagen` ships `py.typed`, so the comment's stated reason was already false;
+the diagnostic it actually suppressed was `reportPrivateImportUsage`. The
+mechanism, measured in both store paths rather than assumed:
+
+| mutagen | `id3/__init__.py` spells | PEP 561 verdict |
+| --- | --- | --- |
+| pinned (1.47.x) | `from ._frames import (..., TIT2, ...)` | not re-exported → diagnostic |
+| gate (1.48.1) | `from ._frames import ... TIT2 as TIT2 ...` | re-exported → no diagnostic |
+
+A py.typed module re-exports a symbol only via the redundant `X as X` form
+(or `__all__`). Upstream converted to that form between the two versions, so
+the suppression became unnecessary and `reportUnnecessaryTypeIgnoreComment`
+(an `error` in both pyright configs) failed the phase. Watch for that
+conversion in any library this repo suppresses an import diagnostic against —
+it is what flips a required comment into a forbidden one.
+
+There is no comment-based form that survives this: a scoped
+`# pyright: ignore[reportPrivateImportUsage]` is reported by that same
+`reportUnnecessaryTypeIgnoreComment` rule the moment it stops being needed
+(measured, not assumed — probe a clean line with one and pyright says
+`Unnecessary "# pyright: ignore" rule`). The version-robust
+fix is to remove the need for a comment — import from the defining module,
+`from mutagen.id3._frames import TIT2`, which is what pyright's own message
+asks for and is clean under both versions.
+
+## Reproducing gate-only path failures locally
+
+Point the suite's RAM root at a deeper directory. It must be tmpfs, and no
+ancestor may be group/other-writable (`scripts/test_tmpfs.sh` enforces both):
+
+```bash
+mkdir -p /run/user/1000/simulated-daily-checks-scratch-root
+CRATEDIGGER_TEST_RAM_ROOT=/run/user/1000/simulated-daily-checks-scratch-root \
+  nix-shell --run "python3 -m unittest tests.test_protected_path_truth_generated"
+```
+
+That reproduces the exact `OSError: AF_UNIX path too long` traceback the gate
+reported, in seconds, with no clone and no flake update.
+
+## The lesson
+
+A green local suite is not evidence for the daily gate, and the gate's
+failures are not flakes. When it reports something the suite cannot, ask what
+differs in the ENVIRONMENT before reading the diff: scratch-path depth, and
+every version the repository lock is deliberately not pinning. A fixture that
+silently depends on either has an undeclared budget, and the honest fix
+removes the budget rather than buying headroom under it.

--- a/scripts/targeted_test_selection.py
+++ b/scripts/targeted_test_selection.py
@@ -224,6 +224,10 @@ EXACT_PATH_NEIGHBOURS: dict[str, tuple[str, ...]] = {
         "tests.test_quality_decisions",
         "tests.test_dispatch_core",
         "tests.test_integration_slices",
+        # ``make_socket_file``'s own end-to-end pin, including the
+        # longer-than-``sun_path`` world that the daily gate's deeper
+        # scratch root exposed and no local run reaches.
+        "tests.test_path_authority",
     ),
     "tests/node_jsonl_worker.py": (
         "tests.test_node_jsonl_worker",

--- a/tests/_tests_typing_ratchet_baseline.py
+++ b/tests/_tests_typing_ratchet_baseline.py
@@ -27,7 +27,6 @@ TESTS_TYPING_RATCHET_BASELINE: dict[str, dict[str, int]] = {
     "tests/test_album_source.py": {"type_ignore": 2},
     "tests/test_artist_compare.py": {"cast": 3},
     "tests/test_artist_compare_generated.py": {"cast": 4},
-    "tests/test_audio_hash.py": {"type_ignore": 1},
     "tests/test_beets_album_op.py": {"type_ignore": 1},
     "tests/test_beets_db.py": {"any": 2, "type_ignore": 2},
     "tests/test_beets_destructive_configs_generated.py": {"any": 3},

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import configparser
 import json
 import os
+import stat
 import tempfile
 import types
 from collections.abc import Callable, Generator, Mapping, Sequence
@@ -81,6 +82,33 @@ _DEPLOYED_BEETS_DB_PATHS = frozenset({
     "/mnt/virtio/Music/beets-library.db",
     "/var/lib/cratedigger-beets-db/beets-library.db",
 })
+
+
+def make_socket_file(path: str) -> None:
+    """Plant one Unix-domain socket file at ``path``, at any depth.
+
+    ``socket.socket(AF_UNIX).bind(path)`` is the obvious way to create the
+    ``S_ISSOCK`` inode these worlds need, and it is how this repository kept
+    creating it — but ``bind`` carries ``sun_path``'s ~107-byte ceiling,
+    which has nothing to do with the filesystem's own limits.
+
+    That ceiling is invisible locally and fatal on the daily unstable gate.
+    Its scratch root is ``/run/cratedigger-daily-checks/scratch`` (23 bytes
+    deeper than an interactive run's ``/run/user/<uid>``), so a socket
+    planted inside a generated album folder overran ``sun_path`` THERE and
+    nowhere else: 3 deterministic IDs and 24 fuzz shards failed with
+    ``OSError: AF_UNIX path too long`` while every local run stayed green
+    (2026-08-15 gate; third recurrence of this class, previously patched
+    per-site by shortening one leaf name).
+
+    ``mknod`` creates the same inode with no path ceiling and no descriptor
+    to keep alive: an unprivileged caller may create a socket or a FIFO
+    (only device nodes need ``CAP_MKNOD``), and ``open`` answers ENXIO on
+    it exactly as it does for a bound one — the only property these worlds
+    assert. Use this everywhere a test needs a socket FILE; a test that
+    needs a real LISTENER still binds a real socket.
+    """
+    os.mknod(path, stat.S_IFSOCK | 0o600)
 
 
 @contextmanager

--- a/tests/test_audio_hash.py
+++ b/tests/test_audio_hash.py
@@ -106,7 +106,19 @@ class TestHashAudioContentTagInvariance(unittest.TestCase):
             shutil.copy(FIXTURE_DIR / "sine_440.mp3", target)
             before = hash_audio_content(target)
 
-            from mutagen.id3 import ID3, TIT2  # type: ignore[import-untyped]
+            # ``TIT2`` comes from its defining module, which is what
+            # pyright's own ``reportPrivateImportUsage`` message asks for:
+            # ``mutagen.id3`` ships ``py.typed`` but re-exports the frame
+            # classes implicitly, so importing ``TIT2`` from there needs a
+            # suppression comment — and whether that comment is REQUIRED or
+            # UNNECESSARY flips with the mutagen version. It was required
+            # here and unnecessary on nixpkgs-unstable, which failed the
+            # 2026-08-15 daily gate's pyright phase (the retired comment
+            # also claimed ``import-untyped``, which was never the
+            # diagnostic). The defining module is clean under both, with
+            # nothing to suppress.
+            from mutagen.id3 import ID3
+            from mutagen.id3._frames import TIT2
             from mutagen.mp3 import MP3
 
             audio = MP3(str(target), ID3=ID3)

--- a/tests/test_materialize_evidence_generated.py
+++ b/tests/test_materialize_evidence_generated.py
@@ -49,7 +49,6 @@ from __future__ import annotations
 import errno
 import os
 import re
-import socket
 import tempfile
 import unittest
 import unittest.mock
@@ -102,6 +101,7 @@ from tests.fakes import FakePipelineDB
 from tests.helpers import (
     make_ctx_with_fake_db,
     make_grab_list_entry,
+    make_socket_file,
 )
 from tests.test_path_authority import assert_publication_invariant
 
@@ -342,7 +342,6 @@ class _World:
         self.cfg = cfg
         self.file = file
         self.restore_modes: list[str] = []
-        self.sockets: list[socket.socket] = []
         # The bytes a refused materialize must not touch, and whether this
         # world has any in the first place. Measured, never assumed: a
         # hardcoded ``source_exists=True`` would make the shared
@@ -356,15 +355,12 @@ class _World:
     def close(self) -> None:
         for path in self.restore_modes:
             os.chmod(path, 0o700)
-        for sock in self.sockets:
-            sock.close()
 
 
 def _build_world(parent: str, world: str, leaf: str) -> _World:
     """Build one failure world; the caller must ``close()`` it.
 
-    ``close`` restores any mode-000 path so the tempdir can be torn down,
-    and releases bound unix sockets.
+    ``close`` restores any mode-000 path so the tempdir can be torn down.
     """
     source = os.path.join(parent, "downloads")
     processing = os.path.join(parent, "processing")
@@ -427,16 +423,13 @@ def _build_world(parent: str, world: str, leaf: str) -> _World:
         # exists for an ``S_ISREG`` check to inspect — the shape that
         # errno-only classification files under the wrong family.
         #
-        # A FIXED SHORT NAME on purpose: AF_UNIX ``sun_path`` is ~107
-        # bytes, and TMPDIR here comes from XDG_RUNTIME_DIR /
-        # CRATEDIGGER_TEST_RAM_ROOT (scripts/test_tmpfs.sh). A generated
-        # leaf under a longer root overruns it, and ``bind`` would raise
-        # "AF_UNIX path too long" — a hard suite failure, since this repo
-        # bans skips.
-        stamped = os.path.join(source, "s")
-        sock = socket.socket(socket.AF_UNIX)
-        built.sockets.append(sock)
-        sock.bind(stamped)
+        # Planted at the real event-stamped path, like every other world
+        # here. This world used to substitute a fixed short leaf name to
+        # stay under AF_UNIX ``sun_path``'s ~107 bytes — a workaround that
+        # both weakened the world (the generated leaf was the one thing
+        # the stamp is supposed to carry) and only moved the ceiling.
+        # ``make_socket_file`` removes it entirely; see its docstring.
+        make_socket_file(stamped)
         file.local_path = stamped
         built.source_path = stamped
         built.source_survives = True

--- a/tests/test_path_authority.py
+++ b/tests/test_path_authority.py
@@ -49,7 +49,11 @@ from lib.import_preview import (
 from lib.processing_paths import canonical_folder_for_row, processing_albums_dir
 from lib.staged_album import StagedAlbum
 from tests.fakes import FakePipelineDB
-from tests.helpers import make_ctx_with_fake_db, make_grab_list_entry
+from tests.helpers import (
+    make_ctx_with_fake_db,
+    make_grab_list_entry,
+    make_socket_file,
+)
 
 
 def assert_publication_invariant(
@@ -180,16 +184,40 @@ class TestAuthorityFailureClassification(unittest.TestCase):
         ``S_ISREG`` check never runs. Classifying by errno alone would
         file a containment-class shape under a storage reason (I3)."""
         with tempfile.TemporaryDirectory() as root:
-            sock = socket.socket(socket.AF_UNIX)
-            try:
-                sock.bind(os.path.join(root, "sock"))
-                with open_directory_path(root) as root_fd, self.assertRaises(FilesystemAuthorityError) as caught:
-                    open_regular_relative(root_fd, "sock")
-            finally:
-                sock.close()
+            make_socket_file(os.path.join(root, "sock"))
+            with open_directory_path(root) as root_fd, self.assertRaises(FilesystemAuthorityError) as caught:
+                open_regular_relative(root_fd, "sock")
         self.assertEqual(caught.exception.code, "not_regular_file")
         self.assertIn(caught.exception.code, _CONTAINMENT_CODES)
         self.assertIsNone(caught.exception.errno_symbol)
+
+    def test_unix_socket_world_survives_a_path_longer_than_sun_path(self) -> None:
+        """The 2026-08-15 daily-gate defect, pinned end to end.
+
+        Socket worlds used to be planted with ``bind``, which enforces
+        ``sun_path``'s ~107-byte ceiling on a path the filesystem itself
+        accepts. Nothing local exceeded it; the daily gate's deeper scratch
+        root did, so 3 deterministic IDs and 24 fuzz shards died with
+        ``OSError: AF_UNIX path too long`` in a lane no developer runs.
+
+        The control ``bind`` is the load-bearing half: it proves this world
+        is still long enough to have tripped the old code, so shortening
+        the fixture can never quietly retire the regression it pins.
+        """
+        with tempfile.TemporaryDirectory() as root:
+            deep = os.path.join(root, "a" * 40, "b" * 40)
+            os.makedirs(deep)
+            path = os.path.join(deep, "01 track.mp3")
+            self.assertGreater(len(path), 107)
+            with socket.socket(socket.AF_UNIX) as control, self.assertRaises(OSError):
+                control.bind(path)
+
+            make_socket_file(path)
+
+            with open_directory_path(deep) as deep_fd, self.assertRaises(FilesystemAuthorityError) as caught:
+                open_regular_relative(deep_fd, "01 track.mp3")
+        self.assertEqual(caught.exception.code, "not_regular_file")
+        self.assertIn(caught.exception.code, _CONTAINMENT_CODES)
 
     def test_regular_file_used_as_a_directory_is_not_called_a_symlink(self) -> None:
         """ENOTDIR gets its own code: naming it ``unsafe_symlink`` would
@@ -338,13 +366,9 @@ class TestUnreadableEntryCountingAndReasonText(unittest.TestCase):
         """A live Unix-domain socket answers ENXIO at ``open`` (issue
         #868), the second of the two silently-dropped codes #1086 fixes."""
         with tempfile.TemporaryDirectory() as root:
-            sock = socket.socket(socket.AF_UNIX)
-            try:
-                sock.bind(os.path.join(root, "sock"))
-                with open_directory_path(root) as root_fd, self.assertRaises(FilesystemAuthorityError) as caught:
-                    open_regular_relative(root_fd, "sock")
-            finally:
-                sock.close()
+            make_socket_file(os.path.join(root, "sock"))
+            with open_directory_path(root) as root_fd, self.assertRaises(FilesystemAuthorityError) as caught:
+                open_regular_relative(root_fd, "sock")
         exc = caught.exception
         self.assertEqual(exc.code, "not_regular_file")
         self.assertFalse(errno_proves_absence(exc.code))

--- a/tests/test_protected_path_truth_generated.py
+++ b/tests/test_protected_path_truth_generated.py
@@ -21,7 +21,6 @@ import itertools
 import os
 import re
 import shutil
-import socket
 import stat
 import tempfile
 import unittest
@@ -59,6 +58,7 @@ from tests.fakes import FakePipelineDB
 from tests.helpers import (
     SeededWrongMatch,
     make_request_row,
+    make_socket_file,
     seed_visible_wrong_match,
 )
 from tests.node_jsonl_worker import NodeJsonlWorker
@@ -707,11 +707,7 @@ def build_explorer_world(
             # A Unix-domain socket: ``O_NOFOLLOW`` answers ENXIO before a
             # descriptor exists (issue #868's ``not_regular_file``), and
             # that refusal is counted since issue #1086 too.
-            sock = socket.socket(socket.AF_UNIX)
-            try:
-                sock.bind(os.path.join(album, f"{index:02d} weird.mp3"))
-            finally:
-                sock.close()
+            make_socket_file(os.path.join(album, f"{index:02d} weird.mp3"))
         else:
             path = os.path.join(album, f"{index:02d} locked-dir")
             os.makedirs(path)
@@ -1872,11 +1868,7 @@ def _build_agreement_world(
                 fixture_flac, os.path.join(external_dir, "hidden.flac"))
             os.symlink(external_dir, path)
         else:  # refused_socket
-            sock = socket.socket(socket.AF_UNIX)
-            try:
-                sock.bind(path)
-            finally:
-                sock.close()
+            make_socket_file(path)
     return locked
 
 

--- a/tests/test_world_invariants.py
+++ b/tests/test_world_invariants.py
@@ -516,6 +516,32 @@ class TestWorldInvariantCheckersTripOnKnownBad(unittest.TestCase):
 
         self.assertEqual(violations, ())
 
+    def test_library_root_containment_trips_on_a_parent_traversal_out_of_root(
+        self,
+    ) -> None:
+        """A folder that only LOOKS like it is under the root — it is
+        spelled with the root as a prefix, then walks back out of it with
+        ``..``. The checker normalizes before comparing, so this is
+        reported exactly like any other album outside the root; a prefix
+        comparison on the raw string would accept it.
+
+        The 2026-08-15 daily gate generated this world into
+        ``test_partially_moved_item_alone_is_rejected``'s "inside" premise
+        and the property failed correctly. The premise was fixed there;
+        the world it found is real, so it is kept here on purpose.
+        """
+        violations = check_library_root_containment((LibraryAlbumSnapshot(
+            album_id=1,
+            release_id="release-a",
+            album_path="/mnt/virtio/Music/Beets/..",
+            item_paths=("/mnt/virtio/Music/Beets/../01.flac",),
+        ),), library_root="/mnt/virtio/Music/Beets")
+
+        self.assertEqual(
+            {v.code for v in violations},
+            {"album_folder_outside_library_root", "album_item_outside_library_root"},
+        )
+
     def test_library_root_containment_fails_closed_when_root_is_unconfigured(
         self,
     ) -> None:

--- a/tests/test_world_invariants_generated.py
+++ b/tests/test_world_invariants_generated.py
@@ -51,6 +51,26 @@ _SEGMENT = st.text(
 )
 
 
+def _stays_under_a_root(segment: str) -> bool:
+    """Does joining ``segment`` onto a root leave the result under it?"""
+    root = "/root"
+    joined = os.path.normpath(os.path.join(root, segment))
+    return joined == root or joined.startswith(root + os.sep)
+
+
+#: A segment for composing a path that is genuinely INSIDE a library root.
+#: ``_SEGMENT`` can produce ``".."``, which composes to a path that escapes
+#: the root — a real world, but not the one an "inside" premise names. The
+#: daily gate generated it and ``test_partially_moved_item_alone_is_rejected``
+#: failed correctly: with ``inside_segment=".."`` the album FOLDER is outside
+#: the root too, so the folder clause fires alongside the item clause the
+#: test isolates (2026-08-15). Production is right; the world contradicted
+#: its own premise. The escaping direction keeps its coverage — the
+#: ``outside`` tests own it, and ``..`` under a root is pinned deterministically
+#: in ``tests/test_world_invariants.py``.
+_INSIDE_SEGMENT = _SEGMENT.filter(_stays_under_a_root)
+
+
 def _decision_denylists_for_test(decision: str) -> bool:
     search_action = post_import_search_action_if_known(decision)
     return bool(
@@ -245,7 +265,7 @@ class TestWorldInvariantGenerated(unittest.TestCase):
         self.assertIn("album_folder_outside_library_root", codes)
         self.assertIn("album_item_outside_library_root", codes)
 
-    @given(release_id=_SEGMENT, inside_segment=_SEGMENT)
+    @given(release_id=_SEGMENT, inside_segment=_INSIDE_SEGMENT)
     def test_any_album_wholly_inside_the_library_root_is_accepted(
         self,
         release_id: str,
@@ -266,7 +286,7 @@ class TestWorldInvariantGenerated(unittest.TestCase):
 
     @given(
         release_id=_SEGMENT,
-        inside_segment=_SEGMENT,
+        inside_segment=_INSIDE_SEGMENT,
         outside_segment=_SEGMENT,
     )
     def test_partially_moved_item_alone_is_rejected(

--- a/tests/test_world_invariants_generated.py
+++ b/tests/test_world_invariants_generated.py
@@ -100,6 +100,27 @@ def _unique(release_id: str, album_id: int, folder: str) -> CurrentBeetsUnique:
     )
 
 
+class TestInsideSegmentPredicate(unittest.TestCase):
+    """The ``_INSIDE_SEGMENT`` guarantee, checked in the SUITE tier.
+
+    Deterministic on purpose: this is test machinery, which never gets a
+    generated property. It exists because of the tier gap — restoring
+    ``_SEGMENT`` on either "inside" test is caught only by the fuzz tier
+    otherwise, stochastically, and the first symptom would again be a red
+    daily gate rather than a red local suite.
+    """
+
+    def test_the_one_escaping_segment_is_rejected(self) -> None:
+        self.assertFalse(_stays_under_a_root(os.pardir))
+
+    def test_ordinary_and_no_op_segments_are_kept(self) -> None:
+        """``"."`` composes back to the root itself, which the checker
+        treats as inside — a legitimate world this must not discard."""
+        self.assertTrue(_stays_under_a_root("Artist - Album [2002]"))
+        self.assertTrue(_stays_under_a_root(os.curdir))
+        self.assertTrue(_stays_under_a_root("..leading-dots"))
+
+
 class TestWorldInvariantGenerated(unittest.TestCase):
     @given(
         codes=st.lists(


### PR DESCRIPTION
## Summary

The 2026-08-15 `cratedigger-daily-checks` run failed two of five stages
(`deterministic full suite`, `generated fuzz burst`) on a tree that was green
on every developer run. Three defects; the overnight RCA named two.

1. **`OSError: AF_UNIX path too long`** — 3 deterministic IDs + 24 fuzz shards
   in `tests.test_protected_path_truth_generated`. Socket worlds were planted
   with `socket.bind`, which enforces `sun_path`'s ~107-byte ceiling on a path
   the filesystem accepts happily. The gate's scratch root
   (`/run/cratedigger-daily-checks/scratch`) is **23 bytes deeper** than an
   interactive run's `/run/user/1000`, so sockets planted inside generated
   album folders fit locally and overran there. Third recurrence of this
   class; the previous two were patched per-site by shortening a leaf name,
   which only moved the ceiling — and in the materialize world discarded the
   generated leaf the event stamp exists to carry.
   Fix: `tests/helpers.py::make_socket_file` uses `os.mknod(S_IFSOCK)` — same
   inode, no path ceiling, no descriptor to keep alive, and `open` still
   answers ENXIO exactly as it does for a bound socket, which is the only
   property these worlds assert. Five inert-socket sites converted; tests that
   need a real LISTENER still bind a real socket and are untouched.

2. **`inside_segment='..'`** — `test_partially_moved_item_alone_is_rejected`.
   `_SEGMENT` can generate `".."`; joined onto the root it composes
   `/library/Beets/..`, which escapes, so the album FOLDER was outside the
   root too and the folder clause fired alongside the item clause the test
   isolates. Production was right; the world contradicted the premise its own
   name states. Fix: `_INSIDE_SEGMENT`. The world the burst found is kept as a
   deterministic pin, latent in the sibling accept-test too.

3. **Not in the RCA: the pyright phase also failed** —
   `Unnecessary "# type: ignore" comment` at `tests/test_audio_hash.py:109`.
   Under the pinned mutagen that comment is REQUIRED; under the gate's it is
   FORBIDDEN. Its stated reason was false either way: mutagen ships
   `py.typed`, so the suppressed diagnostic was `reportPrivateImportUsage`,
   not `import-untyped`. Measured in both store paths:

   | mutagen | `id3/__init__.py` spells | PEP 561 verdict |
   | --- | --- | --- |
   | pinned (1.47.x) | `from ._frames import (..., TIT2, ...)` | not re-exported → diagnostic |
   | gate (1.48.1) | `... TIT2 as TIT2 ...` | re-exported → no diagnostic |

   No comment-based form survives that flip — a scoped
   `# pyright: ignore[rule]` is itself reported by
   `reportUnnecessaryTypeIgnoreComment` once unneeded (measured against the
   pinned pyright, not assumed). Fix: import `TIT2` from its defining module,
   which is what pyright's own message asks for and needs no suppression, so
   nothing is left to become unnecessary. Verified the gate's own mutagen
   1.48.1 store path still ships `id3/_frames.py`, so the import resolves
   there at runtime.

`docs/solutions/testing/daily-gate-runs-a-different-environment.md` records
the two environment-drift defects and the one-command local repro.

## Reproduction and verification

The gate-only path failure reproduces locally in seconds by pointing the
suite's RAM root at a deeper tmpfs directory — no clone, no flake update:

```bash
mkdir -p /run/user/1000/simulated-daily-checks-scratch-root
CRATEDIGGER_TEST_RAM_ROOT=/run/user/1000/simulated-daily-checks-scratch-root \
  nix-shell --run "python3 -m unittest tests.test_protected_path_truth_generated"
```

- **Pre-fix (stashed):** exact `OSError: AF_UNIX path too long` at the same
  `sock.bind` line the gate named.
- **Post-fix:** the three previously-failing classes pass under that root.
- **Fuzz burst** on all three changed generated modules under that same deep
  root, 2000 examples/shard: `ALL GREEN (3 modules, 60 tests)` — the exact
  combination that failed on the gate.
- **Canonical gate:** pass (`/run/user/1000/cratedigger-final-gate.X8usliiX`).

## Kill matrix (per diff site, not per PR)

| Site (assertion / clause / constant) | One-line production mutant | Test that must go RED | Result |
| --- | --- | --- | --- |
| `tests/helpers.py::make_socket_file` — `os.mknod(path, S_IFSOCK)` | restore the bind-based body (`socket(AF_UNIX).bind(path)`) | `test_path_authority.py::test_unix_socket_world_survives_a_path_longer_than_sun_path` | RED with `OSError: AF_UNIX path too long`; the other 53 tests in the module stayed green — which is exactly why this class kept shipping |
| `test_path_authority.py` new pin — control `bind` + `assertGreater(len(path), 107)` | shorten the fixture (`"a" * 40` → `"a"`) so the world no longer exceeds `sun_path` | same test | RED (control `assertRaises(OSError)` gets no exception). Fixture-guard row, stated honestly: its subject is test machinery, so its mutant is a fixture mutation |
| `test_world_invariants.py::test_library_root_containment_trips_on_a_parent_traversal_out_of_root` | `lib/world_invariants.py::_normal_path` → `return os.path.normcase(path)` (stop normalizing) | that test | RED — `/mnt/virtio/Music/Beets/..` passes a raw-prefix comparison, so no violation is reported |
| `test_world_invariants_generated.py::TestInsideSegmentPredicate::test_the_one_escaping_segment_is_rejected` | `_stays_under_a_root` → `return True` | that test only | RED (exit 1); retention test stayed green |
| `test_world_invariants_generated.py::TestInsideSegmentPredicate::test_ordinary_and_no_op_segments_are_kept` | `_stays_under_a_root` → `return False` | that test only | RED (exit 1); rejection test stayed green |

**Stated tier gap:** restoring `_SEGMENT` on either `@given(inside_segment=...)`
binding is caught only by the fuzz tier, stochastically. That wiring is not
suite-tier killable without property-testing the test machinery, which is
forbidden. `TestInsideSegmentPredicate` closes the half that carries the
logic; the remaining one-line wiring revert has no motive and is named here
rather than papered over.

## Reviewer

Plant at least two mutants yourself, aimed at the named subject of each new or
changed test. Worth attention: (a) `make_socket_file`'s ENXIO equivalence —
does an `os.mknod` socket really classify identically to a bound one through
`open_regular_relative`? (b) the `test_materialize_evidence_generated`
`special_socket` world now builds at its real generated `stamped` path rather
than a fixed short name; confirm nothing depended on that substitution.

## Risk

Test-only, plus one docs file. No production code changes — `lib/`, `web/`,
`harness/`, `scripts/pipeline_cli/` are untouched (the only `scripts/` change
is one `EXACT_PATH_NEIGHBOURS` entry so a `tests/helpers.py` edit selects the
new pin). Nothing to deploy: the daily gate clones `main` from GitHub
directly, so merging is the delivery. No nixosconfig change.

The tests-side typing ratchet baseline drops one hatch (`tests/test_audio_hash.py`
`type_ignore` 1 → 0), regenerated as the ratchet instructs.

Live verification is the next `cratedigger-daily-checks` run (~05:00), which is
the only environment that exercises defects 1 and 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
