### PR TITLE
fix(canary): stop publishing a lock nobody reads; rebase the one that matters

### DIFF
--- a/docs/beets-primer.md
+++ b/docs/beets-primer.md
@@ -38,10 +38,15 @@ reference only. Deployment continues to supply the production package, exact
 interpreter, immutable `BEETSDIR`, external state, library, catalogue, secrets,
 and plain operator `beet`; Cratedigger validates that capability but never
 selects it. `beets-tip`, `mutagen-tip` and `mediafile-tip` are checks-only
-advance-warning inputs advanced together by one canary (they are one package
-set: mutagen is a dependency of mediafile and music-tag, mediafile of Beets,
-so a partial advance would test a combination no environment can hold), while
-the reviewed 730-day manifest runs disposable harness/delete contracts for
+advance-warning inputs. One canary advances all three together in a
+disposable clone and publishes nothing: they are one package set (mutagen is a
+dependency of mediafile and music-tag, mediafile of Beets, so a partial
+advance would test a combination no environment can hold), and the canary
+re-resolves each to its branch HEAD at the start of every run, so a committed
+revision would be overwritten before anything read it. The locked tip
+revisions in `flake.lock` therefore record where a human last set them, not
+what was last proven green — the signal is the run itself. Meanwhile the
+reviewed 730-day manifest runs disposable harness/delete contracts for
 each final release. These checks do not establish live-catalog upgrade or downgrade
 safety. LRCLIB and unrelated external plugin behaviour are deployment-owned
 configuration, outside the compatibility promise.

--- a/scripts/daily_beets_tip_update.sh
+++ b/scripts/daily_beets_tip_update.sh
@@ -41,15 +41,16 @@ nix flake update beets-tip mutagen-tip mediafile-tip
 export CRATEDIGGER_SUITE_OWNS_HEADROOM=1
 nix develop .#tip --command bash scripts/run_tests.sh
 
-if git diff --quiet -- flake.lock; then
-    echo "beets tip canary: flake.lock already current"
-    exit 0
-fi
-git commit --only -m "chore(beets): refresh tip canary lock" -m "Refs #992" -- flake.lock
-# Rebase the one-file lock commit onto whatever the branch is NOW. The canary
-# clones, then works for minutes; any push that lands meanwhile made the old
-# unconditional push fail non-fast-forward and reported an ordinary concurrent
-# merge as a canary failure. A lock-only commit rebases cleanly, and a genuine
-# conflict (someone else moved the same lock nodes) still fails loudly.
-git pull --rebase origin "$branch"
-git push origin "HEAD:refs/heads/$branch"
+# Deliberately no lock commit or push. The canary's product is the signal,
+# not a stored revision: it re-resolves every tip input to its branch HEAD at
+# the START of each run, so a committed value is overwritten before anything
+# reads it. The inputs are checks-only besides — flake.nix references
+# `tipPackage` only for its derivation-path string, in assertions that hold
+# for any revision and build nothing. Publishing was therefore one noise
+# commit per day recording a number nobody consumes, and the sole reason an
+# unrelated merge landing mid-run could reject the push and report an
+# ordinary concurrent merge as a red canary.
+#
+# `scripts/daily_flake_update.sh` does still publish, because there the
+# nixpkgs lock IS the deliverable.
+echo "beets tip canary: green against upstream tip (checks-only, nothing published)"

--- a/scripts/daily_beets_tip_update.sh
+++ b/scripts/daily_beets_tip_update.sh
@@ -46,4 +46,10 @@ if git diff --quiet -- flake.lock; then
     exit 0
 fi
 git commit --only -m "chore(beets): refresh tip canary lock" -m "Refs #992" -- flake.lock
+# Rebase the one-file lock commit onto whatever the branch is NOW. The canary
+# clones, then works for minutes; any push that lands meanwhile made the old
+# unconditional push fail non-fast-forward and reported an ordinary concurrent
+# merge as a canary failure. A lock-only commit rebases cleanly, and a genuine
+# conflict (someone else moved the same lock nodes) still fails loudly.
+git pull --rebase origin "$branch"
 git push origin "HEAD:refs/heads/$branch"

--- a/scripts/daily_flake_update.sh
+++ b/scripts/daily_flake_update.sh
@@ -164,6 +164,12 @@ if ! git commit --only \
     echo "daily unstable gate: lock commit failed" >&2
     exit 1
 fi
