### PR TITLE
fix(#1162): admit CD-rip-proven candidates past the spectral generation gate

### DIFF
--- a/docs/quality-verification.md
+++ b/docs/quality-verification.md
@@ -255,6 +255,30 @@ mandatory. If conversion follows, the installed evidence carries this proof
 as source provenance: it continues to describe the FLAC/ALAC source, never the
 derivative bytes.
 
+Because measurement skips the spectral gate outright for these bytes, no
+re-measurement can ever advance a CD-rip-proven candidate row's spectral
+generation. Action-time admission therefore does not demand a current spectral
+generation from a row carrying a **measured** `cd_rip_verification`: demanding
+one is unsatisfiable, and the requeue-to-preview it triggers cannot change its
+own precondition, so the importer and preview livelock (issue #1162 — 2,463
+requeue passes over 39.2 hours on request 712, then 238 more on its successor).
+`carried` provenance is excluded: every writer that puts a CD-rip fact on an
+installed/converted row rewrites it to `carried`, and that row's source-subject
+grade describes the pre-conversion bytes, which must never reach candidate
+policy. Only a proof measured from these exact bytes witnesses the producer's
+own bypass. Admission is not policy — the verified-lossless proof already
+outranks a stale spectral estimate at the decider, so nothing reaches a
+decision here that the proof does not already dominate. Measured over 32 real
+decision worlds, admitting a stale grade alongside the proof produces zero
+outcome flips.
+
+This exemption is deliberately limited to the CD-rip instance.
+`_needs_spectral_check` also skips every codec that is neither MP3 nor a
+lossless candidate, stranding a stale grade the same way — but there the grade
+is decision-relevant, since the dominating proof that makes admission safe
+above exists only on lossless bytes. Those rows need the unusable grade
+cleared rather than admitted; see issue #1167.
+
 ### 1. VBR V0 source probe (implemented)
 
 After lossless-to-V0 conversion, the resulting bitrate reveals source quality:

--- a/lib/quality_evidence.py
+++ b/lib/quality_evidence.py
@@ -1992,7 +1992,39 @@ def _load_candidate_evidence_for_source(
         )
         and not spectral_measurement_generation_is_current(measurement)
     )
