### PR TITLE
Clarify Recents History broken-world colors

### DIFF
--- a/tests/test_web_recents.py
+++ b/tests/test_web_recents.py
@@ -750,7 +750,7 @@ class TestClassifyBadge(unittest.TestCase):
         """Raw enum outcomes must not leak underscores into the badge."""
         result = classify_log_entry(_entry(outcome="measurement_failed"))
         self.assertEqual(result.badge, "Measurement failed")
-        self.assertEqual(result.badge_class, "badge-failed")
+        self.assertEqual(result.badge_class, "badge-warn")
 
     def test_new_import(self):
         """First-time import, nothing on disk before."""
@@ -944,6 +944,7 @@ class TestClassifyBadge(unittest.TestCase):
             outcome="curator_ban", soulseek_username="H@rco"))
         self.assertEqual(result.badge, "Bad rip")
         self.assertEqual(result.badge_class, "badge-rejected")
+        self.assertEqual(result.border_color, "#a33")
         self.assertIn("H@rco", result.verdict)
         self.assertIn("Marked bad rip", result.verdict)
         # The summary keeps its trailing peer attribution: this verdict
@@ -956,12 +957,13 @@ class TestClassifyBadge(unittest.TestCase):
         result = classify_log_entry(_entry(
             outcome="curator_ban", soulseek_username=None))
         self.assertEqual(result.badge, "Bad rip")
+        self.assertEqual(result.border_color, "#a33")
         self.assertEqual(result.verdict, "Marked bad rip")
 
     def test_failed(self):
         result = classify_log_entry(_entry(outcome="failed", beets_scenario="exception"))
         self.assertEqual(result.badge, "Failed")
-        self.assertEqual(result.badge_class, "badge-failed")
+        self.assertEqual(result.badge_class, "badge-warn")
 
     def test_abandoned_auto_import_failed_row_uses_readable_error(self):
         result = classify_log_entry(_entry(
@@ -1005,6 +1007,19 @@ class TestClassifyBadge(unittest.TestCase):
 
 class TestClassifyBorderColor(unittest.TestCase):
 
+    def test_broken_world_history_uses_environment_failure_style(self):
+        """Broken operational worlds are distinct from rejected media."""
+        for outcome, badge in (
+            ("measurement_failed", "Measurement failed"),
+            ("failed", "Failed"),
+            ("have_analysis_error", "Environment failure"),
+        ):
+            with self.subTest(outcome=outcome):
+                result = classify_log_entry(_entry(outcome=outcome))
+                self.assertEqual(result.badge, badge)
+                self.assertEqual(result.badge_class, "badge-warn")
+                self.assertEqual(result.border_color, "#a86f20")
+
     def test_success_green_border(self):
         result = classify_log_entry(_entry(outcome="success"))
         self.assertIn(result.border_color, ("#3a6", "#1a4a2a"))
@@ -1012,6 +1027,12 @@ class TestClassifyBorderColor(unittest.TestCase):
     def test_rejected_red_border(self):
         result = classify_log_entry(_entry(
             outcome="rejected", beets_scenario="quality_downgrade"))
+        self.assertEqual(result.border_color, "#a33")
+
+    def test_timeout_stays_a_failed_red_history_row(self):
+        result = classify_log_entry(_entry(outcome="timeout"))
+        self.assertEqual(result.badge, "Failed")
+        self.assertEqual(result.badge_class, "badge-failed")
         self.assertEqual(result.border_color, "#a33")
 
     def test_transcode_amber_border(self):
@@ -1425,8 +1446,8 @@ class TestExceptionVerdicts(unittest.TestCase):
             beets_detail="generic measurement failure",
         ))
         self.assertEqual(result.badge, "Measurement failed")
