### PR TITLE
fix(#1186): one comment-stripped reader for every whole-file source pin

### DIFF
--- a/scripts/targeted_test_selection.py
+++ b/scripts/targeted_test_selection.py
@@ -159,6 +159,31 @@ EXACT_PATH_NEIGHBOURS: dict[str, tuple[str, ...]] = {
     "tests/_mock_audit_scanner.py": (
         "tests.test_mock_audit",
     ),
+    "tests/_source_pins.py": (
+        # tests.test_source_pins covers the reader exhaustively, but a
+        # behaviour change here (stripping too much, or too little) surfaces
+        # as a pin failing in a consumer, so every consumer is listed. The
+        # module decides what a whole-file source pin can SEE — silently
+        # widening it puts every one of these back where #1172/#1186 found
+        # them, satisfied by commented-out text.
+        "tests.test_source_pins",
+        "tests.test_daily_flake_update",
+        "tests.test_deploy_cycle_verifier",
+        "tests.test_deploy_hold",
+        "tests.test_deploy_pin_script",
+        "tests.test_docs_audit",
+        "tests.test_fuzz_burst",
+        "tests.test_issue_573_boundaries",
+        "tests.test_issue_633_boundaries",
+        "tests.test_js_suite_audit",
+        "tests.test_nix_module",
+        "tests.test_parallel_test_runner",
+        "tests.test_startup_write_probe_generated",
+        "tests.test_targeted_test_selection",
+        "tests.test_test_tmpfs",
+        "tests.test_unused_import_audit",
+        "tests.test_world_model_burst",
+    ),
     "tests/_tests_typing_ratchet_baseline.py": (
         "tests.test_typing_ratchet",
     ),

--- a/tests/_source_pins.py
+++ b/tests/_source_pins.py
@@ -1,0 +1,134 @@
+"""Comment-stripped source reads for whole-file pins (issues #1172, #1186).
+
+A test that pins source text by reading a whole file and asserting a substring
+is satisfied by that substring appearing in a **comment**. So the single most
+likely way a line gets disabled — putting a ``#`` in front of it — leaves the
+pin green while the thing it guards is gone.
+
+This is not hypothetical. #1172 proved it for ``nix/module.nix``: commenting
+out the migrate unit's ``after = optional cfg.pipelineDb.createLocally
+"postgresql-setup.service";`` left ``TestCreateLocallyContract`` passing, so
+the guard that keeps a stranger's first boot from racing NixOS role/database
+provisioning could be switched off with one character. #1186 found the same
+shape across the rest of the tree, most seriously in the deploy runbook, where
+every executable pin sits inside a fenced ``bash`` block and a leading ``#``
+silently disables a real deploy-safety step.
+
+Read pinned source through :func:`pinned_source` and the assertion sees only
+lines that actually do something.
+
+**Deliberately line-start only.** Nothing here parses inline comments, because
+that needs quote tracking and would corrupt real code:
+``sed 's#/cratedigger.py##'`` and ``grep -o '/nix/store/[^ ;]*/bin/cratedigger'``
+both appear in the deploy runbook and both carry a literal ``#`` inside quotes.
+The line-start rule needs no parser and is exactly the mutant class that
+matters — a whole line switched off.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_MARKDOWN_FENCE = "```"
+
+# Full-line comment prefixes per file suffix. An unlisted suffix raises rather
+# than silently returning raw source, so a new kind of pinned artifact has to be
+# considered rather than inheriting the very defect this module exists to
+# remove.
+#
+# ``.json`` is JSONC deliberately, not an oversight: pyright accepts ``//``
+# comments in ``pyrightconfig*.json`` (verified against the pinned pyright), so
+# a config line there really can be commented out. Assuming "JSON has no
+# comments" would have left exactly this file unguarded.
+_LINE_COMMENT_PREFIXES: dict[str, tuple[str, ...]] = {
+    ".bash": ("#",),
+    ".js": ("//",),
+    ".json": ("//",),
+    ".nix": ("#",),
+    ".py": ("#",),
+    ".sh": ("#",),
+    ".sql": ("--",),
+    ".yaml": ("#",),
+    ".yml": ("#",),
+}
+
+
+class UnknownPinnedFormat(AssertionError):
+    """Raised for a suffix with no declared comment syntax.
+
+    Fail closed: returning the raw source instead would reinstate #1172 for
+    whatever new artifact type someone starts pinning.
+    """
+
+
+def strip_line_comments(source: str, prefixes: tuple[str, ...]) -> str:
+    """``source`` with every full-line comment removed.
+
+    A trailing comment after code keeps its line — the code on it is real and
+    must stay pinnable. A first-line ``#!`` shebang is kept too: it is a
+    functional directive, not a disabled line, and removing it would be a lie
+    about what the file does.
+
+    Comment lines are **blanked, not deleted**, which matters twice. Deleting
+    would splice the lines either side of a comment together and could satisfy
+    a multi-line pin that the real file does not contain — turning one false
+    green into another. It would also shift line numbers, and two pinning
+    modules ``ast.parse`` the same source they pin, so a parse error should
+    still name the real line. Several working pins span shell
+    line-continuations (``exec ruff check \\`` + its arguments) and match only
+    because the lines stay adjacent and in order; nothing here reflows.
+    """
+    lines = source.splitlines()
+    kept = [
+        line
+        if ((index == 0 and line.startswith("#!"))
+            or not line.lstrip().startswith(prefixes))
+        else ""
+        for index, line in enumerate(lines)
+    ]
+    return "\n".join(kept)
+
+
+def strip_fenced_comments(source: str) -> str:
+    """Markdown with full-line shell comments removed **inside fences only**.
+
+    Headings are untouched. A Markdown ``#`` at the start of a prose line is a
+    heading, and several pins depend on headings as section anchors
+    (``## Database migrations`` bounds the strict-hold slice); stripping those
+    would destroy the document's structure to fix a problem prose does not
+    have. Inside a fenced block the same character is a shell comment, which is
+    where the real exposure lives: #1186 measured 14 pinned deploy-runbook
+    steps that a single ``# `` disables with the suite green.
+
+    Blanks rather than deletes, for the same reasons as
+    :func:`strip_line_comments`.
+    """
+    kept: list[str] = []
+    inside_fence = False
+    for line in source.splitlines():
+        if line.lstrip().startswith(_MARKDOWN_FENCE):
+            inside_fence = not inside_fence
+            kept.append(line)
+            continue
+        kept.append("" if inside_fence and line.lstrip().startswith("#") else line)
+    return "\n".join(kept)
+
+
+def pinned_source(path: Path) -> str:
+    """Read ``path`` for a source pin, with disabled lines removed.
+
+    Dispatches on suffix and raises :class:`UnknownPinnedFormat` for anything
+    undeclared.
+    """
+    source = path.read_text(encoding="utf-8")
+    if path.suffix == ".md":
+        return strip_fenced_comments(source)
+    try:
+        prefixes = _LINE_COMMENT_PREFIXES[path.suffix]
+    except KeyError:
+        raise UnknownPinnedFormat(
+            f"no declared comment syntax for {path.suffix!r} ({path}). Add it "
+            "to tests/_source_pins.py rather than pinning raw source — a raw "
+            "pin is satisfied by commented-out text (#1172, #1186)."
+        ) from None
+    return strip_line_comments(source, prefixes)

--- a/tests/test_convergence_pipeline_db.py
+++ b/tests/test_convergence_pipeline_db.py
@@ -22,6 +22,81 @@ from tests.test_pipeline_db import TEST_DSN, make_db, requires_postgres
 
 
 @requires_postgres
+class TestConvergenceIndexesExistInTheRealSchema(unittest.TestCase):
+    """#1186. Migration 071's three partial indexes keep convergence reads off
+    a multi-million-row ``download_log``.
+
+    Until now nothing checked they EXIST. ``test_convergence_query_shape``
+    pins their names in the migration's frozen text, which proves what the
+    file once said, not what the database has — a triage mutant commenting
+    out the whole ``CREATE INDEX idx_download_log_convergence_candidates``
+    statement left both that text pin and every behavioural convergence test
+    green. A later migration dropping one would be equally invisible, and
+    text-level pinning cannot see it at all: only the live catalog can.
+    """
+
+    EXPECTED_INDEXES = (
+        "idx_download_log_candidate_evidence_attribution",
+        "idx_import_jobs_candidate_evidence_attribution",
+        "idx_download_log_convergence_candidates",
+    )
+
+    def test_every_convergence_index_is_present_and_partial(self) -> None:
+        db = make_db()
+        try:
+            cur = db._execute(
+                "SELECT indexname, indexdef FROM pg_indexes "
+                "WHERE indexname = ANY(%s)",
+                (list(self.EXPECTED_INDEXES),),
+            )
+            definitions = {
+                str(row["indexname"]): str(row["indexdef"]) for row in cur.fetchall()
+            }
+        finally:
+            db.close()
+
+        self.assertEqual(
+            sorted(definitions), sorted(self.EXPECTED_INDEXES),
+            "a convergence index is missing from the live schema",
+        )
+        for name, definition in definitions.items():
+            # Partial is the whole point: a full index over download_log would
+            # be the cost these exist to avoid.
+            self.assertIn("WHERE", definition, name)
+
+    def test_the_candidate_index_keeps_its_selective_predicate(self) -> None:
+        """The predicate is what excludes cross-walked, non-Soulseek,
+        non-exact and high-distance rows. An index of the same name with a
+        widened predicate would satisfy a name-only check while quietly
+        reintroducing the scan."""
+        db = make_db()
+        try:
+            row = db._execute(
+                "SELECT indexdef FROM pg_indexes WHERE indexname = %s",
+                ("idx_download_log_convergence_candidates",),
+            ).fetchone()
+        finally:
+            db.close()
+
+        self.assertIsNotNone(row)
+        assert row is not None
+        definition = str(row["indexdef"])
+        # Written against the catalog's OWN rendering, not the migration's
+        # text: PostgreSQL normalises the predicate (adding casts and
+        # parentheses), so `beets_distance <= 0.15` in the source file comes
+        # back as `beets_distance <= (0.15)::double precision`. Asserting the
+        # source spelling here would be the same mistake this class exists to
+        # correct — believing the file over the database.
+        for clause in (
+            "candidate_evidence_direct IS TRUE",
+            "source = 'slskd'::text",
+            "beets_scenario = 'strong_match'::text",
+            "beets_distance <= (0.15)::double precision",
+        ):
+            self.assertIn(clause, definition)
+
+
+@requires_postgres
 class TestConvergencePipelineDB(unittest.TestCase):
     def setUp(self) -> None:
         self.db = make_db()

--- a/tests/test_daily_flake_update.py
+++ b/tests/test_daily_flake_update.py
@@ -11,6 +11,7 @@ import unittest
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
+from tests._source_pins import pinned_source
 from tests.fakes.daily_flake_update import FakeDailyFlakeUpdateCommands
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -226,7 +227,7 @@ class TestDailyFlakeUpdateScript(unittest.TestCase):
         tests/test_targeted_test_selection.py's scripts/test.sh pin, so
         deleting just this var (not some other CRATEDIGGER_SUITE_OWNS_
         HEADROOM occurrence) fails this test."""
-        source = SCRIPT.read_text(encoding="utf-8")
+        source = pinned_source(SCRIPT)
 
         self.assertIn(
             'run_stage deterministic_suite "deterministic full suite" \\\n'

--- a/tests/test_deploy_cycle_verifier.py
+++ b/tests/test_deploy_cycle_verifier.py
@@ -6,6 +6,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
+from tests._source_pins import pinned_source
 from tests.fakes.deploy_cycle import FakeDeployCycleCommands
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -334,7 +335,7 @@ class TestDeployCycleVerifier(unittest.TestCase):
         self.assertIn("source", proc.stderr)
 
     def test_skill_calls_tracked_verifier_for_successor_cycle(self) -> None:
-        source = SKILL.read_text(encoding="utf-8")
+        source = pinned_source(SKILL)
         self.assertIn("scripts/verify_cratedigger_cycle.sh", source)
         self.assertIn("capture-current", source)
         self.assertIn("capture-cursor", source)
@@ -364,7 +365,7 @@ class TestDeployCycleVerifier(unittest.TestCase):
         self.assertLess(post_switch_capture, target_capture)
 
     def test_skill_runs_fleet_trigger_without_the_shared_agent(self) -> None:
-        source = SKILL.read_text(encoding="utf-8")
+        source = pinned_source(SKILL)
 
         self.assertIn("env -u SSH_AUTH_SOCK fleet-deploy doc2", source)
         for line in source.splitlines():
@@ -555,7 +556,7 @@ class TestMigrateRanForThisSwitch(unittest.TestCase):
         `fleet-deploy` and assert with it after. Capturing after the switch
         would compare the post-switch value against itself and pass
         unconditionally — which is the whole failure #1161 describes."""
-        source = SKILL.read_text(encoding="utf-8")
+        source = pinned_source(SKILL)
 
         capture = source.index('verify_cratedigger_cycle.sh" capture-migrate')
         trigger = source.index("env -u SSH_AUTH_SOCK fleet-deploy doc2")
@@ -571,7 +572,7 @@ class TestMigrateRanForThisSwitch(unittest.TestCase):
     def test_skill_no_longer_accepts_the_stale_state_triple_alone(self) -> None:
         """The superseded check read only ActiveState/SubState/Result, which a
         RemainAfterExit oneshot satisfies indefinitely."""
-        source = SKILL.read_text(encoding="utf-8")
+        source = pinned_source(SKILL)
 
         self.assertNotIn('test "$migration_active" = active', source)
 

--- a/tests/test_deploy_hold.py
+++ b/tests/test_deploy_hold.py
@@ -65,6 +65,7 @@ from scripts.cratedigger_deploy_hold import (
     verify_held,
 )
 from scripts.pipeline_cli.query import _render_query_table
+from tests._source_pins import pinned_source
 from tests.fakes.deploy_hold import FakeDeployHoldBackend
 
 INVOCATION = "a" * 32
@@ -2008,7 +2009,7 @@ class TestFixedAuthoritySurface(unittest.TestCase):
         helper = REPO_ROOT / "scripts" / "cratedigger_deploy_hold.py"
         skill = REPO_ROOT / ".claude" / "skills" / "deploy" / "SKILL.md"
         helper_source = helper.read_text(encoding="utf-8")
-        skill_source = skill.read_text(encoding="utf-8")
+        skill_source = pinned_source(skill)
 
         self.assertEqual(helper_source.splitlines()[0], "#!/usr/bin/env python3")
         self.assertIn("cratedigger_deploy_hold.py", skill_source)

--- a/tests/test_deploy_pin_script.py
+++ b/tests/test_deploy_pin_script.py
@@ -7,6 +7,7 @@ import time
 import unittest
 from pathlib import Path
 
+from tests._source_pins import pinned_source
 from tests.fakes.deploy_pin import FakeDeployPinCommands
 from tests.structural_audits.deploy_pin import find_shell_contract_violations
 
@@ -38,7 +39,7 @@ class TestDeployPinShellContractAudit(unittest.TestCase):
         )
 
     def test_skill_invokes_entrypoint_instead_of_copying_state_machine(self) -> None:
-        source = SKILL.read_text(encoding="utf-8")
+        source = pinned_source(SKILL)
         self.assertIn("scripts/pin_nixosconfig.sh", source)
         self.assertNotIn("worktree add --detach", source)
         self.assertNotIn("GIT_CONFIG_VALUE_0", source)

--- a/tests/test_fuzz_burst.py
+++ b/tests/test_fuzz_burst.py
@@ -34,6 +34,7 @@ from scripts.run_python_tests import (
     STRATEGY_SPACE_EXHAUSTED,
     HypothesisPropertyStats,
 )
+from tests._source_pins import pinned_source
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 RUNNER = REPO_ROOT / "scripts" / "run_fuzz_tests.py"
@@ -1268,7 +1269,7 @@ class TestFuzzRunnerProcess(unittest.TestCase):
         )
 
     def test_wrapper_delegates_to_the_exact_coverage_runner(self) -> None:
-        source = WRAPPER.read_text(encoding="utf-8")
+        source = pinned_source(WRAPPER)
 
         self.assertIn("python3 scripts/run_fuzz_tests.py", source)
 

--- a/tests/test_issue_573_boundaries.py
+++ b/tests/test_issue_573_boundaries.py
@@ -7,6 +7,8 @@ import importlib
 import unittest
 from pathlib import Path
 
+from tests._source_pins import pinned_source
+
 EXPECTED_VULTURE_SOURCE_ROOTS = (
     "lib",
     "web",
@@ -60,7 +62,7 @@ class TestDispatchImportCoreCallBoundary(unittest.TestCase):
             "lib/dispatch/entry_points.py",
             "lib/download_validation.py",
         ):
-            source = Path(relative_path).read_text(encoding="utf-8")
+            source = pinned_source(Path(relative_path))
             tree = ast.parse(source, filename=relative_path)
             self.assertNotIn("core_kwargs", source, relative_path)
             if relative_path == "lib/download_validation.py":
@@ -80,7 +82,7 @@ class TestDispatchImportCoreCallBoundary(unittest.TestCase):
                 })
 
     def test_production_callable_has_a_pyright_conformance_binding(self) -> None:
-        source = Path("lib/dispatch/__init__.py").read_text(encoding="utf-8")
+        source = pinned_source(Path("lib/dispatch/__init__.py"))
         self.assertIn(
             "_dispatch_core_conformance: DispatchCoreFn = dispatch_import_core",
             source,
@@ -89,7 +91,7 @@ class TestDispatchImportCoreCallBoundary(unittest.TestCase):
 
 class TestDownloadCompletionOwnership(unittest.TestCase):
     def test_processing_is_only_the_completion_orchestrator(self) -> None:
-        source = Path("lib/download_processing.py").read_text(encoding="utf-8")
+        source = pinned_source(Path("lib/download_processing.py"))
         assert_completion_orchestrator_responsibilities(source)
         self.assertIn("from lib import download_validation", source)
 
@@ -103,7 +105,7 @@ class TestDownloadCompletionOwnership(unittest.TestCase):
             self.assertFalse(hasattr(processing, moved_name), moved_name)
 
     def test_validation_functions_have_executable_protocol_bindings(self) -> None:
-        source = Path("lib/download_validation.py").read_text(encoding="utf-8")
+        source = pinned_source(Path("lib/download_validation.py"))
         self.assertIn(
             "_validate_conformance: ValidateFn = _process_beets_validation",
             source,

--- a/tests/test_issue_633_boundaries.py
+++ b/tests/test_issue_633_boundaries.py
@@ -6,6 +6,8 @@ import ast
 import unittest
 from pathlib import Path
 
+from tests._source_pins import pinned_source
+
 
 def _annotation(node: ast.expr | None) -> str | None:
     return ast.unparse(node) if node is not None else None
@@ -97,7 +99,7 @@ class TestProcessAlbumProtocolBoundary(unittest.TestCase):
         self.assertEqual(_annotation(call.returns), _annotation(production.returns))
 
     def test_production_function_has_pyright_conformance_binding(self) -> None:
-        source = Path("lib/download_processing.py").read_text(encoding="utf-8")
+        source = pinned_source(Path("lib/download_processing.py"))
         self.assertIn(
             "_process_completed_album_conformance: ProcessAlbumFn = "
             "process_completed_album",
@@ -105,12 +107,12 @@ class TestProcessAlbumProtocolBoundary(unittest.TestCase):
         )
 
     def test_download_seam_has_no_ellipsis_callable_escape(self) -> None:
-        source = Path("lib/download.py").read_text(encoding="utf-8")
+        source = pinned_source(Path("lib/download.py"))
         self.assertNotIn("Callable[..., CompletionResult]", source)
         self.assertIn("process_album_fn: ProcessAlbumFn | None", source)
 
     def test_test_double_is_protocol_checked_without_broad_splats(self) -> None:
-        fake_source = Path("tests/fakes/download.py").read_text(encoding="utf-8")
+        fake_source = pinned_source(Path("tests/fakes/download.py"))
         self.assertIn(
             "_recorder_conformance: ProcessAlbumFn = RecordingProcessAlbum()",
             fake_source,

--- a/tests/test_js_suite_audit.py
+++ b/tests/test_js_suite_audit.py
@@ -23,6 +23,9 @@ import glob
 import os
 import re
 import unittest
+from pathlib import Path
+
+from tests._source_pins import pinned_source
 
 REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 RUN_TESTS_SH = os.path.join(REPO_ROOT, "scripts", "run_tests.sh")
@@ -90,12 +93,9 @@ class TestJsSuiteAudit(unittest.TestCase):
     """Every tests/test_js_*.mjs file must run every scripts/run_tests.sh pass."""
 
     def setUp(self) -> None:
-        with open(RUN_TESTS_SH, encoding="utf-8") as f:
-            self.wrapper_text = f.read()
-        with open(RUN_TEST_SUITE, encoding="utf-8") as f:
-            self.coordinator_text = f.read()
-        with open(RUN_JS_CHECKS, encoding="utf-8") as f:
-            self.script_text = f.read()
+        self.wrapper_text = pinned_source(Path(RUN_TESTS_SH))
+        self.coordinator_text = pinned_source(Path(RUN_TEST_SUITE))
+        self.script_text = pinned_source(Path(RUN_JS_CHECKS))
 
     def test_every_js_suite_on_disk_is_covered(self) -> None:
         suite_names = _js_suite_names_on_disk()

--- a/tests/test_nix_module.py
+++ b/tests/test_nix_module.py
@@ -34,6 +34,8 @@ import unittest
 from pathlib import Path
 from typing import ClassVar
 
+from tests._source_pins import strip_line_comments
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 MODULE_NIX = REPO_ROOT / "nix" / "module.nix"
 FLAKE_NIX = REPO_ROOT / "flake.nix"
@@ -47,15 +49,11 @@ MODULE_VM_NIX = REPO_ROOT / "nix" / "tests" / "module-vm.nix"
 def _strip_comment_lines(source: str) -> str:
     """``source`` with every full-line ``#`` comment removed.
 
-    Only whole comment lines go; a trailing comment after code is left alone,
-    since the code on that line is real. Nix has no block-comment form we use
-    here, and ``nix/`` carries no shebang lines — if one ever appears inside an
-    embedded script, note that ``#!`` is stripped along with everything else.
+    Thin alias for the shared reader so this module keeps one local name for
+    the operation; the implementation is shared with every other pinning
+    module (#1186) rather than duplicated here.
     """
-    return "\n".join(
-        line for line in source.splitlines()
-        if not line.lstrip().startswith("#")
-    )
+    return strip_line_comments(source, ("#",))
 
 
 def _nix_source(path: Path) -> str:

--- a/tests/test_parallel_test_runner.py
+++ b/tests/test_parallel_test_runner.py
@@ -69,6 +69,7 @@ from scripts.run_test_suite import (
     TEST_RAM_ROOT_EXHAUSTED,
     CheckFailureMarker,
 )
+from tests._source_pins import pinned_source
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 RUNNER = REPO_ROOT / "scripts" / "run_python_tests.py"
@@ -1549,8 +1550,8 @@ class TestHypothesisStatsRecorder(unittest.TestCase):
 
 class TestRunTestsWiring(unittest.TestCase):
     def test_full_suite_uses_parallel_python_runner(self) -> None:
-        shell_source = RUN_TESTS_SH.read_text(encoding="utf-8")
-        coordinator_source = RUN_SUITE.read_text(encoding="utf-8")
+        shell_source = pinned_source(RUN_TESTS_SH)
+        coordinator_source = pinned_source(RUN_SUITE)
         self.assertIn("exec python3 scripts/run_test_suite.py", shell_source)
         self.assertIn('("python3", "scripts/run_python_tests.py")', coordinator_source)
         self.assertNotIn("python3 -m unittest discover", coordinator_source)

--- a/tests/test_source_pins.py
+++ b/tests/test_source_pins.py
@@ -1,0 +1,184 @@
+"""Contracts for the comment-stripping source reader (issues #1172, #1186)."""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from tests._source_pins import (
+    UnknownPinnedFormat,
+    pinned_source,
+    strip_fenced_comments,
+    strip_line_comments,
+)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEPLOY_SKILL = REPO_ROOT / ".claude" / "skills" / "deploy" / "SKILL.md"
+
+
+class TestStripLineComments(unittest.TestCase):
+    def test_a_commented_line_is_removed(self) -> None:
+        self.assertEqual(strip_line_comments("# stopIfChanged = false;", ("#",)), "")
+
+    def test_an_indented_comment_is_removed(self) -> None:
+        """Nix and shell alike nest, so a disabled line is almost always
+        indented rather than at column zero."""
+        self.assertEqual(
+            strip_line_comments("      # stopIfChanged = false;", ("#",)), "",
+        )
+
+    def test_a_trailing_comment_keeps_its_code(self) -> None:
+        source = "NoNewPrivileges = true; # no setuid exec"
+        self.assertIn("NoNewPrivileges = true;", strip_line_comments(source, ("#",)))
+
+    def test_sql_uses_its_own_prefix(self) -> None:
+        source = "-- CREATE INDEX disabled;\nCREATE INDEX live;"
+        stripped = strip_line_comments(source, ("--",))
+        self.assertNotIn("CREATE INDEX disabled;", stripped)
+        self.assertIn("CREATE INDEX live;", stripped)
+
+    def test_a_hash_does_not_comment_sql(self) -> None:
+        """Applying the wrong prefix must not silently strip real code."""
+        self.assertIn("# not a comment here", strip_line_comments(
+            "# not a comment here", ("--",)))
+
+    def test_a_first_line_shebang_survives(self) -> None:
+        """A shebang is a functional directive, not a disabled line. Some
+        tests read a script, mutate it, and write it back out executable —
+        dropping the shebang there would corrupt the fixture."""
+        source = "#!/usr/bin/env bash\n# disabled\nreal\n"
+        stripped = strip_line_comments(source, ("#",))
+        self.assertIn("#!/usr/bin/env bash", stripped)
+        self.assertNotIn("# disabled", stripped)
+
+    def test_a_shebang_below_the_first_line_is_still_a_comment(self) -> None:
+        """``#!`` only means anything on line 1; anywhere else it is an
+        ordinary comment and must not become an escape hatch."""
+        source = "real\n#!/usr/bin/env bash\n"
+        self.assertNotIn("#!/usr/bin/env bash", strip_line_comments(source, ("#",)))
+
+    def test_a_comment_is_blanked_not_deleted(self) -> None:
+        """Deleting would splice the surrounding lines together and could
+        satisfy a multi-line pin the real file does not contain — trading one
+        false green for another. It would also shift line numbers, and two
+        pinning modules ``ast.parse`` the source they pin."""
+        stripped = strip_line_comments("alpha\n# gone\nbeta\n", ("#",))
+        self.assertNotIn("alpha\nbeta", stripped)
+        self.assertEqual(stripped, "alpha\n\nbeta")
+
+    def test_line_continuations_stay_adjacent(self) -> None:
+        """Multi-line pins match only because the lines stay adjacent and in
+        order — three working pins depend on this, so nothing may reflow."""
+        source = 'exec ruff check \\\n  --output-format full \\\n  "$@"\n'
+        self.assertIn(
+            'exec ruff check \\\n  --output-format full \\\n  "$@"',
+            strip_line_comments(source, ("#",)),
+        )
+
+
+class TestStripFencedComments(unittest.TestCase):
+    """#1186: in Markdown the exposure is inside fenced code blocks, where
+    ``#`` is a shell comment — NOT in prose, where it is a heading."""
+
+    def test_a_shell_comment_inside_a_fence_is_removed(self) -> None:
+        source = "```bash\n# fleet-deploy doc2\nreal-command\n```"
+        stripped = strip_fenced_comments(source)
+        self.assertNotIn("fleet-deploy doc2", stripped)
+        self.assertIn("real-command", stripped)
+
+    def test_a_heading_in_prose_survives(self) -> None:
+        """Section headings are load-bearing anchors — several pins slice the
+        runbook on them. Stripping these would break the document."""
+        source = "## Database migrations\n\nordinary prose\n"
+        self.assertIn("## Database migrations", strip_fenced_comments(source))
+
+    def test_a_heading_after_a_closed_fence_survives(self) -> None:
+        """Fence state must actually toggle back off; a stuck-open scanner
+        would eat every heading in the rest of the file."""
+        source = "```bash\n# disabled\n```\n\n## Still A Heading\n"
+        stripped = strip_fenced_comments(source)
+        self.assertNotIn("# disabled", stripped)
+        self.assertIn("## Still A Heading", stripped)
+
+    def test_an_inline_hash_inside_a_fence_survives(self) -> None:
+        """``sed 's#/cratedigger.py##'`` is real runbook code carrying a
+        literal ``#``. A to-end-of-line stripper would corrupt it, which is
+        why this is deliberately line-start only."""
+        source = "```bash\nsed 's#/cratedigger.py##'\n```"
+        self.assertIn("sed 's#/cratedigger.py##'", strip_fenced_comments(source))
+
+    def test_the_fence_markers_themselves_survive(self) -> None:
+        source = "```bash\nreal-command\n```"
+        self.assertEqual(strip_fenced_comments(source).count("```"), 2)
+
+
+class TestPinnedSourceDispatch(unittest.TestCase):
+    def _write(self, name: str, body: str) -> Path:
+        directory = Path(tempfile.mkdtemp())
+        self.addCleanup(lambda: None)
+        path = directory / name
+        path.write_text(body, encoding="utf-8")
+        return path
+
+    def test_shell_suffix_strips_hash(self) -> None:
+        path = self._write("x.sh", "# exec real\nexec live\n")
+        stripped = pinned_source(path)
+        self.assertNotIn("exec real", stripped)
+        self.assertIn("exec live", stripped)
+
+    def test_sql_suffix_strips_double_dash(self) -> None:
+        path = self._write("x.sql", "-- CREATE INDEX gone;\nCREATE INDEX live;\n")
+        self.assertNotIn("CREATE INDEX gone;", pinned_source(path))
+
+    def test_markdown_suffix_uses_the_fence_rule(self) -> None:
+        path = self._write("x.md", "# Heading\n\n```bash\n# gone\nlive\n```\n")
+        stripped = pinned_source(path)
+        self.assertIn("# Heading", stripped)
+        self.assertNotIn("# gone", stripped)
+
+    def test_json_is_treated_as_jsonc(self) -> None:
+        """Pyright accepts ``//`` comments in pyrightconfig*.json, verified
+        against the pinned pyright. Assuming "JSON has no comments" would have
+        left exactly that file unguarded."""
+        path = self._write("x.json", '{\n  // "reportShadowedImports": "error",\n}\n')
+        self.assertNotIn("reportShadowedImports", pinned_source(path))
+
+    def test_an_undeclared_suffix_fails_closed(self) -> None:
+        """Returning raw source for an unknown format would reinstate the very
+        defect this module removes, so it raises instead."""
+        path = self._write("x.toml", "key = 'value'\n")
+        with self.assertRaisesRegex(UnknownPinnedFormat, r"\.toml"):
+            pinned_source(path)
+
+
+class TestAgainstTheRealDeployRunbook(unittest.TestCase):
+    """End-to-end over the real file, driving the exact #1186 mutant."""
+
+    def test_commenting_out_a_runbook_step_defeats_its_pin(self) -> None:
+        """`test_skill_calls_tracked_verifier_for_successor_cycle` pins this
+        step. Deleting it goes RED; commenting it out inside the fence left the
+        pin GREEN, which is #1186's founding measurement."""
+        step = 'verify-migrate-ran "$PRE_SWITCH_MIGRATE_INVOCATION"'
+        raw = DEPLOY_SKILL.read_text(encoding="utf-8")
+        # The runbook invokes it twice (ordinary and strict-held deploys), and
+        # a pin is only defeated once EVERY occurrence is disabled.
+        self.assertEqual(raw.count(step), 2)
+
+        commented = raw.replace(f"  {step}", f"  # {step}")
+        # The defect: still present, as comment text.
+        self.assertIn(step, commented)
+        # The fix: absent from what the pin actually reads.
+        self.assertNotIn(step, strip_fenced_comments(commented))
+
+    def test_real_runbook_headings_and_steps_both_survive_stripping(self) -> None:
+        """A must-still-work guard: the stripper must not fail closed on the
+        real document by eating headings or live commands."""
+        stripped = pinned_source(DEPLOY_SKILL)
+        self.assertIn("## Database migrations", stripped)
+        self.assertIn("env -u SSH_AUTH_SOCK fleet-deploy doc2", stripped)
+        self.assertIn("scripts/verify_cratedigger_cycle.sh", stripped)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_startup_write_probe_generated.py
+++ b/tests/test_startup_write_probe_generated.py
@@ -57,6 +57,7 @@ from lib.startup_write_probe import (
     web_required_paths,
     youtube_ingest_required_paths,
 )
+from tests._source_pins import pinned_source
 from tests.finite_domain import finite_generated_domain
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -419,9 +420,7 @@ class TestStartupWriteProbeBrokenPathGenerated(unittest.TestCase):
 
 class TestUnfindableNeverWired(unittest.TestCase):
     def test_run_unfindable_detection_never_imports_the_probe(self) -> None:
-        source = (
-            REPO_ROOT / "scripts" / "run_unfindable_detection.py"
-        ).read_text(encoding="utf-8")
+        source = pinned_source(REPO_ROOT / "scripts" / "run_unfindable_detection.py")
         self.assertNotIn("startup_write_probe", source)
         self.assertNotIn("probe_startup_paths", source)
 

--- a/tests/test_targeted_test_selection.py
+++ b/tests/test_targeted_test_selection.py
@@ -33,6 +33,7 @@ from scripts.targeted_test_selection import (
     assert_selection_complete,
     expand_test_selection,
 )
+from tests._source_pins import pinned_source
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 #: The runner's own --pattern default (scripts/run_python_tests.py), sourced
@@ -360,7 +361,7 @@ class TestTargetedSuiteWiring(unittest.TestCase):
         )
 
     def test_shell_entrypoint_forwards_every_selector_to_targeted_runner(self) -> None:
-        source = (REPO_ROOT / "scripts" / "test.sh").read_text(encoding="utf-8")
+        source = pinned_source(REPO_ROOT / "scripts" / "test.sh")
 
         self.assertIn("scripts/run_targeted_tests.py", source)
         self.assertIn('"$@"', source)
@@ -372,7 +373,7 @@ class TestTargetedSuiteWiring(unittest.TestCase):
         scripts/test.sh's own nix-shell invocation would leave every other
         test green while M2 silently reverts to the old shell-entry-dies-
         under-contention shape."""
-        source = (REPO_ROOT / "scripts" / "test.sh").read_text(encoding="utf-8")
+        source = pinned_source(REPO_ROOT / "scripts" / "test.sh")
 
         self.assertIn(
             "env CRATEDIGGER_SUITE_OWNS_HEADROOM=1 nix-shell", source

--- a/tests/test_test_tmpfs.py
+++ b/tests/test_test_tmpfs.py
@@ -12,6 +12,8 @@ import unittest
 from collections.abc import Mapping
 from pathlib import Path
 
+from tests._source_pins import pinned_source
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 TMPFS_SETUP = REPO_ROOT / "scripts" / "test_tmpfs.sh"
 NIX_SHELL = REPO_ROOT / "nix" / "shell.nix"
@@ -280,7 +282,7 @@ class TestTmpfsSetup(unittest.TestCase):
         self.assertEqual(completed.returncode, 7, completed.stderr)
 
     def test_nix_shell_activates_tmpfs_before_dev_commands(self) -> None:
-        source = NIX_SHELL.read_text(encoding="utf-8")
+        source = pinned_source(NIX_SHELL)
 
         self.assertIn("scripts/test_tmpfs.sh", source)
         self.assertIn("setup_cratedigger_test_tmpfs", source)

--- a/tests/test_unused_import_audit.py
+++ b/tests/test_unused_import_audit.py
@@ -12,6 +12,8 @@ import unittest
 from collections import Counter
 from pathlib import Path
 
+from tests._source_pins import pinned_source
+
 EXPECTED_PRODUCTION_ROOTS = (
     "lib",
     "web",
@@ -435,7 +437,7 @@ class TestUnusedImportAudit(unittest.TestCase):
             .splitlines()
             if line.strip() and not line.lstrip().startswith("#")
         )
-        script = Path("scripts/find_dead_code.sh").read_text(encoding="utf-8")
+        script = pinned_source(Path("scripts/find_dead_code.sh"))
 
         self.assertEqual(roots, EXPECTED_PRODUCTION_ROOTS)
         self.assertNotIn("tests", roots)
@@ -444,9 +446,9 @@ class TestUnusedImportAudit(unittest.TestCase):
         self.assertIn('vulture "${VULTURE_ARGS[@]}" "${SOURCES[@]}"', script)
 
     def test_full_suite_calls_the_canonical_repo_wide_ruff_gate(self) -> None:
-        suite = Path("scripts/run_tests.sh").read_text(encoding="utf-8")
-        coordinator = Path("scripts/run_test_suite.py").read_text(encoding="utf-8")
-        runner = Path("scripts/run_ruff.sh").read_text(encoding="utf-8")
+        suite = pinned_source(Path("scripts/run_tests.sh"))
+        coordinator = pinned_source(Path("scripts/run_test_suite.py"))
+        runner = pinned_source(Path("scripts/run_ruff.sh"))
 
         self.assertIn("scripts/run_test_suite.py", suite)
         self.assertIn('("bash", "scripts/run_ruff.sh")', coordinator)
@@ -499,7 +501,7 @@ class TestUnusedImportAudit(unittest.TestCase):
         config = tomllib.loads(
             Path("ruff.toml").read_text(encoding="utf-8")
         )
-        shell = Path("nix/shell.nix").read_text(encoding="utf-8")
+        shell = pinned_source(Path("nix/shell.nix"))
 
         self.assertEqual(result.returncode, 0, result.stderr)
         version = tuple(

--- a/tests/test_world_model_burst.py
+++ b/tests/test_world_model_burst.py
@@ -7,6 +7,8 @@ import subprocess
 import unittest
 from pathlib import Path
 
+from tests._source_pins import pinned_source
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SCRIPT = REPO_ROOT / "scripts" / "world_model_burst.sh"
 RUN_TESTS_SCRIPT = REPO_ROOT / "scripts" / "run_tests.sh"
@@ -51,7 +53,7 @@ class TestWorldModelBurstScript(unittest.TestCase):
         self.assertIn("root_seed=", result.stdout)
 
     def test_wrapper_delegates_to_dedicated_coordinator(self) -> None:
-        script = SCRIPT.read_text(encoding="utf-8")
+        script = pinned_source(SCRIPT)
 
         self.assertIn("scripts/run_world_model_burst.py", script)
         self.assertNotIn("python3 -m unittest", script)
@@ -115,11 +117,11 @@ class TestWorldModelBurstScript(unittest.TestCase):
         self.assertIn("randomized real-storage lifecycle hammer", result.stdout)
 
     def test_standard_suite_runs_only_the_deterministic_world_budget(self) -> None:
-        script = RUN_TESTS_SCRIPT.read_text(encoding="utf-8")
+        script = pinned_source(RUN_TESTS_SCRIPT)
         coordinator = (
             REPO_ROOT / "scripts" / "run_test_suite.py"
         ).read_text(encoding="utf-8")
-        runner = PYTHON_RUNNER.read_text(encoding="utf-8")
+        runner = pinned_source(PYTHON_RUNNER)
 
         self.assertIn("scripts/run_test_suite.py", script)
         self.assertIn('("python3", "scripts/run_python_tests.py")', coordinator)


### PR DESCRIPTION
## Summary

#1172 fixed whole-file source pins over `nix/*.nix`. The defect class was never
Nix-specific: a pin that reads a whole file and asserts a substring is satisfied
by that substring appearing in a **comment**, so commenting out the real line
leaves the pin green.

Four triage agents planted mutants across every remaining artifact family before
any fix was written. They also found sites my AST scan structurally missed —
`source.index()` ordering assertions (not `assertIn`) and a module using
`open()`/`read()` — so the real exposure was wider than the 86 pins I counted.

### The three worst findings

**`scripts/run_tests.sh` is 7 lines and line 6 is its only executable
statement.** Commented out, the canonical suite exits 0 having run **no tests at
all**, and `run_final_gate.sh` mints a clean receipt over the empty run. FOUR
separate tests claim to guard that line; every one was satisfied by the comment
text.

**16 of 16 Python `assertIn` pins were exposed.** Worst is
`unset_environment=("TEST_DB_DSN", …)` — one `#` lets the world-model child
inherit a production DSN, which is precisely the hazard its sibling test calls
out. Five more are Protocol-conformance bindings whose pin is their **only**
guard: unused module-level assignments existing purely for Pyright, not covered
by Vulture either. One `#` silently deletes the type check with every gate green.

**Markdown was the surprise, and it is the opposite of the naive reading.** "`#`
is a heading, so SKILL.md is safe" is wrong: every executable pin in the deploy
runbook sits inside a ` ```bash ` fence where `#` IS a shell comment, and the
file already carries 19 such comments, so a mutant is indistinguishable from
house style. The control experiment settles it — **deleting** the pinned line
goes RED, **commenting** it stays GREEN. Those pins guard the #1161 migrate-ran
proof, the #837 agent-free fleet trigger, and the strict-hold boundaries.

### The fix

`tests/_source_pins.py` is now the one reader, dispatching on suffix and
**raising** for an undeclared one so a new pinned artifact must be considered
rather than silently inheriting the defect. `test_nix_module`'s
`_strip_comment_lines` becomes a thin alias — one implementation, per the
no-parallel-code-paths rule.

Three decisions the triage forced, none cosmetic:

- **Comments are BLANKED, not deleted.** Deleting splices the surrounding lines
  together and can satisfy a multi-line pin the real file does not contain —
  trading one false green for another. It also shifts line numbers, and two
  pinning modules `ast.parse` the source they pin. This is a latent flaw in what
  #1185 shipped, fixed here by consolidation.
- **A first-line shebang survives.** It is a functional directive, not a disabled
  line, and some tests read a script, mutate it, and write it back executable.
- **`.json` is JSONC.** Pyright accepts `//` comments in `pyrightconfig*.json`
  (verified against the pinned pyright), so assuming "JSON has no comments" would
  have left exactly that file unguarded.

Markdown strips only full-line `#` **inside fences**. Headings are untouched
(pins slice the runbook on `## Database migrations`), and nothing parses inline
comments — `sed 's#/cratedigger.py##'` is real runbook code carrying a literal
`#` that a to-end-of-line stripper would corrupt.

### Deliberately NOT converted, with evidence

- **The 14 migration-071 SQL pins.** A shipped migration is frozen by rule so the
  comment-out threat model does not exist; PostgreSQL is a far louder guard
  (commenting mid-statement makes `apply_migrations` raise `SyntaxError` and
  errors every PG-backed module); and doing it properly needs `/* */` handling,
  i.e. the prohibited semantic-scanner shape. **The real gap there was
  different, and is closed here instead** — see below.
- **The `pyrightconfig` pin**: `assertNotIn`, so comments make it falsely RED,
  never falsely green, and a live backstop already exists.
- **`test_docs_audit`'s beets-docs anchors**: all prose, no fenced code, no
  realistic disable vector that preserves the string.
- **Four raw reads kept raw on purpose**: three in `test_unused_import_audit` and
  one in `test_nix_module` build in-test mutants or need raw text to comment a
  line out in the first place.

### The unbacked hole the SQL triage found

Migration 071's three partial indexes keep convergence reads off a
multi-million-row `download_log`, and **nothing checked they exist**. The text
pins prove what the file once said, not what the database has: a mutant
commenting out the whole `CREATE INDEX idx_download_log_convergence_candidates`
statement left both the text pin and every behavioural convergence test green.
`TestConvergenceIndexesExistInTheRealSchema` now asserts against `pg_indexes`,
which also survives a later migration dropping one — something no text pin can
see. Written against the catalog's own rendering, since PostgreSQL normalises
`beets_distance <= 0.15` to `beets_distance <= (0.15)::double precision`.

## Kill matrix (per diff site, not per PR)

Per artifact family plus every high-severity individual site. All planted and
run; the shell/Nix/Markdown rows were also confirmed to **survive** before the
fix by the triage agents.

| Site (assertion / clause / constant) | One-line production mutant | Test that must go RED | Result |
| --- | --- | --- | --- |
| `pinned_source` over `scripts/run_tests.sh` | comment out `exec python3 scripts/run_test_suite.py` | `test_full_suite_uses_parallel_python_runner` | KILLED |
| same line, second guard | same mutant | `test_every_js_suite_on_disk_is_covered` | KILLED |
| `pinned_source` over `scripts/world_model_burst.sh` | comment out `scripts/run_world_model_burst.py` | `test_wrapper_delegates_to_dedicated_coordinator` | KILLED |
| `pinned_source` over `scripts/test.sh` | comment out `scripts/run_targeted_tests.py` | `test_shell_entrypoint_forwards_every_selector_to_targeted_runner` | KILLED |
| `pinned_source` over `scripts/fuzz_burst.sh` | comment out `python3 scripts/run_fuzz_tests.py` | `test_wrapper_delegates_to_the_exact_coverage_runner` | KILLED |
| `pinned_source` over `scripts/find_dead_code.sh` | comment out `vulture "${VULTURE_ARGS[@]}" "${SOURCES[@]}"` | `test_vulture_keeps_its_production_only_roots` | KILLED |
| `pinned_source` over `scripts/run_python_tests.py` | comment out `unset_environment=("TEST_DB_DSN"` | `test_standard_suite_runs_only_the_deterministic_world_budget` | KILLED |
| `pinned_source` over `lib/dispatch/__init__.py` | comment out `_dispatch_core_conformance: DispatchCoreFn = …` | `test_production_callable_has_a_pyright_conformance_binding` | KILLED |
| `pinned_source` over `nix/shell.nix` | comment out `setup_cratedigger_test_tmpfs` | `test_nix_shell_activates_tmpfs_before_dev_commands` | KILLED |
| `strip_fenced_comments` (Markdown) | comment out both `verify-migrate-ran "$PRE_SWITCH_MIGRATE_INVOCATION"` sites | `test_skill_captures_before_the_trigger_and_verifies_after` | KILLED |
| same, #837 trigger | comment out `env -u SSH_AUTH_SOCK fleet-deploy doc2` | `test_skill_runs_fleet_trigger_without_the_shared_agent` | KILLED |
| same, cursor/target scoping | comment out `"$POST_SWITCH_CRATEDIGGER_CURSOR" "$CRATEDIGGER_SOURCE"` | `test_skill_calls_tracked_verifier_for_successor_cycle` | KILLED |
| same, pin entrypoint | comment out `scripts/pin_nixosconfig.sh` | `test_skill_invokes_entrypoint_instead_of_copying_state_machine` | KILLED |
| `EXPECTED_INDEXES` existence assertion | `DROP INDEX idx_download_log_candidate_evidence_attribution` | `test_every_convergence_index_is_present_and_partial` | KILLED |
| same | `DROP INDEX idx_import_jobs_candidate_evidence_attribution` | same | KILLED |
| same | `DROP INDEX idx_download_log_convergence_candidates` | same | KILLED |
| predicate assertion | control: all indexes restored | same | GREEN (must-still-work) |
| `_source_pins` fail-closed dispatch | pin a `.toml` file | `test_an_undeclared_suffix_fails_closed` | covered by its own contract |

## Reviewer

Two places to aim your own mutants. First, `strip_fenced_comments` is a
two-state scanner — an unbalanced fence in a future SKILL.md would leave it
stuck open and start eating headings; `test_a_heading_after_a_closed_fence_survives`
covers the balanced case only. Second, the blanking change alters behaviour
`#1185` shipped, so it is worth checking that no existing Nix pin depended on
deletion splicing lines together — the full suite says no, but that is the
change most likely to surprise.

## Risk

Tests, one shared test helper, and one selection-registry entry. No production
Python, shell, Nix or SQL behaviour changes — the scripts mutated during the kill
matrix were all reverted and are untouched in the diff. The guards they carry
were already correct; they were simply invisible to their own tests.

Canonical suite: receipt-backed pass on `e72fd425`, clean tree.
