### PR TITLE
fix(#1175): measure the window the Discogs cap governs, not handler lifetime

### DIFF
--- a/tests/test_discogs_artist_concurrency.py
+++ b/tests/test_discogs_artist_concurrency.py
@@ -18,9 +18,22 @@ from web import discogs
 
 
 class _DiscogsMirror:
-    def __init__(self, *, delay: float = 0, fail_masters: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        delay: float = 0,
+        fail_masters: bool = False,
+        handler_exit_delay: float = 0,
+    ) -> None:
         self.delay = delay
         self.fail_masters = fail_masters
+        # Issue #1175. Stands in for the scheduling gap full-suite load opens
+        # between a handler finishing its response and its thread being
+        # scheduled again to tear down. The client has already read the body
+        # and released its semaphore slot by then, so anything still counted
+        # during this window is measuring handler lifetime rather than the
+        # window the cap governs.
+        self.handler_exit_delay = handler_exit_delay
         self.active = 0
         self.max_active = 0
         self.lock = threading.Lock()
@@ -32,8 +45,27 @@ class _DiscogsMirror:
                 with mirror.lock:
                     mirror.active += 1
                     mirror.max_active = max(mirror.max_active, mirror.active)
+                counted = True
+
+                def leave() -> None:
+                    # Closes the counted window at the last moment before this
+                    # response becomes readable by the client. Everything after
+                    # it -- writing bytes, this thread being descheduled, the
+                    # handler returning -- happens while the client may already
+                    # have read the body and released its semaphore slot, so
+                    # counting it would measure handler lifetime instead of the
+                    # window the cap governs (#1175). Idempotent, so the
+                    # ``finally`` below still guarantees exactly one decrement
+                    # on the paths that raise before reaching a response.
+                    nonlocal counted
+                    if counted:
+                        counted = False
+                        with mirror.lock:
+                            mirror.active -= 1
+
                 try:
                     if masters and mirror.fail_masters:
+                        leave()
                         self.send_response(500)
                         self.end_headers()
                         return
@@ -42,14 +74,16 @@ class _DiscogsMirror:
                     body = json.dumps({
                         "results": [], "total": 0, "page": 1, "per_page": 1,
                     }).encode()
+                    leave()
                     self.send_response(200)
                     self.send_header("Content-Type", "application/json")
                     self.send_header("Content-Length", str(len(body)))
                     self.end_headers()
                     self.wfile.write(body)
                 finally:
-                    with mirror.lock:
-                        mirror.active -= 1
+                    if mirror.handler_exit_delay:
+                        time.sleep(mirror.handler_exit_delay)
+                    leave()
 
             def log_message(self, format: str, *_args: object) -> None:
                 pass
@@ -69,13 +103,17 @@ class _DiscogsMirror:
 
 
 def assert_discogs_cap(max_active: int) -> None:
-    if max_active > 2:
+    """The budget is read from the production constant, not re-typed here — a
+    hand-written literal would pin a number rather than the invariant that the
+    mirror's configured budget is honoured."""
+    cap = discogs._DISCOGS_ARTIST_CONCURRENCY
+    if max_active > cap:
         raise AssertionError(f"Discogs mirror cap exceeded: {max_active}")
 
 
 class TestDiscogsArtistGlobalConcurrency(unittest.TestCase):
-    def _run_calls(self, calls: int) -> _DiscogsMirror:
-        mirror = _DiscogsMirror(delay=0.03)
+    def _run_calls(self, calls: int, *, handler_exit_delay: float = 0) -> _DiscogsMirror:
+        mirror = _DiscogsMirror(delay=0.03, handler_exit_delay=handler_exit_delay)
         with mirror as base, patch.object(discogs, "DISCOGS_API_BASE", base), patch(
             "web.discogs._cache.memoize_meta", side_effect=lambda _key, fetch: fetch(),
         ), concurrent.futures.ThreadPoolExecutor(max_workers=calls) as executor:
@@ -94,8 +132,25 @@ class TestDiscogsArtistGlobalConcurrency(unittest.TestCase):
 
     def test_three_top_level_artist_reads_share_one_two_request_budget(self) -> None:
         mirror = self._run_calls(3)
+        # Saturation AND the cap in one assertion: with the budget honoured the
+        # only value three concurrent readers can produce is the budget itself.
+        # A degenerate counted window (reading 1) fails here just as a breached
+        # cap does.
+        self.assertEqual(mirror.max_active, discogs._DISCOGS_ARTIST_CONCURRENCY)
+
+    def test_slow_handler_teardown_does_not_inflate_the_measured_window(self) -> None:
+        """#1175: the counter must measure the window the client's semaphore
+        hold governs, not handler lifetime.
+
+        A handler descheduled after writing its response has already released
+        the client's slot — the client read the body and left ``_get``'s
+        ``with`` block. Counting that trailing window let a third reader be
+        observed while the client-side cap of two was never breached, which is
+        why this failed intermittently under full-suite load and passed in
+        isolation.
+        """
+        mirror = self._run_calls(3, handler_exit_delay=0.02)
         assert_discogs_cap(mirror.max_active)
-        self.assertGreater(mirror.max_active, 1)
 
     @settings(max_examples=8)
     @given(calls=st.integers(min_value=1, max_value=5))


### PR DESCRIPTION
## Summary

`tests/test_discogs_artist_concurrency.py` failed intermittently under full-suite
load with `Discogs mirror cap exceeded: 3`, and passed in isolation. **The cap was
never breached; the measurement was wrong.**

The production cap is a client-side `BoundedSemaphore` in `web/discogs.py`,
released when `_get`'s `with` block exits — *after* the response body has been
read. The test counted server-side, decrementing in a `finally` that runs *after*
`wfile.write()`. A client that has finished reading has already released its slot,
so a third client can legitimately acquire and reach the server while the first
handler's thread has not yet been scheduled to run its teardown. The counter
measured **handler lifetime, which strictly outlives the client's semaphore hold**.
Suite load widens that scheduling gap — hence parallel-only.

Verified before fixing: instrumenting both windows and injecting a 5 ms delay
before the handler's decrement drives the server counter to 4 while the client
semaphore hold never exceeds 2.

| injected `finally` delay | server-handler max | client-semaphore max |
| --- | --- | --- |
| 0.0 | 2 | 2 |
| 0.005 | **4** | 2 |
| 0.02 | **4** | 2 |

The counted window now closes immediately before the response becomes readable by
the client, making it a **strict subset** of the client's hold — so it cannot
overshoot. `leave()` is idempotent and the `finally` still guarantees exactly one
decrement on paths that raise before reaching a response.

Pinned with a deterministic contract rather than left as a known flake
(`.claude/rules/code-quality.md`: test-infrastructure defects get an exact
contract, not an exemption). `handler_exit_delay` makes the scheduling gap
explicit; against the old handler it reproduces the exact production failure
(`cap exceeded: 4`), against the fixed one it falls outside the window.

Two cleanups ride along, both load-bearing rather than cosmetic:
`assert_discogs_cap` reads the budget from `_DISCOGS_ARTIST_CONCURRENCY` instead
of a hand-typed `2`, and the three-reader test asserts saturation and the cap in
one equality. The previous `assert_discogs_cap(...)` + `assertGreater(max, 1)`
pair is exactly equivalent to `max == 2` once the cap holds, so this is a
simplification that additionally fails on a degenerate counted window.

Test-infrastructure only — deterministic contract, no property
(`.claude/rules/code-quality.md`: never property-test the test machinery). The
existing generated production property over the cap is untouched.

## Kill matrix (per diff site, not per PR)

| Site (assertion / clause / constant) | One-line production mutant | Test that must go RED | Result |
| --- | --- | --- | --- |
| `leave()` before response emission (both response paths) | replace both early `leave()` calls with `pass`, leaving the `finally` as the only decrement — i.e. restore the pre-#1175 handler | `test_slow_handler_teardown_does_not_inflate_the_measured_window` | RED, `cap exceeded: 4` (1 failure) |
| `assert_discogs_cap` threshold derived from `discogs._DISCOGS_ARTIST_CONCURRENCY` | `web/discogs.py:144` `with _mirror_semaphore(url):` → `with contextlib.nullcontext():` | `test_three_top_level_artist_reads_share_one_two_request_budget` | RED, `6 != 2` (3 failures, incl. the generated property) |
| `assertEqual(max_active, _DISCOGS_ARTIST_CONCURRENCY)` — the saturation half | move `leave()` above `time.sleep(mirror.delay)`, collapsing the counted window | `test_three_top_level_artist_reads_share_one_two_request_budget` | RED, `1 != 2` (1 failure) |

Every mutant was planted and run; results are the observed assertion messages, not
inferred from reading the pins.

## Reviewer

Row 3 exists because rows 1 and 2 do not qualify it: narrowing the window is only
safe if something still fails when the window is narrowed *too far*. Worth
planting a mutant that makes `leave()` non-idempotent (drop the `counted` guard)
— the `finally` then double-decrements and `active` goes negative; check whether
any assertion catches it, since I did not add a row for that.

## Risk

Test-only. No production file changes. The cap itself, `web/discogs.py`, and the
generated property's strategy are untouched — this changes only where the test's
observation boundary sits. The narrowed window can in principle *under*-count,
which is why the saturation equality (row 3) is now asserted rather than
`assertGreater(..., 1)`.