+# Same rebase as the tip canary, and this runner needs it more: its window
+# between clone and push is the whole candidate gate, tens of minutes.
+if ! git pull --rebase origin "$branch"; then
+    echo "daily unstable gate: lock rebase failed; verify the remote branch state" >&2
+    exit 1
+fi
 if ! git push origin "HEAD:refs/heads/$branch"; then
     echo "daily unstable gate: push failed; verify the remote branch state" >&2
     exit 1

--- a/tests/fakes/daily_flake_update.py
+++ b/tests/fakes/daily_flake_update.py
@@ -54,9 +54,22 @@ with state_path.with_suffix(".lock").open("a+", encoding="utf-8") as lock:
             state["lock_at_commit"] = json.loads(
                 Path.cwd().joinpath("flake.lock").read_text(encoding="utf-8")
             )
+        elif args[:2] == ["pull", "--rebase"]:
+            if state.get("fault") == "pull":
+                fail("fake rebase failed")
+            # A concurrent push to the branch is ordinary, not a canary
+            # failure: the runner rebases its lock-only commit onto it and
+            # the push that follows fast-forwards.
+            state["pull_count"] += 1
+            state["remote_moved"] = False
         elif args[:2] == ["push", "origin"]:
             if state.get("fault") == "push":
                 fail("fake push failed")
+            if state["remote_moved"]:
+                fail(
+                    "fake push rejected: remote contains work you do not have "
+                    "(the runner must rebase onto the branch before pushing)"
+                )
             state["push_count"] += 1
             state["push_ref"] = args[2]
         else:
@@ -178,6 +191,11 @@ class FakeDailyFlakeUpdateCommands:
                 "commit_args": [],
                 "push_count": 0,
                 "push_ref": None,
