### PR TITLE
fix: reap an abandoned attempt's files without waiting out the age gate

### DIFF
--- a/lib/pipeline_db/transfer_ledger.py
+++ b/lib/pipeline_db/transfer_ledger.py
@@ -173,6 +173,34 @@ class _TransferLedgerMixin(_PipelineDBBase):
         )
         return {r["local_path"] for r in cur.fetchall()}
 
+    def get_abandoned_owned_local_paths(self) -> set[str]:
+        """Owned ``local_path`` values whose attempt is provably abandoned.
+
+        A request sitting at ``wanted`` with no ``active_download_state``
+        holds no reference to any file: its attempt ended, and the next
+        cycle re-derives from scratch. The files that attempt completed are
+        still ledger-owned, so the reaper may take them — but under
+        ``ORPHAN_MIN_AGE_DAYS`` it would wait seven days, while the retry
+        arrives in minutes and re-downloads to a byte-identical path. slskd
+        then resolves that collision by appending to the name, which for a
+        cap-length name overflows and strands the transfer.
+
+        Deliberately keyed on ``wanted`` alone. ``downloading`` is already
+        covered by the active-protection half of the model, and
+        ``processing`` must never enter a reaper status set
+        (``.claude/rules/pipeline-db.md``) — materialization holds open
+        descriptors on exactly these files.
+        """
+        cur = self._execute(
+            "SELECT l.local_path "
+            "FROM slskd_transfer_ledger AS l "
+            "JOIN album_requests AS r ON r.id = l.request_id "
+            "WHERE l.local_path IS NOT NULL "
+            "AND r.status = 'wanted' "
+            "AND r.active_download_state IS NULL",
+        )
+        return {r["local_path"] for r in cur.fetchall()}
+
     def prune_transfer_ledger(self, older_than: datetime) -> int:
         """Hard-delete rows strictly older than ``older_than`` (T3).
 

--- a/lib/slskd_transfers.py
+++ b/lib/slskd_transfers.py
@@ -1082,6 +1082,21 @@ def reap_disk_orphans(ctx: CratediggerContext) -> DiskReapSummary:
             "— fail-closed")
         return DiskReapSummary(aborted=True)
     _owned_dirs, owned_files = _owned_paths_from_ledger(root, db)
+    try:
+        abandoned_files: set[str] = {
+            normalize_processing_path(str(p))
+            for p in db.get_abandoned_owned_local_paths()
+            if path_is_within_root(normalize_processing_path(str(p)), root)
+        }
+    except Exception:
+        # Age-exemption is an optimisation over the ordinary threshold; if
+        # it cannot be established, fall back to waiting rather than
+        # widening what may be deleted.
+        logger.warning(
+            "DISK-REAP: could not read abandoned-attempt paths; every owned "
+            "file keeps the ordinary age threshold this cycle",
+            exc_info=True)
+        abandoned_files = set()
 
     threshold = time.time() - ORPHAN_MIN_AGE_DAYS * 86400
     removed = 0
@@ -1122,7 +1137,7 @@ def reap_disk_orphans(ctx: CratediggerContext) -> DiskReapSummary:
                 mtime = os.path.getmtime(full_path)
             except OSError:
                 continue
-            if mtime >= threshold:
+            if mtime >= threshold and norm_path not in abandoned_files:
                 skipped_young += 1
                 continue
             try:
@@ -1140,8 +1155,12 @@ def reap_disk_orphans(ctx: CratediggerContext) -> DiskReapSummary:
             removed_bytes += size
             touched_dirs.add(dirpath)
             logger.info(
-                "DISK-REAP removed %s (age>=%dd, %d bytes)",
-                full_path, ORPHAN_MIN_AGE_DAYS, size)
+                "DISK-REAP removed %s (%s, %d bytes)",
+                full_path,
+                "abandoned attempt"
+                if norm_path in abandoned_files
+                else f"age>={ORPHAN_MIN_AGE_DAYS}d",
+                size)
 
     pruned = 0
     for touched_dir in touched_dirs:

--- a/tests/fakes/pipeline_db.py
+++ b/tests/fakes/pipeline_db.py
@@ -8545,6 +8545,23 @@ class FakePipelineDB:
             if r.local_path is not None
         }
 
+    def get_abandoned_owned_local_paths(self) -> set[str]:
+        """Mirror the real join: owned paths whose request sits at ``wanted``
+        with no ``active_download_state``, i.e. holds no reference to them."""
+        abandoned: set[str] = set()
+        for row in self._transfer_ledger.values():
+            if row.local_path is None:
+                continue
+            request = self._requests.get(row.request_id)
+            if request is None:
+                continue
+            if (
+                request.get("status") == "wanted"
+                and request.get("active_download_state") is None
+            ):
+                abandoned.add(row.local_path)
+        return abandoned
+
     def prune_transfer_ledger(self, older_than: datetime) -> int:
         """Mirror strict age pruning: pending intents ignore request status;
         accepted rows retain active wanted/downloading protection."""

--- a/tests/test_disk_reaper_generated.py
+++ b/tests/test_disk_reaper_generated.py
@@ -643,6 +643,69 @@ class TestDiskReaperDeterministicPins(unittest.TestCase):
             self.assertEqual(summary.removed, 0)
             self.assertEqual(summary.skipped_young, 1)
 
+    def _seed_abandoned(self, fake_db, root, *, status="wanted",
+                        active_download_state=None):
+        """Plant one young, owned, unprotected file for ``request 3``."""
+        fake_db.seed_request(make_request_row(
+            id=3, status=status,
+            active_download_state=active_download_state))
+        path = os.path.join(root, "Weird Folder", "stray.flac")
+        pair = ("op", "op\\stray.flac")
+        _ledger_seed(
+            fake_db, request_id=3, file_pairs=[pair],
+            local_paths={pair: path}, with_fingerprint=False)
+        _write_aged_file(path, age_days=_YOUNG_DAYS)
+        return path
+
+    def test_abandoned_attempt_is_reaped_without_waiting_for_the_age_gate(self):
+        """A request back at ``wanted`` holding no download state references
+        nothing, so its completed files are dead weight. Waiting the full
+        age gate lets the retry collide with them on disk."""
+        with tempfile.TemporaryDirectory() as root:
+            fake_db = FakePipelineDB()
+            path = self._seed_abandoned(fake_db, root)
+
+            summary = reap_disk_orphans(_make_ctx(root, fake_db=fake_db))
+
+            self.assertFalse(os.path.exists(path))
+            self.assertEqual(summary.removed, 1)
+            self.assertEqual(summary.skipped_young, 0)
+
+    def test_wanted_request_still_holding_download_state_keeps_the_age_gate(self):
+        """``active_download_state`` is a live reference — not abandoned."""
+        with tempfile.TemporaryDirectory() as root:
+            fake_db = FakePipelineDB()
+            path = self._seed_abandoned(
+                fake_db, root, active_download_state={"files": []})
+
+            summary = reap_disk_orphans(_make_ctx(root, fake_db=fake_db))
+
+            self.assertTrue(os.path.exists(path))
+            self.assertEqual(summary.removed, 0)
+            self.assertEqual(summary.skipped_young, 1)
+
+    def test_non_wanted_statuses_keep_the_age_gate(self):
+        """Only ``wanted`` is age-exempt. ``processing`` must never enter a
+        reaper status set — materialization holds open descriptors on
+        exactly these files.
+
+        ``downloading`` is deliberately absent: it is covered by the active
+        -protection half of the model, and seeding one here without a
+        decodable ``active_download_state`` trips the fail-closed abort, so
+        the file would survive for a reason that has nothing to do with the
+        age gate this test is about.
+        """
+        for status in ("imported", "processing", "unsearchable"):
+            with self.subTest(status=status), \
+                    tempfile.TemporaryDirectory() as root:
+                fake_db = FakePipelineDB()
+                path = self._seed_abandoned(fake_db, root, status=status)
+
+                summary = reap_disk_orphans(_make_ctx(root, fake_db=fake_db))
+
+                self.assertTrue(os.path.exists(path), status)
+                self.assertEqual(summary.removed, 0, status)
+
     def test_same_request_retry_old_stamp_reaped_new_stamp_protected(self):
         """A retry protects only its current exact event stamp."""
         with tempfile.TemporaryDirectory() as root:
@@ -1559,6 +1622,95 @@ class TestDiskReaperCheckerTripsOnViolations(unittest.TestCase):
 # ============================================================================
 # Reaper authority wiring: exact event stamps, never canonical folders
 # ============================================================================
+
+def abandonment_violations(
+    *, status: str, has_state: bool, aged: bool, removed: bool,
+) -> list[str]:
+    """Collect every way age-exemption departed from its contract.
+
+    An owned, unprotected file is reaped when it is aged (the ordinary
+    threshold) OR when its attempt is provably abandoned — ``wanted`` with
+    no ``active_download_state``. Accumulating rather than short-circuiting
+    so each clause stays independently reachable.
+    """
+    violations: list[str] = []
+    abandoned = status == "wanted" and not has_state
+    expected = aged or abandoned
+    if expected and not removed:
+        violations.append(
+            f"kept a file it should have reaped (status={status!r} "
+            f"has_state={has_state} aged={aged})"
+        )
+    if removed and not expected:
+        violations.append(
+            f"reaped a file that was neither aged nor abandoned "
+            f"(status={status!r} has_state={has_state})"
+        )
+    return violations
+
+
+def assert_abandonment_contract(
+    *, status: str, has_state: bool, aged: bool, removed: bool,
+) -> None:
+    """Check the age-exemption contract for one reaper run."""
+    violations = abandonment_violations(
+        status=status, has_state=has_state, aged=aged, removed=removed)
+    if violations:
+        raise AssertionError("; ".join(violations))
+
+
+class TestGeneratedAbandonmentAgeExemption(unittest.TestCase):
+    """Patrol which owned, unprotected files skip the age threshold.
+
+    ``downloading`` is excluded deliberately: it is covered by the
+    active-protection half of the model, and a row seeded here without a
+    decodable ``active_download_state`` trips the fail-closed abort, which
+    would settle the outcome for a reason unrelated to age-exemption.
+    """
+
+    @given(
+        status=st.sampled_from(
+            ["wanted", "imported", "processing", "unsearchable"]),
+        has_state=st.booleans(),
+        aged=st.booleans(),
+    )
+    @example(status="wanted", has_state=False, aged=False)
+    @example(status="processing", has_state=False, aged=False)
+    def test_only_abandoned_attempts_skip_the_age_threshold(
+        self, status: str, has_state: bool, aged: bool,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as root:
+            fake_db = FakePipelineDB()
+            fake_db.seed_request(make_request_row(
+                id=3, status=status,
+                active_download_state={"files": []} if has_state else None))
+            path = os.path.join(root, "Weird Folder", "stray.flac")
+            pair = ("op", "op\\stray.flac")
+            _ledger_seed(
+                fake_db, request_id=3, file_pairs=[pair],
+                local_paths={pair: path}, with_fingerprint=False)
+            _write_aged_file(
+                path, age_days=_OLD_DAYS if aged else _YOUNG_DAYS)
+
+            reap_disk_orphans(_make_ctx(root, fake_db=fake_db))
+
+            assert_abandonment_contract(
+                status=status, has_state=has_state, aged=aged,
+                removed=not os.path.exists(path))
+
+
+class TestAbandonmentCheckerTripsOnViolations(unittest.TestCase):
+    def test_trips_when_an_expected_reap_did_not_happen(self):
+        with self.assertRaisesRegex(AssertionError, "should have reaped"):
+            assert_abandonment_contract(
+                status="wanted", has_state=False, aged=False, removed=False)
+
+    def test_trips_when_a_protected_file_was_reaped(self):
+        with self.assertRaisesRegex(
+                AssertionError, "neither aged nor abandoned"):
+            assert_abandonment_contract(
+                status="imported", has_state=False, aged=False, removed=True)
+
 
 def assert_exact_stamp_protected(
     stamp_path: str,

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -8449,6 +8449,47 @@ class TestFakePipelineDBTransferLedger(unittest.TestCase):
             "p0", "a.flac", "/downloads/a.flac")
         self.assertEqual(db.get_owned_local_paths(), {"/downloads/a.flac"})
 
+    def test_get_abandoned_owned_local_paths_selects_only_wanted_without_state(self):
+        from tests.helpers import make_request_row
+
+        cases = [
+            ("wanted, no state -> abandoned", "wanted", None, True),
+            ("wanted, holding state", "wanted", {"files": []}, False),
+            ("imported", "imported", None, False),
+            ("processing", "processing", None, False),
+            ("downloading", "downloading", None, False),
+        ]
+        for desc, status, state, expected in cases:
+            with self.subTest(desc=desc):
+                db = FakePipelineDB()
+                db.seed_request(make_request_row(
+                    id=1, status=status, active_download_state=state))
+                db.record_transfer_enqueue([
+                    TransferLedgerRow(
+                        request_id=1, username="p0", filename="a.flac"),
+                ])
+                db.confirm_transfer_enqueue("p0", "a.flac")
+                db.stamp_transfer_completion(
+                    "p0", "a.flac", "/downloads/a.flac")
+
+                paths = db.get_abandoned_owned_local_paths()
+
+                self.assertEqual(
+                    paths, {"/downloads/a.flac"} if expected else set())
+
+    def test_get_abandoned_owned_local_paths_ignores_unstamped_rows(self):
+        from tests.helpers import make_request_row
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=1, status="wanted", active_download_state=None))
+        db.record_transfer_enqueue([
+            TransferLedgerRow(request_id=1, username="p0", filename="a.flac"),
+        ])
+        db.confirm_transfer_enqueue("p0", "a.flac")
+
+        self.assertEqual(db.get_abandoned_owned_local_paths(), set())
+
     def test_get_owned_transfer_keys_empty_before_any_record(self):
         self.assertEqual(FakePipelineDB().get_owned_transfer_keys(), set())
 

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -16387,6 +16387,45 @@ class TestTransferLedgerRoundTrip(unittest.TestCase):
             self.db.get_owned_transfer_keys(), fake.get_owned_transfer_keys())
         self.assertEqual(
             self.db.get_owned_local_paths(), fake.get_owned_local_paths())
+        # The seeded request is ``wanted`` with no active_download_state,
+        # i.e. the abandoned shape — both sides must agree it is reapable.
+        self.assertEqual(
+            self.db.get_abandoned_owned_local_paths(),
+            fake.get_abandoned_owned_local_paths())
+        self.assertEqual(
+            self.db.get_abandoned_owned_local_paths(), {"/downloads/a.flac"})
+
+    def test_abandoned_owned_local_paths_selects_only_wanted_without_state(self):
+        """Real-PG contract for the reaper's age-exemption predicate: a
+        request parked at ``wanted`` holding no ``active_download_state``
+        references nothing, so its stamped files are reap-eligible now."""
+        cases = [
+            ("wanted, no state", "wanted", False, True),
+            ("wanted, holding state", "wanted", True, False),
+            ("imported", "imported", False, False),
+            ("downloading", "downloading", False, False),
+        ]
+        for index, (desc, status, with_state, expected) in enumerate(cases):
+            with self.subTest(desc=desc):
+                rid = self._seed_request(status)
+                path = f"/downloads/{index}.flac"
+                self.db.record_transfer_enqueue([
+                    TransferLedgerRow(
+                        request_id=rid, username=f"u{index}",
+                        filename=f"{index}.flac"),
+                ])
+                self.db.confirm_transfer_enqueue(f"u{index}", f"{index}.flac")
+                self.db.stamp_transfer_completion(
+                    f"u{index}", f"{index}.flac", path)
+                if with_state:
+                    self.db._execute(
+                        "UPDATE album_requests SET active_download_state = "
+                        "%s::jsonb WHERE id = %s",
+                        ('{"files": []}', rid))
+
+                paths = self.db.get_abandoned_owned_local_paths()
+
+                self.assertEqual(path in paths, expected, desc)
 
     def test_prune_removes_old_inactive_accepted_rows(self):
         active = self._seed_request("downloading")


### PR DESCRIPTION
## What

A request returned to `wanted` with no `active_download_state` references nothing — its attempt ended and the next cycle re-derives from scratch. The files that attempt completed stay ledger-owned, so the disk reaper may take them, but under `ORPHAN_MIN_AGE_DAYS` it waits **seven days** while the retry arrives in minutes.

## Why it's not merely untidy

Truncated download names are deterministic, so the retry re-downloads to a **byte-identical path** and collides with the leftovers. slskd resolves a destination collision in `FileService.MoveFile` by appending `_{DateTime.UtcNow.Ticks}`, which for a cap-length name overflows the filesystem limit. The move throws, the transfer never finalizes, and the completed files are stranded in the incomplete directory with no completion event.

Downstream that surfaced as `event_path_never_stamped` on request 8867 — three hours after the preceding fix appeared to work — and needed manual deletion of 776 MB across two orphaned copies to clear. This is the third distinct failure mode in that chain and the only one that wasn't a length bug.

## Approach

`_owned_paths_from_ledger` already documents this exact shape: its owned set covers "a request reset-to-wanted after a retry". Only the age gate stood between that and cleanup, so this **narrows the gate** rather than adding bespoke teardown to the failure handler (CLAUDE.md invariant 7 — don't duplicate convergence).

The predicate is deliberately narrow: `wanted` **and** `active_download_state IS NULL`.

- `downloading` is already covered by the active-protection half of the two-part ownership model.
- `processing` must never enter a reaper status set (`.claude/rules/pipeline-db.md`), and materialization holds open descriptors on exactly these files.
- A `wanted` row still holding `active_download_state` is a live reference, not an abandoned attempt.

Everything else keeps the seven-day threshold. The unowned rule is untouched — a file with no positive ownership signal is still never deleted whatever its age (#571 good-citizen doctrine). Reading the abandoned set is best-effort: a failure falls back to the ordinary threshold rather than widening what may be deleted.

## Kill matrix

| Site (assertion / clause / constant) | One-line mutant | Test that goes RED | Result |
| --- | --- | --- | --- |
| age-gate exemption in `reap_disk_orphans` | drop `and norm_path not in abandoned_files` | `test_abandoned_attempt_is_reaped_without_waiting_for_the_age_gate` + `test_only_abandoned_attempts_skip_the_age_threshold` | 2 RED |
| fake's `active_download_state is None` clause | replace with `True` | same pair | 2 RED |

## Tests

Pin + generated property ship together, with a message-asserting known-bad self-test for each checker clause.

One deliberate exclusion worth flagging: `downloading` is left out of the status sweep in **both** the pin and the property. Seeded without a decodable `active_download_state` it trips the fail-closed abort, so the file would survive for a reason unrelated to the age gate — a green assertion proving nothing. I hit exactly that while writing this and removed it rather than keep a hollow pass.

New read has a real-PG contract plus fake↔production parity (the `test_read_projection_audit` requirement).

## Test evidence

Canonical suite: `pass`, receipt `/run/user/1000/cratedigger-final-gate.vrm1Hwjx`.
