### PR TITLE
fix: anchor dev-shell GC roots at repo top level; restore pyright's suppressed default excludes (#1208 item 3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /.venv
-/result
-/result-*
+result
+result-*
 __pycache__/
 *.pyc
 *.egg-info/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,10 +12,13 @@ Do not use Compound Engineering (`ce-*`, `compound-engineering:*`, or `lfg`) in
 this repository. Native agent planning, implementation, debugging, and review
 are sufficient.
 
-Work in an isolated git worktree, and clean it up when it is no longer useful.
-Keep the shared checkout on `main` and reasonably current; after merging to
-`main`, pull it forward. Use judgment around active or dirty trees, and never
-disturb another agent's work.
+Work in an isolated git worktree, and remove it when your task ends — durable
+work lives on pushed branches, never in worktrees. A stale worktree that is
+clean and whose commits are on `main` may be swept by any session, via
+`git worktree remove` without `--force` so the tool itself refuses dirty
+trees (#1208); never disturb another agent's live work. Keep the shared
+checkout on `main` and reasonably current; after merging to `main`, pull it
+forward.
 
 `.claude/memory/` is the exception: it is written in the shared checkout, not
 task worktrees. Notice and preserve those changes when cleaning up or advancing

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -77,16 +77,24 @@ pkgs.mkShell {
     # spurious reportMissingImports. Refreshed every shell entry (the store path
     # changes on ``nix flake update``); registered as an indirect GC root so
     # ``nix-collect-garbage`` won't sever the symlink.
+    # Anchor both GC roots at the repo TOP LEVEL, never $PWD (issue #1208
+    # item 3): a shell entered from a subdirectory used to plant these
+    # symlinks in-repo where the root-anchored pyright excludes cannot see
+    # them — two .nixpkgs-src links under docs/research/calibration-data/
+    # made every whole-repo pyright run analyze the entire nixpkgs Python
+    # corpus (~20 CPU-minutes and an OOM-scale node heap per run).
+    _cd_root="$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")"
     _cd_pyenv="$(${testPythonEnv}/bin/python3 -c 'import sys,os;print(os.path.dirname(os.path.dirname(sys.executable)))')"
-    nix-store --realise "$_cd_pyenv" --indirect --add-root "$PWD/.pyright-venv" >/dev/null 2>&1 \
-      || ln -sfn "$_cd_pyenv" "$PWD/.pyright-venv"
+    nix-store --realise "$_cd_pyenv" --indirect --add-root "$_cd_root/.pyright-venv" >/dev/null 2>&1 \
+      || ln -sfn "$_cd_pyenv" "$_cd_root/.pyright-venv"
     unset _cd_pyenv
 
     # GC-root the pinned nixpkgs source tree (fetched by the flake.lock
     # shim above) so nix-collect-garbage doesn't force a re-download on
     # the next shell entry. Same pattern as .pyright-venv.
-    nix-store --realise ${pkgs.path} --indirect --add-root "$PWD/.nixpkgs-src" >/dev/null 2>&1 \
-      || ln -sfn ${pkgs.path} "$PWD/.nixpkgs-src"
+    nix-store --realise ${pkgs.path} --indirect --add-root "$_cd_root/.nixpkgs-src" >/dev/null 2>&1 \
+      || ln -sfn ${pkgs.path} "$_cd_root/.nixpkgs-src"
+    unset _cd_root
 
     # The harness wrapper (harness/run_beets_harness.sh) execs this
     # interpreter. In production the guarded [Beets] runtime contract names

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,5 +1,7 @@
 {
-  "extraPaths": ["."],
+  "extraPaths": [
+    "."
+  ],
   "venvPath": ".",
   "venv": ".pyright-venv",
   "pythonVersion": "3.13",
@@ -8,8 +10,9 @@
   "exclude": [
     "build",
     "tools/vulture",
-    ".pyright-venv",
-    ".nixpkgs-src",
-    ".claude/worktrees"
+    "**/.*",
+    "**/node_modules",
+    "**/result",
+    "**/result-*"
   ]
 }

--- a/pyrightconfig.production.json
+++ b/pyrightconfig.production.json
@@ -34,9 +34,10 @@
   "exclude": [
     "build",
     "tools/vulture",
-    ".pyright-venv",
-    ".nixpkgs-src",
-    ".claude/worktrees",
-    "tests"
+    "**/.*",
+    "**/node_modules",
+    "tests",
+    "**/result",
+    "**/result-*"
   ]
 }


### PR DESCRIPTION
Item 3 of issue #1208, plus the operator's ruling that worktree hygiene is policy + a one-time sweep, not maintained machinery (recorded verbatim on the issue).

**Root cause, fully attributed (the worktree pile was a bystander):** `nix/shell.nix` planted its `.nixpkgs-src` / `.pyright-venv` GC-root symlinks at `$PWD`, so nix-shells entered from subdirectories (July's #829 calibration dirs) left symlinks to the **entire nixpkgs source** inside the repo where the root-anchored pyright excludes couldn't see them. Every whole-repo pyright run then analyzed the nixpkgs Python corpus: ~20 CPU-minutes, OOM-scale node heap, killed at every cap — the mechanism behind the 2026-08-19 gate OOM cascade. Deleting the four stray links healed the shared checkout from 200s-timeout-killed to an 87s clean pass with no other change.

**Changes (config + one shellHook anchor + policy line; no new machinery, no tests owed — evidence is empirical before/after):**

- `nix/shell.nix`: both GC roots anchor via `git rev-parse --show-toplevel` (silent `$PWD` fallback outside a repo / without git — reviewer verified byte-identical old behavior in that case, silent stderr, correct worktree-root semantics for `venvPath: "."`). Verified: a subdir shell entry now plants nothing locally.
- Both pyright configs: review discovered our explicit `exclude` lists were **suppressing pyright's built-in defaults** (`**/node_modules`, `**/__pycache__`, `**/.*`, `autoExcludeVenv` — applied only when `exclude` is empty; read out of the pinned 1.1.412 binary), so `.ruff_cache`'s 46,994 entries were walked on every run of both configs (~31× traversal amplification over 1,495 tracked files). Now: `**/.*` (zero tracked `.py` under any dot-directory — verified; subsumes the venv, the nixpkgs pin, `.claude`, and every cache) + `**/node_modules` + `**/result` + `**/result-*` (zero tracked exact `result`/`result-*` segments; `results-*.tsv.gz` provably cannot match — glob semantics verified against the pinned binary's compiled regex). Independently proven: a planted top-level `result` symlink to a 666M store path reproduced the blowup class (46.5s pass → 200s kill) and the exclude stops it with the link still present.
- `.gitignore`: `/result` anchors dropped so git and pyright agree on subdirectory result links (a subdir link would otherwise dirty the tree the final-gate receipt requires clean).
- `CLAUDE.md`: standing sweep policy — a stale worktree that is **clean and merged to main** may be swept by any session, `git worktree remove` **without** `--force` so the tool itself refuses dirty trees. The operator's broader one-time remove-all authorization is quoted verbatim on #1208 and was executed this session (55 worktrees; `git worktree list` is now just the shared checkout).

**Review:** one independent opus round (blocking findings all applied: authority citation recorded on the issue instead of claimed in CLAUDE.md; policy narrowed to clean+merged with the no-`--force` dirtiness check; suppressed-defaults discovery; `.gitignore` alignment; commit-message imprecision fixes) + orchestrator final read. Canonical suite receipt `pass` on this exact commit; pyright verified green at normal runtime (46.6s capped) in the worktree with the dot-glob in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
