### PR TITLE
Consolidate album path fingerprint derivation

### DIFF
--- a/lib/import_preview.py
+++ b/lib/import_preview.py
@@ -109,12 +109,12 @@ from lib.quality_evidence import (
     current_evidence_rebuild_reasons,
     current_spectral_evidence_policy_usable,
     evidence_from_measurement,
+    fingerprint_album_path,
     load_or_backfill_current_evidence,
     neutral_v0_metric_from_probe,
     persist_candidate_evidence_from_import_result,
     persist_candidate_evidence_from_measurement,
     snapshot_audio_files,
-    snapshot_fingerprint,
     spectral_measurement_generation_is_current,
 )
 from lib.v0_probe import probe_installed_album_as_v0
@@ -786,7 +786,7 @@ def persist_exact_current_spectral_from_attempt(
             "attempt did not resolve a current Beets path",
         )
     try:
-        measured_files = snapshot_audio_files(measured_existing_path)
+        measured_fingerprint = fingerprint_album_path(measured_existing_path)
     except OSError as exc:
         return EvidenceBuildResult(
             current_evidence,
@@ -794,9 +794,7 @@ def persist_exact_current_spectral_from_attempt(
             f"{type(exc).__name__}: {exc}",
         )
     if (
-        not measured_files
-        or snapshot_fingerprint(measured_files)
-            != current_evidence.snapshot_fingerprint
+        measured_fingerprint != current_evidence.snapshot_fingerprint
     ):
         return EvidenceBuildResult(
             current_evidence,

--- a/lib/quality_evidence.py
+++ b/lib/quality_evidence.py
@@ -658,15 +658,9 @@ def fingerprint_album_path(album_path: str) -> str | None:
     ``None`` when nothing is there to witness (#1089 NOTE-H / NOTE-I,
     review round 3).
 
-    The composition of the two primitives above (``snapshot_audio_files`` +
-    ``snapshot_fingerprint``) shared by ``lib.merge_rekey_service`` and
-    ``lib.world_audit_service``, which had two textually-identical copies
-    of the same formula before this extraction (CLAUDE.md's "No Parallel
-    Code Paths"). NOT yet universal: ``lib.sidecar_service`` and
-    ``lib.import_preview`` still re-derive the same two-call sequence
-    independently for their own quality-critical paths — deliberately out
-    of scope for this extraction (#1089 m2, review round 4), tracked as a
-    follow-up consolidation rather than folded in here.
+    This is the sole high-level composition of ``snapshot_audio_files`` and
+    ``snapshot_fingerprint`` for consumers that need to know whether an
+    album path can currently witness an evidence fingerprint.
 
     Deliberately DIFFERENT from ``snapshot_fingerprint([])``'s own
     contract: that primitive treats the empty list as a well-defined,

--- a/lib/sidecar_service.py
+++ b/lib/sidecar_service.py
@@ -27,8 +27,7 @@ from lib.quality import QualityRankConfig
 from lib.quality_evidence import (
     QualityEvidenceDB,
     SnapshotAudioFilesError,
-    snapshot_audio_files,
-    snapshot_fingerprint,
+    fingerprint_album_path,
 )
 from lib.sidecar import SIDECAR_FILENAME, build_sidecar, should_write_sidecar
 
@@ -115,13 +114,12 @@ def write_sidecar_for_request(
     # bytes next to it. If the current evidence no longer matches the on-disk
     # audio — e.g. the post-import evidence refresh failed and
     # current_evidence_id still points at a prior row — skip rather than
-    # publish a stale payload. snapshot_fingerprint mirrors how
-    # propagate_candidate_evidence_to_current derived the row's fingerprint.
+    # publish a stale payload.
     try:
-        on_disk = snapshot_audio_files(album_path)
+        on_disk_fingerprint = fingerprint_album_path(album_path)
     except SnapshotAudioFilesError:
         return SidecarWriteResult(OUTCOME_SKIPPED_NO_ALBUM_PATH)
-    if snapshot_fingerprint(on_disk) != evidence.snapshot_fingerprint:
+    if on_disk_fingerprint != evidence.snapshot_fingerprint:
         return SidecarWriteResult(OUTCOME_SKIPPED_EVIDENCE_STALE)
 
     sidecar = build_sidecar(

--- a/tests/test_import_preview.py
+++ b/tests/test_import_preview.py
@@ -1418,6 +1418,164 @@ class TestImportPreviewPath(unittest.TestCase):
             shutil.rmtree(source, ignore_errors=True)
             shutil.rmtree(other, ignore_errors=True)
 
+    def test_attempt_scan_empty_path_is_stale_not_an_empty_digest_match(self):
+        db = self._db()
+        source = tempfile.mkdtemp()
+        try:
+            evidence = make_album_quality_evidence(
+                mb_release_id="mbid-42",
+                source_path=source,
+                files=[],
+            )
+            db.upsert_album_quality_evidence(evidence)
+            current = db.find_album_quality_evidence(
+                mb_release_id=evidence.mb_release_id,
+                snapshot_fingerprint=evidence.snapshot_fingerprint,
+            )
+            assert current is not None and current.id is not None
+            db.set_request_current_evidence(42, current.id)
+
+            result = persist_exact_current_spectral_from_attempt(
+                db,
+                request_id=42,
+                current_evidence=current,
+                measured_existing=SpectralAnalysisDetail(
+                    attempted=True,
+                    grade="genuine",
+                    bitrate_kbps=96,
+                    spectral_measurement_version=SPECTRAL_MEASUREMENT_VERSION,
+                ),
+                measured_existing_path=source,
+            )
+
+            self.assertEqual(result.status, "stale")
+            self.assertEqual(
+                result.reason,
+                "attempt HAVE path does not match current evidence fingerprint",
+            )
+        finally:
+            shutil.rmtree(source, ignore_errors=True)
+
+    def test_attempt_scan_missing_path_is_stale(self):
+        db = self._db()
+        source = self._source_dir()
+        try:
+            evidence = make_album_quality_evidence(
+                mb_release_id="mbid-42",
+                source_path=source,
+                files=snapshot_audio_files(source),
+            )
+            db.upsert_album_quality_evidence(evidence)
+            current = db.find_album_quality_evidence(
+                mb_release_id=evidence.mb_release_id,
+                snapshot_fingerprint=evidence.snapshot_fingerprint,
+            )
+            assert current is not None and current.id is not None
+            db.set_request_current_evidence(42, current.id)
+
+            result = persist_exact_current_spectral_from_attempt(
+                db,
+                request_id=42,
+                current_evidence=current,
+                measured_existing=SpectralAnalysisDetail(
+                    attempted=True,
+                    grade="genuine",
+                    bitrate_kbps=96,
+                    spectral_measurement_version=SPECTRAL_MEASUREMENT_VERSION,
+                ),
+                measured_existing_path=os.path.join(source, "missing"),
+            )
+
+            self.assertEqual(result.status, "stale")
+            self.assertEqual(
+                result.reason,
+                "attempt HAVE path does not match current evidence fingerprint",
+            )
+        finally:
+            shutil.rmtree(source, ignore_errors=True)
+
+    def test_attempt_scan_mismatched_path_is_stale(self):
+        db = self._db()
+        source = self._source_dir()
+        try:
+            evidence = make_album_quality_evidence(
+                mb_release_id="mbid-42",
+                source_path=source,
+                files=snapshot_audio_files(source),
+            )
+            db.upsert_album_quality_evidence(evidence)
+            current = db.find_album_quality_evidence(
+                mb_release_id=evidence.mb_release_id,
+                snapshot_fingerprint=evidence.snapshot_fingerprint,
+            )
+            assert current is not None and current.id is not None
+            db.set_request_current_evidence(42, current.id)
+            with open(os.path.join(source, "02.mp3"), "wb") as handle:
+                handle.write(b"different snapshot")
+
+            result = persist_exact_current_spectral_from_attempt(
+                db,
+                request_id=42,
+                current_evidence=current,
+                measured_existing=SpectralAnalysisDetail(
+                    attempted=True,
+                    grade="genuine",
+                    bitrate_kbps=96,
+                    spectral_measurement_version=SPECTRAL_MEASUREMENT_VERSION,
+                ),
+                measured_existing_path=source,
+            )
+
+            self.assertEqual(result.status, "stale")
+            self.assertEqual(
+                result.reason,
+                "attempt HAVE path does not match current evidence fingerprint",
+            )
+        finally:
+            shutil.rmtree(source, ignore_errors=True)
+
+    def test_attempt_scan_snapshot_error_is_failed_with_its_detail(self):
+        db = self._db()
+        source = self._source_dir()
+        try:
+            evidence = make_album_quality_evidence(
+                mb_release_id="mbid-42",
+                source_path=source,
+                files=snapshot_audio_files(source),
+            )
+            db.upsert_album_quality_evidence(evidence)
+            current = db.find_album_quality_evidence(
+                mb_release_id=evidence.mb_release_id,
+                snapshot_fingerprint=evidence.snapshot_fingerprint,
+            )
+            assert current is not None and current.id is not None
+            db.set_request_current_evidence(42, current.id)
+            os.unlink(os.path.join(source, "01.mp3"))
+            os.symlink(
+                os.path.join(source, "vanished.mp3"),
+                os.path.join(source, "01.mp3"),
+            )
+
+            result = persist_exact_current_spectral_from_attempt(
+                db,
+                request_id=42,
+                current_evidence=current,
+                measured_existing=SpectralAnalysisDetail(
+                    attempted=True,
+                    grade="genuine",
+                    bitrate_kbps=96,
+                    spectral_measurement_version=SPECTRAL_MEASUREMENT_VERSION,
+                ),
+                measured_existing_path=source,
+            )
+
+            self.assertEqual(result.status, "failed")
+            self.assertTrue((result.reason or "").startswith(
+                "SnapshotAudioFilesError: could not stat audio file "
+            ))
+        finally:
+            shutil.rmtree(source, ignore_errors=True)
+
     def test_fresh_have_failure_overrides_stored_spectral_success(self):
         db = self._db()
         source = self._source_dir()

--- a/tests/test_quality_evidence_fingerprint.py
+++ b/tests/test_quality_evidence_fingerprint.py
@@ -10,6 +10,7 @@ would scramble the post-deploy lookup.
 from __future__ import annotations
 
 import hashlib
+import inspect
 import json
 import os
 import tempfile
@@ -151,10 +152,7 @@ class TestSnapshotFingerprintFormula(unittest.TestCase):
 
 
 class TestFingerprintAlbumPath(unittest.TestCase):
-    """#1089 NOTE-H / NOTE-I (review round 3): the ONE canonical
-    ``snapshot_audio_files`` + ``snapshot_fingerprint`` composition, shared
-    by ``lib.world_audit_service`` and ``lib.merge_rekey_service`` — never a
-    second, textually-duplicated formula."""
+    """The one canonical album-path fingerprint composition."""
 
     def test_matches_the_manual_composition_for_a_real_directory(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -192,6 +190,24 @@ class TestFingerprintAlbumPath(unittest.TestCase):
             )
             with self.assertRaises(SnapshotAudioFilesError):
                 fingerprint_album_path(tmp_dir)
+
+
+class TestFingerprintAlbumPathConsumerWiring(unittest.TestCase):
+    """The two quality-critical consumers delegate their path witness."""
+
+    def test_consumers_use_the_helper_not_the_primitives(self) -> None:
+        from lib.import_preview import persist_exact_current_spectral_from_attempt
+        from lib.sidecar_service import write_sidecar_for_request
+
+        for consumer in (
+            persist_exact_current_spectral_from_attempt,
+            write_sidecar_for_request,
+        ):
+            with self.subTest(consumer=consumer.__name__):
+                source = inspect.getsource(consumer)
+                self.assertIn("fingerprint_album_path(", source)
+                self.assertNotIn("snapshot_audio_files(", source)
+                self.assertNotIn("snapshot_fingerprint(", source)
 
 
 if __name__ == "__main__":

--- a/tests/test_quality_evidence_fingerprint_generated.py
+++ b/tests/test_quality_evidence_fingerprint_generated.py
@@ -1,0 +1,146 @@
+"""Generated filesystem patrol for the album-path fingerprint consumers."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import unittest
+
+from hypothesis import example, given
+from hypothesis import strategies as st
+
+import tests._hypothesis_profiles  # noqa: F401  (loads the active profile)
+from lib.beets_db import AlbumInfo
+from lib.import_preview import persist_exact_current_spectral_from_attempt
+from lib.quality import (
+    AlbumQualityEvidence,
+    AlbumQualityEvidenceFile,
+    AudioQualityMeasurement,
+    SpectralAnalysisDetail,
+    VerifiedLosslessProof,
+)
+from lib.quality_evidence import snapshot_audio_files
+from lib.sidecar import SIDECAR_FILENAME
+from lib.sidecar_service import write_sidecar_for_request
+from lib.spectral_check import SPECTRAL_MEASUREMENT_VERSION
+from tests.fakes import FakeBeetsDB, FakePipelineDB
+from tests.helpers import make_album_quality_evidence, make_request_row
+
+_MBID = "rel-1140"
+_REQUEST_ID = 1140
+
+
+def _seed_current_evidence(
+    db: FakePipelineDB,
+    evidence: AlbumQualityEvidence,
+) -> AlbumQualityEvidence:
+    db.upsert_album_quality_evidence(evidence)
+    stored = db.find_album_quality_evidence(
+        mb_release_id=evidence.mb_release_id,
+        snapshot_fingerprint=evidence.snapshot_fingerprint,
+    )
+    assert stored is not None and stored.id is not None
+    db.set_request_current_evidence(_REQUEST_ID, stored.id)
+    return stored
+
+
+def _verified_lossless_evidence(
+    files: list[AlbumQualityEvidenceFile],
+) -> AlbumQualityEvidence:
+    return make_album_quality_evidence(
+        mb_release_id=_MBID,
+        files=files,
+        measurement=AudioQualityMeasurement(
+            min_bitrate_kbps=900,
+            avg_bitrate_kbps=1000,
+            format="flac",
+            spectral_grade="genuine",
+            spectral_subject="source",
+            spectral_provenance="measured",
+            was_converted_from="flac",
+        ),
+        storage_format="FLAC",
+        verified_lossless_proof=VerifiedLosslessProof(
+            provenance="measured", source="flac", classifier="spectral",
+        ),
+    )
+
+
+class TestFingerprintAlbumPathConsumersGenerated(unittest.TestCase):
+    """Empty directories are never a current-evidence witness."""
+
+    @example(consumer="sidecar", file_sizes=[])
+    @example(consumer="preview", file_sizes=[])
+    @given(
+        consumer=st.sampled_from(("sidecar", "preview")),
+        file_sizes=st.lists(st.integers(min_value=1, max_value=64), max_size=3),
+    )
+    def test_real_consumers_accept_only_nonempty_matching_snapshots(
+        self,
+        *,
+        consumer: str,
+        file_sizes: list[int],
+    ) -> None:
+        with tempfile.TemporaryDirectory() as album_path:
+            for index, size in enumerate(file_sizes, start=1):
+                with open(os.path.join(album_path, f"{index:02}.flac"), "wb") as fh:
+                    fh.write(b"x" * size)
+            db = FakePipelineDB()
+            db.seed_request(make_request_row(
+                id=_REQUEST_ID,
+                mb_release_id=_MBID,
+                status="imported",
+            ))
+            files = snapshot_audio_files(album_path)
+
+            if consumer == "sidecar":
+                _seed_current_evidence(
+                    db,
+                    _verified_lossless_evidence(files),
+                )
+                beets = FakeBeetsDB()
+                beets.set_album_info(_MBID, AlbumInfo(
+                    album_id=1,
+                    track_count=max(1, len(files)),
+                    min_bitrate_kbps=900,
+                    is_cbr=True,
+                    album_path=album_path,
+                ))
+
+                result = write_sidecar_for_request(
+                    db, beets, _REQUEST_ID, mb_release_id=_MBID,
+                )
+
+                self.assertEqual(
+                    result.outcome,
+                    "written" if files else "skipped_evidence_stale",
+                )
+                self.assertEqual(
+                    os.path.exists(os.path.join(album_path, SIDECAR_FILENAME)),
+                    bool(files),
+                )
+                return
+
+            current = _seed_current_evidence(db, make_album_quality_evidence(
+                mb_release_id=_MBID,
+                source_path=album_path,
+                files=files,
+            ))
+            result = persist_exact_current_spectral_from_attempt(
+                db,
+                request_id=_REQUEST_ID,
+                current_evidence=current,
+                measured_existing=SpectralAnalysisDetail(
+                    attempted=True,
+                    grade="genuine",
+                    bitrate_kbps=96,
+                    spectral_measurement_version=SPECTRAL_MEASUREMENT_VERSION,
+                ),
+                measured_existing_path=album_path,
+            )
+
+            self.assertEqual(result.status, "ready" if files else "stale")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sidecar_service.py
+++ b/tests/test_sidecar_service.py
@@ -275,6 +275,47 @@ class TestWriteSidecarSkips(_SidecarServiceCase):
             self.db, self.beets, REQUEST_ID, mb_release_id=MBID
         )
         self.assertEqual(result.outcome, "skipped_no_album_path")
+        self.assertFalse(
+            os.path.exists(os.path.join(self.album_path, SIDECAR_FILENAME))
+        )
+
+    def test_empty_album_is_stale_not_an_empty_digest_witness(self):
+        for name in os.listdir(self.album_path):
+            os.unlink(os.path.join(self.album_path, name))
+        self._seed_current_evidence(make_album_quality_evidence(
+            mb_release_id=MBID,
+            files=[],
+            measurement=_verified_lossless_measurement(),
+            storage_format="FLAC",
+            verified_lossless_proof=_proof(),
+        ))
+
+        result = write_sidecar_for_request(
+            self.db, self.beets, REQUEST_ID, mb_release_id=MBID
+        )
+
+        self.assertEqual(result.outcome, "skipped_evidence_stale")
+        self.assertFalse(
+            os.path.exists(os.path.join(self.album_path, SIDECAR_FILENAME))
+        )
+
+    def test_snapshot_error_skips_without_publishing_a_sidecar(self):
+        self._seed_current_evidence(self._verified_lossless_evidence())
+        for name in os.listdir(self.album_path):
+            os.unlink(os.path.join(self.album_path, name))
+        os.symlink(
+            os.path.join(self.album_path, "vanished.flac"),
+            os.path.join(self.album_path, "01 - First.flac"),
+        )
+
+        result = write_sidecar_for_request(
+            self.db, self.beets, REQUEST_ID, mb_release_id=MBID
+        )
+
+        self.assertEqual(result.outcome, "skipped_no_album_path")
+        self.assertFalse(
+            os.path.exists(os.path.join(self.album_path, SIDECAR_FILENAME))
+        )
 
     def test_skips_when_evidence_stale_vs_disk(self):
         # Verified-lossless evidence describing files that are NOT on disk —


### PR DESCRIPTION
## Summary

- route sidecar and import-preview fingerprinting through the existing canonical `fingerprint_album_path`
- make an empty album directory explicitly stale for sidecar publication while preserving all other lifecycle outcomes
- pin both real consumers across matching, mismatch, missing, empty, and filesystem-error worlds
- add a narrow generated real-filesystem patrol and bounded wiring check

## Verification

- canonical six-phase check on clean commit `66c6b35df72f35da1b19c957929f7716c9c7a8fb`
- 10,603 Python tests across 445 targets, plus Pyright, Ruff, Vulture, and JavaScript checks
- focused generated property passed 500 examples
- direct-composition and empty-hash mutants were killed
- independent GPT-5.6 Sol review: no findings

The live census found one historical empty-list fingerprint evidence row, with zero current links and zero verified-lossless rows; no migration or backfill is needed.

Refs #1140
