### PR TITLE
fix: bound staged filenames to the filesystem name limit

### DIFF
--- a/lib/processing_paths.py
+++ b/lib/processing_paths.py
@@ -14,6 +14,7 @@ POST_VALIDATION_STAGING_SUBDIR = "post-validation"
 DUPLICATE_REMOVE_GUARD_SUBDIR = "duplicate-remove-guard"
 MAX_PATH_COMPONENT_BYTES = 255
 _TRUNCATED_COMPONENT_HASH_CHARS = 12
+_MAX_PRESERVED_EXTENSION_BYTES = 16
 
 
 class CanonicalFolderFile(Protocol):
@@ -61,31 +62,69 @@ def sanitize_processing_folder_name(folder_name: str) -> str:
     return re.sub(r'[<>:."/\\|?*]', "", folder_name).strip()
 
 
-def _bounded_processing_component(value: str, *, suffix: str = "") -> str:
-    """Fit one sanitized staging component within ext4's byte limit.
+def _bounded_component_bytes(value: str, *, suffix: str = "") -> str:
+    """Fit ``value`` plus ``suffix`` within one filesystem name.
 
     Truncation works on UTF-8 bytes and decodes with ``errors="ignore"`` so
     it never cuts a multibyte code point in half. A digest of the complete
-    sanitized value prevents two long names with the same retained prefix
-    from collapsing onto one directory. ``suffix`` is reserved verbatim for
-    request ownership markers such as `` [request-42]``.
+    ``value`` prevents two long names with the same retained prefix from
+    collapsing onto one entry, and guarantees a non-empty result even when
+    the retained prefix strips away entirely. ``suffix`` is reserved
+    verbatim.
     """
-    sanitized = sanitize_processing_folder_name(value)
-    complete = f"{sanitized}{suffix}"
+    complete = f"{value}{suffix}"
     if len(complete.encode("utf-8")) <= MAX_PATH_COMPONENT_BYTES:
         return complete
 
-    digest = hashlib.sha256(sanitized.encode("utf-8")).hexdigest()[
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[
         :_TRUNCATED_COMPONENT_HASH_CHARS
     ]
     reserved = f"~{digest}{suffix}"
     max_prefix_bytes = MAX_PATH_COMPONENT_BYTES - len(reserved.encode("utf-8"))
     if max_prefix_bytes < 0:
         raise ValueError("processing path suffix exceeds filesystem limit")
-    prefix = sanitized.encode("utf-8")[:max_prefix_bytes].decode(
+    prefix = value.encode("utf-8")[:max_prefix_bytes].decode(
         "utf-8", errors="ignore",
     ).rstrip()
     return f"{prefix}{reserved}"
+
+
+def _bounded_processing_component(value: str, *, suffix: str = "") -> str:
+    """Fit one sanitized staging component within ext4's byte limit.
+
+    ``suffix`` is reserved verbatim for request ownership markers such as
+    `` [request-42]``.
+    """
+    return _bounded_component_bytes(
+        sanitize_processing_folder_name(value), suffix=suffix,
+    )
+
+
+def bounded_staged_filename(name: str) -> str:
+    """Fit one untrusted remote basename within ext4's byte limit.
+
+    A peer names its own files and is free to exceed the local 255-byte cap,
+    which otherwise fails the copy into the canonical processing album with
+    ``OSError: [Errno 36] File name too long`` — request 8867's tracks were
+    372-555 bytes. Unlike a folder component the extension has to survive,
+    because beets and the quality pipeline both key on it, so it is reserved
+    rather than sanitized away.
+
+    ``name`` must already be a basename; bounding only shortens and appends,
+    so it can never introduce a separator or a traversal segment, but it
+    does not remove one either. Names already within the cap are returned
+    byte-identical, which is load-bearing: ``_canonical_manifest_complete``
+    recomputes these names and compares them against the published album's
+    own directory listing.
+    """
+    stem, dot, extension = name.rpartition(".")
+    if (
+        dot
+        and stem
+        and len(extension.encode("utf-8")) <= _MAX_PRESERVED_EXTENSION_BYTES
+    ):
+        return _bounded_component_bytes(stem, suffix=f"{dot}{extension}")
+    return _bounded_component_bytes(name)
 
 
 def normalize_source_dirs(values: Sequence[object]) -> list[str]:

--- a/lib/staged_album.py
+++ b/lib/staged_album.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from lib.import_execution import CancellationToken, ExecutionCancelled
+from lib.processing_paths import bounded_staged_filename
 
 if TYPE_CHECKING:
     from lib.grab_list import DownloadFile, GrabListEntry
@@ -23,11 +24,16 @@ def _checkpoint(cancellation_token: CancellationToken | None) -> None:
 
 
 def staged_filename(file: DownloadFile) -> str:
-    """Return the local filename used once a track is under album staging."""
+    """Return the local filename used once a track is under album staging.
+
+    The remote basename is peer-controlled and may exceed the local
+    filesystem's 255-byte name cap, so the assembled name is bounded last —
+    after the disc prefix, which is part of what has to fit.
+    """
     filename = file.filename.rsplit("/", 1)[-1].rsplit("\\", 1)[-1]
     if file.disk_no is not None and file.disk_count is not None and file.disk_count > 1:
-        return f"Disk {file.disk_no} - {filename}"
-    return filename
+        filename = f"Disk {file.disk_no} - {filename}"
+    return bounded_staged_filename(filename)
 
 
 @dataclass

--- a/tests/test_processing_paths_generated.py
+++ b/tests/test_processing_paths_generated.py
@@ -14,7 +14,9 @@ from hypothesis import example, given
 from hypothesis import strategies as st
 
 import tests._hypothesis_profiles  # noqa: F401
-from lib.processing_paths import stage_to_ai_path
+from lib.processing_paths import MAX_PATH_COMPONENT_BYTES, stage_to_ai_path
+from lib.staged_album import staged_filename
+from tests.helpers import make_download_file
 
 _UNICODE_METADATA = st.text(
     alphabet=st.characters(blacklist_categories=("Cs",), max_codepoint=0x2FFFF),
@@ -101,6 +103,91 @@ class TestStagePathProperties(unittest.TestCase):
         assert_distinct_stage_paths(first, second)
 
 
+def staged_name_violations(name: str, basename: str) -> list[str]:
+    """Collect every way a staged filename breaks its contract.
+
+    Accumulating rather than short-circuiting so one violation can never
+    mask another, and so each clause is independently reachable by a
+    known-bad self-test.
+    """
+    violations: list[str] = []
+    size = len(name.encode("utf-8"))
+    if size > MAX_PATH_COMPONENT_BYTES:
+        violations.append(
+            f"staged name is {size} bytes, over the "
+            f"{MAX_PATH_COMPONENT_BYTES}-byte cap"
+        )
+    if name in {"", ".", ".."}:
+        violations.append(f"degenerate staged name {name!r} that _safe_relpath rejects")
+    if "/" in name or "\\" in name:
+        violations.append(f"staged name retained a path separator: {name!r}")
+    if len(basename.encode("utf-8")) <= MAX_PATH_COMPONENT_BYTES and name != basename:
+        violations.append(
+            f"rewrote {basename!r} to {name!r} although it already fit"
+        )
+    stem, dot, extension = basename.rpartition(".")
+    if (
+        dot
+        and stem
+        and len(extension.encode("utf-8")) <= 16
+        and not name.endswith(f"{dot}{extension}")
+    ):
+        violations.append(f"dropped extension {extension!r} from {basename!r}")
+    return violations
+
+
+def assert_staged_name_safe(name: str, basename: str) -> None:
+    """Check the staged-filename byte, degeneracy, separator and extension contract."""
+    violations = staged_name_violations(name, basename)
+    if violations:
+        raise AssertionError("; ".join(violations))
+
+
+_FILENAME_TEXT = st.text(
+    alphabet=st.characters(blacklist_categories=("Cs",), max_codepoint=0x2FFFF)
+    .filter(lambda c: c not in "/\\"),
+    max_size=400,
+)
+
+
+class TestStagedFilenameProperties(unittest.TestCase):
+    """Patrol ``staged_filename`` over peer-controlled names (request 8867)."""
+
+    @given(
+        directory=_FILENAME_TEXT,
+        basename=_FILENAME_TEXT.filter(lambda s: s not in {"", ".", ".."}),
+        disc=st.one_of(st.none(), st.integers(min_value=1, max_value=9)),
+    )
+    @example(directory="Album", basename="中" * 128 + ".flac", disc=None)
+    @example(directory="Album", basename="ʅ" + "͡" * 200 + ".flac", disc=None)
+    @example(directory="Album", basename="中" * 128 + ".flac", disc=2)
+    @example(directory="Album", basename="01 - Track.flac", disc=None)
+    def test_staged_names_are_bounded_and_deterministic(
+        self, directory: str, basename: str, disc: int | None,
+    ) -> None:
+        file = make_download_file(filename=f"user\\{directory}\\{basename}")
+        expected_source = basename
+        if disc is not None:
+            file.disk_no = disc
+            file.disk_count = 2
+            expected_source = f"Disk {disc} - {basename}"
+
+        first = staged_filename(file)
+
+        assert_staged_name_safe(first, expected_source)
+        self.assertEqual(first, staged_filename(file))
+
+    @given(basename=_FILENAME_TEXT.filter(lambda s: s not in {"", ".", ".."}))
+    @example(basename="中" * 128 + ".flac")
+    def test_distinct_remote_names_stay_distinct(self, basename: str) -> None:
+        first = staged_filename(
+            make_download_file(filename=f"user\\Album\\A{basename}"))
+        second = staged_filename(
+            make_download_file(filename=f"user\\Album\\B{basename}"))
+
+        assert_distinct_stage_paths(first, second)
+
+
 class TestInvariantCheckersTripOnViolations(unittest.TestCase):
     def test_stage_path_checker_rejects_overlong_component(self):
         bad = f"/staging/auto-import/Artist/{'x' * 256} [request-42]"
@@ -110,6 +197,26 @@ class TestInvariantCheckersTripOnViolations(unittest.TestCase):
     def test_distinctness_checker_rejects_collapsed_paths(self):
         with self.assertRaises(AssertionError):
             assert_distinct_stage_paths("/same", "/same")
+
+    def test_staged_checker_rejects_overlong_name(self):
+        with self.assertRaisesRegex(AssertionError, "over the 255-byte cap"):
+            assert_staged_name_safe("x" * 256, "x" * 256)
+
+    def test_staged_checker_rejects_degenerate_name(self):
+        with self.assertRaisesRegex(AssertionError, "degenerate staged name"):
+            assert_staged_name_safe("..", "..")
+
+    def test_staged_checker_rejects_retained_separator(self):
+        with self.assertRaisesRegex(AssertionError, "retained a path separator"):
+            assert_staged_name_safe("a/b", "a/b")
+
+    def test_staged_checker_rejects_rewriting_a_name_that_already_fit(self):
+        with self.assertRaisesRegex(AssertionError, "although it already fit"):
+            assert_staged_name_safe("changed.flac", "original.flac")
+
+    def test_staged_checker_rejects_dropped_extension(self):
+        with self.assertRaisesRegex(AssertionError, "dropped extension"):
+            assert_staged_name_safe("x" * 200, f"{'x' * 300}.flac")
 
 
 if __name__ == "__main__":

--- a/tests/test_staged_album.py
+++ b/tests/test_staged_album.py
@@ -54,6 +54,96 @@ class TestStagedFilename(unittest.TestCase):
                 self.assertEqual(staged_filename(file), expected)
 
 
+class TestStagedFilenameByteLimit(unittest.TestCase):
+    """``staged_filename`` must fit the filesystem's 255-byte name cap.
+
+    A remote peer names its own files. Request 8867's eight tracks were
+    372-555 UTF-8 bytes, so copying them into the canonical processing album
+    raised ``OSError: [Errno 36] File name too long`` and the album could
+    never import even once the transfer itself succeeded.
+    """
+
+    # 128 CJK characters: 128 characters but 384 UTF-8 bytes, so it clears a
+    # character-based check and still breaks a byte-based one.
+    LONG_STEM = "中" * 128
+    # The shape that actually surfaced this: combining marks cost ~2 bytes
+    # each and render as nothing, so the name looks short and is not.
+    COMBINING_STEM = "ʅ" + ("͡" * 40) + "(" + ("̸̢̛̼̞̭͋ͅ" * 20) + ")"
+
+    def _name(self, remote: str, **attrs: int) -> str:
+        from lib.staged_album import staged_filename
+
+        file = make_download_file(filename=remote)
+        for key, value in attrs.items():
+            setattr(file, key, value)
+        return staged_filename(file)
+
+    def test_bounds_overlong_remote_basename_to_the_byte_cap(self):
+        from lib.processing_paths import MAX_PATH_COMPONENT_BYTES
+
+        for desc, stem in (("cjk", self.LONG_STEM),
+                           ("combining marks", self.COMBINING_STEM)):
+            with self.subTest(desc=desc):
+                name = self._name(f"user\\Album\\{stem}.flac")
+                self.assertGreater(len(f"{stem}.flac".encode()), 255)
+                self.assertLessEqual(
+                    len(name.encode()), MAX_PATH_COMPONENT_BYTES)
+
+    def test_preserves_the_extension(self):
+        name = self._name(f"user\\Album\\{self.LONG_STEM}.flac")
+
+        self.assertTrue(name.endswith(".flac"), name[-20:])
+
+    def test_leaves_names_within_the_cap_byte_identical(self):
+        # Load-bearing: ``_canonical_manifest_complete`` recomputes these
+        # names and compares them against ``os.listdir`` of an already
+        # published album, so any churn here would invalidate every
+        # canonical album on disk.
+        self.assertEqual(
+            self._name("user\\Album\\01 - Track.flac"), "01 - Track.flac")
+
+    def test_is_deterministic(self):
+        remote = f"user\\Album\\{self.LONG_STEM}.flac"
+
+        self.assertEqual(self._name(remote), self._name(remote))
+
+    def test_distinct_overlong_names_do_not_collapse(self):
+        first = self._name(f"user\\Album\\{self.LONG_STEM}one.flac")
+        second = self._name(f"user\\Album\\{self.LONG_STEM}two.flac")
+
+        self.assertNotEqual(first, second)
+
+    def test_never_cuts_a_multibyte_character(self):
+        name = self._name(f"user\\Album\\{self.LONG_STEM}.flac")
+
+        self.assertEqual(name, name.encode().decode("utf-8"))
+        self.assertNotIn("�", name)
+
+    def test_result_carries_no_path_separator(self):
+        name = self._name(f"user\\Album\\{self.LONG_STEM}.flac")
+
+        self.assertNotIn("/", name)
+        self.assertNotIn("\\", name)
+
+    def test_bounds_the_disc_prefixed_name_too(self):
+        from lib.processing_paths import MAX_PATH_COMPONENT_BYTES
+
+        name = self._name(
+            f"user\\Album\\{self.LONG_STEM}.flac", disk_no=1, disk_count=2)
+
+        self.assertLessEqual(len(name.encode()), MAX_PATH_COMPONENT_BYTES)
+        self.assertTrue(name.startswith("Disk 1 - "), name[:20])
+
+    def test_bounding_never_yields_a_traversal_or_empty_name(self):
+        # ``_safe_relpath`` rejects these outright, so bounding must never
+        # manufacture one out of an ordinary overlong name.
+        for desc, stem in (("dots", "." * 300), ("spaces", " " * 300),
+                           ("cjk", self.LONG_STEM)):
+            with self.subTest(desc=desc):
+                name = self._name(f"user\\Album\\{stem}.flac")
+                self.assertNotIn(name, {"", ".", ".."})
+
+
 class TestStagedAlbum(unittest.TestCase):
 
     def test_move_to_moves_contents_without_lifecycle_persistence(self):


### PR DESCRIPTION
## What

A remote peer names its own files and may exceed the local 255-byte name cap. `staged_filename` derived the destination basename straight from `DownloadFile.filename`, so copying into the canonical processing album raised `OSError: [Errno 36] File name too long` and the album could never import. Request 8867's eight tracks were 372-555 bytes.

The limit is **bytes** on Unix, so names heavy in combining marks or CJK overflow while still looking short — 8867's tracks render as a few dozen glyphs each.

Found live: the transfer itself now succeeds (after the paired slskd overlay in nixosconfig, upstream slskd/slskd#1818), and the pipeline failed one step later at materialization with `MATERIALIZE FAILED request=8867 reason=private_materialize_failed`.

## Relationship to the slskd fix

Orthogonal, and both are needed. slskd's governs where *it* writes locally; this governs what *we* name the copy. Deliberately keyed on the remote name rather than reading slskd's truncated basename off `local_path` — that would tie our on-disk naming to slskd's private algorithm and break when upstream changes it, and would mean trusting a remote-influenced string for naming rather than only for location.

## Structure

`lib/processing_paths.py` already solved this for folder components, so the bounding core is extracted to `_bounded_component_bytes` and shared rather than copied. Filenames cannot reuse `_bounded_processing_component`: `sanitize_processing_folder_name` strips `.` and would destroy the extension, which beets and the quality pipeline both key on.

## Safety properties, each pinned

- **Names within the cap return byte-identical.** Load-bearing: `_canonical_manifest_complete` recomputes these names and compares them against a published album's own listing, so churn would invalidate every canonical album on disk. It also means no album that exists today can be affected — an overlong one could never have materialized.
- **Bounding runs after basename extraction** and only shortens or appends, so it cannot introduce a separator or traversal segment; the appended digest means it can never yield `.`, `..` or empty, all three of which `_safe_relpath` rejects.
- **Deterministic**, and the digest keeps distinct overlong names distinct so truncation cannot itself trip `duplicate_final_basename`.
- **Cuts on a character boundary**, never mid-codepoint.
- **Disc prefix applied before bounding**, since it is part of what has to fit.

Attacker-influenced digest: 12 hex chars. A crafted collision fails closed (`duplicate_final_basename`, or `O_EXCL` on the second create) — denial-of-materialization for one album, which a peer can already achieve by serving garbage, not an overwrite.

## Verification

Driven against request 8867's eight real remote filenames: all land at 253-255 bytes, all distinct, all keep `.flac`.

## Kill matrix

| Site (assertion / clause / constant) | One-line mutant | Test that goes RED | Result |
| --- | --- | --- | --- |
| `staged_filename` bounding call | `return filename` (unwire) | byte-cap pins + `test_staged_names_are_bounded_and_deterministic` | 4 RED |
| `_bounded_component_bytes` digest | `reserved = f"{suffix}"` | `test_distinct_overlong_names_do_not_collapse` + `test_distinct_remote_names_stay_distinct` | 2 RED |
| `bounded_staged_filename` extension branch | drop the suffix reservation | `test_preserves_the_extension` + property extension clause | 2 RED |

Pin + generated property ship together, with a message-asserting known-bad self-test for each of the checker's five clauses.

## Test evidence

Canonical suite: `pass`, receipt `/run/user/1000/cratedigger-final-gate.Wyv2cP1p`.

Note: the first gate run failed on `tests/test_discogs_artist_concurrency.py` (`Discogs mirror cap exceeded: 3`) — a pre-existing test-infrastructure measurement race unrelated to this diff. The test's `active` counter decrements only after `wfile.write(body)` in the handler's `finally`, so under suite load a client can take the semaphore slot another just released while that handler has not yet been scheduled to decrement. It counts server-handler lifetime, which strictly outlives the client's semaphore hold. Passes clean in isolation; raised separately rather than mixed into this change.
