### PR TITLE
feat(tip): run the whole deterministic suite against beets/mutagen/mediafile tip

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -371,10 +371,12 @@ entry-time headroom check (`scripts/test_tmpfs.sh`) runs BEFORE this lock is
 even reached, a naive second suite would still die at shell entry under
 contention with the old unnamed message instead of queueing — so every
 automated launcher of the canonical suite (`scripts/test.sh`,
-`scripts/run_final_gate.sh`, and `scripts/daily_flake_update.sh`'s
-`deterministic_suite` stage — the complete set as of issue #1111 review
-MAJOR-1, grepped for every `nix-shell --run .*run_tests.sh` invocation) sets
-`CRATEDIGGER_SUITE_OWNS_HEADROOM=1` before its own `nix-shell` invocation,
+`scripts/run_final_gate.sh`, `scripts/daily_flake_update.sh`'s
+`deterministic_suite` stage, and `scripts/daily_beets_tip_update.sh`, which
+runs the same suite through `nix develop .#tip` — grep for BOTH
+`nix-shell --run .*run_tests.sh` and `nix develop .* run_tests.sh`, since the
+tip canary enters its shell the flake way) sets
+`CRATEDIGGER_SUITE_OWNS_HEADROOM=1` before its own shell invocation,
 which tells that shellHook check to skip only its free-bytes refusal
 (everything else in `setup_cratedigger_test_tmpfs` still runs); `run_suite`'s
 own post-lock headroom precondition is then the single enforcement point for
@@ -398,8 +400,9 @@ a full Nix evaluation per call for zero additional capability. The six
 calls now invoke `sys.executable` directly, so no test currently spawns a
 NESTED `nix-shell` — but this is not dead machinery: the top-level
 free-bytes skip itself is taken on EVERY suite run launched by
-`scripts/test.sh`, `scripts/run_final_gate.sh`, and
-`scripts/daily_flake_update.sh`, and is pinned by
+`scripts/test.sh`, `scripts/run_final_gate.sh`,
+`scripts/daily_flake_update.sh`, and `scripts/daily_beets_tip_update.sh`,
+and is pinned by
 `tests/test_test_tmpfs.py::test_suite_owns_headroom_skips_only_the_free_bytes_refusal`.
 Only the nested-shell-inherits-the-var form has no current example — the
 mechanism remains in `scripts/test_tmpfs.sh` for the next test that

--- a/docs/beets-primer.md
+++ b/docs/beets-primer.md
@@ -37,9 +37,12 @@ The locked Nixpkgs package is this repository's standalone package/dev-shell
 reference only. Deployment continues to supply the production package, exact
 interpreter, immutable `BEETSDIR`, external state, library, catalogue, secrets,
 and plain operator `beet`; Cratedigger validates that capability but never
-selects it. `beets-tip` is a checks-only advance-warning input, while the
-reviewed 730-day manifest runs disposable harness/delete contracts for each
-final release. These checks do not establish live-catalog upgrade or downgrade
+selects it. `beets-tip`, `mutagen-tip` and `mediafile-tip` are checks-only
+advance-warning inputs advanced together by one canary (they are one package
+set: mutagen is a dependency of mediafile and music-tag, mediafile of Beets,
+so a partial advance would test a combination no environment can hold), while
+the reviewed 730-day manifest runs disposable harness/delete contracts for
+each final release. These checks do not establish live-catalog upgrade or downgrade
 safety. LRCLIB and unrelated external plugin behaviour are deployment-owned
 configuration, outside the compatibility promise.
 
@@ -58,14 +61,16 @@ computation (the Replace picker + YouTube resolver) reuses the SAME detected
 era rather than probing `distance()`'s shape a second time. Both/neither
 attribute present fails closed. The admitted production package remains
 pre-#6681 (`cur_artist`/`cur_album`, the 3-arg `distance()`); the modern era is
-exercised only by the `beets-tip` checks above — `task_description` through the
-harness `choose_match`/`resolve_duplicate` contract assertions, and the modern
-branch of `_beets_match_distance` through
-`tests.test_beets_distance.TestBeetsDistanceIntegrationSlice`, which the tip
-leg of the shared `contract` function in `flake.nix` runs in addition to the
-harness contract tests (the
-19-leg historical matrix does not run it — those releases were never a target
-of `lib/beets_distance.py`). One older-release wrinkle the
+exercised only by the tip canary — which runs Cratedigger's WHOLE
+deterministic suite in the `tip` devShell (`nix develop .#tip`), whose Beets,
+mutagen and mediafile are all at upstream tip. `task_description` is covered
+through the harness `choose_match`/`resolve_duplicate` contract assertions and
+the modern branch of `_beets_match_distance` through
+`tests.test_beets_distance.TestBeetsDistanceIntegrationSlice`, both now reached
+as ordinary suite members rather than by name. The 19-leg historical matrix
+still runs the hand-picked `contract` function instead, because those releases
+cannot run the modern suite — and they were never a target of
+`lib/beets_distance.py` anyway. One older-release wrinkle the
 cheap `hasattr(ImportTask, "cur_artist")` class-level check alone cannot see:
 v2.1.0/v2.2.0 assign `cur_artist`/`cur_album` only inside `ImportTask.__init__`,
 never as a class attribute (v2.3.0 added the class-level declaration), so the