-        self.assertEqual(result.badge_class, "badge-failed")
-        self.assertEqual(result.border_color, "#a33")
+        self.assertEqual(result.badge_class, "badge-warn")
+        self.assertEqual(result.border_color, "#a86f20")
         self.assertEqual(
             result.verdict,
             "Measurement failed: ffmpeg decode failed on track 05",

--- a/tests/test_web_recents_generated.py
+++ b/tests/test_web_recents_generated.py
@@ -29,6 +29,7 @@ from web.classify import ClassifiedEntry, LogEntry, classify_log_entry
 from web.download_history_view import (
     _project_current_library_have,
     _project_linked_import_evidence,
+    build_recents_download_log_rows,
 )
 
 REJECT_SCENARIOS = (
@@ -403,7 +404,7 @@ def _raw_download_log_row(
     read seam receives BEFORE ``_overlay_evidence_onto_download_log_row``
     adjudicates them.
     """
-    entry = _entry(outcome="success", beets_scenario="strong_match", **columns)
+    entry = _entry(beets_scenario="strong_match", **columns)
     return {
         **entry.to_json_dict(),
         "verified_lossless_classifier": None,
@@ -1585,6 +1586,39 @@ class TestGeneratedRejectVerdictGrammar(unittest.TestCase):
         )
         self.assertEqual(items[0]["materialized_min_bitrate"], materialized_min)
         self.assertEqual(items[0]["materialized_avg_bitrate"], materialized_avg)
+
+class TestGeneratedBrokenWorldHistoryStyle(unittest.TestCase):
+    @given(
+        outcome=st.sampled_from((
+            "measurement_failed",
+            "failed",
+            "have_analysis_error",
+            "timeout",
+            "rejected",
+            "user_offline",
+            "curator_ban",
+        )),
+    )
+    @example(outcome="measurement_failed")
+    @example(outcome="have_analysis_error")
+    @example(outcome="timeout")
+    @example(outcome="curator_ban")
+    def test_broken_world_history_style_is_distinct_from_rejection(
+        self,
+        outcome: str,
+    ) -> None:
+        row = _raw_download_log_row(
+            lineage=None,
+            classifier=None,
+            outcome=outcome,
+        )
+        result = build_recents_download_log_rows([row])[0]
+        if outcome in ("measurement_failed", "failed", "have_analysis_error"):
+            self.assertEqual(result["badge_class"], "badge-warn")
+            self.assertEqual(result["border_color"], "#a86f20")
+        else:
+            self.assertIn(result["badge_class"], ("badge-failed", "badge-rejected"))
+            self.assertEqual(result["border_color"], "#a33")
 
 
 if __name__ == "__main__":

--- a/tests/web/test_routes_pipeline.py
+++ b/tests/web/test_routes_pipeline.py
@@ -271,7 +271,7 @@ class TestPipelineRouteContracts(_FakeDbWebServerCase):
         expected = {
             "rejected": ("Rejected", "badge-rejected", "#a33"),
             "timeout": ("Failed", "badge-failed", "#a33"),
-            "failed": ("Failed", "badge-failed", "#a33"),
+            "failed": ("Failed", "badge-warn", "#a86f20"),
             "force_import": ("Force imported", "badge-force", "#46a"),
         }
         for outcome, display in expected.items():
@@ -469,8 +469,8 @@ class TestPipelineRouteContracts(_FakeDbWebServerCase):
         self.assertEqual(status, 200)
         item = next(row for row in data["log"] if row["id"] == log_id)
         self.assertEqual(item["badge"], "Measurement failed")
-        self.assertEqual(item["badge_class"], "badge-failed")
-        self.assertEqual(item["border_color"], "#a33")
+        self.assertEqual(item["badge_class"], "badge-warn")
+        self.assertEqual(item["border_color"], "#a86f20")
         self.assertEqual(item["error_message"], diagnostic)
         self.assertEqual(item["verdict"], f"Measurement failed: {diagnostic}")
         self.assertEqual(item["summary"], f"Measurement failed: {diagnostic}")
@@ -487,6 +487,25 @@ class TestPipelineRouteContracts(_FakeDbWebServerCase):
         )
         self.assertEqual(rejected_status, 200)
         self.assertIn(log_id, {row["id"] for row in rejected_data["log"]})
+
+    def test_pipeline_log_failed_uses_environment_failure_style(self):
+        diagnostic = "beets importer exited 1"
+        log_id = self.db.log_download(
+            100,
+            outcome="failed",
+            soulseek_username="testuser",
+            error_message=diagnostic,
+        )
+
+        status, data = self._get("/api/pipeline/log")
+
+        self.assertEqual(status, 200)
+        item = next(row for row in data["log"] if row["id"] == log_id)
+        self.assertEqual(item["badge"], "Failed")
+        self.assertEqual(item["badge_class"], "badge-warn")
+        self.assertEqual(item["border_color"], "#a86f20")
+        self.assertEqual(item["verdict"], f"Import error: {diagnostic}")
+        self.assertEqual(item["summary"], f"Import error: {diagnostic} · testuser")
 
     def test_kept_would_import_uses_complete_canonical_current_have(self):
         import web.server as srv

--- a/web/classify.py
+++ b/web/classify.py
@@ -1548,7 +1548,7 @@ def _classify(
     # ``lib.failure_presentation`` owns the wording (issue #868).
     if entry.outcome == "measurement_failed":
         return _Classification(
-            "Measurement failed", "badge-failed", "#a33",
+            "Measurement failed", "badge-warn", "#a86f20",
             failure.verdict or "Measurement failed",
         )
 
@@ -1571,7 +1571,7 @@ def _classify(
             or _quality_verdict_from_import_result(entry)
             or "Import error"
         )
-        return _Classification("Failed", "badge-failed", "#a33", verdict)
+        return _Classification("Failed", "badge-warn", "#a86f20", verdict)
 
     # --- Force import ---
     if entry.outcome == "force_import":


### PR DESCRIPTION
## Summary

- render production-visible Recents History `measurement_failed` and `failed` rows with the existing Environment-failure warning vocabulary (`badge-warn` / `#a86f20`)
- keep expected negatives red, including download timeouts whose visible badge is also `Failed`, ordinary rejections, triage, Bad Rip, and peer-offline rows
- preserve badge text, verdicts, summaries, quality evidence, lifecycle, and every pipeline behavior

This is deliberately History-only. Review proved preview failures are atomically written as terminal import jobs while the Imports timeline only returns active jobs, so changing its preview-failure colors would alter unreachable branches. Expanding that timeline would be a different behavioral change and is not in this presentation PR.

Refs #1166. The issue remains open for the requeue work and the recorded Imports reachability question.

## Rule D corpus evidence

Fresh export after rebasing onto `1811f282`: 41 read-only full-shape batches, 37,975 live `download_log` rows (IDs 1-40,141), rendered through each ref's complete Recents History path.

| Field | Changed rows |
| --- | ---: |
| `badge_class` | 212 |
| `border_color` | 212 |
| all other watched fields | 0 |

Zero-count watched fields: `analysis_error`, `bad_extensions`, `badge`, `beets_detail_label`, `candidate_reference`, `comparison_basis`, `disambiguation_detail`, `disambiguation_failure`, `downloaded_label`, `existing_format`, `existing_spectral_accusation_withheld`, `existing_spectral_error`, `existing_spectral_grade`, `existing_v0_probe_kind`, `failure_category`, `installed_path`, `materialized_format`, `source_format`, `spectral_accusation_withheld`, `spectral_error`, `spectral_grade`, `stage2_if_stage1_deferred`, `stage2_if_stage1_deferred_verdict`, `summary`, `target_contract_format`, `transfer_message`, `transfer_message_label`, `v0_probe_kind`, `verdict`, `verdict_fired_legs`, `verdict_tier_statement`, `verified_lossless_classifier`, `verified_lossless_generation`, `wrong_match_triage_action`, `wrong_match_triage_detail`, `wrong_match_triage_preview_decision`, `wrong_match_triage_preview_verdict`, `wrong_match_triage_reason`, `wrong_match_triage_stage_chain`, and `wrong_match_triage_summary`.

Live-db browser proof at 1000x900:

- changed: download log 40055, Phoebe Bridgers / Lost Weekend, `failed` -> amber `#a86f20`
- changed: download log 39999, Bill Hicks / Love, Laughter and Truth, `measurement_failed` -> amber `#a86f20`
- control: download log 40133, The Mountain Goats / Taboo VI: The Homecoming, timeout with visible `Failed` badge -> red `#a33`
- control: download log 40139, Charles Manson / Way of the Wolf, rejection -> red `#a33`

The main agent inspected the captured PNGs. Cards and badges were unclipped, the additional proof badge on the measurement-failure card did not collide, and the page had no horizontal overflow or layout regression.

## Validation

- focused History validation: 8 tests passed
- receipt-backed canonical gate: PASS, all 6 phases
- exact checked/reviewed/pushed commit: `9dd8613ddd6c7fb187a2f9de4aea3539b9752572`
- independent Sol review: no findings after the final rebase; exact post-classification adapter mutant killed by both generated and route tests

## Kill matrix (per diff site, not per PR)

| Site (assertion / clause / constant) | One-line production mutant | Test that must go RED | Result |
| --- | --- | --- | --- |
| `measurement_failed` warning class/border | restore `badge-failed` / `#a33` | deterministic History matrix; generated outer-adapter property; real `/api/pipeline/log` measurement-failure test | RED |
| `failed` warning class/border | restore `badge-failed` / `#a33` | deterministic History matrix; generated outer-adapter property; real `/api/pipeline/log` failed-row test | RED |
| complete History adapter preserves `failed` presentation | overwrite projected `failed` rows to `badge-failed` / `#a33` after classification | generated outer-adapter property; real `/api/pipeline/log` failed-row test | RED |
| existing `have_analysis_error` warning control | change its border to `#a33` | deterministic broken-world matrix; generated outer-adapter property | RED |
| timeout red control | change timeout to `badge-warn` / `#a86f20` | deterministic timeout pin; generated outer-adapter property | RED |
| ordinary rejection red control | change rejected border to `#a86f20` | deterministic rejection pin; generated outer-adapter property | RED |
| Bad Rip red control | change `curator_ban` border to `#a86f20` | deterministic Bad Rip pins; generated explicit example | RED |
| peer-offline red control | change `user_offline` border to `#a86f20` | generated outer-adapter property | RED |

## Risk

Low and presentation-only. Two existing classifier return values change color fields. No API fields, queries, persistence, migrations, CSS, JavaScript, lifecycle, retries, or import behavior change. The Imports timeline is intentionally untouched.
