### PR TITLE
docs: trim always-loaded guidance duplicated by its own rules files

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -658,21 +658,10 @@ composition stalled every automation import in production.
   diff — that is precisely why diff-scoped adversarial review converged
   with no findings on #858.
 
-## Frontend (JavaScript)
-- ES6 modules in `web/js/` — no inline `<script>` in HTML
-- `// @ts-check` + JSDoc types on all exported functions
-- Pure functions in `web/js/util.js` — testable via Node without DOM
-- Shared state in `web/js/state.js` — no bare globals across modules
-- Cross-module onclick handlers go through `window.*` bindings in `main.js`
-- `node --check web/js/*.js` must pass (runs in pre-commit + CI)
-- JS unit tests in `tests/test_js_util.mjs` — run with `node`, no npm
-- Static JS served at `/js/*.js` by server.py
+## Frontend and server-route conventions
 
-## Backend (Server Routes)
-- Route handlers in `web/routes/*.py` — server.py is routing/cache/main only
-- Route functions take `(handler, params)` or `(handler, body)`, not `self`
-- All beets queries go through `lib/beets_db.py` `BeetsDB` class — no raw `sqlite3.connect()` in handlers
-- Route modules access server globals via `_server()` deferred import
+JavaScript and `web/routes/*.py` conventions live in `.claude/rules/web.md`
+(`paths: web/**`), which loads whenever you touch the web surface.
 
 ## Finish What You Start
 - Don't build infrastructure without wiring it up. Every new function, dataclass, or mode must be called from production code. If it's only reachable via manual config nobody sets, it's dead code.

--- a/.claude/rules/web.md
+++ b/.claude/rules/web.md
@@ -11,7 +11,11 @@ paths:
 - Beets queries via `lib/beets_db.py` `BeetsDB` class — never raw `sqlite3.connect()` in handlers
 - MusicBrainz queries through local mirror at `http://192.168.1.35:5200` via `web/mb.py`
 - Redis cache: `meta:` namespace only — pure MB/Discogs mirror metadata, 24h TTL via `memoize_meta` in `web/mb.py`/`web/discogs.py`. The routing-level response cache was REMOVED by #101 (it baked pipeline overlay state into cached responses); do not reintroduce response caching or reference `cache_api.cached(...)` — it no longer exists
-- Static JS served at `/js/*.js` — `node --check` validates syntax in CI
+- Static JS served at `/js/*.js` by server.py — `node --check web/js/*.js` must pass (pre-commit + CI)
+- `// @ts-check` + JSDoc types on all exported functions; no inline `<script>` in HTML
+- Pure functions in `web/js/util.js` — testable via Node without DOM; JS unit tests in `tests/test_js_util.mjs`, run with `node`, no npm
+- Shared state in `web/js/state.js` — no bare globals across modules; cross-module onclick handlers go through `window.*` bindings in `main.js`
+- Route functions take `(handler, params)` or `(handler, body)`, not `self`; route modules access server globals via `_server()` deferred import
 - Fetch-on-input UI must stamp requests with a module-scoped in-flight token and discard stale responses before rendering
 - The web UI reads download_log JSONB columns (import_result, validation_result) — use the typed field names from the dataclasses, not arbitrary strings
 - **Visible UI changes are verified with the dev-server screenshot loop BEFORE pushing** — live-db dev server + CDP chromium + playwright agent, and the main agent Reads the PNGs itself. Tests+review alone shipped three visually-obvious defects on #575. Full recipe + gotchas: `docs/solutions/ui-dev-server-screenshot-loop.md`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,20 +118,9 @@ SQL
 
 ## Repository layout
 
-```
-cratedigger.py    — Main loop + thin wrappers; delegates to lib/
-album_source.py   — AlbumRecord, DatabaseSource abstraction
-web/              — Web UI (server.py, routes/, mb.py, discogs.py, js/)
-lib/              — Pipeline modules (quality/ package = pure decisions, split by concern; pipeline_db.py = PG CRUD + advisory locks)
-harness/          — beets_harness.py (JSON protocol), import_one.py
-migrations/       — Versioned SQL (NNN_name.sql), run by lib/migrator.py
-scripts/          — pipeline_cli/ (operator CLI package, split by command family) + dev/ops scripts
-tests/            — shared infra in fakes.py + helpers.py
-nix/              — package.nix, beets.nix, shell.nix, module.nix, VM check
-examples/         — sample consumer + mirror NixOS configs
-docs/             — subsystem docs; docs/solutions/ = compounding lessons (grep when debugging)
-.claude/rules/    — shared rules (Claude auto-loads; Codex reads as directed below)
-```
+`ls` shows the tree. The two non-obvious directories: `docs/solutions/` holds
+compounding lessons (grep it when debugging), and `.claude/rules/` holds the
+shared rules (Claude auto-loads them; Codex reads as directed below).
 
 `lib/config.py`/`lib/context.py` hold the typed `CratediggerConfig`/`CratediggerContext` — never construct a partial config; always `CratediggerConfig.from_ini()`.
 