-    if spectral_generation_stale and not (
+    # A measured CD-rip bit verification makes the PRODUCER skip the spectral
+    # gate outright (``lib/measurement.py``: `if cd_rip_verification is None
+    # and _needs_spectral_check(...)`), so no re-measurement of these bytes can
+    # ever advance this row's spectral generation. Demanding a current one is
+    # unsatisfiable by construction, and the requeue it triggers cannot change
+    # its own precondition: the importer requeues to preview, preview declines
+    # to re-grade, and the pair never converges (#1162 — job 60635 ran 2,463
+    # passes over 39.2 h, its successor another 238, both ended from outside).
+    # Admitting it is also safe rather than merely expedient: the proof is
+    # strictly stronger evidence than the spectral estimate it displaces, and
+    # the decider already lets it outrank a stale grade, so nothing reaches
+    # policy here that the verified-lossless proof does not already dominate.
+    # ``carried`` provenance is deliberately excluded: every writer that puts a
+    # CD-rip fact on an installed/converted row rewrites it to ``carried``
+    # (``evidence_from_album_info``), and that row's source-subject grade
+    # describes the PRE-CONVERSION bytes, which must never reach candidate
+    # policy. Only a proof measured from these exact bytes witnesses the
+    # producer's own bypass.
+    #
+    # This closes the CD-rip instance ONLY. ``_needs_spectral_check`` also
+    # skips every codec that is neither MP3 nor a lossless candidate
+    # (AAC/Vorbis/Opus/WMA), stranding a stale grade the same way — but there
+    # the grade is decision-relevant, because the dominating proof that makes
+    # admission safe here exists only on lossless bytes. Bypassing it for a
+    # lossy candidate would trade a livelock for a silent wrong reject, so
+    # that instance needs the unusable grade cleared rather than admitted and
+    # is tracked separately (#1167).
+    cd_rip_bypasses_spectral = (
+        evidence.cd_rip_verification is not None
+        and evidence.cd_rip_verification.provenance
+        == EVIDENCE_PROVENANCE_MEASURED
+    )
+    if spectral_generation_stale and not cd_rip_bypasses_spectral and not (
         admission == "decision"
         and preimport_fact is not None
     ):

--- a/tests/test_candidate_admission_progress_generated.py
+++ b/tests/test_candidate_admission_progress_generated.py
@@ -1,0 +1,406 @@
+"""Generated patrol: candidate admission never blocks on an unsatisfiable fact.
+
+Issue #1162. The importer requeues a job to preview whenever candidate
+evidence is not admissible, on the premise that a re-measurement will
+change the world. That premise is load-bearing: when it is false the two
+workers form a livelock neither can escape, because each pass re-derives
+exactly the same state (job 60635 ran 2,463 passes over 39.2 h; its
+successor 60708 another 238; both were ended from outside the pipeline).
+
+The invariant this patrols:
+
+    Admission must never demand a fact that a re-measurement of the same
+    bytes is DEFINED not to produce -- and must not, in exempting one,
+    stop enforcing anything else.
+
+The instance covered here is the CD-rip bypass. ``lib/measurement.py``
+skips the spectral gate outright when a measured CD-rip bit verification
+is present, so those bytes are never re-graded and their spectral
+generation can never advance. The sibling instance -- lossy codecs that
+``_needs_spectral_check`` skips for a codec reason -- is NOT exempted,
+deliberately (issue #1167), and the ``spectral_vl`` proof shape below
+pins that the exemption is keyed on the CD-rip fact itself rather than on
+any measured verified-lossless proof.
+
+This composes the real evidence rows with the real admission loaders.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from typing import ClassVar, Literal
+
+from hypothesis import example, given
+from hypothesis import strategies as st
+
+import tests._hypothesis_profiles  # noqa: F401
+from lib.quality import (
+    AccurateRipBitMatch,
+    AudioQualityMeasurement,
+    CdRipBitVerification,
+    CdTocIdentity,
+    EvidenceProvenance,
+    VerifiedLosslessProof,
+)
+from lib.quality.decisions import mint_verified_lossless_proof
+from lib.quality_evidence import (
+    load_candidate_evidence_for_decision,
+    load_candidate_evidence_for_source,
+    snapshot_audio_files,
+)
+from lib.spectral_check import SPECTRAL_MEASUREMENT_VERSION
+from tests.fakes import FakePipelineDB
+from tests.helpers import make_album_quality_evidence, make_request_row
+
+Generation = Literal["null", "old", "current"]
+ProofShape = Literal["none", "measured", "carried", "spectral_vl"]
+# No ``bitrate``-only member: ``storage_validation_errors`` rejects a spectral
+# bitrate without a grade ("spectral bitrate requires a spectral grade"), so a
+# PERSISTED row can never carry one, and this loader only ever reads persisted
+# rows. Production's staleness predicate still tests the bitrate as
+# fail-closed legislation for a future writer; that half is unreachable from
+# here by construction rather than untested.
+SpectralFact = Literal["none", "grade", "both"]
+
+_GENERATION_GATE_REASON = "spectral measurement generation is not current"
+
+
+def _generation_value(generation: Generation) -> int | None:
+    if generation == "null":
+        return None
+    if generation == "old":
+        return max(0, SPECTRAL_MEASUREMENT_VERSION - 1)
+    return SPECTRAL_MEASUREMENT_VERSION
+
+
+def cd_rip_proof(
+    *,
+    provenance: EvidenceProvenance = "measured",
+) -> CdRipBitVerification:
+    """A production-shaped AccurateRip all-track bit match."""
+    return CdRipBitVerification(
+        provenance=provenance,
+        source_format="flac",
+        toc=CdTocIdentity(
+            track_offsets_sectors=[0, 7013],
+            leadout_sector=38019,
+            accuraterip_id="001f0be7-0195fc21-030a4a12",
+            musicbrainz_disc_id="8NDppmvWEFT9wu_FMwlZKkhZDgE-",
+        ),
+        accuraterip=AccurateRipBitMatch(
+            provider="accuraterip",
+            url="https://www.accuraterip.com/accuraterip/x.bin",
+            checksum_version="arv2",
+            read_offset_samples=0,
+            track_confidences=[12, 12],
+            track_checksums=[0xAABBCCDD, 0x11223344],
+            response_sha256="a" * 64,
+        ),
+    )
+
+
+def spectral_verified_lossless_proof() -> VerifiedLosslessProof:
+    """A measured verified-lossless proof that is NOT a CD-rip proof.
+
+    Minted by the production policy owner rather than hand-typed, so the
+    classifier is whatever production actually spells (Rule C).
+    """
+    proof = mint_verified_lossless_proof(
+        True,
+        was_converted_from="flac",
+        detected_source_format="flac",
+        spectral_grade="genuine",
+    )
+    assert proof is not None
+    return proof
+
+
+def admission_progress_violations(
+    *,
+    generation: Generation,
+    proof_shape: ProofShape,
+    spectral_fact: SpectralFact,
+    policy_error: bool,
+    decision_admitted: bool,
+    decision_reason: str,
+    cache_admitted: bool,
+) -> list[str]:
+    """Name every violated admission-progress invariant.
+
+    Accumulating rather than short-circuiting, so clause ordering can never
+    mask a violation (``.claude/rules/code-quality.md``).
+    """
+    violations: list[str] = []
+    stale = spectral_fact != "none" and _generation_value(generation) != (
+        SPECTRAL_MEASUREMENT_VERSION
+    )
+    # Only a MEASURED CD-rip fact witnesses the producer's own spectral skip.
+    # A measured verified-lossless proof with a spectral classifier does not:
+    # those bytes are re-gradable, so the demand stays satisfiable.
+    bypassed = proof_shape == "measured"
+
+    # The bypass exempts exactly one demand. An independent policy defect must
+    # still block, or the exemption has become a blanket admission (#1162
+    # review F2).
+    if policy_error and decision_admitted:
+        violations.append(
+            "an independent policy error was swallowed by the bypass"
+        )
+    if policy_error and cache_admitted:
+        violations.append(
+            "cache admitted a row carrying an independent policy error"
+        )
+
+    if policy_error:
+        return violations
+
+    if stale and bypassed and not decision_admitted:
+        violations.append(
+            "a re-measurement cannot re-grade CD-rip-proven bytes, so this "
+            "block is unsatisfiable and requeues forever"
+        )
+    if stale and bypassed and _GENERATION_GATE_REASON in decision_reason:
+        violations.append(
+            "CD-rip-proven bytes were blocked by the generation gate"
+        )
+    if stale and bypassed and not cache_admitted:
+        violations.append(
+            "cache admission re-measures CD-rip-proven bytes every pass"
+        )
+    if stale and not bypassed and decision_admitted:
+        violations.append(
+            "a re-gradable stale spectral tuple reached the decider"
+        )
+    if not stale and not decision_admitted:
+        violations.append("generation-current evidence was blocked")
+    return violations
+
+
+class TestCandidateAdmissionProgressGenerated(unittest.TestCase):
+    # The exact live world: a pre-stamp grade preserved on CD-rip-proven
+    # bytes (evidence 29228, request 712).
+    @example(
+        generation="null",
+        proof_shape="measured",
+        spectral_fact="grade",
+        policy_error=False,
+    )
+    # A carried proof does not witness the producer's own bypass.
+    @example(
+        generation="old",
+        proof_shape="carried",
+        spectral_fact="grade",
+        policy_error=False,
+    )
+    # Nor does a measured verified-lossless proof with a spectral classifier.
+    @example(
+        generation="old",
+        proof_shape="spectral_vl",
+        spectral_fact="grade",
+        policy_error=False,
+    )
+    # The bypass must not swallow an unrelated policy defect.
+    @example(
+        generation="null",
+        proof_shape="measured",
+        spectral_fact="grade",
+        policy_error=True,
+    )
+    # A grade carrying its paired bitrate is stale on the same terms.
+    @example(
+        generation="old",
+        proof_shape="none",
+        spectral_fact="both",
+        policy_error=False,
+    )
+    @given(
+        generation=st.sampled_from(("null", "old", "current")),
+        proof_shape=st.sampled_from(
+            ("none", "measured", "carried", "spectral_vl")
+        ),
+        spectral_fact=st.sampled_from(("none", "grade", "both")),
+        policy_error=st.booleans(),
+    )
+    def test_admission_never_blocks_on_an_unsatisfiable_fact(
+        self,
+        generation: Generation,
+        proof_shape: ProofShape,
+        spectral_fact: SpectralFact,
+        policy_error: bool,
+    ) -> None:
+        db = FakePipelineDB()
+        db.seed_request(
+            make_request_row(id=42, mb_release_id="admission-release")
+        )
+        download_log_id = db.log_download(request_id=42, outcome="rejected")
+
+        with tempfile.TemporaryDirectory() as root:
+            source = Path(root, "candidate")
+            source.mkdir()
+            for track in ("01 - Intro.flac", "02 - Drunk Driving.flac"):
+                Path(source, track).write_bytes(b"fLaC audio")
+            files = snapshot_audio_files(str(source))
+
+            cd_rip = (
+                cd_rip_proof(provenance="measured")
+                if proof_shape == "measured"
+                else cd_rip_proof(provenance="carried")
+                if proof_shape == "carried"
+                else None
+            )
+            if cd_rip is not None:
+                verified_lossless = cd_rip.verified_lossless_proof()
+            elif proof_shape == "spectral_vl":
+                verified_lossless = spectral_verified_lossless_proof()
+            else:
+                verified_lossless = None
+
+            has_fact = spectral_fact != "none"
+            evidence = make_album_quality_evidence(
+                preserve_spectral_measurement_version=True,
+                mb_release_id="admission-release",
+                # A blank source_path is the download_log 37206 shape: a real
+                # policy defect that is independent of the spectral gate.
+                source_path="" if policy_error else str(source),
+                files=files,
+                codec="flac",
+                container="flac",
+                storage_format="FLAC",
+                cd_rip_verification=cd_rip,
+                verified_lossless_proof=verified_lossless,
+                measurement=AudioQualityMeasurement(
+                    min_bitrate_kbps=380,
+                    avg_bitrate_kbps=460,
+                    median_bitrate_kbps=451,
+                    format="FLAC",
+                    is_cbr=False,
+                    spectral_grade=(
+                        "likely_transcode"
+                        if spectral_fact in ("grade", "both")
+                        else None
+                    ),
+                    spectral_bitrate_kbps=(
+                        900 if spectral_fact == "both" else None
+                    ),
+                    spectral_subject="source" if has_fact else None,
+                    spectral_provenance="measured" if has_fact else None,
+                    spectral_measurement_version=(
+                        _generation_value(generation) if has_fact else None
+                    ),
+                ),
+            )
+            db.upsert_album_quality_evidence(evidence)
+            stored = db.find_album_quality_evidence(
+                mb_release_id=evidence.mb_release_id,
+                snapshot_fingerprint=evidence.snapshot_fingerprint,
+            )
+            assert stored is not None and stored.id is not None
+            db.set_download_log_candidate_evidence(download_log_id, stored.id)
+
+            decision = load_candidate_evidence_for_decision(
+                db,
+                source_path=str(source),
+                download_log_id=download_log_id,
+            )
+            cache = load_candidate_evidence_for_source(
+                db,
+                source_path=str(source),
+                download_log_id=download_log_id,
+            )
+
+            violations = admission_progress_violations(
+                generation=generation,
+                proof_shape=proof_shape,
+                spectral_fact=spectral_fact,
+                policy_error=policy_error,
+                decision_admitted=decision.evidence is not None,
+                decision_reason=decision.reason or "",
+                cache_admitted=cache.evidence is not None,
+            )
+            self.assertEqual(violations, [], "; ".join(violations))
+
+
+class TestAdmissionProgressCheckerTripsOnViolations(unittest.TestCase):
+    """Per-clause known-bad proof: every clause can actually fail."""
+
+    _BASE: ClassVar[dict[str, object]] = {
+        "generation": "null",
+        "proof_shape": "measured",
+        "spectral_fact": "grade",
+        "policy_error": False,
+        "decision_admitted": True,
+        "decision_reason": "",
+        "cache_admitted": True,
+    }
+
+    def test_swallowed_policy_error_clause_trips(self) -> None:
+        violations = admission_progress_violations(
+            **{**self._BASE, "policy_error": True, "cache_admitted": False}
+        )
+        self.assertIn(
+            "independent policy error was swallowed", "; ".join(violations)
+        )
+
+    def test_cache_swallowed_policy_error_clause_trips(self) -> None:
+        violations = admission_progress_violations(
+            **{
+                **self._BASE,
+                "policy_error": True,
+                "decision_admitted": False,
+            }
+        )
+        self.assertIn(
+            "cache admitted a row carrying", "; ".join(violations)
+        )
+
+    def test_unsatisfiable_block_clause_trips(self) -> None:
+        violations = admission_progress_violations(
+            **{**self._BASE, "decision_admitted": False}
+        )
+        self.assertIn("unsatisfiable", "; ".join(violations))
+
+    def test_generation_gate_reason_clause_trips(self) -> None:
+        violations = admission_progress_violations(
+            **{**self._BASE, "decision_reason": _GENERATION_GATE_REASON}
+        )
+        self.assertIn(
+            "blocked by the generation gate", "; ".join(violations)
+        )
+
+    def test_cache_remeasure_clause_trips(self) -> None:
+        violations = admission_progress_violations(
+            **{**self._BASE, "cache_admitted": False}
+        )
+        self.assertIn("every pass", "; ".join(violations))
+
+    def test_regradable_stale_admission_clause_trips(self) -> None:
+        violations = admission_progress_violations(
+            **{**self._BASE, "proof_shape": "none"}
+        )
+        self.assertIn("reached the decider", "; ".join(violations))
+
+    def test_spectral_vl_proof_does_not_count_as_bypassed(self) -> None:
+        """A measured non-CD-rip proof must not license the exemption."""
+        violations = admission_progress_violations(
+            **{**self._BASE, "proof_shape": "spectral_vl"}
+        )
+        self.assertIn("reached the decider", "; ".join(violations))
+
+    def test_current_generation_block_clause_trips(self) -> None:
+        violations = admission_progress_violations(
+            **{
+                **self._BASE,
+                "generation": "current",
+                "proof_shape": "none",
+                "decision_admitted": False,
+            }
+        )
+        self.assertIn(
+            "generation-current evidence was blocked", "; ".join(violations)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_import_evidence.py
+++ b/tests/test_import_evidence.py
@@ -25,10 +25,13 @@ from lib.import_evidence import (
 )
 from lib.quality import (
     CURRENT_EVIDENCE_LINEAGE_VERSION,
+    AccurateRipBitMatch,
     AlbumQualityEvidence,
     AlbumQualityEvidenceFile,
     AlbumQualityV0Metric,
     AudioQualityMeasurement,
+    CdRipBitVerification,
+    CdTocIdentity,
     QualityRankConfig,
     VerifiedLosslessProof,
 )
@@ -48,6 +51,10 @@ class TestImportEvidenceAcquisition(unittest.TestCase):
         self.root = tempfile.mkdtemp()
         with open(os.path.join(self.root, "01 - Track.mp3"), "wb") as handle:
             handle.write(b"audio")
+        self.flac_root = tempfile.mkdtemp()
+        for track in ("01 - Intro.flac", "02 - Drunk Driving.flac"):
+            with open(os.path.join(self.flac_root, track), "wb") as handle:
+                handle.write(b"fLaC audio")
         self.db = FakePipelineDB()
         self.db.seed_request(make_request_row(id=42, mb_release_id="release-1"))
         self.download_log_id = self.db.log_download(
@@ -57,6 +64,123 @@ class TestImportEvidenceAcquisition(unittest.TestCase):
 
     def tearDown(self) -> None:
         shutil.rmtree(self.root, ignore_errors=True)
+        shutil.rmtree(self.flac_root, ignore_errors=True)
+
+    def _cd_rip_proof(self) -> CdRipBitVerification:
+        """An AccurateRip all-track bit match, shaped like request 712's."""
+        return CdRipBitVerification(
+            provenance="measured",
+            source_format="flac",
+            toc=CdTocIdentity(
+                track_offsets_sectors=[0, 7013],
+                leadout_sector=38019,
+                accuraterip_id="001f0be7-0195fc21-030a4a12",
+                musicbrainz_disc_id="8NDppmvWEFT9wu_FMwlZKkhZDgE-",
+            ),
+            accuraterip=AccurateRipBitMatch(
+                provider="accuraterip",
+                url="https://www.accuraterip.com/accuraterip/x.bin",
+                checksum_version="arv2",
+                read_offset_samples=0,
+                track_confidences=[12, 12],
+                track_checksums=[0xAABBCCDD, 0x11223344],
+                response_sha256="a" * 64,
+            ),
+        )
+
+    def _persist_stale_generation_candidate(
+        self,
+        *,
+        cd_rip_proven: bool,
+    ) -> int:
+        """Persist a FLAC candidate carrying a pre-stamp spectral grade.
+
+        This is issue #1162's shrunk world: a grade with no generation
+        stamp, on bytes a re-measurement will never re-grade.
+        """
+        cd_rip = self._cd_rip_proof() if cd_rip_proven else None
+        evidence = make_album_quality_evidence(
+            preserve_spectral_measurement_version=True,
+            mb_release_id="release-1",
+            source_path=self.flac_root,
+            files=snapshot_audio_files(self.flac_root),
+            codec="flac",
+            container="flac",
+            storage_format="FLAC",
+            cd_rip_verification=cd_rip,
+            # Derived from the producer, never hand-typed: the row's scalar
+            # proof must be exactly what the structured fact projects.
+            verified_lossless_proof=(
+                cd_rip.verified_lossless_proof() if cd_rip is not None else None
+            ),
+            measurement=AudioQualityMeasurement(
+                min_bitrate_kbps=380,
+                avg_bitrate_kbps=460,
+                median_bitrate_kbps=451,
+                format="FLAC",
+                is_cbr=False,
+                spectral_grade="likely_transcode",
+                spectral_subject="source",
+                spectral_provenance="measured",
+                spectral_measurement_version=None,
+            ),
+        )
+        self.db.upsert_album_quality_evidence(evidence)
+        persisted = self.db.find_album_quality_evidence(
+            mb_release_id=evidence.mb_release_id,
+            snapshot_fingerprint=evidence.snapshot_fingerprint,
+        )
+        assert persisted is not None and persisted.id is not None
+        self.db.set_download_log_candidate_evidence(
+            self.download_log_id, persisted.id
+        )
+        return persisted.id
+
+    def test_cd_rip_proven_candidate_admits_despite_stale_generation(self):
+        """#1162: the gate honours the bypass the producer already takes.
+
+        ``lib.measurement`` skips the spectral gate entirely when a CD-rip
+        bit verification is present, so no re-measurement can ever advance
+        this row's generation. Demanding one is unsatisfiable, and the
+        importer requeued to preview forever (job 60635: 2,463 passes).
+        """
+        self._persist_stale_generation_candidate(cd_rip_proven=True)
+
+        result = ensure_candidate_evidence_for_action(
+            self.db,
+            source_path=self.flac_root,
+            download_log_id=self.download_log_id,
+        )
+
+        self.assertTrue(result.available)
+        self.assertFalse(result.provenance.fail_closed)
+        self.assertNotIn(
+            "spectral measurement generation",
+            result.provenance.fallback_reason or "",
+        )
+
+    def test_unproven_candidate_still_blocks_on_stale_generation(self):
+        """The must-still-work half: the bypass is keyed on the proof alone.
+
+        Without a CD-rip bit verification a re-measurement WILL re-grade
+        these bytes, so the generation demand is satisfiable and must
+        still be enforced — admitting a pre-#829 codec-blind grade here
+        would silently reject a legitimate import.
+        """
+        self._persist_stale_generation_candidate(cd_rip_proven=False)
+
+        result = ensure_candidate_evidence_for_action(
+            self.db,
+            source_path=self.flac_root,
+            download_log_id=self.download_log_id,
+        )
+
+        self.assertFalse(result.available)
+        self.assertTrue(result.provenance.fail_closed)
+        self.assertIn(
+            "spectral measurement generation is not current",
+            result.provenance.fallback_reason or "",
+        )
 
     def _candidate_evidence(self) -> AlbumQualityEvidence:
         return make_album_quality_evidence(


### PR DESCRIPTION
Fixes #1162.

## What and why

`lib/measurement.py:1024` skips the spectral gate outright when a **measured** CD-rip bit verification is present — the bit-exact proof is strictly stronger evidence than a spectral estimate. Action-time admission (`lib/quality_evidence.py`) did not honour that bypass: it demanded a current spectral generation from any row carrying a grade, including rows the producer will never re-grade.

That demand is unsatisfiable by construction, and the requeue it triggers **cannot change its own precondition**. The importer requeued to preview, preview declined to re-measure spectral, and the pair livelocked at ~55 s/pass — job 60635 ran **2,463 passes over 39.2 hours** without ever launching Beets or writing a `download_log` row; its successor 60708 ran another 238. Both were ended from outside the pipeline.

The stale grade survives because the upsert's `ON CONFLICT` guard replaces the spectral pair only when the incoming grade is non-NULL, so a pre-#829 codec-blind `likely_transcode` was preserved forever on bytes proven bit-identical to the CD.

The invariant, written down first:

> Admission must never demand a fact that a re-measurement of the same bytes is DEFINED not to produce — and must not, in exempting one, stop enforcing anything else.

## Why this is safe, not just expedient

Measured through the real decider (`full_pipeline_decision_from_evidence`) over 32 worlds — 2 targets × 4 HAVE shapes × 4 candidate grades — admitting a stale grade alongside the proof produced **zero flips** in `(final_status, imported, denylisted, keep_searching)`. Mechanically: a CD-rip proof only ever sits on FLAC/ALAC, and `interpret_spectral_evidence` gives lossless `decision_grade=False`, so the stale grade can never supply a Stage-1 class. The no-proof control **does** flip (`imported` True → False), which is exactly why the exemption is keyed on the proof.

## Scope, stated honestly

This closes the **CD-rip instance only**. `_needs_spectral_check` also skips every codec that is neither MP3 nor a lossless candidate (AAC/Vorbis/Opus/WMA), stranding a stale grade the same way — but there the grade **is** decision-relevant, so bypassing it would trade a loud livelock for a silent wrong reject. Those rows need the unusable grade cleared rather than admitted: filed as #1167 with the live cohort measured. #1166 tracks the requeue watcher that would bound any future member of this class.

`carried` provenance is excluded: every writer that puts a CD-rip fact on an installed/converted row rewrites it to `carried`, and that row's source-subject grade describes the pre-conversion bytes, which must never reach candidate policy.

## Kill matrix (per diff site)

| Site (assertion / clause / constant) | One-line mutant | Test that goes RED | Result |
| --- | --- | --- | --- |
| `lib/quality_evidence.py` bypass condition | remove `and not cd_rip_bypasses_spectral` (revert the fix) | `test_cd_rip_proven_candidate_admits_despite_stale_generation` + generated property | killed |
| `lib/quality_evidence.py` bypass predicate | `cd_rip_bypasses_spectral = True` | `test_unproven_candidate_still_blocks_on_stale_generation` + generated property | killed |
| `== EVIDENCE_PROVENANCE_MEASURED` | drop the provenance clause | generated property (`carried` example) | killed |
| discriminator identity | swap `cd_rip_verification` → `verified_lossless_proof` | generated property (`spectral_vl` example) | killed (added this round) |
| bypass scope (`if errors:`) | `if errors and not cd_rip_bypasses_spectral:` | generated property (`policy_error` axis) | killed (added this round) |
| checker clause 1 (unsatisfiable block) | n/a — self-test | `test_unsatisfiable_block_clause_trips` | trips |
| checker clause 2 (generation-gate reason) | n/a — self-test | `test_generation_gate_reason_clause_trips` | trips |
| checker clause 3 (cache re-measure) | n/a — self-test | `test_cache_remeasure_clause_trips` | trips |
| checker clause 4 (re-gradable stale admitted) | n/a — self-test | `test_regradable_stale_admission_clause_trips` | trips |
| checker clause 5 (current generation blocked) | n/a — self-test | `test_current_generation_block_clause_trips` | trips |
| checker clause 6/7 (swallowed policy error) | n/a — self-test | `test_swallowed_policy_error_clause_trips`, `test_cache_swallowed_policy_error_clause_trips` | trips |

Equivalent mutant, recorded rather than chased: removing `or measurement.spectral_bitrate_kbps is not None` from the staleness predicate survives, because `storage_validation_errors` rejects a spectral bitrate without a grade ("spectral bitrate requires a spectral grade"). A **persisted** row can never carry one, and this loader only reads persisted rows. That half of the predicate is fail-closed legislation for a future writer — unreachable here by construction rather than untested, and the strategy documents it in place of a `bitrate`-only world.

## Tests

- **Pin** `tests/test_import_evidence.py::test_cd_rip_proven_candidate_admits_despite_stale_generation` — the shrunk live world (evidence 29228), driven through the real outermost adapter `ensure_candidate_evidence_for_action`. Its scalar proof is derived from the producer (`cd_rip.verified_lossless_proof()`), not hand-typed (Rule C).
- **Must-still-work guard** `::test_unproven_candidate_still_blocks_on_stale_generation` — same row without the proof still blocks, so the fix cannot fail open.
- **Property** `tests/test_candidate_admission_progress_generated.py` — composes real evidence rows with both real admission loaders across generation × proof-shape × spectral-fact × policy-error, with an accumulating (non-short-circuiting) checker and a per-clause known-bad self-test for all seven clauses.

## Verification

- Canonical receipt-backed suite: **pass** (`scripts/run_final_gate.sh`, clean committed tree).
- Independent adversarial review (opus) found 1 major surviving mutant, 2 minor, and 1 false universal claim; all four addressed in this commit, and the two live-reachable mutants now die. The review's F1 became #1167.
- Live: the production instance was unblocked by clearing evidence 29228's poisoned spectral pair as an operator one-shot; job 60708 converged on the next pass and request 712 imported (beets id 19859, Opus 128 replaced by the bit-verified FLAC). This PR is what stops it recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
