### PR TITLE
fix: fail-closed lib/ selection coverage + delete dead deploy-window fallback (#1199)

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -318,21 +318,26 @@ few remaining directory prefix rules, or an admitted gap in
 mechanically enforces that no module under `tests/` imports it, not just
 review); one with none of those fails the whole
 entrypoint closed (`scripts/test.sh` exit code 2) before any phase runs —
-silent under-selection there is worse than a loud refusal. A changed `lib/**.py`
+silent under-selection there is worse than a loud refusal. A changed `lib/**/*.py`
 module gets the same fail-closed treatment on the OTHER side of the same gap
 (issue #1199): if its full resolution — the same `EXACT_PATH_NEIGHBOURS`
 entry/prefix-rule mechanism, plus `_direct_test_candidates`'s `tests.test_<
-stem>` probe, which is keyed on basename only and so misses real coverage
-filed under the file's full path (e.g. `lib/dispatch/core.py`) — yields zero
-test modules, selection fails the same way unless the path is admitted in
-`LIB_MODULES_WITHOUT_SELECTION_COVERAGE` (measured fresh at 39 files,
-`tests/test_lib_selection_coverage_audit.py` proves the registry exact in
-both directions: no stale admission, no unregistered zero-neighbour file).
-Unlike the tests/-side registry, an admitted lib/ gap does not skip the rest
-of selection — it still resolves normally and only short-circuits when that
-resolution is genuinely empty — so selection proceeds with a loud stderr line
-naming the admitted gap, never a silent cap. This is development
-feedback; the full suite remains the exhaustive pre-review boundary.
+stem>`/`tests.test_<stem>_generated` probes, which are keyed on basename only
+and so miss real coverage filed under the file's full path (e.g.
+`lib/dispatch/core.py`) — yields zero test modules, selection fails the same
+way unless the path is admitted in `LIB_MODULES_WITHOUT_SELECTION_COVERAGE`
+(measured fresh at 35 files, `tests/test_lib_selection_coverage_audit.py`
+proves the registry exact in both directions: no stale admission, no
+unregistered zero-neighbour file). Unlike the tests/-side registry, an
+admitted lib/ gap does not early-return at all — the full resolution already
+ran normally before this check ever sees it; nothing short-circuits. When
+that resolution comes back genuinely empty AND the path is registered, this
+branch only prints a loud stderr line naming the admitted gap and falls
+through to the SAME return every other path takes — never a silent cap, and
+a registration that later gains real coverage is selected immediately with
+no code change here (only the now-stale registry entry needs deleting,
+which the audit demands). This is development feedback; the full suite
+remains the exhaustive pre-review boundary.
 
 Always use `nix-shell --run` for Python (`.claude/rules/nix-shell.md`). Direct
 Nix-shell runs are ordinary development feedback; fix their failures in the

--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -318,7 +318,20 @@ few remaining directory prefix rules, or an admitted gap in
 mechanically enforces that no module under `tests/` imports it, not just
 review); one with none of those fails the whole
 entrypoint closed (`scripts/test.sh` exit code 2) before any phase runs —