@@ -170,13 +159,11 @@ Push cratedigger (GitHub) → `nix flake update cratedigger-src` on doc1 → sig
 
 ## Database migrations
 
-Schema lives in `migrations/NNN_name.sql`; the migrate oneshot runs them on every switch. `cratedigger-web` and other long-running workers `requires` the migrate unit and start after it; `cratedigger` and `cratedigger-unfindable` are timer-driven (`restartIfChanged = false`) so they only `wants`+`after` it — a `requires` edge would let the migrate unit's every-deploy restart SIGTERM a mid-flight cycle — and instead gate on schema currency themselves at startup (`lib/migrator.py::assert_schema_current`). Add a numbered SQL file — no manual psql, **never** edit a shipped migration, **never** add DDL inside `PipelineDB` methods. Full workflow in `.claude/rules/deploy.md`.
+Schema lives in `migrations/NNN_name.sql`; the migrate oneshot runs them on every switch. Add a numbered SQL file — no manual psql, **never** edit a shipped migration, **never** add DDL inside `PipelineDB` methods. The unit-ordering contract (why `cratedigger`/`cratedigger-unfindable` only `wants`+`after` the migrate unit and gate on `assert_schema_current` instead) and the full workflow are in `.claude/rules/deploy.md` § "Database migrations".
 
 ## Running tests
 
-Choose validation timing and depth during development using engineering
-judgment based on the change, current evidence, and concrete risk. Always use
-`nix-shell --run` for Python:
+Always use `nix-shell --run` for Python:
 
 ```bash
 bash scripts/test.sh tests.test_X                       # explicit target + adjacent/ambient gates
@@ -185,41 +172,16 @@ nix-shell --run "python3 -m unittest tests.test_X -v"    # isolated test debuggi
 nix-shell --run "bash scripts/run_tests.sh"              # exhaustive suite
 ```
 
-Use `scripts/test.sh` for normal development validation. It adds the selected
-test's deterministic/generated sibling, tests adjacent to changed production
-surfaces, every repository audit and ratchet, JavaScript checks, both Pyright
-contracts, Ruff, and Vulture to one failure bundle. Use direct `unittest` only
-to debug an isolated failure, not as local convergence evidence. Exit code 2
-with no phase output at all means a changed shared `tests/**.py` module has no
-mapping in `scripts/targeted_test_selection.py` — map it there (or record it
-in `SHARED_MODULES_WITHOUT_COVERAGE` if it genuinely has no consuming test —
-`tests/test_negative_coverage_audit.py` mechanically enforces that no module
-under `tests/` imports it),
-not a failure in your change.
+`scripts/test.sh` is normal development validation; direct `unittest` is for
+debugging an isolated failure, never local convergence evidence; the `check`
+skill owns the one receipt-backed canonical-suite confirmation before
+independent-review handoff.
 