--- a/flake.lock
+++ b/flake.lock
@@ -17,6 +17,40 @@
         "type": "github"
       }
     },
+    "mediafile-tip": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1782758427,
+        "narHash": "sha256-c21+ECCnHO7J4j+zhwt+S/o1lhz6qhTP99yFcI1S3Yk=",
+        "owner": "beetbox",
+        "repo": "mediafile",
+        "rev": "faaf7444f1c58d6a39f0ba51dad8ea43a71fdf3a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "beetbox",
+        "ref": "master",
+        "repo": "mediafile",
+        "type": "github"
+      }
+    },
+    "mutagen-tip": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1783925026,
+        "narHash": "sha256-I9NZBGQYOmqeguOrlT92KqPwSX+x8jthtuy0SNmnASo=",
+        "owner": "quodlibet",
+        "repo": "mutagen",
+        "rev": "8b11398c473a4337c095b5fba8e4a041a0e40129",
+        "type": "github"
+      },
+      "original": {
+        "owner": "quodlibet",
+        "ref": "main",
+        "repo": "mutagen",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1786384358,
@@ -36,6 +70,8 @@
     "root": {
       "inputs": {
         "beets-tip": "beets-tip",
+        "mediafile-tip": "mediafile-tip",
+        "mutagen-tip": "mutagen-tip",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -7,9 +7,21 @@
       url = "github:beetbox/beets/master";
       flake = false;
     };
+    # The audio-authority libraries the suite actually asserts against:
+    # mutagen reads every tag and stream fact, mediafile is Beets' tag layer.
+    # Checks-only, exactly like beets-tip. Note the branch names differ —
+    # mutagen releases from `main`, the beetbox repositories from `master`.
+    mutagen-tip = {
+      url = "github:quodlibet/mutagen/main";
+      flake = false;
+    };
+    mediafile-tip = {
+      url = "github:beetbox/mediafile/master";
+      flake = false;
+    };
   };
 
-  outputs = { self, nixpkgs, beets-tip }:
+  outputs = { self, nixpkgs, beets-tip, mutagen-tip, mediafile-tip }:
     let
       systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
       forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f {
@@ -49,6 +61,26 @@
     in {
       devShells = forAllSystems ({ pkgs, ... }: {
         default = import ./nix/shell.nix { inherit pkgs; };
+        # The same dev shell, with Beets/mutagen/mediafile at upstream tip.
+        # Deliberately built by handing overridden `pkgs` to the ONE shell
+        # definition rather than by forking it: the canary must run the
+        # environment developers and the daily gate run, differing only in
+        # the three packages under test. `nix/beets.nix` and
+        # `nix/package.nix` both resolve through `pkgs.python3*`, so they
+        # pick up the tip set without knowing it exists.
+        tip = import ./nix/shell.nix {
+          pkgs = pkgs.extend (_final: prev: let
+            tipPython = import ./nix/tip-python.nix {
+              pkgs = prev;
+              beetsSrc = beets-tip;
+              mutagenSrc = mutagen-tip;
+              mediafileSrc = mediafile-tip;
+            };
+          in {
+            python3 = tipPython;
+            python3Packages = tipPython.pkgs;
+          });
+        };
       });
 
       packages = forAllSystems ({ pkgs, ... }: let
@@ -95,7 +127,7 @@
           hash = entry.narHash;
         };
         compatPackage = entry: import ./nix/beets-compat-package.nix {
-          inherit pkgs;
+          python = pkgs.python3Packages;
           version = entry.version;
           buildBackend = entry.buildBackend;
           src = compatSource entry;
@@ -107,21 +139,21 @@
             "mbsync, discogs, fetchart, embedart, lyrics, lastgenre, scrub, info, missing, duplicates, edit, fromfilename, ftintitle, the, inline, permissions"
           else
             "musicbrainz, mbsync, discogs, fetchart, embedart, lyrics, lastgenre, scrub, info, missing, duplicates, edit, fromfilename, ftintitle, the, inline, permissions";
-          # Only the tip leg — not the 19-leg historical matrix, whose
-          # releases lib/beets_distance.py was never written or verified
-          # against. This is what actually exercises the modern
-          # (>= era #6681) branch of _beets_match_distance for real:
-          # without it, that branch's arity was type-erased to
-          # Callable[..., Distance] for pyright, so a wrong adaptation
-          # would fail soft into "distance_failed" with the canary staying
-          # green (issue #1088 review finding 2).
+          # The historical matrix keeps a hand-picked list because a 19-leg
+          # sweep of old releases cannot run the modern suite. The tip leg
+          # no longer uses this function at all: it runs the whole
+          # deterministic suite in the `tip` devShell, so
+          # `tests.test_beets_distance.TestBeetsDistanceIntegrationSlice` —
+          # named here explicitly for the tip leg after #1088 review
+          # finding 2, because a wrong `_beets_match_distance` adaptation
+          # would otherwise fail soft into "distance_failed" with the canary
+          # green — is now reached as an ordinary suite member, along with
+          # every other test a curated list could omit.
           testTargets = [
             "tests.test_harness_beets2_contract.TestHarnessBeets2Contract.test_help_stays_on_normal_stdout_and_protocol_is_private"
             "tests.test_harness_beets2_contract.TestHarnessBeets2Contract.test_real_beets_import_library_and_duplicate_action"
             "tests.test_harness_beets2_contract.TestHarnessBeets2Contract.test_real_incremental_import_uses_external_statefile_only"
             "tests.test_harness_beets2_contract.TestHarnessBeets2Contract.test_real_harness_pretend_keeps_source_manifest_unchanged"
-          ] ++ nixpkgs.lib.optionals (name == "beets-tip") [
-            "tests.test_beets_distance.TestBeetsDistanceIntegrationSlice"
           ];
           authority = pkgs.runCommand "cratedigger-${name}-matrix-authority" { } ''
             mkdir -p "$out/beets" "$out/secrets"
@@ -226,7 +258,7 @@ EOF
           touch "$out"
         '';
         tipPackage = import ./nix/beets-compat-package.nix {
-          inherit pkgs;
+          python = pkgs.python3Packages;
           version = "2.13.1";
           buildBackend = "hatchling";
           src = beets-tip;
@@ -243,33 +275,14 @@ EOF
         # `nix flake check` must build the CLI bundle (U8): a stranger's
         # `nix run .#pipeline-cli` is only as green as this check.
         packageDefault = self.packages.${system}.default;
-        beetsTipBuild = tipPackage;
-        beetsTipContract = contract "beets-tip" tipPackage;
-        beetsTipPyright = let
-          cratedigger = import ./nix/package.nix { inherit pkgs; beetsPackage = tipPackage; };
-          python = pkgs.python3.withPackages (ps: cratedigger.pythonPackages ps ++ [
-            ps.coverage
-            ps.hypothesis
-            ps.tree-sitter
-            ps.tree-sitter-javascript
-            ps.vulture
-          ]);
-          source = pkgs.runCommand "cratedigger-beets-tip-pyright-source" { } ''
-            cp -R ${self}/. "$out"
-            chmod -R u+w "$out"
-            ln -s ${python} "$out/.pyright-venv"
-          '';
-        in pkgs.runCommand "cratedigger-beets-tip-pyright" { nativeBuildInputs = [ pkgs.pyright ]; } ''
-          export HOME="$TMPDIR/home"
-          mkdir -p "$HOME"
-          cd ${source}
-          pyright_threads="$(${pkgs.coreutils}/bin/nproc)"
-          if (( pyright_threads > 8 )); then
-            pyright_threads=8
-          fi
-          ${pkgs.pyright}/bin/pyright --threads "$pyright_threads"
-          touch "$out"
-        '';
+        # No beetsTip* checks: scripts/daily_beets_tip_update.sh now runs the
+        # whole deterministic suite in the `tip` devShell, which subsumes all
+        # three (the build is a prerequisite of entering the shell, the
+        # harness contract tests are suite members, and the suite's own
+        # pyright phase resolves against the tip interpreter through the
+        # shellHook's .pyright-venv pin). `tipPackage` itself stays: the
+        # topology check and beetsStableCandidate both assert against its
+        # derivation path.
 
         # Execute the installed configuration checker, rather than merely
         # inspecting its wrapper source. A caller-controlled PYTHONPATH

--- a/nix/beets-compat-package.nix
+++ b/nix/beets-compat-package.nix
@@ -1,10 +1,16 @@
-{ pkgs, src, version, buildBackend }:
+{ python, src, version, buildBackend }:
 
 # Checks-only historical/tip Beets package.  Production consumes the
 # deployment-selected runtime package through nix/module.nix; this builder is
 # deliberately not available to packages, shells, or the exported module.
+#
+# ``python`` is a Python PACKAGE SET (``pkgs.python3Packages``, or the ``prev``
+# set inside a ``packageOverrides`` overlay) rather than ``pkgs``. The overlay
+# case is why: the tip devShell rebuilds Beets INSIDE a set whose own mutagen
+# and mediafile are already at tip, and reaching back through ``pkgs`` there
+# would resolve the un-overridden set — silently pairing tip Beets with pinned
+# tag libraries, which is the one combination the canary must never test.
 let
-  python = pkgs.python3Packages;
   backend = if buildBackend == "hatchling" then python.hatchling
     else if buildBackend == "poetry-core" then python.poetry-core
     else throw "unsupported Beets compatibility build backend: ${buildBackend}";

--- a/nix/tip-python.nix
+++ b/nix/tip-python.nix
@@ -1,0 +1,57 @@
+# Checks-only Python package set with the audio-authority libraries at
+# upstream tip.
+#
+# Returns a `python3` whose package set has Beets, mutagen and mediafile built
+# from the tip flake inputs. Everything else resolves normally, so a package
+# that does not depend on the three keeps its pinned store path and is not
+# rebuilt.
+#
+# Why one SET rather than three separate packages: mutagen is a dependency of
+# both mediafile and music-tag, and mediafile is a dependency of Beets. Three
+# independent `src` swaps would put two mutagens in one environment — the
+# `withPackages` collision hook would either fail the build or silently
+# resolve one of them, and a canary that tests an impossible combination
+# proves nothing. `packageOverrides` rebuilds the dependents so the whole
+# environment agrees on one tip mutagen.
+#
+# Production never sees this. Deployment consumes the pinned runtime package
+# through nix/module.nix, and flake.nix's own topology check asserts the tip
+# inputs never reach a runtime closure.
+{ pkgs, beetsSrc, mutagenSrc, mediafileSrc }:
+
+let
+  # Upstream tip carries no release version, and both packages' nixpkgs
+  # expressions pin patches against a released tree. Clearing `patches` is
+  # required, not cosmetic: the pinned mutagen patch deletes a test file that
+  # tip no longer ships, so the build fails at patchPhase without it.
+  fromTip = prev: src: prev.overridePythonAttrs (_: {
+    inherit src;
+    version = "0-unstable-tip";
+    patches = [];
+    # Upstream's own suite is not our contract, and running it at tip turns
+    # any upstream test flake into a red canary that says nothing about
+    # Cratedigger. Our full suite is the assertion.
+    doCheck = false;
+    dontCheckPythonMetadata = true;
+  });
+
+  python = pkgs.python3.override {
+    self = python;
+    packageOverrides = _final: prev: {
+      mutagen = fromTip prev.mutagen mutagenSrc;
+      mediafile = fromTip prev.mediafile mediafileSrc;
+      # Beets goes through the shared checks-only builder, which owns the
+      # PEP 517 backend and metadata handling a non-release tree needs.
+      # `prev` is deliberate: it resolves Beets' own base expression from
+      # the un-overridden set while its dependencies still come from the
+      # overridden one.
+      beets = import ./beets-compat-package.nix {
+        python = prev;
+        src = beetsSrc;
+        version = "2.13.1";
+        buildBackend = "hatchling";
+      };
+    };
+  };
+in
+python

--- a/scripts/daily_beets_tip_update.sh
+++ b/scripts/daily_beets_tip_update.sh
@@ -1,5 +1,15 @@
 #!/usr/bin/env bash
-# Checks-only upstream Beets tip canary. Never changes deployment authority.
+# Checks-only upstream tip canary. Never changes deployment authority.
+#
+# Runs Cratedigger's whole deterministic suite once, in a dev shell whose
+# Beets, mutagen and mediafile are all at upstream tip. It used to run three
+# targeted checks instead — a build, four named harness contract methods, and
+# pyright — and that hand-picked list is exactly what this replaces: a test
+# nobody remembered to name could not fail it. The first full-suite run found
+# two real upstream removals in a test the old list did not include.
+#
+# The suite is deterministic (generated tests run derandomized); the fuzz
+# tier deliberately stays in the nixpkgs candidate gate, not here.
 set -euo pipefail
 
 repository="${CRATEDIGGER_UPDATE_REPOSITORY:-https://github.com/abl030/cratedigger.git}"
@@ -16,10 +26,20 @@ unset TEST_DB_DSN BEETSDIR CRATEDIGGER_RUNTIME_CONFIG
 
 git clone --quiet --branch "$branch" --single-branch "$repository" "$checkout"
 cd "$checkout"
-nix flake update beets-tip
-nix build .#checks.x86_64-linux.beetsTipBuild --print-build-logs
-nix build .#checks.x86_64-linux.beetsTipContract --print-build-logs
-nix build .#checks.x86_64-linux.beetsTipPyright --print-build-logs
+nix flake update beets-tip mutagen-tip mediafile-tip
+
+# One update, one suite run: the three inputs advance together because they
+# are tested together. mutagen is a dependency of both mediafile and
+# music-tag, and mediafile of Beets, so the shell overrides them as one
+# package set — advancing a subset would test a combination that no
+# environment can actually hold.
+
+# run_suite() owns the admission lock and the post-lock headroom
+# precondition for every suite run started this way, so the shellHook's own
+# entry-time free-bytes refusal defers to it (issue #1111). Every automated
+# launcher of the canonical suite sets this.
+export CRATEDIGGER_SUITE_OWNS_HEADROOM=1
+nix develop .#tip --command bash scripts/run_tests.sh
 
 if git diff --quiet -- flake.lock; then
     echo "beets tip canary: flake.lock already current"

--- a/tests/fakes/daily_flake_update.py
+++ b/tests/fakes/daily_flake_update.py
@@ -65,14 +65,18 @@ with state_path.with_suffix(".lock").open("a+", encoding="utf-8") as lock:
         raise SystemExit(0)
 
     if command == "nix":
-        if args in (["flake", "update", "nixpkgs"], ["flake", "update", "beets-tip"]):
+        if args[:2] == ["flake", "update"] and args[2:]:
+            targets = args[2:]
+            unknown = [t for t in targets if t not in state["seed_lock"]["nodes"]]
+            if unknown:
+                fail(f"unexpected flake update targets: {unknown!r}")
             if state.get("fault") == "update":
                 fail("fake flake update failed")
             if state["lock_changed"]:
-                target = args[2]
                 lock_path = Path.cwd().joinpath("flake.lock")
                 lock = json.loads(lock_path.read_text(encoding="utf-8"))
-                lock["nodes"][target]["locked"]["rev"] = "new-" + target
+                for target in targets:
+                    lock["nodes"][target]["locked"]["rev"] = "new-" + target
                 lock_path.write_text(json.dumps(lock, sort_keys=True), encoding="utf-8")
                 state["lock_after_update"] = lock
             save()
@@ -84,23 +88,13 @@ with state_path.with_suffix(".lock").open("a+", encoding="utf-8") as lock:
         ]:
             stage = "stable-candidate"
         elif args == [
-            "build",
-            ".#checks.x86_64-linux.beetsTipBuild",
-            "--print-build-logs",
+            "develop",
+            ".#tip",
+            "--command",
+            "bash",
+            "scripts/run_tests.sh",
         ]:
-            stage = "tip-build"
-        elif args == [
-            "build",
-            ".#checks.x86_64-linux.beetsTipContract",
-            "--print-build-logs",
-        ]:
-            stage = "tip-contract"
-        elif args == [
-            "build",
-            ".#checks.x86_64-linux.beetsTipPyright",
-            "--print-build-logs",
-        ]:
-            stage = "tip-pyright"
+            stage = "tip-suite"
         else:
             fail(f"unexpected nix argv: {args!r}")
     elif command == "nix-shell":
@@ -186,9 +180,18 @@ class FakeDailyFlakeUpdateCommands:
                 "push_ref": None,
                 "seed_lock": {
                     "nodes": {
-                        "root": {"inputs": {"nixpkgs": "nixpkgs", "beets-tip": "beets-tip"}},
+                        "root": {
+                            "inputs": {
+                                "nixpkgs": "nixpkgs",
+                                "beets-tip": "beets-tip",
+                                "mutagen-tip": "mutagen-tip",
+                                "mediafile-tip": "mediafile-tip",
+                            }
+                        },
                         "nixpkgs": {"locked": {"rev": "old-nixpkgs"}},
                         "beets-tip": {"locked": {"rev": "old-beets-tip"}},
+                        "mutagen-tip": {"locked": {"rev": "old-mutagen-tip"}},
+                        "mediafile-tip": {"locked": {"rev": "old-mediafile-tip"}},
                     },
                     "root": "root",
                     "version": 7,

--- a/tests/test_daily_beets_tip_update.py
+++ b/tests/test_daily_beets_tip_update.py
@@ -23,20 +23,30 @@ class TestDailyBeetsTipUpdateScript(unittest.TestCase):
         state = self.fake.state
 
         self.assertEqual(proc.returncode, 0, proc.stderr)
-        self.assertIn(["nix", "flake", "update", "beets-tip"], state["events"])
-        self.assertEqual(
-            state["stages"], ["tip-build", "tip-contract", "tip-pyright"]
+        self.assertIn(
+            [
+                "nix", "flake", "update",
+                "beets-tip", "mutagen-tip", "mediafile-tip",
+            ],
+            state["events"],
         )
+        # One run of the whole deterministic suite, against a shell whose
+        # Beets, mutagen and mediafile are all at tip. The hand-picked
+        # target list it replaced could not fail on a test nobody had
+        # remembered to name.
+        self.assertEqual(state["stages"], ["tip-suite"])
         self.assertEqual(state["commit_count"], 1)
         self.assertEqual(state["push_count"], 1)
         self.assertEqual(state["push_ref"], "HEAD:refs/heads/main")
         self.assertEqual(state["commit_args"][-2:], ["--", "flake.lock"])
         self.assertIn("Refs #992", state["commit_args"])
-        self.assertIsNone(state["stage_env"]["tip-contract"]["TEST_DB_DSN"])
-        self.assertEqual(
-            state["lock_after_update"]["nodes"]["beets-tip"]["locked"]["rev"],
-            "new-beets-tip",
-        )
+        self.assertIsNone(state["stage_env"]["tip-suite"]["TEST_DB_DSN"])
+        for node in ("beets-tip", "mutagen-tip", "mediafile-tip"):
+            self.assertEqual(
+                state["lock_after_update"]["nodes"][node]["locked"]["rev"],
+                f"new-{node}",
+                f"{node} must advance with the canary",
+            )
         self.assertEqual(
             state["lock_after_update"]["nodes"]["nixpkgs"],
             state["lock_before"]["nodes"]["nixpkgs"],
@@ -44,13 +54,13 @@ class TestDailyBeetsTipUpdateScript(unittest.TestCase):
         self.assertEqual(state["lock_at_commit"], state["lock_after_update"])
 
     def test_failed_canary_never_commits_or_pushes(self) -> None:
-        self.fake.update_state(fault="tip-contract")
+        self.fake.update_state(fault="tip-suite")
 
         proc = self.fake.run(SCRIPT)
         state = self.fake.state
 
         self.assertNotEqual(proc.returncode, 0)
-        self.assertEqual(state["stages"], ["tip-build", "tip-contract"])
+        self.assertEqual(state["stages"], ["tip-suite"])
         self.assertEqual(state["commit_count"], 0)
         self.assertEqual(state["push_count"], 0)
 
@@ -61,9 +71,7 @@ class TestDailyBeetsTipUpdateScript(unittest.TestCase):
         state = self.fake.state
 
         self.assertEqual(proc.returncode, 0, proc.stderr)
-        self.assertEqual(
-            state["stages"], ["tip-build", "tip-contract", "tip-pyright"]
-        )
+        self.assertEqual(state["stages"], ["tip-suite"])
         self.assertEqual(state["commit_count"], 0)
         self.assertEqual(state["push_count"], 0)
         self.assertIn("flake.lock already current", proc.stdout)

--- a/tests/test_daily_flake_update.py
+++ b/tests/test_daily_flake_update.py
@@ -85,10 +85,12 @@ class TestDailyFlakeUpdateScript(unittest.TestCase):
             state["lock_after_update"]["nodes"]["nixpkgs"]["locked"]["rev"],
             "new-nixpkgs",
         )
-        self.assertEqual(
-            state["lock_after_update"]["nodes"]["beets-tip"],
-            state["lock_before"]["nodes"]["beets-tip"],
-        )
+        for node in ("beets-tip", "mutagen-tip", "mediafile-tip"):
+            self.assertEqual(
+                state["lock_after_update"]["nodes"][node],
+                state["lock_before"]["nodes"][node],
+                f"the nixpkgs candidate must not advance {node}",
+            )
         self.assertEqual(state["lock_at_commit"], state["lock_after_update"])
 
         clone_path = Path(state["clone_path"])
@@ -277,16 +279,17 @@ class TestDailyFlakeUpdateScript(unittest.TestCase):
         self.assertRegex(stdout, r"status=(?:valid|invalid) ")
 
     def test_red_tip_canary_cannot_block_green_nixpkgs_candidate(self) -> None:
-        # The fake recognises tip-contract as a fault only if a runner invokes
-        # that named canary check. The stable updater deliberately does not.
-        self.fake.update_state(fault="tip-contract")
+        # The fault must name the canary's CURRENT stage, or this test
+        # passes for the wrong reason: a fault nothing can trigger proves
+        # nothing about which runner ran what.
+        self.fake.update_state(fault="tip-suite")
 
         proc = self.fake.run(SCRIPT)
         state = self.fake.state
 
         self.assertEqual(proc.returncode, 0, proc.stderr)
         self.assertIn("stable-candidate", state["stages"])
-        self.assertNotIn("tip-contract", state["stages"])
+        self.assertNotIn("tip-suite", state["stages"])
         self.assertEqual(state["commit_count"], 1)
 
     def test_shared_flock_serializes_nixpkgs_and_tip_processes(self) -> None:
@@ -309,7 +312,9 @@ class TestDailyFlakeUpdateScript(unittest.TestCase):
             index for index, event in enumerate(state["events"])
             if event[:2] == ["git", "push"]
         )
-        update_tip = state["events"].index(["nix", "flake", "update", "beets-tip"])
+        update_tip = state["events"].index(
+            ["nix", "flake", "update", "beets-tip", "mutagen-tip", "mediafile-tip"]
+        )
         self.assertLess(update_nixpkgs, daily_push)
         self.assertLess(daily_push, update_tip)
 

--- a/tests/test_harness_beets2_contract.py
+++ b/tests/test_harness_beets2_contract.py
@@ -471,7 +471,6 @@ import beets
 from beets import config as bconfig
 from beets import plugins as bplugins
 from beets.library import Album, Library
-from beets.util import functemplate
 
 consumer = json.loads(os.environ["AUNIQUE_CONSUMER_CONFIG"])
 TEMPLATE = consumer["template"]
@@ -496,9 +495,17 @@ def find_collisions(lib, template, worlds):
     (Passenger, 2026-07-18)."""
     import re as _re
 
-    tmpl = functemplate.template(template)
-    stem_tmpl = functemplate.template(
-        _re.sub(r"%aunique\{[^}]*\}", "", template))
+    # Hand ``evaluate_template`` the template STRING, never a compiled
+    # ``Template``. Both Beets APIs this probe used moved at upstream tip:
+    # ``functemplate.template`` was removed, and ``evaluate_template`` now
+    # compiles internally through a hashing cache that raises
+    # ``TypeError: unhashable type: 'Template'`` on a pre-compiled object.
+    # A string is accepted by every Beets this repository tests, so the
+    # probe no longer depends on either moving part. Both breaks were found
+    # by the tip canary's full-suite run, which reaches this test; the
+    # canary's older hand-picked target list did not.
+    tmpl = template
+    stem_tmpl = _re.sub(r"%aunique\{[^}]*\}", "", template)
     bad = []
     for a, b in worlds:
         da = a.evaluate_template(tmpl, True).rsplit("/", 1)[0]


### PR DESCRIPTION
## Summary

The tip canary ran three targeted checks: a build, four named harness contract
methods, and pyright — 45s, and only ever able to fail on a test somebody
remembered to name. It had already failed that way once:
`TestBeetsDistanceIntegrationSlice` was added by #1088 review finding 2 after a
reviewer noticed that a wrong `_beets_match_distance` adaptation would fail
soft into `distance_failed` with the canary staying green.

It now runs Cratedigger's **whole deterministic suite, once** (10,529 tests,
~110-140s) in a `tip` devShell whose Beets, mutagen and mediafile are all at
upstream tip. Reporting, lock-commit and push behaviour are unchanged.

**The first full-suite run immediately found two real upstream removals**, in a
test the old list did not name:

- `beets.util.functemplate.template` — removed at tip (it was only an
  `lru_cache`'d `Template(fmt)` constructor)
- `evaluate_template` — now compiles internally through a hashing cache, so a
  pre-compiled `Template` raises `TypeError: unhashable type: 'Template'`

Both are fixed version-agnostically in the first commit: pass the template
STRING, which pinned Beets (`str | Template`) and tip (`str`) both accept. No
production code was affected — `lib/beets_retag.py` only names
`functemplate.template` in prose.

**Why mutagen and mediafile join Beets:** they are what the suite actually
asserts against — mutagen reads every tag and stream fact, mediafile is Beets'
tag layer. They advance as ONE package set rather than three `src` swaps,
because mutagen is a dependency of mediafile and music-tag, and mediafile of
Beets: independent overrides put two mutagens in one environment, and a canary
testing a combination no environment can hold proves nothing.

**Design notes**

- The tip shell hands overridden `pkgs` to the ONE existing `nix/shell.nix`
  rather than forking it, so the canary runs the environment developers and the
  daily gate run, differing only in the three packages under test.
- `nix/beets-compat-package.nix` now takes a Python package SET instead of
  `pkgs`, so the overlay can reuse it. Reaching back through `pkgs` inside
  `packageOverrides` would resolve the un-overridden set and silently pair tip
  Beets with pinned tag libraries — the one combination the canary must never
  test.
- `beetsTipBuild`/`beetsTipContract`/`beetsTipPyright` are removed as subsumed:
  the build is a prerequisite of entering the shell, the contract tests are
  suite members, and the suite's pyright phase resolves against the tip
  interpreter through the shellHook's `.pyright-venv` pin. `tipPackage` stays —
  the topology check and `beetsStableCandidate` both assert against its
  derivation path. The `contract` function keeps its hand-picked list for the
  19-leg historical matrix, which cannot run the modern suite.

## Kill matrix (per diff site, not per PR)

| Site (assertion / clause / constant) | One-line production mutant | Test that must go RED | Result |
| --- | --- | --- | --- |
| `find_collisions` passing the template STRING (`tests/test_harness_beets2_contract.py`) | restore `functemplate.template(template)` | `TestAuniqueCollisionContract::test_consumer_template_never_collides_same_key_siblings` under `nix develop .#tip` | RED — `AttributeError: module 'beets.util.functemplate' has no attribute 'template'`. This is the mutant upstream planted for us; it is how the defect was found |
| same site, `Template` object vs string | pass `functemplate.Template(template)` instead of the string | same test under `nix develop .#tip` | RED — `TypeError: unhashable type: 'Template'`. Verified as its own step: fixing only the first break left this one behind |
| `daily_beets_tip_update.sh` runs one suite stage | revert to the three `nix build .#checks…beetsTip*` calls | `test_daily_beets_tip_update::test_green_tip_canary_updates_only_its_lock_and_pushes` (`stages == ["tip-suite"]`) | RED — fake fails the run with `unexpected nix argv`, since those checks no longer exist |
| `flake update` advances all three tip inputs | drop `mutagen-tip mediafile-tip` from the argv | same test's per-node `new-{node}` loop | RED — `mutagen-tip` keeps `old-mutagen-tip` |
| nixpkgs candidate must not advance tip inputs (`test_daily_flake_update`) | add `mutagen-tip` to `daily_flake_update.sh`'s update argv | `test_green_candidate_runs_every_gate_and_pushes_only_lock` | RED — the node moves when the assertion requires it unchanged |
| `fault="tip-suite"` in `test_red_tip_canary_cannot_block_green_nixpkgs_candidate` | make `daily_flake_update.sh` invoke the tip suite stage | that test | RED — the fault fires and the candidate exits nonzero. Under the OLD `fault="tip-contract"` this same mutant was INVISIBLE, which is why the name was repointed |

## Reviewer

Plant at least two mutants yourself, aimed at the named subject of each new or
changed test. Two places worth the attention:

1. **The package-set consistency claim.** Break it deliberately — override
   `mutagen` only in `nix/tip-python.nix` and leave `mediafile`/`beets` on the
   pinned set — and check what `nix develop .#tip` actually produces. The claim
   is that independent overrides yield an inconsistent environment; verify that
   rather than taking the comment's word for it.
2. **`beets-compat-package.nix`'s `prev` vs `final`.** The comment says passing
   `final` there would resolve Beets against the overridden set and recurse.
   Confirm the failure mode is what the comment claims.

## Risk

The canary is checks-only and cannot touch deployment: `flake.nix`'s own
topology check asserts the tip inputs never reach a runtime closure, and
`beetsStableCandidate` asserts `tipPackage`'s derivation is not among its
inputs. Both still evaluate (`nix flake check --no-build` passes). The tip lock
is advisory — a red canary blocks only its own lock advance.

**This PR requires a matching nixosconfig change before it can run
unattended**: `cratedigger-beets-tip-canary` has no private scratch tmpfs (the
nixpkgs unit has a 16G one; the tip unit gets only `/mnt`), so a suite run
there would put ~a dozen ephemeral PostgreSQL clusters on doc1's shared 12 GiB
`/run`. Landing order is nixosconfig first, then this.

Evidence: canonical gate pass (`cratedigger-final-gate.AUAr4IB7`), and the
full suite green under `nix develop .#tip` on this exact tree (6/6 phases,
`cratedigger-checks.yhbs0w0z`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