+                "pull_count": 0,
+                # Set by a test to model another push landing on the branch
+                # while the runner was busy. The fake's push then refuses
+                # until a rebase clears it, exactly as Git does.
+                "remote_moved": False,
                 "seed_lock": {
                     "nodes": {
                         "root": {

--- a/tests/test_daily_beets_tip_update.py
+++ b/tests/test_daily_beets_tip_update.py
@@ -18,7 +18,7 @@ class TestDailyBeetsTipUpdateScript(unittest.TestCase):
         self.addCleanup(self.tempdir.cleanup)
         self.fake = FakeDailyFlakeUpdateCommands(Path(self.tempdir.name))
 
-    def test_green_tip_canary_updates_only_its_lock_and_pushes(self) -> None:
+    def test_green_tip_canary_proves_the_suite_and_publishes_nothing(self) -> None:
         proc = self.fake.run(SCRIPT)
         state = self.fake.state
 
@@ -35,47 +35,42 @@ class TestDailyBeetsTipUpdateScript(unittest.TestCase):
         # target list it replaced could not fail on a test nobody had
         # remembered to name.
         self.assertEqual(state["stages"], ["tip-suite"])
-        self.assertEqual(state["commit_count"], 1)
-        self.assertEqual(state["push_count"], 1)
-        self.assertEqual(state["push_ref"], "HEAD:refs/heads/main")
-        self.assertEqual(state["commit_args"][-2:], ["--", "flake.lock"])
-        self.assertIn("Refs #992", state["commit_args"])
         self.assertIsNone(state["stage_env"]["tip-suite"]["TEST_DB_DSN"])
         for node in ("beets-tip", "mutagen-tip", "mediafile-tip"):
             self.assertEqual(
                 state["lock_after_update"]["nodes"][node]["locked"]["rev"],
                 f"new-{node}",
-                f"{node} must advance with the canary",
+                f"{node} must advance for the run",
             )
         self.assertEqual(
             state["lock_after_update"]["nodes"]["nixpkgs"],
             state["lock_before"]["nodes"]["nixpkgs"],
         )
-        self.assertEqual(state["lock_at_commit"], state["lock_after_update"])
+        # The canary's product is the signal, not a stored revision. It
+        # re-resolves every tip input at the START of each run, so a
+        # published value would be overwritten before anything read it —
+        # and publishing was the sole reason an unrelated merge landing
+        # mid-run could reject the push and report someone else's merge as
+        # a red canary (observed live, 2026-08-15).
+        self.assertEqual(state["commit_count"], 0)
+        self.assertEqual(state["push_count"], 0)
+        self.assertIn("nothing published", proc.stdout)
 
-    def test_concurrent_branch_push_is_rebased_onto_not_reported_as_failure(
-        self,
-    ) -> None:
-        """A merge landing on main while the canary runs its suite is
-        ordinary. Before the rebase the runner pushed unconditionally and
-        Git rejected it non-fast-forward, turning someone else's merge into
-        a red canary and an RCA alert (observed live, 2026-08-15)."""
+    def test_a_moved_branch_cannot_reach_the_canary_at_all(self) -> None:
+        """The fake refuses a push whenever the branch has moved. A canary
+        that publishes nothing never reaches that refusal, so this world is
+        indistinguishable from the ordinary one — which is the whole point
+        of not publishing."""
         self.fake.update_state(remote_moved=True)
 
         proc = self.fake.run(SCRIPT)
         state = self.fake.state
 
         self.assertEqual(proc.returncode, 0, proc.stderr)
-        self.assertEqual(state["pull_count"], 1)
-        self.assertEqual(state["push_count"], 1)
-        events = [event[:2] for event in state["events"]]
-        self.assertLess(
-            events.index(["git", "pull"]),
-            events.index(["git", "push"]),
-            "the rebase must precede the push",
-        )
+        self.assertEqual(state["stages"], ["tip-suite"])
+        self.assertEqual(state["push_count"], 0)
 
-    def test_failed_canary_never_commits_or_pushes(self) -> None:
+    def test_failed_canary_reports_the_failure(self) -> None:
         self.fake.update_state(fault="tip-suite")
 
         proc = self.fake.run(SCRIPT)
@@ -85,8 +80,12 @@ class TestDailyBeetsTipUpdateScript(unittest.TestCase):
         self.assertEqual(state["stages"], ["tip-suite"])
         self.assertEqual(state["commit_count"], 0)
         self.assertEqual(state["push_count"], 0)
+        self.assertNotIn("nothing published", proc.stdout)
 
-    def test_unchanged_tip_lock_still_proves_the_canary(self) -> None:
+    def test_unmoved_upstream_still_gets_a_full_suite_run(self) -> None:
+        """The canary never short-circuits on the lock — it does not
+        consult it. An upstream that has not moved since yesterday is still
+        proved today, because the suite around it changed."""
         self.fake.update_state(lock_changed=False)
 
         proc = self.fake.run(SCRIPT)
@@ -96,7 +95,6 @@ class TestDailyBeetsTipUpdateScript(unittest.TestCase):
         self.assertEqual(state["stages"], ["tip-suite"])
         self.assertEqual(state["commit_count"], 0)
         self.assertEqual(state["push_count"], 0)
-        self.assertIn("flake.lock already current", proc.stdout)
 
 
 if __name__ == "__main__":

--- a/tests/test_daily_beets_tip_update.py
+++ b/tests/test_daily_beets_tip_update.py
@@ -53,6 +53,28 @@ class TestDailyBeetsTipUpdateScript(unittest.TestCase):
         )
         self.assertEqual(state["lock_at_commit"], state["lock_after_update"])
 
+    def test_concurrent_branch_push_is_rebased_onto_not_reported_as_failure(
+        self,
+    ) -> None:
+        """A merge landing on main while the canary runs its suite is
+        ordinary. Before the rebase the runner pushed unconditionally and
+        Git rejected it non-fast-forward, turning someone else's merge into
+        a red canary and an RCA alert (observed live, 2026-08-15)."""
+        self.fake.update_state(remote_moved=True)
+
+        proc = self.fake.run(SCRIPT)
+        state = self.fake.state
+
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(state["pull_count"], 1)
+        self.assertEqual(state["push_count"], 1)
+        events = [event[:2] for event in state["events"]]
+        self.assertLess(
+            events.index(["git", "pull"]),
+            events.index(["git", "push"]),
+            "the rebase must precede the push",
+        )
+
     def test_failed_canary_never_commits_or_pushes(self) -> None:
         self.fake.update_state(fault="tip-suite")
 

--- a/tests/test_daily_flake_update.py
+++ b/tests/test_daily_flake_update.py
@@ -98,6 +98,23 @@ class TestDailyFlakeUpdateScript(unittest.TestCase):
         for stage, stage_env in state["stage_env"].items():
             self.assertIsNone(stage_env["TEST_DB_DSN"], stage)
 
+    def test_concurrent_branch_push_is_rebased_onto_not_reported_as_failure(
+        self,
+    ) -> None:
+        """This runner's clone-to-push window is the whole candidate gate,
+        so an unrelated merge landing meanwhile is likelier here than in the
+        tip canary — and used to lose the whole night's green lock to a
+        non-fast-forward rejection."""
+        self.fake.update_state(remote_moved=True)
+
+        proc = self.fake.run(SCRIPT)
+        state = self.fake.state
+
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(state["pull_count"], 1)
+        self.assertEqual(state["push_count"], 1)
+        self.assertIn("pushed updated flake.lock", proc.stdout)
+
     def test_failed_gate_runs_later_gates_and_pushes_nothing(self) -> None:
         self.fake.update_state(fault="world")
 


### PR DESCRIPTION
## Summary

The tip canary ran its suite green on 2026-08-15 and then failed the run on
`! [rejected] HEAD -> main (fetch first)` — an unrelated PR had merged during
the two minutes it was testing. Two separate problems, fixed separately.

**1. The tip canary published a lock nobody reads (commit 2).** It ended by
committing and pushing `flake.lock`. Nothing consumes that value:

- The canary runs `nix flake update beets-tip mutagen-tip mediafile-tip` at the
  START of every run, re-resolving each input to its branch HEAD. The published
  revision is overwritten before anything reads it.
- The tip inputs are checks-only. `flake.nix` references `tipPackage` solely
  for its `drvPath` **string**, in assertions ("must not appear in the runtime
  closure") that hold for any revision and build nothing. Since #1169 folded
  the tip checks into the suite run, nothing builds it at all.

So it was one `chore(beets): refresh tip canary lock` commit per day recording
a discarded number, and the sole reason a concurrent merge could turn someone
else's work into a red canary and an RCA alert. Removed.

**2. The Nixpkgs runner keeps the fix it actually needs (commit 1).** There,
publishing the lock IS the deliverable, and the clone-to-push window is the
entire candidate gate — tens of minutes — so a concurrent merge losing a
night's green lock is a real loss. It now rebases its lock-only commit onto the
current branch before pushing. A genuine conflict (someone else moved the same
lock nodes) still fails loudly.

Stated consequence, documented in `docs/beets-primer.md`: the locked tip
revisions now record where a human last set them rather than what was last
proven green, so reproducing a canary failure locally means running the
`nix flake update` yourself first.

## Kill matrix (per diff site, not per PR)

| Site (assertion / clause / constant) | One-line production mutant | Test that must go RED | Result |
| --- | --- | --- | --- |
| `daily_flake_update.sh` rebases before pushing | delete the `git pull --rebase origin "$branch"` block | `test_daily_flake_update::test_concurrent_branch_push_is_rebased_onto_not_reported_as_failure` | RED — the fake refuses the push while `remote_moved`, exactly as Git did live |
| `daily_beets_tip_update.sh` publishes nothing | append back the `git commit --only` + `git push` pair | `test_daily_beets_tip_update::test_green_tip_canary_proves_the_suite_and_publishes_nothing` (plus 2 siblings) | RED ×3 — every no-publish assertion dies; the run also inherits the push refusal |
| fake's `remote_moved` push refusal | make the fake's `push` branch ignore `state["remote_moved"]` | both runners' concurrent-push tests | RED — without the refusal the tests pass trivially and prove nothing |

The fake models the real failure rather than asserting an extra command was
recorded: with `remote_moved` set, its `push` refuses the way Git did, so a
runner that does not rebase (or does not publish) is the only way through.

## Reviewer

Plant at least two mutants yourself at the named subject of each changed test.
Worth checking specifically: does `test_a_moved_branch_cannot_reach_the_canary_at_all`
actually distinguish anything, or is it vacuous now that the canary never
pushes? It is deliberately a must-still-work control — the mutant that restores
publishing is what gives it teeth, and that mutant is listed above. If you think
it reads as unfalsifiable without that context, say so.

## Risk

Test-infrastructure and unattended-runner scripts only; no production code. The
tip canary's behaviour change is a strict reduction — it no longer writes to
the repository at all. The Nixpkgs runner's publish path gains one rebase step
before an unchanged push.

All tests are deterministic `unittest`; nothing here is property-tested, per
the test-infrastructure rule.

Evidence: canonical gate pass (`cratedigger-final-gate.V8H2xOjA`).

Follow-up needed after merge: bump `cratedigger-src` in nixosconfig and deploy
doc1, since the unit executes the runner from that pin rather than from the
clone it makes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