-silent under-selection there is worse than a loud refusal. This is development
+silent under-selection there is worse than a loud refusal. A changed `lib/**.py`
+module gets the same fail-closed treatment on the OTHER side of the same gap
+(issue #1199): if its full resolution — the same `EXACT_PATH_NEIGHBOURS`
+entry/prefix-rule mechanism, plus `_direct_test_candidates`'s `tests.test_<
+stem>` probe, which is keyed on basename only and so misses real coverage
+filed under the file's full path (e.g. `lib/dispatch/core.py`) — yields zero
+test modules, selection fails the same way unless the path is admitted in
+`LIB_MODULES_WITHOUT_SELECTION_COVERAGE` (measured fresh at 39 files,
+`tests/test_lib_selection_coverage_audit.py` proves the registry exact in
+both directions: no stale admission, no unregistered zero-neighbour file).
+Unlike the tests/-side registry, an admitted lib/ gap does not skip the rest
+of selection — it still resolves normally and only short-circuits when that
+resolution is genuinely empty — so selection proceeds with a loud stderr line
+naming the admitted gap, never a silent cap. This is development
 feedback; the full suite remains the exhaustive pre-review boundary.
 
 Always use `nix-shell --run` for Python (`.claude/rules/nix-shell.md`). Direct

--- a/README.md
+++ b/README.md
@@ -203,8 +203,13 @@ other non-`test_*.py` file) with no registered mapping in
 `scripts/targeted_test_selection.py` fails closed with exit code 2 before any
 phase runs, JS and Pyright included — see that module's
 `EXACT_PATH_NEIGHBOURS` / `SHARED_MODULES_WITHOUT_COVERAGE` for the mapping
-and the admitted-gap registry. `run_tests.sh` remains the one canonical
-complete suite.
+and the admitted-gap registry. A changed `lib/**/*.py` module gets the same
+fail-closed treatment on the other side of the same gap: one that resolves
+zero test neighbours (the basename-only `tests.test_<stem>` probe misses real
+coverage filed under a nested path, e.g. `lib/dispatch/core.py`) fails closed
+too unless admitted in `LIB_MODULES_WITHOUT_SELECTION_COVERAGE`, which
+`tests/test_lib_selection_coverage_audit.py` keeps exact in both directions.
+`run_tests.sh` remains the one canonical complete suite.
 `run_final_gate.sh` runs that exact suite on a clean commit and adds a receipt;
 it does not select different checks. CI does not enforce this local workflow.
 

--- a/docs/pipeline-db-schema.md
+++ b/docs/pipeline-db-schema.md
@@ -738,29 +738,22 @@ no app-clock-vs-PG-clock assumption, no skew window, no failure direction
 to reason about — a stale attempt's ledger rows simply carry a different
 fingerprint and never match, however new their `enqueued_at` looks.
 
-The PRE-#1196 time predicate — `AND l.enqueued_at >= COALESCE((r.
-active_download_state ->> 'enqueued_at')::timestamptz, '-infinity')`, the
-same `enqueued_at` witness the poll path already threads as
-`not_before=state.enqueued_at` — survives ONLY as the deploy-window
-fallback, taken when the owner's state exists but LACKS the
-`attempt_fingerprint` key (an in-flight download claimed by code from
-before this field existed). It can be deleted once no request claimed
-pre-deploy remains `'downloading'`. A NULL/missing/malformed
-`active_download_state` still fails CLOSED unconditionally through this
-SAME fallback expression — `->>` on a NULL or non-object jsonb value
-returns NULL for any key, so `COALESCE(..., '-infinity')` substitutes the
-minimum timestamp and every real `l.enqueued_at` compares `>=` true, i.e.
-every accepted row for that `'downloading'` owner counts as in-scope
-(blocks). (A syntactically present but malformed `enqueued_at` *string* —
-never producible today, since `build_active_download_state` always writes
-`datetime.now(UTC).isoformat()` — would instead raise
-`InvalidDatetimeFormat` at the `::timestamptz` cast inside that same
-`COALESCE`, failing the whole cross-cycle check rather than either fail-open
-or fail-closed on this predicate.) A dedicated `CASE WHEN
-active_download_state IS NULL THEN TRUE` arm was tried and found redundant
-on real PG (`->>` on NULL already returns NULL, so the `COALESCE` above
-does the same job) — the fail-closed guarantee lives entirely in that
-`COALESCE`, not a separate NULL check.
+As of issue #1199 item 2, the ELSE arm is unconditional `TRUE`: a NULL,
+missing, or malformed `active_download_state` — or one that exists but
+LACKS the `attempt_fingerprint` key — fails CLOSED unconditionally, with
+no clock involved at all. Every accepted row for that `'downloading'`
+owner counts as in-scope (blocks), regardless of the ledger row's own
+`enqueued_at`. A PRE-#1199 version of this query instead fell back to a
+clock comparison (`AND l.enqueued_at >= COALESCE((r.active_download_state
+->> 'enqueued_at')::timestamptz, '-infinity')`) when the state existed but
+lacked the fingerprint key — a deploy-window accommodation for an
+in-flight download claimed by code from before that field existed. Live
+measurement on 2026-08-19 found the cohort empty (1 `downloading` request,
+0 NULL states, 0 lacking `attempt_fingerprint`), so the fallback arm, its
+`::timestamptz` cast, and its fake mirror were deleted as dead code per
+the no-deprecated-helpers rule (`.claude/rules/scope.md`) — there is no
+longer any attempt-boundary rescue for a fingerprint-less state; only the
+fingerprint-equality arm above scopes to the current attempt.
 
 A `replaced` owner (Replace-lineage attempt sharing) or one that has already
 moved on (`wanted`/`imported`) never blocks; the same request re-claiming its

--- a/docs/pipeline-db-schema.md
+++ b/docs/pipeline-db-schema.md
@@ -753,7 +753,15 @@ measurement on 2026-08-19 found the cohort empty (1 `downloading` request,
 `::timestamptz` cast, and its fake mirror were deleted as dead code per
 the no-deprecated-helpers rule (`.claude/rules/scope.md`) — there is no
 longer any attempt-boundary rescue for a fingerprint-less state; only the
-fingerprint-equality arm above scopes to the current attempt.
+fingerprint-equality arm above scopes to the current attempt. A live
+`'downloading'` owner reaching this ELSE arm is possible only via a
+NULL/malformed state or a pre-#1196 historical row: `build_active_download_
+state` sets `attempt_fingerprint` to `None` only when `entry.files` is
+empty, and every enqueue persist site in `lib/enqueue.py` guards
+`files_to_enqueue`/`planned_files` non-empty before that state is ever
+built — a future change that lets an empty-files claim through would
+silently make that owner's every accepted key block, not just its current
+attempt's (issue #1199 review F9).
 
 A `replaced` owner (Replace-lineage attempt sharing) or one that has already
 moved on (`wanted`/`imported`) never blocks; the same request re-claiming its

--- a/lib/pipeline_db/transfer_ledger.py
+++ b/lib/pipeline_db/transfer_ledger.py
@@ -235,9 +235,8 @@ class _TransferLedgerMixin(_PipelineDBBase):
         downloading a fresh peer's files would falsely block a sibling
         on a queue key from that SAME owner's OWN abandoned attempt from
         30 days earlier. The join is therefore additionally scoped to
-        the owner's CURRENT attempt only -- by exact fingerprint identity
-        where available, falling back to the ``enqueued_at`` witness
-        otherwise (both detailed below).
+        the owner's CURRENT attempt only, by exact fingerprint identity
+        (detailed below).
 
         **Attempt identity, not a clock comparison (#1196 item 1).**
         ``ActiveDownloadState.attempt_fingerprint`` (written at claim time
@@ -255,26 +254,23 @@ class _TransferLedgerMixin(_PipelineDBBase):
         ledger rows simply carry a different fingerprint and never match,
         however new their ``enqueued_at`` looks.
 
-        The time predicate above (``l.enqueued_at >= COALESCE(...,
-        '-infinity')``) is retained ONLY as the deploy-window fallback,
-        taken when the owner's state exists but LACKS the
-        ``attempt_fingerprint`` key -- an in-flight download claimed by
-        code from before this field existed. It can be deleted once no
-        request claimed pre-deploy remains ``'downloading'``. A NULL (or,
-        by the same ``->>`` extraction returning NULL for a non-object
-        value, malformed) ``active_download_state`` still fails CLOSED
-        unconditionally, and it does so through this SAME ``ELSE`` arm,
-        not a dedicated ``CASE WHEN ... IS NULL`` arm: ``->>`` applied to
-        a SQL NULL (or non-object) jsonb value returns NULL for ANY key,
-        so both the ``attempt_fingerprint`` ``WHEN`` test and the
-        ``enqueued_at`` extraction inside ``COALESCE`` see NULL, and
-        ``COALESCE(NULL, '-infinity')`` makes the comparison
-        ``l.enqueued_at >= '-infinity'`` -- true for any real
-        timestamp -- fail CLOSED (blocks) exactly like every other
-        deploy-window row. A dedicated ``IS NULL`` arm was tried and
-        proven redundant on real PG (identical result, one fewer
-        branch); the fail-closed guarantee lives entirely in this
-        ``COALESCE``, not in an explicit NULL check.
+        **Fail closed on a missing fingerprint (#1199 item 2).** A prior
+        version of this query fell back to a clock comparison
+        (``l.enqueued_at >= COALESCE(..., '-infinity')``) when the owner's
+        state existed but LACKED the ``attempt_fingerprint`` key -- a
+        deploy-window accommodation for an in-flight download claimed by
+        code from before that field existed. Live measurement on
+        2026-08-19 found the cohort empty (1 ``downloading`` request, 0
+        NULL states, 0 lacking ``attempt_fingerprint``), so the fallback
+        arm is dead code and is deleted per the no-deprecated-helpers rule.
+        The ``ELSE`` arm is now unconditional ``TRUE``: a NULL, malformed
+        (``->>`` returns NULL for a non-object jsonb value regardless of
+        key), or fingerprint-less ``active_download_state`` fails CLOSED
+        -- every accepted row for that ``'downloading'`` owner counts as
+        in-scope (blocks), with no attempt-boundary rescue and no clock
+        involved at all. Only an owner whose state DOES carry
+        ``attempt_fingerprint`` gets attempt-scoped blocking; the equality
+        test itself is unchanged from #1196.
         """
         if not keys:
             return set()
@@ -304,11 +300,7 @@ class _TransferLedgerMixin(_PipelineDBBase):
                           IS NOT NULL THEN
                           l.attempt_fingerprint =
                               r.active_download_state ->> 'attempt_fingerprint'
-                      ELSE l.enqueued_at >= COALESCE(
-                          (r.active_download_state ->> 'enqueued_at')
-                              ::timestamptz,
-                          '-infinity'
-                      )
+                      ELSE TRUE
                   END
               )
             """,

--- a/lib/pipeline_db/transfer_ledger.py
+++ b/lib/pipeline_db/transfer_ledger.py
@@ -271,6 +271,17 @@ class _TransferLedgerMixin(_PipelineDBBase):
         involved at all. Only an owner whose state DOES carry
         ``attempt_fingerprint`` gets attempt-scoped blocking; the equality
         test itself is unchanged from #1196.
+
+        A live ``'downloading'`` owner reaching this ELSE arm today is
+        possible only via a NULL/malformed state or a pre-#1196 historical
+        row -- ``build_active_download_state`` sets ``attempt_fingerprint``
+        to ``None`` ONLY when ``entry.files`` is empty (issue #1199 review
+        F9), and every enqueue persist site in ``lib/enqueue.py`` guards
+        ``files_to_enqueue``/``planned_files`` non-empty (``if not
+        files_to_enqueue: ... continue``) before that state is ever built,
+        so a future change that lets an empty-files claim through would
+        silently make THIS owner's every accepted key block, not just its
+        current attempt's.
         """
         if not keys:
             return set()

--- a/scripts/targeted_test_selection.py
+++ b/scripts/targeted_test_selection.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import subprocess
+import sys
 from collections import Counter
 from collections.abc import Iterable, Mapping, Sequence
 from pathlib import Path, PurePosixPath
@@ -404,32 +405,261 @@ SHARED_MODULES_WITHOUT_COVERAGE: dict[str, str] = {
 }
 
 
+#: Changed `lib/**/*.py` files whose full neighbour resolution (EXACT_PATH_
+#: NEIGHBOURS + prefix rules + direct candidates that actually exist) yields
+#: ZERO test modules — the lib/ twin of SHARED_MODULES_WITHOUT_COVERAGE
+#: (issue #1199 item 1, the durable fix behind #1196 item 4). Unlike the
+#: tests/-side registry, _changed_path_neighbours does NOT early-return for
+#: a path listed here: the full resolution still runs, so a module that
+#: later gains real neighbours (an EXACT_PATH_NEIGHBOURS entry, a new prefix
+#: rule, or a newly-created tests.test_<stem> module) simply stops being
+#: zero and is returned normally — no code change needed to "un-admit" it.
+#: tests/test_lib_selection_coverage_audit.py proves both directions: a
+#: registered path that now resolves neighbours (stale — must be removed),
+#: and a lib/**/*.py file with zero neighbours that is NOT registered here
+#: (must be added, or given real coverage). Population is a fresh
+#: measurement (driving the real resolution function), never hand-curated —
+#: hand-curated neighbour lists are exactly the mechanism that produced
+#: #1196's own false-claim correction round.
+LIB_MODULES_WITHOUT_SELECTION_COVERAGE: dict[str, str] = {
+    "lib/artist_catalogue.py": (
+        "measured 2026-08-19: zero neighbours -- tests.test_artist_catalogue "
+        "does not exist and no EXACT_PATH_NEIGHBOURS/prefix rule covers it "
+        "(issue #1199)"
+    ),
+    "lib/banding.py": (
+        "measured 2026-08-19: zero neighbours -- tests.test_banding does "
+        "not exist and no EXACT_PATH_NEIGHBOURS/prefix rule covers it "
+        "(issue #1199)"
+    ),
+    "lib/beets_startup.py": (
+        "measured 2026-08-19: zero neighbours -- tests.test_beets_startup "
+        "does not exist and no EXACT_PATH_NEIGHBOURS/prefix rule covers it "
+        "(issue #1199)"
+    ),
+    "lib/convergence.py": (
+        "measured 2026-08-19: zero neighbours -- tests.test_convergence "
+        "does not exist and no EXACT_PATH_NEIGHBOURS/prefix rule covers it "
+        "(issue #1199)"
+    ),
+    "lib/current_library_display.py": (
+        "measured 2026-08-19: zero neighbours -- "
+        "tests.test_current_library_display does not exist and no "
+        "EXACT_PATH_NEIGHBOURS/prefix rule covers it (issue #1199)"
+    ),
+    "lib/destructive_release_service.py": (
+        "measured 2026-08-19: zero neighbours -- "
+        "tests.test_destructive_release_service does not exist and no "
+        "EXACT_PATH_NEIGHBOURS/prefix rule covers it (issue #1199)"
+    ),
+    "lib/dispatch/__init__.py": (
+        "measured 2026-08-19: zero neighbours -- _direct_test_candidates "
+        "derives tests.test___init__ from the basename, which does not "
+        "exist and no EXACT_PATH_NEIGHBOURS/prefix rule covers it "
+        "(issue #1199)"
+    ),
+    "lib/dispatch/core.py": (
+        "measured 2026-08-19: zero neighbours -- _direct_test_candidates "
+        "derives tests.test_core from the basename (ignoring the dispatch/ "
+        "subdirectory), which does not exist; no EXACT_PATH_NEIGHBOURS/"
+        "prefix rule covers it either (issue #1199)"
+    ),
+    "lib/dispatch/evidence_gate.py": (
+        "measured 2026-08-19: zero neighbours -- basename-derived "
+        "tests.test_evidence_gate does not exist and no EXACT_PATH_"
+        "NEIGHBOURS/prefix rule covers it (issue #1199)"
+    ),
+    "lib/dispatch/helpers.py": (
+        "measured 2026-08-19: zero neighbours -- basename-derived "
+        "tests.test_helpers does not exist and no EXACT_PATH_NEIGHBOURS/"
+        "prefix rule covers it (issue #1199)"
+    ),
+    "lib/dispatch/manifest_guard.py": (
+        "measured 2026-08-19: zero neighbours -- basename-derived "
+        "tests.test_manifest_guard does not exist and no EXACT_PATH_"
+        "NEIGHBOURS/prefix rule covers it (issue #1199)"
+    ),
+    "lib/dispatch/outcome_actions.py": (
+        "measured 2026-08-19: zero neighbours -- basename-derived "
+        "tests.test_outcome_actions does not exist and no EXACT_PATH_"
+        "NEIGHBOURS/prefix rule covers it (issue #1199)"
+    ),
+    "lib/dispatch/post_import.py": (
+        "measured 2026-08-19: zero neighbours -- basename-derived "
+        "tests.test_post_import does not exist and no EXACT_PATH_"
+        "NEIGHBOURS/prefix rule covers it (issue #1199)"
+    ),
+    "lib/dispatch/quality_gate.py": (
+        "measured 2026-08-19: zero neighbours -- basename-derived "
+        "tests.test_quality_gate does not exist and no EXACT_PATH_"
+        "NEIGHBOURS/prefix rule covers it (issue #1199)"
+    ),
+    "lib/dispatch/subprocess_runner.py": (
+        "measured 2026-08-19: zero neighbours -- basename-derived "
+        "tests.test_subprocess_runner does not exist and no EXACT_PATH_"
+        "NEIGHBOURS/prefix rule covers it (issue #1199)"
+    ),
+    "lib/dispatch/types.py": (
+        "measured 2026-08-19: zero neighbours -- basename-derived "
+        "tests.test_types does not exist and no EXACT_PATH_NEIGHBOURS/"
+        "prefix rule covers it (issue #1199)"
+    ),
+    "lib/download_materialization.py": (
+        "measured 2026-08-19: zero neighbours -- "
+        "tests.test_download_materialization does not exist and no "
+        "EXACT_PATH_NEIGHBOURS/prefix rule covers it (issue #1199)"
+    ),
+    "lib/download_ownership.py": (
+        "measured 2026-08-19: zero neighbours -- "
+        "tests.test_download_ownership does not exist and no EXACT_PATH_"
+        "NEIGHBOURS/prefix rule covers it (issue #1199)"
+    ),
+    "lib/download_processing.py": (
+        "measured 2026-08-19: zero neighbours -- "
+        "tests.test_download_processing does not exist and no EXACT_PATH_"
+        "NEIGHBOURS/prefix rule covers it (issue #1199)"
+    ),
+    "lib/download_reconstruction.py": (
+        "measured 2026-08-19: zero neighbours -- "
+        "tests.test_download_reconstruction does not exist and no "
+        "EXACT_PATH_NEIGHBOURS/prefix rule covers it (issue #1199)"
+    ),
+    "lib/download_rejection.py": (
+        "measured 2026-08-19: zero neighbours -- "
+        "tests.test_download_rejection does not exist and no EXACT_PATH_"
+        "NEIGHBOURS/prefix rule covers it (issue #1199)"
+    ),
+    "lib/download_validation.py": (
+        "measured 2026-08-19: zero neighbours -- "
+        "tests.test_download_validation does not exist and no EXACT_PATH_"
+        "NEIGHBOURS/prefix rule covers it (issue #1199)"
+    ),
+    "lib/enqueue.py": (
+        "measured 2026-08-19: zero neighbours -- tests.test_enqueue does "
+        "not exist and no EXACT_PATH_NEIGHBOURS/prefix rule covers it "
+        "(issue #1199)"
+    ),
+    "lib/ephemeral_postgres.py": (
+        "measured 2026-08-19: zero neighbours -- "
+        "tests.test_ephemeral_postgres does not exist and no EXACT_PATH_"
+        "NEIGHBOURS/prefix rule covers it (issue #1199)"
+    ),
+    "lib/evidence_action_file.py": (
+        "measured 2026-08-19: zero neighbours -- "
+        "tests.test_evidence_action_file does not exist and no EXACT_PATH_"
+        "NEIGHBOURS/prefix rule covers it (issue #1199)"
+    ),
+    "lib/evidence_media_identity.py": (
+        "measured 2026-08-19: zero neighbours -- "
+        "tests.test_evidence_media_identity does not exist and no "
+        "EXACT_PATH_NEIGHBOURS/prefix rule covers it (issue #1199)"
+    ),
+    "lib/fs_authority.py": (
+        "measured 2026-08-19: zero neighbours -- tests.test_fs_authority "
+        "does not exist and no EXACT_PATH_NEIGHBOURS/prefix rule covers it "
+        "(issue #1199)"
+    ),
+    "lib/import_job_recovery_service.py": (
+        "measured 2026-08-19: zero neighbours -- "
+        "tests.test_import_job_recovery_service does not exist and no "
+        "EXACT_PATH_NEIGHBOURS/prefix rule covers it (issue #1199)"
+    ),
+    "lib/release_snapshot.py": (
+        "measured 2026-08-19: zero neighbours -- "
+        "tests.test_release_snapshot does not exist and no EXACT_PATH_"
+        "NEIGHBOURS/prefix rule covers it (issue #1199)"
+    ),
+    "lib/replace_status.py": (
+        "measured 2026-08-19: zero neighbours -- tests.test_replace_status "
+        "does not exist and no EXACT_PATH_NEIGHBOURS/prefix rule covers it "
+        "(issue #1199)"
+    ),
+    "lib/search_plan_inspection.py": (
+        "measured 2026-08-19: zero neighbours -- "
+        "tests.test_search_plan_inspection does not exist and no "
+        "EXACT_PATH_NEIGHBOURS/prefix rule covers it (issue #1199)"
+    ),
+    "lib/search_scheduler.py": (
+        "measured 2026-08-19: zero neighbours -- "
+        "tests.test_search_scheduler does not exist and no EXACT_PATH_"
+        "NEIGHBOURS/prefix rule covers it (issue #1199)"
+    ),
+    "lib/slskd_transfer_ledger.py": (
+        "measured 2026-08-19: zero neighbours -- "
+        "tests.test_slskd_transfer_ledger does not exist and no EXACT_PATH_"
+        "NEIGHBOURS/prefix rule covers it (issue #1199)"
+    ),
+    "lib/slskd_transfers.py": (
+        "measured 2026-08-19: zero neighbours -- "
+        "tests.test_slskd_transfers does not exist and no EXACT_PATH_"
+        "NEIGHBOURS/prefix rule covers it (issue #1199)"
+    ),
+    "lib/startup_reconciliation.py": (
+        "measured 2026-08-19: zero neighbours -- "
+        "tests.test_startup_reconciliation does not exist and no "
+        "EXACT_PATH_NEIGHBOURS/prefix rule covers it (issue #1199)"
+    ),
+    "lib/v0_probe.py": (
+        "measured 2026-08-19: zero neighbours -- tests.test_v0_probe does "
+        "not exist and no EXACT_PATH_NEIGHBOURS/prefix rule covers it "
+        "(issue #1199)"
+    ),
+    "lib/wrong_match_delete_service.py": (
+        "measured 2026-08-19: zero neighbours -- "
+        "tests.test_wrong_match_delete_service does not exist and no "
+        "EXACT_PATH_NEIGHBOURS/prefix rule covers it (issue #1199)"
+    ),
+    "lib/wrong_match_policy.py": (
+        "measured 2026-08-19: zero neighbours -- "
+        "tests.test_wrong_match_policy does not exist and no EXACT_PATH_"
+        "NEIGHBOURS/prefix rule covers it (issue #1199)"
+    ),
+    "lib/wrong_matches.py": (
+        "measured 2026-08-19: zero neighbours -- tests.test_wrong_matches "
+        "does not exist and no EXACT_PATH_NEIGHBOURS/prefix rule covers it "
+        "(issue #1199)"
+    ),
+}
+
+
 def _assert_no_double_registration(
     exact_path_neighbours: Mapping[str, tuple[str, ...]],
-    shared_modules_without_coverage: Mapping[str, str],
+    admitted_gap_registry: Mapping[str, str],
+    *,
+    gap_registry_name: str = "SHARED_MODULES_WITHOUT_COVERAGE",
 ) -> None:
     """A path cannot be both a real mapping and an admitted coverage gap.
 
-    _changed_path_neighbours returns early for any path in
+    Shared shape for both admitted-gap registries (SHARED_MODULES_WITHOUT_
+    COVERAGE on the tests/ side, LIB_MODULES_WITHOUT_SELECTION_COVERAGE on
+    the lib/ side): _changed_path_neighbours returns early for any path in
     SHARED_MODULES_WITHOUT_COVERAGE, before EXACT_PATH_NEIGHBOURS or any
     prefix rule runs — so a path present in BOTH registries would silently
     discard its real, hand-authored EXACT_PATH_NEIGHBOURS mapping (issue
     #1081 review round: the tree-walking pin's assertion that a registered
     path selects nothing was a tautology of the early-return condition and
-    could never have caught this on its own). Fail at import time instead of
-    merely detecting it later — the contradiction becomes impossible to ship.
+    could never have caught this on its own). LIB_MODULES_WITHOUT_SELECTION_
+    COVERAGE does not early-return, but the same contradiction — a path
+    claiming zero neighbours while EXACT_PATH_NEIGHBOURS gives it real ones
+    — is still nonsensical and worth failing on at import time rather than
+    merely detecting it later.
     """
     contradictions = sorted(
-        set(exact_path_neighbours) & set(shared_modules_without_coverage)
+        set(exact_path_neighbours) & set(admitted_gap_registry)
     )
     if contradictions:
         raise ValueError(
-            "path(s) registered in both EXACT_PATH_NEIGHBOURS and "
-            f"SHARED_MODULES_WITHOUT_COVERAGE: {', '.join(contradictions)}"
+            f"path(s) registered in both EXACT_PATH_NEIGHBOURS and "
+            f"{gap_registry_name}: {', '.join(contradictions)}"
         )
 
 
 _assert_no_double_registration(EXACT_PATH_NEIGHBOURS, SHARED_MODULES_WITHOUT_COVERAGE)
+_assert_no_double_registration(
+    EXACT_PATH_NEIGHBOURS,
+    LIB_MODULES_WITHOUT_SELECTION_COVERAGE,
+    gap_registry_name="LIB_MODULES_WITHOUT_SELECTION_COVERAGE",
+)
 
 
 def _module_path(module: str, repo_root: Path) -> Path:
@@ -504,19 +734,19 @@ def _direct_test_candidates(path: PurePosixPath) -> tuple[str, ...]:
     return ()
 
 
-def _changed_path_neighbours(
+def _resolve_neighbours(
     relative_path: str,
+    path: PurePosixPath,
     repo_root: Path,
-) -> tuple[str, ...]:
-    if relative_path in SHARED_MODULES_WITHOUT_COVERAGE:
-        # An admitted gap always selects nothing beyond ambient, regardless
-        # of what a prefix rule below would otherwise contribute — a
-        # registration must not be a lookalike neighbour set (issue #1081
-        # review round: mirror_harness.py was registered but the
-        # tests/world_model/ prefix rule below would still have populated
-        # WORLD_MODEL_NEIGHBOURS for it).
-        return ()
-    path = PurePosixPath(relative_path)
+) -> list[str]:
+    """The full EXACT_PATH_NEIGHBOURS + self-selector + direct-candidate +
+    prefix-rule resolution, with NEITHER admitted-gap registry's fail-closed
+    check applied yet. Split out of _changed_path_neighbours so both the
+    tests/ and lib/ fail-closed checks can run against the SAME raw result,
+    and so a one-off measurement (issue #1199 item 1's registry population)
+    can call this directly without tripping the fail-closed raise for every
+    still-unregistered zero-neighbour file.
+    """
     neighbours: list[str] = list(EXACT_PATH_NEIGHBOURS.get(relative_path, ()))
     module = _path_module(path)
     if module is not None and module.startswith("tests."):
@@ -554,6 +784,23 @@ def _changed_path_neighbours(
                 "tests.test_quality_generated",
             )
         )
+    return neighbours
+
+
+def _changed_path_neighbours(
+    relative_path: str,
+    repo_root: Path,
+) -> tuple[str, ...]:
+    if relative_path in SHARED_MODULES_WITHOUT_COVERAGE:
+        # An admitted gap always selects nothing beyond ambient, regardless
+        # of what a prefix rule below would otherwise contribute — a
+        # registration must not be a lookalike neighbour set (issue #1081
+        # review round: mirror_harness.py was registered but the
+        # tests/world_model/ prefix rule below would still have populated
+        # WORLD_MODEL_NEIGHBOURS for it).
+        return ()
+    path = PurePosixPath(relative_path)
+    neighbours = _resolve_neighbours(relative_path, path, repo_root)
     if path.suffix == ".py" and path.parts[:1] == ("tests",) and not neighbours:
         # A non-test .py file under tests/ with no direct self-selector, no
         # EXACT_PATH_NEIGHBOURS entry, and no matching prefix rule is shared
@@ -570,6 +817,30 @@ def _changed_path_neighbours(
             "EXACT_PATH_NEIGHBOURS entry or a prefix rule for it in "
             "scripts/targeted_test_selection.py"
         )
+    if path.suffix == ".py" and path.parts[:1] == ("lib",) and not neighbours:
+        # The lib/ twin of the tests/-side check above (issue #1199 item 1,
+        # the durable fix behind #1196 item 4): a changed lib/**/*.py file
+        # that resolves zero test neighbours under-selects silently unless
+        # it is an admitted, reviewed gap. Unlike the tests/ case, an
+        # admitted lib/ gap does not return early above — it reaches here
+        # having already tried every real mechanism — so selection proceeds
+        # (ambient gates still run) but logs loudly naming the admitted gap;
+        # no silent caps.
+        if relative_path in LIB_MODULES_WITHOUT_SELECTION_COVERAGE:
+            print(
+                "admitted selection gap: "
+                f"{relative_path} resolves zero test neighbours "
+                f"({LIB_MODULES_WITHOUT_SELECTION_COVERAGE[relative_path]})",
+                file=sys.stderr,
+            )
+        else:
+            raise ValueError(
+                f"unmapped lib module: {relative_path} resolves zero test "
+                "neighbours — add an EXACT_PATH_NEIGHBOURS entry or a "
+                "prefix rule for it in scripts/targeted_test_selection.py, "
+                "or register it in LIB_MODULES_WITHOUT_SELECTION_COVERAGE "
+                "if genuinely uncovered"
+            )
     return tuple(neighbours)
 
 

--- a/scripts/targeted_test_selection.py
+++ b/scripts/targeted_test_selection.py
@@ -412,9 +412,15 @@ SHARED_MODULES_WITHOUT_COVERAGE: dict[str, str] = {
 #: tests/-side registry, _changed_path_neighbours does NOT early-return for
 #: a path listed here: the full resolution still runs, so a module that
 #: later gains real neighbours (an EXACT_PATH_NEIGHBOURS entry, a new prefix
-#: rule, or a newly-created tests.test_<stem> module) simply stops being
-#: zero and is returned normally — no code change needed to "un-admit" it.
-#: tests/test_lib_selection_coverage_audit.py proves both directions: a
+#: rule, or a newly-created tests.test_<stem> module) SELECTS them
+#: immediately, on its very next diff, with no code change here — but the
+#: registration itself goes stale the moment that happens and the entry
+#: must then be deleted, which tests/test_lib_selection_coverage_audit.py
+#: enforces (issue #1199 review F1: caught by adding a real test module for
+#: a registered path and observing the audit go RED demanding removal — a
+#: prior version of this comment claimed "no code change needed to un-admit
+#: it" at all, which was false; selection self-corrects, the registry does
+#: not). tests/test_lib_selection_coverage_audit.py proves both directions: a
 #: registered path that now resolves neighbours (stale — must be removed),
 #: and a lib/**/*.py file with zero neighbours that is NOT registered here
 #: (must be added, or given real coverage). Population is a fresh
@@ -441,11 +447,6 @@ LIB_MODULES_WITHOUT_SELECTION_COVERAGE: dict[str, str] = {
         "measured 2026-08-19: zero neighbours -- tests.test_convergence "
         "does not exist and no EXACT_PATH_NEIGHBOURS/prefix rule covers it "
         "(issue #1199)"
-    ),
-    "lib/current_library_display.py": (
-        "measured 2026-08-19: zero neighbours -- "
-        "tests.test_current_library_display does not exist and no "
-        "EXACT_PATH_NEIGHBOURS/prefix rule covers it (issue #1199)"
     ),
     "lib/destructive_release_service.py": (
         "measured 2026-08-19: zero neighbours -- "
@@ -549,11 +550,6 @@ LIB_MODULES_WITHOUT_SELECTION_COVERAGE: dict[str, str] = {
         "tests.test_evidence_action_file does not exist and no EXACT_PATH_"
         "NEIGHBOURS/prefix rule covers it (issue #1199)"
     ),
-    "lib/evidence_media_identity.py": (
-        "measured 2026-08-19: zero neighbours -- "
-        "tests.test_evidence_media_identity does not exist and no "
-        "EXACT_PATH_NEIGHBOURS/prefix rule covers it (issue #1199)"
-    ),
     "lib/fs_authority.py": (
         "measured 2026-08-19: zero neighbours -- tests.test_fs_authority "
         "does not exist and no EXACT_PATH_NEIGHBOURS/prefix rule covers it "
@@ -579,11 +575,6 @@ LIB_MODULES_WITHOUT_SELECTION_COVERAGE: dict[str, str] = {
         "tests.test_search_plan_inspection does not exist and no "
         "EXACT_PATH_NEIGHBOURS/prefix rule covers it (issue #1199)"
     ),
-    "lib/search_scheduler.py": (
-        "measured 2026-08-19: zero neighbours -- "
-        "tests.test_search_scheduler does not exist and no EXACT_PATH_"
-        "NEIGHBOURS/prefix rule covers it (issue #1199)"
-    ),
     "lib/slskd_transfer_ledger.py": (
         "measured 2026-08-19: zero neighbours -- "
         "tests.test_slskd_transfer_ledger does not exist and no EXACT_PATH_"
@@ -608,11 +599,6 @@ LIB_MODULES_WITHOUT_SELECTION_COVERAGE: dict[str, str] = {
         "measured 2026-08-19: zero neighbours -- "
         "tests.test_wrong_match_delete_service does not exist and no "
         "EXACT_PATH_NEIGHBOURS/prefix rule covers it (issue #1199)"
-    ),
-    "lib/wrong_match_policy.py": (
-        "measured 2026-08-19: zero neighbours -- "
-        "tests.test_wrong_match_policy does not exist and no EXACT_PATH_"
-        "NEIGHBOURS/prefix rule covers it (issue #1199)"
     ),
     "lib/wrong_matches.py": (
         "measured 2026-08-19: zero neighbours -- tests.test_wrong_matches "
@@ -724,7 +710,13 @@ def _direct_test_candidates(path: PurePosixPath) -> tuple[str, ...]:
         return ()
     stem = path.stem
     if path.parts[:1] == ("lib",):
-        return (f"tests.test_{stem}",)
+        # tests.test_<stem>_generated is the same mechanical basename-only
+        # probe as tests.test_<stem> above, just for the generated sibling
+        # (issue #1199 review F5) -- both are checked for real existence by
+        # the caller via _existing_module before being added, so this is
+        # not hand-curation: a lib/ file whose ONLY coverage is a generated
+        # module (no deterministic tests.test_<stem>) now resolves too.
+        return (f"tests.test_{stem}", f"tests.test_{stem}_generated")
     if path.parts[:1] == ("scripts",):
         return (f"tests.test_{stem}",)
     if path.parts[:1] == ("web",) and path.parts[:2] != ("web", "routes"):
@@ -834,12 +826,16 @@ def _changed_path_neighbours(
                 file=sys.stderr,
             )
         else:
+            # Mirrors the tests/-side raise above: names only the real
+            # mapping mechanisms, never advertises the admitted-gap
+            # registry as an easy way out (issue #1199 review F6) — a
+            # registration there is a reviewed admission, made by touching
+            # LIB_MODULES_WITHOUT_SELECTION_COVERAGE directly, not something
+            # this error should suggest as equivalent to real coverage.
             raise ValueError(
                 f"unmapped lib module: {relative_path} resolves zero test "
                 "neighbours — add an EXACT_PATH_NEIGHBOURS entry or a "
-                "prefix rule for it in scripts/targeted_test_selection.py, "
-                "or register it in LIB_MODULES_WITHOUT_SELECTION_COVERAGE "
-                "if genuinely uncovered"
+                "prefix rule for it in scripts/targeted_test_selection.py"
             )
     return tuple(neighbours)
 

--- a/tests/fakes/pipeline_db.py
+++ b/tests/fakes/pipeline_db.py
@@ -8577,32 +8577,6 @@ class FakePipelineDB:
         return abandoned
 
     @staticmethod
-    def _attempt_enqueued_at(request: Mapping[str, object]) -> datetime | None:
-        """Mirror ``(active_download_state ->> 'enqueued_at')::timestamptz``
-        -- tolerant of the fake's mixed storage shapes: a JSON string (as
-        written by ``update_download_state_if_downloading``/
-        ``claim_downloading``) or a plain dict (as some tests seed
-        directly). Returns ``None`` on anything unparseable, mirroring
-        SQL NULL for a missing/malformed state."""
-        raw = request.get("active_download_state")
-        if raw is None:
-            return None
-        if isinstance(raw, str):
-            try:
-                raw = json.loads(raw)
-            except (TypeError, ValueError):
-                return None
-        if not isinstance(raw, dict):
-            return None
-        enqueued_at = raw.get("enqueued_at")
-        if not isinstance(enqueued_at, str):
-            return None
-        try:
-            return datetime.fromisoformat(enqueued_at)
-        except ValueError:
-            return None
-
-    @staticmethod
     def _attempt_fingerprint_from_state(
         request: Mapping[str, object],
     ) -> str | None:
@@ -8645,28 +8619,21 @@ class FakePipelineDB:
         ``keys`` whose owning request is CURRENTLY 'downloading' on its
         CURRENT attempt, excluding ``exclude_request_id`` (#1178 PR2,
         attempt-scoped per review F2; exact fingerprint identity added
-        #1196 item 1). A missing request row (never seeded, or
-        hard-deleted) mirrors the real INNER JOIN -- never a conflict.
+        #1196 item 1; deploy-window time fallback deleted #1199 item 2 --
+        the measured cohort was empty). A missing request row (never
+        seeded, or hard-deleted) mirrors the real INNER JOIN -- never a
+        conflict.
 
-        Two-armed, mirroring the real SQL ``CASE`` exactly (#1196
-        review F3 removed the real query's REDUNDANT ``WHEN
-        active_download_state IS NULL THEN TRUE`` arm -- proven on
-        real PG to behave identically to the ELSE arm's own
-        ``COALESCE``, since ``->>`` on a NULL jsonb also returns NULL
-        for any key):
+        Two-armed, mirroring the real SQL ``CASE`` exactly:
 
           1. State carries a string ``attempt_fingerprint`` -- EXACT
              equality against the ledger row's own
              ``attempt_fingerprint`` decides in/out of scope; no clock
              comparison.
-          2. Else (state is NULL, malformed, or lacks the key) --
-             deploy-window fallback to the ``enqueued_at`` witness: a
-             row older than the owner's current attempt boundary
-             belongs to an abandoned earlier attempt and never
-             conflicts; a NULL/missing witness (including a NULL
-             top-level state -- ``_attempt_enqueued_at`` returns
-             ``None`` for that too) fails CLOSED (mirrors the real
-             query's ``COALESCE(..., '-infinity')``).
+          2. Else (state is NULL, malformed, or lacks the key) -- fails
+             CLOSED unconditionally: every accepted row for that
+             ``'downloading'`` owner counts as in-scope (blocks),
+             mirroring the real query's ``ELSE TRUE``.
         """
         key_set = set(keys)
         conflicting: set[int] = set()
@@ -8683,17 +8650,11 @@ class FakePipelineDB:
             if request.get("status") != "downloading":
                 continue
             fingerprint = self._attempt_fingerprint_from_state(request)
-            if fingerprint is not None:
-                if row.attempt_fingerprint == fingerprint:
-                    conflicting.add(row.request_id)
+            if fingerprint is None:
+                conflicting.add(row.request_id)
                 continue
-            attempt_enqueued_at = self._attempt_enqueued_at(request)
-            if (
-                attempt_enqueued_at is not None
-                and row.enqueued_at < attempt_enqueued_at
-            ):
-                continue
-            conflicting.add(row.request_id)
+            if row.attempt_fingerprint == fingerprint:
+                conflicting.add(row.request_id)
         return conflicting
 
     def prune_transfer_ledger(self, older_than: datetime) -> int:

--- a/tests/test_cross_request_enqueue_guard_generated.py
+++ b/tests/test_cross_request_enqueue_guard_generated.py
@@ -107,12 +107,15 @@ class GuardAttempt:
     resulting_status: _OwnerStatus
     # #1196 item 1: whether a won attempt's ``active_download_state``
     # carries the ``attempt_fingerprint`` key. Defaults True so every
-    # existing (pre-#1196) example pin below exercises the NEW primary
-    # fingerprint-equality mechanism without modification. False
-    # simulates the deploy-window gap -- an in-flight download claimed
-    # by code from before this field existed, whose ledger rows STILL
-    # carry a fingerprint (that column predates this change) while its
-    # state does not, so the guard must fall back to the time predicate.
+    # existing (pre-#1196) example pin below exercises the fingerprint-
+    # equality mechanism without modification. False simulates a state
+    # that exists but lacks the key -- the ledger rows STILL carry a
+    # fingerprint (that column predates this change) while the state
+    # does not, so the guard fails CLOSED unconditionally (#1199 item 2:
+    # the deploy-window time-predicate fallback this used to exercise
+    # was deleted -- the measured cohort was empty -- so this now blocks
+    # EVERY accepted key the owner has ever won, not just its current
+    # attempt's keys).
     state_has_fingerprint: bool = True
 
 
@@ -193,8 +196,9 @@ def _run_world(world: GuardWorld) -> dict[tuple[int, int], bool]:
     fingerprint column predates this change and is never conditional.
     The STATE's ``attempt_fingerprint`` key is written only when
     ``attempt.state_has_fingerprint`` is True, so the property drives
-    the guard's real fingerprint-equality arm AND its deploy-window
-    time-predicate fallback arm across the same generated world space.
+    the guard's real fingerprint-equality arm AND its fail-closed
+    missing-fingerprint arm (#1199 item 2) across the same generated
+    world space.
 
     (#1196 item 1, review F1) The two sides are deliberately NOT sourced
     from one shared local variable: the STATE'S value comes from calling
@@ -305,14 +309,27 @@ def expected_guard_decisions(world: GuardWorld) -> dict[tuple[int, int], bool]:
     separate real seam, exercised by the deterministic try_enqueue pins
     in tests/test_enqueue_fanout.py, not by this guard-only property).
 
-    Cross-cycle (review F2/F3): only a request's CURRENT (most recently
-    WON) attempt can ever conflict -- ``current_attempt`` is overwritten
-    on every win, so an earlier, superseded attempt for the SAME request
-    (even one that settled 'downloading' before being retried) is
-    excluded exactly like the real attempt-boundary predicate excludes
-    it.
+    Cross-cycle (review F2/F3, #1199 item 2): an owner's CURRENT (most
+    recently WON) attempt's ``state_has_fingerprint`` decides the scope
+    of what can conflict --
+
+    * ``True`` (the #1196 fingerprint-equality arm): only the CURRENT
+      attempt's own keys can conflict -- ``current_attempt_keys`` is
+      overwritten on every win, so an earlier, superseded attempt for
+      the SAME request is excluded exactly like the real fingerprint
+      predicate excludes it (a stale attempt's ledger rows carry a
+      different fingerprint and never match).
+    * ``False`` (the #1199 fail-closed arm): EVERY key the owner has
+      EVER won, across every attempt, can conflict -- there is no
+      attempt-boundary rescue once the current state lacks the
+      fingerprint key, mirroring the real query's unconditional
+      ``ELSE TRUE``. ``all_accepted_keys`` therefore accumulates across
+      every win and is never overwritten, unlike ``current_attempt_keys``.
     """
-    current_attempt: dict[int, tuple[_OwnerStatus, frozenset[tuple[str, str]]]] = {}
+    current_status: dict[int, _OwnerStatus] = {}
+    current_attempt_keys: dict[int, frozenset[tuple[str, str]]] = {}
+    current_state_has_fingerprint: dict[int, bool] = {}
+    all_accepted_keys: dict[int, set[tuple[str, str]]] = {}
     expected: dict[tuple[int, int], bool] = {}
     for cycle_idx, cycle in enumerate(world.cycles):
         claimed_this_cycle: dict[tuple[str, str], int] = {}
@@ -323,17 +340,31 @@ def expected_guard_decisions(world: GuardWorld) -> dict[tuple[int, int], bool]:
             )
             cross_cycle_conflict = not same_cycle_conflict and any(
                 owner_id != attempt.request_id
-                and status == "downloading"
-                and any(k in owner_keys for k in attempt.keys)
-                for owner_id, (status, owner_keys) in current_attempt.items()
+                and current_status.get(owner_id) == "downloading"
+                and (
+                    any(
+                        k in current_attempt_keys[owner_id]
+                        for k in attempt.keys
+                    )
+                    if current_state_has_fingerprint.get(owner_id, False)
+                    else any(
+                        k in all_accepted_keys[owner_id] for k in attempt.keys
+                    )
+                )
+                for owner_id in all_accepted_keys
             )
             won = not same_cycle_conflict and not cross_cycle_conflict
             expected[(cycle_idx, attempt.request_id)] = won
             if won:
                 for k in attempt.keys:
                     claimed_this_cycle[k] = attempt.request_id
-                current_attempt[attempt.request_id] = (
-                    attempt.resulting_status, frozenset(attempt.keys))
+                current_status[attempt.request_id] = attempt.resulting_status
+                current_attempt_keys[attempt.request_id] = frozenset(
+                    attempt.keys)
+                current_state_has_fingerprint[attempt.request_id] = (
+                    attempt.state_has_fingerprint)
+                all_accepted_keys.setdefault(
+                    attempt.request_id, set()).update(attempt.keys)
     return expected
 
 
@@ -414,11 +445,13 @@ _ABANDONED_ATTEMPT_DOES_NOT_BLOCK = GuardWorld(cycles=(
     )),
 ))
 # Same reproduction as above, but with the owner's state carrying NO
-# ``attempt_fingerprint`` key on either attempt (#1196 item 1
-# deploy-window: a request claimed by code from before this field
-# existed) -- the guard must still resolve correctly through the
-# time-predicate fallback, not the new equality arm.
-_ABANDONED_ATTEMPT_DOES_NOT_BLOCK_WITHOUT_FINGERPRINT = GuardWorld(cycles=(
+# ``attempt_fingerprint`` key on either attempt (a state that exists but
+# lacks the key) -- #1199 item 2 deleted the deploy-window time-predicate
+# fallback this used to exercise (the measured cohort was empty), so the
+# guard now fails CLOSED unconditionally: request 2's sibling attempt on
+# the OWNER's OLD, abandoned key is now BLOCKED too, unlike the
+# fingerprint-scoped world above where only the CURRENT key blocks.
+_MISSING_FINGERPRINT_STATE_BLOCKS_EVERY_HISTORICAL_KEY = GuardWorld(cycles=(
     GuardCycle(attempts=(
         GuardAttempt(1, (("OLD", "old.flac"),), "downloading",
                      state_has_fingerprint=False),
@@ -448,7 +481,7 @@ class TestGeneratedCrossRequestEnqueueGuard(unittest.TestCase):
     @example(world=_REPLACE_LINEAGE_DOES_NOT_BLOCK)
     @example(world=_IMPORTED_OWNER_DOES_NOT_BLOCK)
     @example(world=_ABANDONED_ATTEMPT_DOES_NOT_BLOCK)
-    @example(world=_ABANDONED_ATTEMPT_DOES_NOT_BLOCK_WITHOUT_FINGERPRINT)
+    @example(world=_MISSING_FINGERPRINT_STATE_BLOCKS_EVERY_HISTORICAL_KEY)
     def test_guard_never_double_claims_or_over_blocks(self, world: GuardWorld):
         proceeded = _run_world(world)
         assert_no_double_claim(world, proceeded)
@@ -549,13 +582,18 @@ class TestCrossRequestGuardDecisivePins(unittest.TestCase):
             {(0, 1): True, (1, 1): True, (1, 2): True},
         )
 
-    def test_abandoned_attempt_does_not_block_without_fingerprint(self):
-        """#1196 item 1 deploy-window: the same reproduction with no
-        ``attempt_fingerprint`` on the owner's state resolves identically
-        through the time-predicate fallback."""
+    def test_missing_fingerprint_state_blocks_every_historical_key(self):
+        """#1199 item 2: the same reproduction with no
+        ``attempt_fingerprint`` on the owner's state now fails CLOSED --
+        request 2's attempt on the owner's OLD, abandoned key is BLOCKED
+        (unlike the fingerprint-scoped
+        test_abandoned_attempt_does_not_block_but_current_attempt_does
+        above, where the same shape does NOT block), because the deleted
+        time-predicate fallback was the only thing that used to rescue
+        an abandoned attempt when the state lacks a fingerprint."""
         self.assertEqual(
-            _run_world(_ABANDONED_ATTEMPT_DOES_NOT_BLOCK_WITHOUT_FINGERPRINT),
-            {(0, 1): True, (1, 1): True, (1, 2): True},
+            _run_world(_MISSING_FINGERPRINT_STATE_BLOCKS_EVERY_HISTORICAL_KEY),
+            {(0, 1): True, (1, 1): True, (1, 2): False},
         )
 
 

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -8640,9 +8640,17 @@ class TestFakePipelineDBTransferLedger(unittest.TestCase):
 
         self.assertEqual(conflicting, {99})
 
-    def test_get_conflicting_transfer_request_ids_scopes_to_current_attempt(self):
-        """#1178 PR2 review F2: an abandoned earlier attempt's accepted
-        row must not block; the current attempt's row still does."""
+    def test_get_conflicting_transfer_request_ids_missing_fingerprint_key_blocks(
+        self,
+    ):
+        """#1199 item 2 fake twin: an active_download_state that EXISTS
+        but lacks "attempt_fingerprint" fails CLOSED unconditionally --
+        both an old (30-day) and a current accepted row block, with no
+        attempt-boundary rescue by age. Equivalence note: this replaces
+        test_get_conflicting_transfer_request_ids_scopes_to_current_
+        attempt, which asserted the OLD row did NOT block under the
+        now-deleted deploy-window time-predicate fallback; that
+        differentiation no longer exists in production."""
         from tests.helpers import make_request_row
 
         db = FakePipelineDB()
@@ -8669,14 +8677,14 @@ class TestFakePipelineDBTransferLedger(unittest.TestCase):
         self.assertEqual(
             db.get_conflicting_transfer_request_ids(
                 [("OLD", "old.flac")], exclude_request_id=1),
-            set(),
-            "abandoned attempt must not block",
+            {99},
+            "missing fingerprint key fails closed regardless of age",
         )
         self.assertEqual(
             db.get_conflicting_transfer_request_ids(
                 [("NEW", "new.flac")], exclude_request_id=1),
             {99},
-            "current attempt must still block",
+            "missing fingerprint key still blocks the current key too",
         )
 
     def test_get_conflicting_transfer_request_ids_null_state_fails_closed(self):

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -8700,6 +8700,38 @@ class TestFakePipelineDBTransferLedger(unittest.TestCase):
 
         self.assertEqual(conflicting, {99})
 
+    def test_get_conflicting_transfer_request_ids_explicit_json_null_fingerprint_blocks(
+        self,
+    ):
+        """Fake parity twin for the real-PG hostile-shape pin (issue #1199
+        review F8): an explicit ``"attempt_fingerprint": None`` value
+        (mirroring an explicit JSON ``null``, distinct from the key being
+        absent) fails closed exactly like a missing key. ``_attempt_
+        fingerprint_from_state`` already handles this correctly --
+        ``dict.get`` returns ``None`` for an explicit ``None`` value the
+        same as for a missing key, and the ``isinstance(value, str)``
+        check treats both as "no fingerprint" -- so this test proves that
+        existing behaviour rather than changing it."""
+        from tests.helpers import make_request_row
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=99, status="downloading"))
+        db.record_transfer_enqueue([
+            TransferLedgerRow(
+                request_id=99, username="p0", filename="a.flac",
+                attempt_fingerprint="deadbeef"),
+        ])
+        db.confirm_transfer_enqueue("p0", "a.flac")
+        db.request(99)["active_download_state"] = {
+            "filetype": "flac", "enqueued_at": datetime.now(UTC).isoformat(),
+            "files": [], "attempt_fingerprint": None,
+        }
+
+        conflicting = db.get_conflicting_transfer_request_ids(
+            [("p0", "a.flac")], exclude_request_id=1)
+
+        self.assertEqual(conflicting, {99})
+
     def test_get_conflicting_transfer_request_ids_status_filter(self):
         # 'processing' included specifically to kill the
         # status-filter-widened mutant (#1178 PR2 review F1); every other

--- a/tests/test_lib_selection_coverage_audit.py
+++ b/tests/test_lib_selection_coverage_audit.py
@@ -1,0 +1,192 @@
+"""Audit: `LIB_MODULES_WITHOUT_SELECTION_COVERAGE` stays exact (issue #1199).
+
+`scripts/targeted_test_selection.py::LIB_MODULES_WITHOUT_SELECTION_COVERAGE`
+is the lib/ twin of `SHARED_MODULES_WITHOUT_COVERAGE` — a changed
+`lib/**/*.py` file whose full neighbour resolution (`EXACT_PATH_NEIGHBOURS` +
+prefix rules + direct candidates that actually exist) yields zero test
+modules now fails closed in `_changed_path_neighbours` (an exit-code-2
+refusal through `scripts/test.sh`, the same shape the tests/-side unmapped-
+module check already had) unless the path is admitted here.
+
+Unlike `SHARED_MODULES_WITHOUT_COVERAGE`, `_changed_path_neighbours` does
+NOT early-return for a registered lib/ path — the full resolution still
+runs, so a registration can go stale the moment someone adds a real
+`EXACT_PATH_NEIGHBOURS` entry, a new prefix rule, or a `tests.test_<stem>`
+module for it, and the registry's own claim ("resolves zero test
+neighbours") silently becomes false with nothing to say so. This audit
+proves the registry exact by construction in BOTH directions, driving the
+REAL resolution function (not a reimplementation):
+
+1. every registered path still resolves zero neighbours (else it is a
+   STALE admission and must be removed); and
+2. every `lib/**/*.py` file NOT registered here still resolves at least one
+   neighbour (else it is an UNLISTED gap and must be registered, or given
+   real coverage).
+
+This is deliberately test infrastructure (selection machinery), so — per
+`.claude/rules/code-quality.md` § "Never property-test the test machinery"
+— it is a deterministic audit, no generated property. Direction 2 is proven
+for free by `_changed_path_neighbours` itself: an unregistered zero-
+neighbour lib/ path raises `ValueError` naming the path, so simply calling
+it for every real `lib/**/*.py` file (inside a `subTest` so unittest reports
+every offender, not just the first) is the check.
+"""
+
+from __future__ import annotations
+
+import unittest
+from collections.abc import Mapping
+from pathlib import Path
+
+from scripts.targeted_test_selection import (
+    LIB_MODULES_WITHOUT_SELECTION_COVERAGE,
+    _changed_path_neighbours,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _stale_lib_selection_gaps(
+    registry: Mapping[str, str],
+    repo_root: Path,
+) -> list[str]:
+    """Return one message per STALE registry entry — a path registered as
+    "resolves zero neighbours" that now resolves real ones. Drives the
+    REAL `_changed_path_neighbours`, never a reimplementation of its logic.
+    """
+    violations: list[str] = []
+    for path in sorted(registry):
+        neighbours = _changed_path_neighbours(path, repo_root)
+        if neighbours:
+            violations.append(
+                f"{path} is registered in "
+                "LIB_MODULES_WITHOUT_SELECTION_COVERAGE as resolving zero "
+                f"test neighbours, but now resolves: {', '.join(neighbours)}"
+            )
+    return violations
+
+
+class TestLibSelectionCoverageRegistryIsExact(unittest.TestCase):
+    """The real registry, verified against the real resolution function."""
+
+    def test_no_registered_gap_is_stale(self) -> None:
+        violations = _stale_lib_selection_gaps(
+            LIB_MODULES_WITHOUT_SELECTION_COVERAGE, REPO_ROOT
+        )
+        self.assertEqual(
+            violations,
+            [],
+            "A path registered in LIB_MODULES_WITHOUT_SELECTION_COVERAGE "
+            "as a zero-neighbour gap now resolves real coverage — remove "
+            "the stale registration:\n  " + "\n  ".join(violations),
+        )
+
+    def test_registry_is_non_empty(self) -> None:
+        """Pin: this audit has something real to check today."""
+        self.assertTrue(LIB_MODULES_WITHOUT_SELECTION_COVERAGE)
+
+    def test_registered_paths_carry_a_non_empty_rationale(self) -> None:
+        for path, rationale in LIB_MODULES_WITHOUT_SELECTION_COVERAGE.items():
+            with self.subTest(path=path):
+                self.assertTrue(
+                    rationale.strip(),
+                    f"{path} is registered with an empty rationale",
+                )
+
+    def test_registered_paths_still_exist_on_disk(self) -> None:
+        for path in LIB_MODULES_WITHOUT_SELECTION_COVERAGE:
+            with self.subTest(path=path):
+                self.assertTrue(
+                    (REPO_ROOT / path).is_file(),
+                    f"registered lib/ gap does not exist on disk: {path}",
+                )
+
+    def test_every_lib_module_resolves_or_is_registered(self) -> None:
+        """Tree-walking pin: every real `lib/**/*.py` file either resolves
+        at least one neighbour, or is admitted in
+        LIB_MODULES_WITHOUT_SELECTION_COVERAGE. Calls the REAL
+        `_changed_path_neighbours` for every file — an unregistered
+        zero-neighbour file raises `ValueError` naming itself, which
+        `subTest` reports as that file's own failure without stopping the
+        walk (so every offender is named in one run, not just the first).
+        """
+        lib_files = sorted(
+            path for path in (REPO_ROOT / "lib").rglob("*.py")
+            if "__pycache__" not in path.parts
+        )
+        self.assertTrue(lib_files, "expected lib/**/*.py files to exist")
+
+        for path in lib_files:
+            relative = path.relative_to(REPO_ROOT).as_posix()
+            with self.subTest(path=relative):
+                _changed_path_neighbours(relative, REPO_ROOT)
+
+
+class TestLibSelectionCoverageCheckerTripsOnViolations(unittest.TestCase):
+    """Known-bad self-tests, driven through synthetic registries/paths —
+    never the real registry — so the checker's own correctness is proven
+    independently of today's registrations happening to be clean."""
+
+    def test_unmapped_zero_neighbour_lib_file_fails_closed_with_its_name(
+        self,
+    ) -> None:
+        """Direction 2 (unlisted gap): a lib/ path with zero neighbours
+        that is NOT registered must raise, naming itself. The path need
+        not exist on disk — `_changed_path_neighbours` never stats its
+        own target, only candidate test modules (mirrors the existing
+        tests/-side known-bad self-test's same non-existent-path shape,
+        `test_unmapped_shared_test_module_fails_closed_with_the_file_name`
+        in tests/test_targeted_test_selection.py)."""
+        with self.assertRaisesRegex(
+            ValueError,
+            r"lib/_totally_unmapped_selection_probe\.py",
+        ):
+            _changed_path_neighbours(
+                "lib/_totally_unmapped_selection_probe.py", REPO_ROOT
+            )
+
+    def test_registered_gap_with_zero_neighbours_does_not_raise(self) -> None:
+        """Must-still-work: a genuinely zero-neighbour path that IS
+        registered proceeds (ambient-only selection), never raises."""
+        registered = next(iter(LIB_MODULES_WITHOUT_SELECTION_COVERAGE))
+        self.assertEqual(
+            _changed_path_neighbours(registered, REPO_ROOT), ()
+        )
+
+    def test_stale_registration_checker_trips_on_a_planted_stale_entry(
+        self,
+    ) -> None:
+        """Direction 1 (stale admission): a fabricated registry entry
+        naming a lib/ path the real prefix rules actually cover (here,
+        the lib/pipeline_db/ prefix rule, which unconditionally extends
+        PIPELINE_DB_NEIGHBOURS regardless of whether the file exists) must
+        be reported as stale, naming the path and what it now resolves
+        to. The real module-level registry is never touched."""
+        fabricated = {
+            "lib/pipeline_db/_selection_probe.py": (
+                "synthetic stale entry for self-test"
+            ),
+        }
+
+        violations = _stale_lib_selection_gaps(fabricated, REPO_ROOT)
+
+        self.assertEqual(len(violations), 1)
+        self.assertIn("lib/pipeline_db/_selection_probe.py", violations[0])
+        self.assertIn("tests.test_pipeline_db", violations[0])
+
+    def test_stale_registration_checker_is_quiet_on_a_genuine_gap(
+        self,
+    ) -> None:
+        """Must-still-work: a fabricated registry entry that genuinely
+        resolves zero neighbours (an existing real gap) produces no
+        violation."""
+        registered = next(iter(LIB_MODULES_WITHOUT_SELECTION_COVERAGE))
+        fabricated = {registered: "synthetic rationale for self-test"}
+
+        violations = _stale_lib_selection_gaps(fabricated, REPO_ROOT)
+
+        self.assertEqual(violations, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lib_selection_coverage_audit.py
+++ b/tests/test_lib_selection_coverage_audit.py
@@ -34,6 +34,8 @@ every offender, not just the first) is the check.
 
 from __future__ import annotations
 
+import contextlib
+import io
 import unittest
 from collections.abc import Mapping
 from pathlib import Path
@@ -144,6 +146,47 @@ class TestLibSelectionCoverageCheckerTripsOnViolations(unittest.TestCase):
             _changed_path_neighbours(
                 "lib/_totally_unmapped_selection_probe.py", REPO_ROOT
             )
+
+    def test_unmapped_nested_lib_file_fails_closed_with_its_name(
+        self,
+    ) -> None:
+        """Direction 2, NESTED shape (issue #1199 review F2): the
+        top-level probe above (`lib/_totally_unmapped_selection_probe.py`,
+        `len(path.parts) == 2`) cannot by itself distinguish the real
+        `path.parts[:1] == ("lib",)` guard from a narrower
+        `len(path.parts) == 2` mutant — every nested lib/ file in the real
+        tree today happens to be registered, so that survivor was never
+        exercised. This probe is nested three levels deep
+        (`len(path.parts) == 3`) and unregistered, so only the real
+        first-component guard, not a top-level-only narrowing, can make
+        this raise."""
+        with self.assertRaisesRegex(
+            ValueError,
+            r"lib/dispatch/_totally_unmapped_nested_probe\.py",
+        ):
+            _changed_path_neighbours(
+                "lib/dispatch/_totally_unmapped_nested_probe.py", REPO_ROOT
+            )
+
+    def test_admitted_gap_log_names_the_path_and_its_rationale(
+        self,
+    ) -> None:
+        """The loud admitted-gap stderr line (issue #1199 review F4) must
+        name BOTH the registered path AND its registered rationale — not
+        merely print SOME line. Captures the real stderr `_changed_path_
+        neighbours` writes for a real registered path, driven through the
+        public entry point."""
+        registered = next(iter(LIB_MODULES_WITHOUT_SELECTION_COVERAGE))
+        rationale = LIB_MODULES_WITHOUT_SELECTION_COVERAGE[registered]
+        buffer = io.StringIO()
+
+        with contextlib.redirect_stderr(buffer):
+            result = _changed_path_neighbours(registered, REPO_ROOT)
+
+        self.assertEqual(result, ())
+        emitted = buffer.getvalue()
+        self.assertIn(registered, emitted)
+        self.assertIn(rationale, emitted)
 
     def test_registered_gap_with_zero_neighbours_does_not_raise(self) -> None:
         """Must-still-work: a genuinely zero-neighbour path that IS

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -16716,21 +16716,34 @@ class TestTransferLedgerRoundTrip(unittest.TestCase):
 
         self.assertEqual(conflicting, {owner})
 
-    def test_get_conflicting_transfer_request_ids_scopes_to_current_attempt(self):
-        """#1178 PR2 review F2 reproduction: live-DB measurement found
-        80.3% of accepted ledger rows belong to a non-current attempt (up
-        to 76 accepted attempt fingerprints for one request); an owner
-        downloading a FRESH peer's files must not block a sibling on a
-        queue key from that SAME owner's OWN 30-day-old abandoned attempt.
-        The same key re-enqueued as part of the CURRENT attempt (at/after
-        the active_download_state witness) must still block."""
+    def test_get_conflicting_transfer_request_ids_missing_fingerprint_key_blocks(
+        self,
+    ):
+        """#1199 item 2: an owner's ``active_download_state`` that exists
+        but LACKS the ``attempt_fingerprint`` key fails CLOSED
+        unconditionally -- every accepted row for that ``'downloading'``
+        owner counts as in-scope (blocks), with no attempt-boundary
+        rescue by age. Proven with BOTH a 30-day-old row and a
+        just-written row so age plays no part in either direction; a
+        prior version of this query fell back to a clock comparison here
+        (deleted -- the measured deploy-window cohort was empty) that
+        would have excluded the old row.
+
+        Equivalence note: this test replaces
+        ``test_get_conflicting_transfer_request_ids_scopes_to_current_
+        attempt``, which asserted the OLD key did NOT block under the
+        now-deleted time-predicate fallback. That differentiation no
+        longer exists in production; attempt-scoping now lives ONLY in
+        the fingerprint-equality arm, covered by
+        ``test_get_conflicting_transfer_request_ids_fingerprint_match_
+        blocks`` and ``test_get_conflicting_transfer_request_ids_
+        different_fingerprint_beats_newer_time``.
+        """
         owner = self._seed_request("downloading")
         old_username, old_filename = "OLD", "old.flac"
         current_username, current_filename = "NEW", "new.flac"
         candidate = self._seed_request("wanted")
 
-        # OLD abandoned attempt: accepted 30 days ago, no state references
-        # it any more.
         self.db.record_transfer_enqueue([
             TransferLedgerRow(
                 request_id=owner, username=old_username, filename=old_filename),
@@ -16743,10 +16756,8 @@ class TestTransferLedgerRoundTrip(unittest.TestCase):
             (owner, old_username),
         )
 
-        # CURRENT attempt: active_download_state's witness is captured,
-        # THEN the ledger row is written -- the same ordering
-        # lib/enqueue.py's real claim uses (claim.enqueued_at captured
-        # strictly before the write-ahead ledger insert).
+        # active_download_state exists (proving this is NOT the NULL-state
+        # pin below) but carries no "attempt_fingerprint" key.
         current_state = {
             "filetype": "flac", "enqueued_at": datetime.now(UTC).isoformat(),
             "files": [],
@@ -16766,15 +16777,16 @@ class TestTransferLedgerRoundTrip(unittest.TestCase):
         self.assertEqual(
             self.db.get_conflicting_transfer_request_ids(
                 [(old_username, old_filename)], exclude_request_id=candidate),
-            set(),
-            "an abandoned earlier attempt's key must NOT block",
+            {owner},
+            "a missing fingerprint key fails closed regardless of the "
+            "ledger row's age",
         )
         self.assertEqual(
             self.db.get_conflicting_transfer_request_ids(
                 [(current_username, current_filename)],
                 exclude_request_id=candidate),
             {owner},
-            "the current attempt's key must still block",
+            "a missing fingerprint key still blocks the current key too",
         )
 
     def test_get_conflicting_transfer_request_ids_status_filter(self):
@@ -16842,11 +16854,13 @@ class TestTransferLedgerRoundTrip(unittest.TestCase):
     def test_get_conflicting_transfer_request_ids_matches_fake(self):
         """The fake must mirror the real join's semantics exactly
         (test-fidelity.md Rule A pattern applied to a read method) --
-        including the attempt-boundary predicate (review F6): without a
-        scoped owner carrying BOTH an old (excluded) and current
-        (included) attempt row, every case above takes the
-        COALESCE-null fallback arm and the boundary predicate itself is
-        never exercised on either side."""
+        including the missing-fingerprint fail-closed arm (review F6,
+        updated for #1199 item 2): without a scoped owner carrying BOTH
+        an old and a current accepted row under a fingerprint-less
+        state, every case above takes the unconditional NULL-state ELSE
+        arm through a DIFFERENT code path (no active_download_state row
+        at all) and the "state exists but lacks the key" arm is never
+        exercised on either side."""
         from tests.fakes import FakePipelineDB
 
         fake = FakePipelineDB()
@@ -16875,10 +16889,11 @@ class TestTransferLedgerRoundTrip(unittest.TestCase):
                 db.confirm_transfer_enqueue(username, "a.flac")
             keys.append((username, "a.flac"))
 
-        # F6: a scoped owner carrying BOTH an old (excluded) attempt row
-        # and a current (included) attempt row, seeded identically on
-        # both the real and fake sides so parity is proven AT the
-        # boundary, not just at the null fallback.
+        # F6: a scoped owner carrying BOTH an old and a current accepted
+        # row, with a state that EXISTS but lacks "attempt_fingerprint",
+        # seeded identically on both the real and fake sides so parity is
+        # proven at that specific arm -- not just at the simpler
+        # no-state-at-all case every "cases" entry above exercises.
         scoped_owner = self._seed_request("downloading")
         fake.seed_request({
             "id": scoped_owner, "status": "downloading",
@@ -16930,12 +16945,12 @@ class TestTransferLedgerRoundTrip(unittest.TestCase):
 
         # #1196 item 1: a SECOND scoped owner whose state carries
         # ``attempt_fingerprint`` -- seeded identically on both sides so
-        # parity is proven at the NEW fingerprint-equality branch too,
-        # not just the deploy-window fallback ``scoped_owner`` above
-        # exercises. Its old row's ``enqueued_at`` is pushed AFTER the
-        # witness -- deliberately the shape the time predicate alone
-        # would get wrong -- so this only stays excluded on both sides
-        # because the fingerprint (not the clock) decides it.
+        # parity is proven at the fingerprint-equality branch too, not
+        # just the missing-fingerprint fail-closed arm ``scoped_owner``
+        # above exercises. Its old row's ``enqueued_at`` is pushed AFTER
+        # the witness -- deliberately a shape a clock comparison would
+        # get wrong -- so this only stays excluded on both sides because
+        # the fingerprint (not any clock) decides it.
         fp_owner = self._seed_request("downloading")
         fake.seed_request({
             "id": fp_owner, "status": "downloading",
@@ -16988,12 +17003,14 @@ class TestTransferLedgerRoundTrip(unittest.TestCase):
             fake.get_conflicting_transfer_request_ids(
                 keys, exclude_request_id=candidate),
         )
-        # The boundary must actually be earning its keep: the old key is
-        # excluded, the current key still blocks.
+        # The missing-fingerprint arm must actually be earning its keep:
+        # BOTH the old and the current key block, regardless of age --
+        # there is no attempt-boundary rescue when the state lacks the
+        # fingerprint key.
         self.assertEqual(
             self.db.get_conflicting_transfer_request_ids(
                 [(old_username, old_filename)], exclude_request_id=candidate),
-            set(),
+            {scoped_owner},
         )
         self.assertEqual(
             self.db.get_conflicting_transfer_request_ids(
@@ -17118,74 +17135,19 @@ class TestTransferLedgerRoundTrip(unittest.TestCase):
             "its enqueued_at is newer than the current-attempt witness",
         )
 
-    def test_get_conflicting_transfer_request_ids_missing_fingerprint_key_falls_back_to_time(self):
-        """#1196 item 1 world (c): a state that carries
-        active_download_state but LACKS the attempt_fingerprint key
-        (deploy-window: claimed by code from before this field existed)
-        falls back to the pre-#1196 time predicate, proven both
-        directions -- the old attempt excluded, the current attempt
-        still blocks."""
-        owner = self._seed_request("downloading")
-        old_username, old_filename = "OLD", "old.flac"
-        current_username, current_filename = "NEW", "new.flac"
-        candidate = self._seed_request("wanted")
-
-        self.db.record_transfer_enqueue([
-            TransferLedgerRow(
-                request_id=owner, username=old_username,
-                filename=old_filename),
-        ])
-        self.db.confirm_transfer_enqueue(old_username, old_filename)
-        self.db._execute(
-            "UPDATE slskd_transfer_ledger SET enqueued_at = "
-            "NOW() - INTERVAL '30 days' "
-            "WHERE request_id = %s AND username = %s",
-            (owner, old_username),
-        )
-
-        current_state = {
-            "filetype": "flac", "enqueued_at": datetime.now(UTC).isoformat(),
-            "files": [],
-            # No "attempt_fingerprint" key -- deploy-window state.
-        }
-        self.db._execute(
-            "UPDATE album_requests SET active_download_state = %s::jsonb "
-            "WHERE id = %s",
-            (json.dumps(current_state), owner),
-        )
-        self.db.record_transfer_enqueue([
-            TransferLedgerRow(
-                request_id=owner, username=current_username,
-                filename=current_filename),
-        ])
-        self.db.confirm_transfer_enqueue(current_username, current_filename)
-
-        self.assertEqual(
-            self.db.get_conflicting_transfer_request_ids(
-                [(old_username, old_filename)], exclude_request_id=candidate),
-            set(),
-            "fallback: an abandoned earlier attempt must not block",
-        )
-        self.assertEqual(
-            self.db.get_conflicting_transfer_request_ids(
-                [(current_username, current_filename)],
-                exclude_request_id=candidate),
-            {owner},
-            "fallback: the current attempt must still block",
-        )
-
     def test_get_conflicting_transfer_request_ids_null_state_blocks(self):
-        """#1196 item 1 world (d): a NULL active_download_state still
-        fails CLOSED unconditionally -- every accepted row for that
-        'downloading' owner counts as in-scope, regardless of the
-        ledger row's own fingerprint. (Review F3: this is NOT a
-        dedicated ``IS NULL`` SQL arm -- that arm was proven redundant
-        on real PG and removed. The fail-closed guarantee this pin
-        protects lives in the ELSE arm's ``COALESCE(...,
-        '-infinity')``: ``->>`` on a NULL jsonb state returns NULL for
-        any key, so ``COALESCE`` substitutes ``'-infinity'``, which
-        every real ``enqueued_at`` compares ``>=`` true. This pin kills
-        a mutant that removes or inverts that COALESCE.)"""
+        """#1196 item 1 world (d), updated for #1199 item 2: a NULL
+        active_download_state still fails CLOSED unconditionally --
+        every accepted row for that 'downloading' owner counts as
+        in-scope, regardless of the ledger row's own fingerprint. (Review
+        F3: this is NOT a dedicated ``IS NULL`` SQL arm -- that arm was
+        proven redundant on real PG and removed. The fail-closed
+        guarantee this pin protects lives in the ELSE arm, which #1199
+        item 2 simplified from a clock ``COALESCE`` to unconditional
+        ``TRUE``: ``->>`` on a NULL jsonb state returns NULL for the
+        ``attempt_fingerprint`` key regardless, so the ``CASE`` always
+        reaches ``ELSE TRUE``. This pin kills a mutant that inverts or
+        removes that ``TRUE``.)"""
         owner = self._seed_accepted_row(
             status="downloading", username="p0", filename="a.flac")
         row = self.db.get_request(owner)

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -17160,6 +17160,51 @@ class TestTransferLedgerRoundTrip(unittest.TestCase):
 
         self.assertEqual(conflicting, {owner})
 
+    def test_get_conflicting_transfer_request_ids_explicit_json_null_fingerprint_blocks(
+        self,
+    ):
+        """Hostile-shape pin (issue #1199 review F8): an
+        ``active_download_state`` that carries an EXPLICIT JSON ``null``
+        for ``attempt_fingerprint`` (``{"attempt_fingerprint": null, ...}``
+        -- distinct from the key being ABSENT, and never producible by
+        ``build_active_download_state``'s ``omit_defaults=True``, but
+        constructible by hostile/manual data) must still fail CLOSED
+        (block). This is the world that distinguishes ``->>`` from ``->``
+        in the WHEN test: ``->>`` extracts a JSON null as SQL NULL (so the
+        CASE reaches ``ELSE TRUE`` and blocks); ``->`` would instead
+        extract a non-NULL jsonb 'null' scalar, taking the WHEN branch and
+        comparing it against the ledger's own (non-null) text
+        ``attempt_fingerprint`` -- which never matches, so a ``->``
+        regression would fail OPEN (not block) on exactly this shape."""
+        owner = self._seed_request("downloading")
+        username, filename = "p0", "a.flac"
+        self.db.record_transfer_enqueue([
+            TransferLedgerRow(
+                request_id=owner, username=username, filename=filename,
+                attempt_fingerprint="deadbeef"),
+        ])
+        self.db.confirm_transfer_enqueue(username, filename)
+        state = {
+            "filetype": "flac", "enqueued_at": datetime.now(UTC).isoformat(),
+            "files": [], "attempt_fingerprint": None,
+        }
+        self.db._execute(
+            "UPDATE album_requests SET active_download_state = %s::jsonb "
+            "WHERE id = %s",
+            (json.dumps(state), owner),
+        )
+        candidate = self._seed_request("wanted")
+
+        conflicting = self.db.get_conflicting_transfer_request_ids(
+            [(username, filename)], exclude_request_id=candidate)
+
+        self.assertEqual(
+            conflicting, {owner},
+            "an explicit JSON null attempt_fingerprint must fail closed "
+            "(block), exactly like a missing key or a NULL top-level "
+            "state -- a -> regression instead of ->> would fail open here",
+        )
+
 @requires_postgres
 class TestReadProjectionParity(unittest.TestCase):
     """#481 item 2 — fake<->production READ-projection parity gate.


### PR DESCRIPTION
## Summary

Refs #1199 (non-closing; deploy + live proof pending), both items.

**Item 1 — fail-closed selection for `lib/`.** A changed `lib/**/*.py` resolving zero test neighbours now refuses loudly (the existing exit-code-2 contract) unless listed in the new `LIB_MODULES_WITHOUT_SELECTION_COVERAGE` admitted-gap registry — measured fresh at **35 entries** after a mechanical `tests.test_<stem>_generated` sibling rule (same class as the existing `tests.test_<stem>` probe) converted four false gaps into real coverage. Admitted gaps log a stderr line naming the path and rationale (pinned by stderr capture). A deterministic audit drives the real resolution per entry and fails in both directions: stale admissions (file now resolves neighbours — entry must be deleted) and unlisted zero-neighbour files. The shared `_resolve_neighbours` refactor was proven behavior-preserving by a whole-tree differential (0 differences across 1,486 tracked paths), and the refusal is depth-pinned by a nested `lib/dispatch/` probe world (the review's narrowing mutant survived 31 tests before that pin existed). Deletion-only diffs, renames, new-file-with-new-test flows all verified unaffected.

**Item 2 — dead deploy-window fallback deleted.** Cohort measured live before implementation (2026-08-19 04:17 AWST): 1 `downloading` request, 0 NULL states, **0 lacking `attempt_fingerprint`** — the clock-predicate arm of `get_conflicting_transfer_request_ids` was dead. Per the no-deprecated-helpers rule, it's gone: fingerprint equality when the owner's state carries a fingerprint, everything else fails closed (blocks), and the `::timestamptz` cast and its `InvalidDatetimeFormat` caveat disappear repo-wide. The one shape that could mint a fingerprint-less owner (empty `files` at claim) is unreachable via the non-empty `files_to_enqueue`/`planned_files` guards, now named in the docstring and schema doc — with the honest consequence stated (such an owner would block every key it ever accepted). Review probed 11 degenerate JSONB state shapes on real PG; the fake matched point-identically on all 11, and an explicit-JSON-null fingerprint pin now kills the `->>` → `->` weakening the review found survivable. Deleted attempt-scoping tests carry equivalence notes in the commit; scoping for the only reachable owner shape stays covered in both directions by the fingerprint-arm tests.

## Kill matrix (per diff site)

| Site (assertion / clause / constant) | One-line production mutant | Test that must go RED | Result |
| --- | --- | --- | --- |
| SQL fingerprint equality (WHEN arm) | force `FALSE` | real-PG `..._fingerprint_match_blocks` | RED → GREEN |
| SQL `ELSE TRUE` (fail closed) | `ELSE FALSE` | `..._missing_fingerprint_key_blocks` + `..._null_state_blocks` | RED → GREEN |
| SQL WHEN condition | weaken to `state IS NOT NULL` | `..._missing_fingerprint_key_blocks` (others stay green — distinct site) | RED → GREEN |
| SQL `->>' operator | `->` (explicit-JSON-null flips to fail open) | `..._explicit_json_null_fingerprint_blocks` (real PG + fake parity twin) | RED → GREEN |
| fake fail-closed arm | fail open on missing fingerprint | fake self-test + real↔fake parity | RED → GREEN |
| generated reference model | revert to attempt-scoped semantics | property (suite profile, with and without the `@example` pin) | RED → GREEN |
| lib/ refusal presence | bypass the block | `test_unmapped_zero_neighbour_lib_file_fails_closed_with_its_name` | RED → GREEN |
| lib/ refusal depth | narrow to `len(path.parts)==2` | `test_unmapped_nested_lib_file_fails_closed_with_its_name` | RED → GREEN |
| admitted-gap loud log | delete or gut the stderr line | `test_admitted_gap_log_names_the_path_and_its_rationale` | RED → GREEN (both mutants) |
| registry stale-entry direction | admit a covered file | `test_no_registered_gap_is_stale` (names the file) | RED → GREEN |
| registry unlisted-gap direction | remove a real entry | `test_every_lib_module_resolves_or_is_registered` (names the file) | RED → GREEN |
| `_resolve_neighbours` existence check | drop it | selection tests (5 failures) | RED → GREEN |

## Reviewer

One independent Opus round: item 2 verified solid outright; item 1's mechanism sound but three shipped claims unverified/false (the "no code change to un-admit" sentence — this series' recurring failure mode; the unpinned loud-log contract; the narrowable refusal) plus README staleness and four convertible false gaps — all fixed and re-killed in the correction round. Reviewer's whole-tree resolver differential and 11-shape SQL sweep are recorded above. Stated residual: a real double-registration is caught by the stale audit rather than the import-time disjointness guard (benign, reviewer-verified).

## Risk

Item 1 is test-infrastructure only (selection); its failure mode is a loud refusal, never silent under-selection. Item 2 tightens production SQL in the fail-closed direction for owner shapes that cannot exist live (cohort measured empty; producer guards named). No schema change, no status-set change, no unfindable-input change.