-Direct runs are development feedback; before independent-review handoff, use
-the `check` skill on the converged, clean, committed tree for the one
-receipt-backed canonical-suite confirmation. Reuse that receipt before push if
-the reviewed commit remains unchanged. The complete operational contract —
-suite bundle, specialized evidence, generated/fuzz testing, no-skips policy,
-and hooks — is in `.claude/rules/code-quality.md` § "Test execution, evidence,
-and hooks".
-
-**The shared host's test RAM root is a fixed-size tmpfs with no other admission
-control, so every `run_suite` invocation admits one at a time** (issue #1111):
-an advisory lock, stale-scratch reaping, and a headroom precondition all run
-before any phase. This covers BOTH the canonical suite AND `scripts/test.sh`
-targeted runs — `scripts/run_targeted_tests.py` calls the identical
-`run_suite` with no override, so it shares the same lock (#1111's own
-incident record includes a `scripts/test.sh` collision; excluding them would
-leave that case unprotected). Only the `nix-shell` shellHook entry level is
-excluded, since gating it would also serialize interactive dev shells that
-never call `run_suite`. A second concurrent `run_suite` call waits, bounded,
-instead of colliding with the first one's roughly a dozen ephemeral
-PostgreSQL clusters. Full mechanism — holder
-identity, the shellHook's deferral via `CRATEDIGGER_SUITE_OWNS_HEADROOM`, the
-collapsed `test RAM root exhausted` failure entry, and stated residuals — is
-in `.claude/rules/code-quality.md` § "Test execution, evidence, and hooks".
+The complete operational contract — selection rules and the exit-code-2 refusal,
+suite bundle, the `check` receipt, the shared-tmpfs admission lock (#1111),
+specialized evidence, generated/fuzz testing, no-skips policy, and hooks — is in
+`.claude/rules/code-quality.md` § "Test execution, evidence, and hooks", which
+is always loaded alongside this file. Do not restate it here.
 
 ## Shared AI surfaces
 
@@ -272,7 +234,7 @@ Codex consumes its generated adapter. Always use HTTPS (HTTP times out).
 
 ## Hunting production bugs — generated-first (the house method)
 
-**Production bugs are hunted with generated tests, not log-trawling.** Write down the invariant the symptom violates, probe the cheapest suspicious seam with real production functions, then build a generated harness (`tests/test_*_generated.py`) that drives the REAL code path over generated worlds and let Hypothesis find + shrink the reproduction — RED → fix → GREEN in one PR, with the shrunk world pinned forever. Test runners, selectors, fixtures, audits, and other test infrastructure are deterministic-only; never schedule generated tests of the test machinery. Proven on #550: a live bug static analysis and disk forensics could not reproduce fell to this method in one session. Full workflow: `.claude/rules/code-quality.md` § "Production Bug Hunting — Generated-First" + `docs/generated-testing.md`.
+**Production bugs are hunted with generated tests, not log-trawling** — write the invariant down, drive the REAL code path over generated worlds, let Hypothesis find and shrink the reproduction, ship RED → fix → GREEN in one PR with the shrunk world pinned forever. Test infrastructure is deterministic-only. Proven on #550. Full workflow: `.claude/rules/code-quality.md` § "Production Bug Hunting — Generated-First" + `docs/generated-testing.md`.
 
 For quality-decision bugs the simulator is the tool within the method: `pipeline-cli show / quality / debug-download / search-plan show / query` are the diagnostic entry points; add the failing scenario to the album test set and verify against real albums in the live DB. Command reference + triage signals in `docs/debugging-cli.md`.
 


### PR DESCRIPTION
## Summary

Docs-only. `CLAUDE.md` restated four blocks that an always-loaded sibling rules file already owns, so every session paid for both copies. Each is replaced by a pointer:

| Block cut from `CLAUDE.md` | Already owned by |
| --- | --- |
| § Running tests (2,915 chars) | `code-quality.md` § "Test execution, evidence, and hooks" (13,064 chars) |
| § Hunting production bugs (1,223) | `code-quality.md` § "Production Bug Hunting — Generated-First" (2,645) |
| § Database migrations (709) | `deploy.md` § "Database migrations" (4,793) |
| § Repository layout — the fenced tree (~800) | `ls` |

Every prohibition and non-derivable gloss is preserved: `CratediggerConfig.from_ini()`, the three migration "never" rules, and the `docs/solutions/` grep hint. The `nix-shell --run` command block stays (not guessable).

Also merges `code-quality.md` § "Frontend (JavaScript)" + § "Backend (Server Routes)" into the path-scoped `.claude/rules/web.md` (`paths: web/**`), which already half-duplicated them — so they load only under `web/**` instead of always.

**Deliberately NOT moved:** § "HTTP request bodies" and § "API Contract Tests". Both are cited by live code and tests — `web/routes/_pydantic.py`, `web/routes/api_index.py`, the failure message at `tests/test_pydantic_route_audit.py:107`, plus six archival `docs/plans` / `docs/solutions` files. Moving them would falsify all of those pointers, and rewriting archival plan docs to chase a section move is the wrong trade for ~600 tokens.

Always-loaded memory: **99,703 → 95,792 chars (~978 est. tokens/session)**. `web.md` grows 1,587 → 2,134 (lazy).

Origin: a `/doctor` pass over the Claude Code setup; the rest of that cleanup was user/local-scope config and touched no repo file.

## Kill matrix (per diff site, not per PR)

Not applicable — this PR changes no production code, no test, no assertion, no checker clause, and no constant. The diff is three markdown files (`CLAUDE.md`, `.claude/rules/code-quality.md`, `.claude/rules/web.md`). There is no one-line production mutation any test could go RED on, because no executable surface changed.

The relevant mechanical evidence is instead that the repo's own reference audits still pass against the rewritten prose — `tests/test_docs_audit.py` (48/48, dead-link + repo-path + symbol resolution) and `tests/test_pydantic_route_audit.py`, whose failure message names a `code-quality.md` section this PR deliberately left in place.

## Reviewer

Two things worth checking by hand, since no test can:

1. **Every cut block's content survives at its pointer target.** Confirm the four `CLAUDE.md` sections' load-bearing facts are actually present in the named sibling section, not just plausibly nearby.
2. **The two unmoved web sections.** Confirm the cross-reference list above is complete — `grep -rn 'HTTP request bodies\|API Contract Tests' --include='*.py' --include='*.md' .` — and that nothing else points at the two sections that DID move (`grep -rn 'Frontend (JavaScript)\|Backend (Server Routes)'` returned only `code-quality.md` itself).

## Risk

Low, and bounded to agent context. No production code, no schema, no deployed artifact — `CLAUDE.md` and `.claude/rules/` are agent guidance, not shipped by the Nix module. Nothing to deploy or verify live.

What this does not change: any invariant, prohibition, or safety rule (all preserved verbatim or by pointer to an always-loaded file); the always-loaded status of `code-quality.md`, `deploy.md`, `scope.md`, `test-fidelity.md`; `AGENTS.md` (symlink to `CLAUDE.md`, follows automatically); and the Codex shared-rule loading contract in § "Shared rule loading", which still names the same four files.

Final gate: `scripts/run_final_gate.sh` → `pass`, receipt pinned to `c49075a8`, clean tree, 10,585 tests / 443 targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
