### PR TITLE
fix(#1214): bind BeetsContractWorld lifetime to the Hypothesis example, not the test method

### DIFF
--- a/docs/generated-testing.md
+++ b/docs/generated-testing.md
@@ -1006,6 +1006,27 @@ may still patrol nothing; only review and mutant-kill counts show that.
   `class`/`def`** — that is what wires the module into the suite/fuzz tiers,
   and both `tests/test_hypothesis_profile_audit.py` and the suite runner's
   own `assert_hypothesis_deadlines_disabled` fail without it.
+- **A resource built inside a `@given` body is example-scoped, not
+  method-scoped — bind its lifetime with a `with` block, never
+  `self.addCleanup(...)`/`self.enterContext(...)`.** Hypothesis re-executes
+  the body once per EXAMPLE; `addCleanup`/`enterContext` fire once per test
+  METHOD. A resource constructed directly in the body and registered there
+  leaks one live copy per example until the method finally returns (issue
+  #1214: 2491 concurrently-live `BeetsContractWorld` fixtures, 1.59 GB, from
+  ONE test method at the daily gate's real budget — the exposure that OOM'd
+  `cratedigger-daily-checks.service` in production).
+  `tests/test_given_body_cleanup_audit.py` enforces the direct-construction
+  shape of this mistake, but cannot see through a helper method the body
+  merely calls by name (a bounded syntactic audit, not a call-graph tracer
+  — `.claude/rules/code-quality.md` § "Semantic source scanners are
+  prohibited"), so review still owns that shape. This is the OPPOSITE of
+  `NodeJsonlWorker`'s pattern above — that worker is deliberately built
+  ONCE per method in `setUp()` and REUSED across every example, so
+  method-scoped `addCleanup` is exactly right there. The rule follows the
+  resource's own intended lifetime, not a blanket ban on `addCleanup` near
+  `@given`: a resource meant to be fresh per example needs a `with` block
+  inside the body; a resource meant to be shared across the whole method's
+  examples is correctly `addCleanup`-scoped in `setUp()`.
 - Discard an unanswerable world with `assume(...)`, never a bare `return`.
   A `return` spends the example as a PASS and silently shrinks the real
   budget; `assume` marks it invalid so Hypothesis refills. Issue #882 found

--- a/docs/generated-testing.md
+++ b/docs/generated-testing.md
@@ -1011,10 +1011,14 @@ may still patrol nothing; only review and mutant-kill counts show that.
   `self.addCleanup(...)`/`self.enterContext(...)`.** Hypothesis re-executes
   the body once per EXAMPLE; `addCleanup`/`enterContext` fire once per test
   METHOD. A resource constructed directly in the body and registered there
-  leaks one live copy per example until the method finally returns (issue
-  #1214: 2491 concurrently-live `BeetsContractWorld` fixtures, 1.59 GB, from
-  ONE test method at the daily gate's real budget — the exposure that OOM'd
-  `cratedigger-daily-checks.service` in production).
+  leaks one live copy per example until the method finally returns. Issue
+  #1214: a fresh re-measurement found 2491 concurrently-live
+  `BeetsContractWorld` fixtures, 1.59 GB, from ONE test method at the daily
+  gate's real budget (issue #1214 itself first measured 2469 / 1576.99 MB
+  from a slightly different run). That was the exposure that filled
+  `cratedigger-daily-checks.service`'s tmpfs — `OSError: [Errno 28] No
+  space left on device`, an ENOSPC exception, NOT a host OOM kill; issue
+  #1214 states explicitly that no host OOM kill occurred.
   `tests/test_given_body_cleanup_audit.py` enforces the direct-construction
   shape of this mistake, but cannot see through a helper method the body
   merely calls by name (a bounded syntactic audit, not a call-graph tracer

--- a/scripts/targeted_test_selection.py
+++ b/scripts/targeted_test_selection.py
@@ -216,6 +216,9 @@ EXACT_PATH_NEIGHBOURS: dict[str, tuple[str, ...]] = {
         "tests.test_beets_config_startup_generated",
         "tests.test_beets_config_contract",
         "tests.test_beets_config_contract_integration",
+        "tests.test_beets_config_contract_generated",
+        "tests.test_beets_config_contract_regressions_generated",
+        "tests.test_beets_contract_world_lifetime",
     ),
     "tests/fakes/daily_flake_update.py": (
         "tests.test_daily_flake_update",

--- a/tests/fakes/beets_contract.py
+++ b/tests/fakes/beets_contract.py
@@ -10,6 +10,7 @@ import sys
 import tempfile
 from collections.abc import Callable
 from pathlib import Path
+from typing import Self
 
 import yaml
 
@@ -620,6 +621,12 @@ class BeetsContractWorld:
     def assert_readonly(path: Path) -> None:
         if path.stat().st_mode & stat.S_IWUSR:
             raise AssertionError(f"expected readonly fixture component: {path}")
+
+    def __enter__(self) -> Self:
+        return self
+
+    def __exit__(self, *_args: object) -> None:
+        self.close()
 
     def close(self) -> None:
         if self._closed:

--- a/tests/fakes/beets_contract.py
+++ b/tests/fakes/beets_contract.py
@@ -279,38 +279,71 @@ class BeetsContractWorld:
     ``/dev/shm`` and a declared leaf trips the very ancestor-ownership check
     the sealed/admitted baseline needs to pass.
 
-    The unavoidable consequence: if this process is SIGKILLed (OOM-killed --
-    the exact #1214 incident scenario) while a world is sealed, its
-    authority tree is left owned by that subordinate uid, mode
-    ``dr-xr-x---`` -- unremovable by this process's own real uid via any
-    ordinary tool (``rm -rf``, plain ``chown``), because ``chmod``/``chown``
-    require OWNERSHIP, which the real uid no longer has. No in-process
+    **What actually happened in #1214 (review finding A2 -- correcting an
+    earlier draft of this docstring, which called it an OOM kill): an
+    ENOSPC exception, not a process kill.** Issue #1214 states explicitly
+    that there were no host OOM kills; the symptom was
+    ``OSError: [Errno 28] No space left on device`` from
+    ``cratedigger-daily-checks.service`` filling the tmpfs the fuzz phase
+    runs on. That distinction matters here specifically: an ``OSError``
+    raised while EXECUTING INSIDE an already-entered
+    ``with BeetsContractWorld() as world:`` block is an ordinary Python
+    exception -- the ``with`` statement's normal unwinding semantics
+    guarantee ``__exit__`` (and therefore ``close()``, therefore
+    ``unseal()``) runs regardless of what exception type propagates through
+    the block. So the failure mode that actually occurred in production is
+    fully handled by this issue's core fix; this docstring must not argue
+    the fix is weaker than it is by resting its case on an event that did
+    not happen.
+
+    What remains a genuinely open, narrower, UNCONFIRMED residual: a
+    process-level kill the interpreter cannot catch at all (a real SIGKILL
+    or OOM-killer action -- distinct from, and not what occurred in, the
+    #1214 incident), or disk exhaustion striking mid-``_seal()``'s own
+    ``unshare``/``chown`` subprocess call -- i.e. DURING ``__init__``,
+    BEFORE the ``with`` statement's ``__enter__`` even completes, so no
+    context-manager protocol is active yet to catch it. No in-process
     mechanism -- not ``close()``'s own ``finally``, not an ``atexit`` hook,
     not a ``weakref.finalize`` callback, not a caught-signal handler -- runs
-    on SIGKILL; the kernel terminates the process before any of that code
-    can execute. Reclaiming such a directory requires deliberately
-    re-running the same ``unshare --map-root-user --map-auto chown`` trick
-    against it -- reaper machinery this issue's review explicitly declines
-    to add here (owned, if wanted, by the test-suite runner's own scratch
-    lifecycle, a separate worktree/workstream -- not this fixture).
+    on an uncatchable kill; the kernel terminates the process before any of
+    that code can execute. If either of these narrower cases strands a
+    world, its authority tree is left owned by that subordinate uid, mode
+    ``dr-xr-x---`` -- unremovable by this process's own real uid via any
+    ordinary tool (``rm -rf``, plain ``chown``), because ``chmod``/``chown``
+    require OWNERSHIP, which the real uid no longer has. Reclaiming such a
+    directory requires deliberately re-running the same
+    ``unshare --map-root-user --map-auto chown`` trick this fixture's own
+    ``_chown_path`` uses. **This residual is accepted and currently
+    UNOWNED** -- no existing or planned workstream reclaims a stranded
+    sealed authority tree (an earlier draft of this docstring named the
+    test-suite runner's own scratch-reaper work as the owner; that claim
+    was checked and is false -- that workstream contains no reference to
+    ``/dev/shm`` or this fixture, and structurally could not reclaim one
+    with an ordinary ``rmtree`` regardless, since only the exact
+    ``unshare``-based chown this class itself uses can undo the seal).
+    Each stranded tree costs about 16 KB of tmpfs (measured: one sealed
+    ``authority_root``, ``du -sh`` block accounting on ``/dev/shm``) --
+    small enough, and the window narrow enough (see below), that this is a
+    reasoned, bounded, accepted gap, not an oversight.
 
     What IS fixed, and is the real lever available without weakening the
-    tested contract: the SIZE of the exposure window. Before issue #1214's
-    core fix, every ``@given`` example's world leaked past its own example
-    (``addCleanup`` fires once per test METHOD, but Hypothesis re-executes
-    the body once per EXAMPLE) and stayed alive -- sealed -- for the rest of
-    the method, so up to ``max_examples`` worlds (2491 measured at the daily
-    gate's real budget, ``CRATEDIGGER_FUZZ_MAX_EXAMPLES=2500``) were
-    simultaneously sealed at any instant a kill could land. Binding each
-    world's lifetime to the example that created it
+    tested contract: the SIZE of the exposure window for that narrower
+    residual. Before issue #1214's core fix, every ``@given`` example's
+    world leaked past its own example (``addCleanup`` fires once per test
+    METHOD, but Hypothesis re-executes the body once per EXAMPLE) and
+    stayed alive -- sealed -- for the rest of the method, so up to
+    ``max_examples`` worlds (a fresh re-measurement found 2491 at the daily
+    gate's real budget, ``CRATEDIGGER_FUZZ_MAX_EXAMPLES=2500``; issue #1214
+    itself first measured 2469 from a slightly different run) were
+    simultaneously sealed at any instant an uncatchable kill could land.
+    Binding each world's lifetime to the example that created it
     (``with BeetsContractWorld() as world:``) means ``close()`` -- and
     therefore ``unseal()`` -- runs before the NEXT example's world is even
     constructed, so at most ONE world is ever sealed and resident at a time.
     That is roughly a 2500x reduction in the instantaneous exposure surface
-    for the same failure class, without touching the ownership semantics the
-    contract tests depend on. A residual, bounded-to-one-world SIGKILL race
-    is accepted as unavoidable given the above; it is not evidence of an
-    incomplete fix.
+    for the narrower, unconfirmed hard-kill residual described above -- it
+    is not a claim about the actual #1214 incident, which this fix handles
+    completely by ordinary exception unwinding.
     """
 
     _scratch_validated = False

--- a/tests/fakes/beets_contract.py
+++ b/tests/fakes/beets_contract.py
@@ -250,7 +250,68 @@ def snapshot_contract_world(world: BeetsContractWorld) -> dict[str, object]:
 
 
 class BeetsContractWorld:
-    """One real file/config world; filesystem permissions are the capability."""
+    """One real file/config world; filesystem permissions are the capability.
+
+    **Issue #1214 review finding F6 -- the sealed-authority-tree residual,
+    analyzed and accepted, not papered over.** While sealed (from the end of
+    ``__init__`` until ``close()``/``unseal()`` runs), ``authority_root`` and
+    its interior directories are chown'd via
+    ``unshare --map-root-user --map-auto chown`` to a subordinate uid, NOT
+    this process's own real uid. That is not cosmetic:
+    ``lib.beets_config_contract._has_app_owned_component`` walks every
+    ancestor of a declared authority path (``authority_root`` is always one,
+    since ``beets_dir``/``secret_dir``/``state_dir`` all live directly under
+    it) and treats ANY ancestor owned by the running process's own euid as
+    "app-owned" -- i.e. mutable, unsafe -- and real production call sites
+    depend on exactly this (``_immutable_declared_file`` on ``runtime.ini``
+    and the secret/main-config sources; ``_nonreplaceable_declared_path`` on
+    ``state_file``). Leaving ``authority_root`` (or any directory between it
+    and a declared leaf) real-user-owned, even with every write bit stripped
+    by ``chmod``, would make every "this authority tree is safely immutable"
+    test scenario fail against real production logic, because
+    chmod-without-chown is always self-reversible by its owner (``chmod()``
+    only requires ownership, not the CURRENT mode bits) -- exactly the
+    mutability the contract exists to detect. So genuine foreign ownership,
+    not merely restrictive permissions, is load-bearing for every test that
+    exercises the sealed/admitted path, not just the handful of explicit
+    tamper-detection tests. No directory layout change moves this
+    requirement: any real-user-owned buffer directory anywhere between
+    ``/dev/shm`` and a declared leaf trips the very ancestor-ownership check
+    the sealed/admitted baseline needs to pass.
+
+    The unavoidable consequence: if this process is SIGKILLed (OOM-killed --
+    the exact #1214 incident scenario) while a world is sealed, its
+    authority tree is left owned by that subordinate uid, mode
+    ``dr-xr-x---`` -- unremovable by this process's own real uid via any
+    ordinary tool (``rm -rf``, plain ``chown``), because ``chmod``/``chown``
+    require OWNERSHIP, which the real uid no longer has. No in-process
+    mechanism -- not ``close()``'s own ``finally``, not an ``atexit`` hook,
+    not a ``weakref.finalize`` callback, not a caught-signal handler -- runs
+    on SIGKILL; the kernel terminates the process before any of that code
+    can execute. Reclaiming such a directory requires deliberately
+    re-running the same ``unshare --map-root-user --map-auto chown`` trick
+    against it -- reaper machinery this issue's review explicitly declines
+    to add here (owned, if wanted, by the test-suite runner's own scratch
+    lifecycle, a separate worktree/workstream -- not this fixture).
+
+    What IS fixed, and is the real lever available without weakening the
+    tested contract: the SIZE of the exposure window. Before issue #1214's
+    core fix, every ``@given`` example's world leaked past its own example
+    (``addCleanup`` fires once per test METHOD, but Hypothesis re-executes
+    the body once per EXAMPLE) and stayed alive -- sealed -- for the rest of
+    the method, so up to ``max_examples`` worlds (2491 measured at the daily
+    gate's real budget, ``CRATEDIGGER_FUZZ_MAX_EXAMPLES=2500``) were
+    simultaneously sealed at any instant a kill could land. Binding each
+    world's lifetime to the example that created it
+    (``with BeetsContractWorld() as world:``) means ``close()`` -- and
+    therefore ``unseal()`` -- runs before the NEXT example's world is even
+    constructed, so at most ONE world is ever sealed and resident at a time.
+    That is roughly a 2500x reduction in the instantaneous exposure surface
+    for the same failure class, without touching the ownership semantics the
+    contract tests depend on. A residual, bounded-to-one-world SIGKILL race
+    is accepted as unavoidable given the above; it is not evidence of an
+    incomplete fix.
+    """
 
     _scratch_validated = False
 

--- a/tests/test_automation_recovery_debris_generated.py
+++ b/tests/test_automation_recovery_debris_generated.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import functools
 import os
 import sys
+import tempfile
 import unittest
 from typing import Self
 
@@ -154,56 +155,64 @@ class TestRecoveryDebrisWorldGenerated(_StartupRecoveryBuilders, unittest.TestCa
     ) -> None:
         self._fresh_state()
         case = self._case()
-        path = self._album_dir("world", "01 - Track.mp3")
+        # Scoped locally per example, not via self._album_dir() -- that
+        # helper's addCleanup binds to the whole @given test METHOD, not
+        # each Hypothesis example (issue #1214 defect class). Mirrors
+        # _album_dir("world", "01 - Track.mp3")'s exact layout.
+        with tempfile.TemporaryDirectory(prefix="startup-recovery-") as root:
+            path = os.path.join(root, "albums", "world")
+            os.makedirs(path)
+            with open(os.path.join(path, "01 - Track.mp3"), "wb") as handle:
+                handle.write(b"audio")
 
-        if launched:
-            owner, lease = self._launched_owner(path)
-        else:
-            owner, lease = self._preview_owner(path)
-        if journal_present:
-            self._journal(owner.id, path)
+            if launched:
+                owner, lease = self._launched_owner(path)
+            else:
+                owner, lease = self._preview_owner(path)
+            if journal_present:
+                self._journal(owner.id, path)
 
-        item_paths = (
-            self._item_paths_for(path_world, source_path=path)
-            if album_present
-            else None
-        )
-        stub_delete = _RecordingBeetsDelete()
-        debris_fn = functools.partial(
-            remove_recovery_debris,
-            beets_db_factory=lambda: _FastBeetsDB(item_paths),
-            beets_delete_fn=stub_delete,
-        )
+            item_paths = (
+                self._item_paths_for(path_world, source_path=path)
+                if album_present
+                else None
+            )
+            stub_delete = _RecordingBeetsDelete()
+            debris_fn = functools.partial(
+                remove_recovery_debris,
+                beets_db_factory=lambda: _FastBeetsDB(item_paths),
+                beets_delete_fn=stub_delete,
+            )
 
-        self._recover(owner.id, lease, debris_removal_fn=debris_fn)
+            self._recover(owner.id, lease, debris_removal_fn=debris_fn)
 
-        # CLAUSE no_denylist: this recovery path writes ZERO source_denylist
-        # rows in EVERY world — proven at a finer grain (a planted
-        # `add_denylist` mutant in both the real PipelineDB and the fake
-        # mirror) by the #1089 review's own mutant kill matrix.
-        case.assertEqual(
-            self.db.list_denylist_rows(),
-            [],
-            f"world: album_present={album_present} path_world={path_world} "
-            f"journal_present={journal_present} launched={launched}",
-        )
-
-        # CLAUSE never_remove_unconfined: the admitted delete lane is only
-        # ever reached when this job actually authorized a Beets launch AND
-        # every item path is confined to that exact launch source — never
-        # for a library-root or mixed world, whatever else varies.
-        should_reach_delete_lane = (
-            launched and album_present and path_world == "all_source"
-        )
-        if should_reach_delete_lane:
-            case.assertEqual(len(stub_delete.requests), 1)
-        else:
+            # CLAUSE no_denylist: this recovery path writes ZERO source_denylist
+            # rows in EVERY world — proven at a finer grain (a planted
+            # `add_denylist` mutant in both the real PipelineDB and the fake
+            # mirror) by the #1089 review's own mutant kill matrix.
             case.assertEqual(
-                stub_delete.requests,
+                self.db.list_denylist_rows(),
                 [],
                 f"world: album_present={album_present} path_world={path_world} "
                 f"journal_present={journal_present} launched={launched}",
             )
+
+            # CLAUSE never_remove_unconfined: the admitted delete lane is only
+            # ever reached when this job actually authorized a Beets launch AND
+            # every item path is confined to that exact launch source — never
+            # for a library-root or mixed world, whatever else varies.
+            should_reach_delete_lane = (
+                launched and album_present and path_world == "all_source"
+            )
+            if should_reach_delete_lane:
+                case.assertEqual(len(stub_delete.requests), 1)
+            else:
+                case.assertEqual(
+                    stub_delete.requests,
+                    [],
+                    f"world: album_present={album_present} path_world={path_world} "
+                    f"journal_present={journal_present} launched={launched}",
+                )
 
 
 if __name__ == "__main__":

--- a/tests/test_beets_config_contract_generated.py
+++ b/tests/test_beets_config_contract_generated.py
@@ -154,28 +154,27 @@ class TestGeneratedDeclaredFileFailures(unittest.TestCase):
         case: tuple[str, str],
     ) -> None:
         authority, corruption = case
-        world = BeetsContractWorld()
-        self.addCleanup(world.close)
-        _corrupt_declared_authority(
-            world,
-            authority=authority,
-            corruption=corruption,
-        )
+        with BeetsContractWorld() as world:
+            _corrupt_declared_authority(
+                world,
+                authority=authority,
+                corruption=corruption,
+            )
 
-        if authority == "runtime":
-            with self.assertRaises(
-                (OSError, UnicodeError, configparser.Error, ValueError)
-            ):
-                world.cfg()
-            return
+            if authority == "runtime":
+                with self.assertRaises(
+                    (OSError, UnicodeError, configparser.Error, ValueError)
+                ):
+                    world.cfg()
+                return
 
-        if authority == "secret" and corruption == "nonmapping":
-            report = check_beets_config(world.cfg(), role="importer")
-            assert_hard_code(report.hard_failures, "secret_schema")
-            return
+            if authority == "secret" and corruption == "nonmapping":
+                report = check_beets_config(world.cfg(), role="importer")
+                assert_hard_code(report.hard_failures, "secret_schema")
+                return
 
-        with self.assertRaises(BeetsConfigError):
-            check_beets_config(world.cfg(), role="importer")
+            with self.assertRaises(BeetsConfigError):
+                check_beets_config(world.cfg(), role="importer")
 
 
 class TestGeneratedTokenOnlySecret(unittest.TestCase):
@@ -184,14 +183,12 @@ class TestGeneratedTokenOnlySecret(unittest.TestCase):
     @settings(max_examples=40)
     @given(st.text(min_size=1, max_size=60).map(lambda value: f"SECRET::{value}::TOKEN"))
     def test_any_scalar_token_remains_data_and_never_report_content(self, token: str) -> None:
-        world = BeetsContractWorld(token=token)
-        self.addCleanup(world.close)
+        with BeetsContractWorld(token=token) as world:
+            report = check_beets_config(world.cfg(), role="importer")
+            encoded = msgspec.json.encode(report).decode()
 
-        report = check_beets_config(world.cfg(), role="importer")
-        encoded = msgspec.json.encode(report).decode()
-
-        self.assertTrue(report.ok, report.hard_failures)
-        assert_token_absent_from_owned_report(encoded, token)
+            self.assertTrue(report.ok, report.hard_failures)
+            assert_token_absent_from_owned_report(encoded, token)
 
     @given(st.one_of(
         st.just(""),
@@ -203,84 +200,79 @@ class TestGeneratedTokenOnlySecret(unittest.TestCase):
         st.dictionaries(st.text(max_size=8), st.integers(), max_size=3),
     ))
     def test_invalid_designated_token_values_are_always_missing(self, token: object) -> None:
-        world = BeetsContractWorld()
-        self.addCleanup(world.close)
-        world.unseal()
-        world.secret_include.write_text(
-            yaml.safe_dump({"discogs": {"user_token": token}}),
-            encoding="utf-8",
-        )
-        world._seal("importer")
+        with BeetsContractWorld() as world:
+            world.unseal()
+            world.secret_include.write_text(
+                yaml.safe_dump({"discogs": {"user_token": token}}),
+                encoding="utf-8",
+            )
+            world._seal("importer")
 
-        assert_discogs_token_missing(check_beets_config(world.cfg(), role="importer"))
+            assert_discogs_token_missing(check_beets_config(world.cfg(), role="importer"))
 
     @given(st.sampled_from(["library", "directory", "statefile", "import", "paths", "plugins"]))
     def test_any_extra_top_level_secret_authority_is_rejected(self, key: str) -> None:
-        world = BeetsContractWorld()
-        self.addCleanup(world.close)
-        world.unseal()
-        world.secret_include.write_text(
-            yaml.safe_dump({"discogs": {"user_token": "safe"}, key: {}}),
-            encoding="utf-8",
-        )
-        world._seal("importer")
+        with BeetsContractWorld() as world:
+            world.unseal()
+            world.secret_include.write_text(
+                yaml.safe_dump({"discogs": {"user_token": "safe"}, key: {}}),
+                encoding="utf-8",
+            )
+            world._seal("importer")
 
-        report = check_beets_config(world.cfg(), role="importer")
+            report = check_beets_config(world.cfg(), role="importer")
 
-        self.assertEqual([finding.code for finding in report.hard_failures], ["secret_schema"])
+            self.assertEqual([finding.code for finding in report.hard_failures], ["secret_schema"])
 
     @given(st.integers(min_value=0, max_value=3))
     def test_designated_secret_requires_exactly_one_occurrence(self, count: int) -> None:
-        world = BeetsContractWorld()
-        self.addCleanup(world.close)
-        world.unseal()
-        world._write_main_config(include=[str(world.secret_include)] * count)
-        world._seal("importer")
+        with BeetsContractWorld() as world:
+            world.unseal()
+            world._write_main_config(include=[str(world.secret_include)] * count)
+            world._seal("importer")
 
-        report = check_beets_config(world.cfg(), role="importer")
+            report = check_beets_config(world.cfg(), role="importer")
 
-        if count == 1:
-            self.assertTrue(report.ok, report.hard_failures)
-        else:
-            assert_hard_code(report.hard_failures, "secret_include_count")
+            if count == 1:
+                self.assertTrue(report.ok, report.hard_failures)
+            else:
+                assert_hard_code(report.hard_failures, "secret_include_count")
 
     @given(st.sampled_from(("discogs.yaml", "", 0, False, True)))
     def test_every_scalar_include_shape_is_rejected(self, include: object) -> None:
-        world = BeetsContractWorld()
-        self.addCleanup(world.close)
-        world.unseal()
-        world._write_main_config(include=include)
-        world._seal("importer")
+        with BeetsContractWorld() as world:
+            world.unseal()
+            world._write_main_config(include=include)
+            world._seal("importer")
 
-        report = check_beets_config(world.cfg(), role="importer")
+            report = check_beets_config(world.cfg(), role="importer")
 
-        assert_hard_code(report.hard_failures, "include_shape")
+            assert_hard_code(report.hard_failures, "include_shape")
 
     @given(st.sampled_from(("top_level", "nested_token")))
     def test_duplicate_designated_secret_keys_are_always_rejected(
         self,
         duplicate_at: str,
     ) -> None:
-        world = BeetsContractWorld()
-        self.addCleanup(world.close)
-        world.unseal()
-        if duplicate_at == "top_level":
-            raw = (
-                "discogs:\n  user_token: first\n"
-                "discogs:\n  user_token: second\n"
-            )
-        else:
-            raw = (
-                "discogs:\n"
-                "  user_token: first\n"
-                "  user_token: second\n"
-            )
-        world.secret_include.write_text(raw, encoding="utf-8")
-        world._seal("importer")
+        with BeetsContractWorld() as world:
+            world.unseal()
+            if duplicate_at == "top_level":
+                raw = (
+                    "discogs:\n  user_token: first\n"
+                    "discogs:\n  user_token: second\n"
+                )
+            else:
+                raw = (
+                    "discogs:\n"
+                    "  user_token: first\n"
+                    "  user_token: second\n"
+                )
+            world.secret_include.write_text(raw, encoding="utf-8")
+            world._seal("importer")
 
-        report = check_beets_config(world.cfg(), role="importer")
+            report = check_beets_config(world.cfg(), role="importer")
 
-        assert_hard_code(report.hard_failures, "secret_duplicate_key")
+            assert_hard_code(report.hard_failures, "secret_duplicate_key")
 
     @given(st.sampled_from((
         "? [discogs]\n: token\n",
@@ -290,15 +282,14 @@ class TestGeneratedTokenOnlySecret(unittest.TestCase):
         self,
         raw: str,
     ) -> None:
-        world = BeetsContractWorld()
-        self.addCleanup(world.close)
-        world.unseal()
-        world.secret_include.write_text(raw, encoding="utf-8")
-        world._seal("importer")
+        with BeetsContractWorld() as world:
+            world.unseal()
+            world.secret_include.write_text(raw, encoding="utf-8")
+            world._seal("importer")
 
-        assert_native_config_rejection(
-            lambda: check_beets_config(world.cfg(), role="importer")
-        )
+            assert_native_config_rejection(
+                lambda: check_beets_config(world.cfg(), role="importer")
+            )
 
 
 class TestGeneratedEffectiveSettings(unittest.TestCase):
@@ -326,26 +317,25 @@ class TestGeneratedEffectiveSettings(unittest.TestCase):
         authority: tuple[str, str],
         alias_depth: int,
     ) -> None:
-        world = BeetsContractWorld()
-        self.addCleanup(world.close)
-        target = Path("/")
-        for index in range(alias_depth):
-            alias = world.root / f"root-alias-{index}"
-            alias.symlink_to(target)
-            target = alias
-        field, expected_code = authority
-        value = (
-            str(target / "beets-library.db")
-            if field == "beets_library_db"
-            else str(target)
-        )
+        with BeetsContractWorld() as world:
+            target = Path("/")
+            for index in range(alias_depth):
+                alias = world.root / f"root-alias-{index}"
+                alias.symlink_to(target)
+                target = alias
+            field, expected_code = authority
+            value = (
+                str(target / "beets-library.db")
+                if field == "beets_library_db"
+                else str(target)
+            )
 
-        report = check_beets_config(
-            replace(world.cfg(), **{field: value}),
-            role="importer",
-        )
+            report = check_beets_config(
+                replace(world.cfg(), **{field: value}),
+                role="importer",
+            )
 
-        assert_hard_code(report.hard_failures, expected_code)
+            assert_hard_code(report.hard_failures, expected_code)
 
     @given(
         field=st.sampled_from(RUNTIME_AUTHORITIES),
@@ -356,15 +346,13 @@ class TestGeneratedEffectiveSettings(unittest.TestCase):
         field: str,
         role: BeetsRole,
     ) -> None:
-        world = BeetsContractWorld(role=role)
-        self.addCleanup(world.close)
+        with BeetsContractWorld(role=role) as world:
+            report = check_beets_config(
+                replace(world.cfg(), **{field: ""}),
+                role=role,
+            )
 
-        report = check_beets_config(
-            replace(world.cfg(), **{field: ""}),
-            role=role,
-        )
-
-        assert_hard_code(report.hard_failures, "runtime_authority_missing")
+            assert_hard_code(report.hard_failures, "runtime_authority_missing")
 
     @given(
         field=st.sampled_from(RUNTIME_AUTHORITIES),
@@ -375,29 +363,28 @@ class TestGeneratedEffectiveSettings(unittest.TestCase):
         field: str,
         raw_case: str,
     ) -> None:
-        world = BeetsContractWorld()
-        self.addCleanup(world.close)
-        ini_key = {
-            "beets_config_dir": "config_dir",
-            "beets_library_db": "library",
-            "beets_directory": "directory",
-            "beets_state_file": "state_file",
-            "beets_python": "python",
-            "beets_secret_include": "secret_include",
-        }[field]
-        world.unseal()
-        if raw_case == "missing":
-            parser = configparser.RawConfigParser()
-            parser.read(world.runtime_config, encoding="utf-8")
-            parser.remove_option("Beets", ini_key)
-            with world.runtime_config.open("w", encoding="utf-8") as handle:
-                parser.write(handle)
-        else:
-            blank = "" if raw_case == "empty" else " \t "
-            world._write_runtime_config(**{ini_key: blank})
-        world._seal("importer")
+        with BeetsContractWorld() as world:
+            ini_key = {
+                "beets_config_dir": "config_dir",
+                "beets_library_db": "library",
+                "beets_directory": "directory",
+                "beets_state_file": "state_file",
+                "beets_python": "python",
+                "beets_secret_include": "secret_include",
+            }[field]
+            world.unseal()
+            if raw_case == "missing":
+                parser = configparser.RawConfigParser()
+                parser.read(world.runtime_config, encoding="utf-8")
+                parser.remove_option("Beets", ini_key)
+                with world.runtime_config.open("w", encoding="utf-8") as handle:
+                    parser.write(handle)
+            else:
+                blank = "" if raw_case == "empty" else " \t "
+                world._write_runtime_config(**{ini_key: blank})
+            world._seal("importer")
 
-        assert_raw_authority_rejected(world.cfg)
+            assert_raw_authority_rejected(world.cfg)
 
     @given(st.sampled_from((
         ("python", "python_mismatch"),
@@ -410,32 +397,31 @@ class TestGeneratedEffectiveSettings(unittest.TestCase):
         case: tuple[str, str],
     ) -> None:
         authority, expected_code = case
-        world = BeetsContractWorld()
-        self.addCleanup(world.close)
-        cfg = world.cfg()
-        if authority == "python":
-            cfg = replace(cfg, beets_python=str(world.root / "other-python"))
-        elif authority == "library":
-            other_library = world.root / "other-library.db"
-            other_library.write_bytes(world.library_db.read_bytes())
-            cfg = replace(cfg, beets_library_db=str(other_library))
-        elif authority == "directory":
-            other_directory = world.root / "other-library-root"
-            other_directory.mkdir()
-            cfg = replace(cfg, beets_directory=str(other_directory))
-        else:
-            other_state = world.root / "other-state.pickle"
-            other_state.write_bytes(b"other-state")
-            cfg = replace(cfg, beets_state_file=str(other_state))
+        with BeetsContractWorld() as world:
+            cfg = world.cfg()
+            if authority == "python":
+                cfg = replace(cfg, beets_python=str(world.root / "other-python"))
+            elif authority == "library":
+                other_library = world.root / "other-library.db"
+                other_library.write_bytes(world.library_db.read_bytes())
+                cfg = replace(cfg, beets_library_db=str(other_library))
+            elif authority == "directory":
+                other_directory = world.root / "other-library-root"
+                other_directory.mkdir()
+                cfg = replace(cfg, beets_directory=str(other_directory))
+            else:
+                other_state = world.root / "other-state.pickle"
+                other_state.write_bytes(b"other-state")
+                cfg = replace(cfg, beets_state_file=str(other_state))
 
-        if authority == "python":
-            with self.assertRaises(BeetsConfigError):
-                check_beets_config(cfg, role="importer")
-            return
+            if authority == "python":
+                with self.assertRaises(BeetsConfigError):
+                    check_beets_config(cfg, role="importer")
+                return
 
-        report = check_beets_config(cfg, role="importer")
+            report = check_beets_config(cfg, role="importer")
 
-        assert_hard_code(report.hard_failures, expected_code)
+            assert_hard_code(report.hard_failures, expected_code)
 
     @given(
         role=st.sampled_from(("main", "preview", "web")),
@@ -446,34 +432,32 @@ class TestGeneratedEffectiveSettings(unittest.TestCase):
         role: BeetsRole,
         mode: int,
     ) -> None:
-        world = BeetsContractWorld(role=role)
-        self.addCleanup(world.close)
-        world.make_state_leaf_app_owned(mode)
-        before = world.state_file.read_bytes()
+        with BeetsContractWorld(role=role) as world:
+            world.make_state_leaf_app_owned(mode)
+            before = world.state_file.read_bytes()
 
-        report = check_beets_config(world.cfg(), role=role)
+            report = check_beets_config(world.cfg(), role=role)
 
-        assert_hard_code(report.hard_failures, "state_owned_by_reader")
-        self.assertNotIn(
-            "state_writable_by_reader",
-            [finding.code for finding in report.hard_failures],
-        )
-        world.state_file.chmod(mode | stat.S_IWUSR)
-        fd = os.open(world.state_file, os.O_WRONLY)
-        os.close(fd)
-        self.assertEqual(world.state_file.read_bytes(), before)
+            assert_hard_code(report.hard_failures, "state_owned_by_reader")
+            self.assertNotIn(
+                "state_writable_by_reader",
+                [finding.code for finding in report.hard_failures],
+            )
+            world.state_file.chmod(mode | stat.S_IWUSR)
+            fd = os.open(world.state_file, os.O_WRONLY)
+            os.close(fd)
+            self.assertEqual(world.state_file.read_bytes(), before)
 
     @given(mode=st.sampled_from((0o600, 0o620, 0o640, 0o660)))
     def test_importer_may_own_its_writable_state_leaf(self, mode: int) -> None:
-        world = BeetsContractWorld(role="importer")
-        self.addCleanup(world.close)
-        world.make_state_leaf_app_owned(mode)
+        with BeetsContractWorld(role="importer") as world:
+            world.make_state_leaf_app_owned(mode)
 
-        report = check_beets_config(world.cfg(), role="importer")
+            report = check_beets_config(world.cfg(), role="importer")
 
-        self.assertTrue(report.ok, report.hard_failures)
-        self.assertEqual(world.state_file.stat().st_uid, os.geteuid())
-        self.assertNotEqual(world.state_dir.stat().st_uid, os.geteuid())
+            self.assertTrue(report.ok, report.hard_failures)
+            self.assertEqual(world.state_file.stat().st_uid, os.geteuid())
+            self.assertNotEqual(world.state_dir.stat().st_uid, os.geteuid())
 
     @given(
         variant=st.sampled_from((
@@ -489,56 +473,54 @@ class TestGeneratedEffectiveSettings(unittest.TestCase):
         self,
         variant: str,
     ) -> None:
-        world = BeetsContractWorld()
-        self.addCleanup(world.close)
-        invocation = Path(sys.executable)
-        resolved = invocation.resolve()
-        self.assertNotEqual(invocation, resolved)
+        with BeetsContractWorld() as world:
+            invocation = Path(sys.executable)
+            resolved = invocation.resolve()
+            self.assertNotEqual(invocation, resolved)
 
-        if variant == "exact":
-            spelling = sys.executable
-            admitted = True
-        elif variant == "dot_segment":
-            spelling = f"{invocation.parent}/./{invocation.name}"
-            admitted = True
-        elif variant == "relative":
-            spelling = os.path.relpath(invocation, Path.cwd())
-            admitted = True
-        elif variant == "resolved_target":
-            spelling = str(resolved)
-            admitted = False
-        else:
-            alias_parent = world.root
-            if variant == "nested_app_symlink":
-                alias_parent = world.root / "python-aliases"
-                alias_parent.mkdir()
-            alias = alias_parent / "python"
-            alias.symlink_to(invocation)
-            spelling = str(alias)
-            admitted = False
+            if variant == "exact":
+                spelling = sys.executable
+                admitted = True
+            elif variant == "dot_segment":
+                spelling = f"{invocation.parent}/./{invocation.name}"
+                admitted = True
+            elif variant == "relative":
+                spelling = os.path.relpath(invocation, Path.cwd())
+                admitted = True
+            elif variant == "resolved_target":
+                spelling = str(resolved)
+                admitted = False
+            else:
+                alias_parent = world.root
+                if variant == "nested_app_symlink":
+                    alias_parent = world.root / "python-aliases"
+                    alias_parent.mkdir()
+                alias = alias_parent / "python"
+                alias.symlink_to(invocation)
+                spelling = str(alias)
+                admitted = False
 
-        report = check_beets_config(
-            replace(world.cfg(), beets_python=spelling),
-            role="importer",
-        )
+            report = check_beets_config(
+                replace(world.cfg(), beets_python=spelling),
+                role="importer",
+            )
 
-        if admitted:
-            self.assertTrue(report.ok, report.hard_failures)
-            self.assertEqual(report.authority.python, sys.executable)
-        else:
-            assert_hard_code(report.hard_failures, "python_mismatch")
-            if variant in {"app_symlink", "nested_app_symlink"}:
-                assert_hard_code(report.hard_failures, "mutable_python")
+            if admitted:
+                self.assertTrue(report.ok, report.hard_failures)
+                self.assertEqual(report.authority.python, sys.executable)
+            else:
+                assert_hard_code(report.hard_failures, "python_mismatch")
+                if variant in {"app_symlink", "nested_app_symlink"}:
+                    assert_hard_code(report.hard_failures, "mutable_python")
 
     @given(kind=st.sampled_from(("same_path", "hardlink")))
     def test_state_and_library_must_never_share_an_inode(self, kind: str) -> None:
-        world = BeetsContractWorld()
-        self.addCleanup(world.close)
-        world.alias_state_to_library(kind)
+        with BeetsContractWorld() as world:
+            world.alias_state_to_library(kind)
 
-        report = check_beets_config(world.cfg(), role="importer")
+            report = check_beets_config(world.cfg(), role="importer")
 
-        assert_hard_code(report.hard_failures, "state_library_alias")
+            assert_hard_code(report.hard_failures, "state_library_alias")
 
     @given(
         field=st.sampled_from(RUNTIME_AUTHORITIES),
@@ -552,10 +534,7 @@ class TestGeneratedEffectiveSettings(unittest.TestCase):
         field: str,
         value: str,
     ) -> None:
-        world = BeetsContractWorld()
-        self.addCleanup(world.close)
-
-        with self.assertRaises(BeetsConfigError):
+        with BeetsContractWorld() as world, self.assertRaises(BeetsConfigError):
             check_beets_config(
                 replace(world.cfg(), **{field: value}),
                 role="importer",
@@ -570,16 +549,15 @@ class TestGeneratedEffectiveSettings(unittest.TestCase):
         kind: str,
         component: str,
     ) -> None:
-        world = BeetsContractWorld()
-        self.addCleanup(world.close)
-        expected_code = world.put_app_owned_readonly_authority(
-            kind,
-            component=component,
-        )
+        with BeetsContractWorld() as world:
+            expected_code = world.put_app_owned_readonly_authority(
+                kind,
+                component=component,
+            )
 
-        report = check_beets_config(world.cfg(), role="importer")
+            report = check_beets_config(world.cfg(), role="importer")
 
-        assert_hard_code(report.hard_failures, expected_code)
+            assert_hard_code(report.hard_failures, expected_code)
 
     @given(st.sampled_from((
         "replaceable_parent",
@@ -587,61 +565,59 @@ class TestGeneratedEffectiveSettings(unittest.TestCase):
         "replaceable_symlink",
     )))
     def test_state_identity_must_not_be_replaceable(self, mutation: str) -> None:
-        world = BeetsContractWorld()
-        self.addCleanup(world.close)
-        world.unseal()
-        if mutation in {"replaceable_parent", "app_owned_readonly_parent"}:
-            state_dir = world.root / f"{mutation}-state"
-            state_dir.mkdir()
-            state = state_dir / "state.pickle"
-            state.write_bytes(world.state_file.read_bytes())
-            if mutation == "app_owned_readonly_parent":
-                state_dir.chmod(
-                    stat.S_IRUSR
-                    | stat.S_IXUSR
-                    | stat.S_IRGRP
-                    | stat.S_IXGRP
-                )
-        else:
-            state = world.runtime_dir / "state-link.pickle"
-            state.symlink_to(world.state_file)
-        world._write_runtime_config(state_file=str(state))
-        world._write_main_config(statefile=str(state))
-        world._seal("importer")
+        with BeetsContractWorld() as world:
+            world.unseal()
+            if mutation in {"replaceable_parent", "app_owned_readonly_parent"}:
+                state_dir = world.root / f"{mutation}-state"
+                state_dir.mkdir()
+                state = state_dir / "state.pickle"
+                state.write_bytes(world.state_file.read_bytes())
+                if mutation == "app_owned_readonly_parent":
+                    state_dir.chmod(
+                        stat.S_IRUSR
+                        | stat.S_IXUSR
+                        | stat.S_IRGRP
+                        | stat.S_IXGRP
+                    )
+            else:
+                state = world.runtime_dir / "state-link.pickle"
+                state.symlink_to(world.state_file)
+            world._write_runtime_config(state_file=str(state))
+            world._write_main_config(statefile=str(state))
+            world._seal("importer")
 
-        report = check_beets_config(world.cfg(), role="importer")
+            report = check_beets_config(world.cfg(), role="importer")
 
-        assert_hard_code(report.hard_failures, "state_replaceable")
+            assert_hard_code(report.hard_failures, "state_replaceable")
 
     @given(st.sampled_from(("main", "nonsecret_include")))
     def test_only_designated_secret_include_may_supply_discogs_token(
         self,
         source: str,
     ) -> None:
-        world = BeetsContractWorld()
-        self.addCleanup(world.close)
-        world.unseal()
-        if source == "main":
-            world._write_main_config(
-                discogs={"user_token": "outside-designated-secret"}
-            )
-        else:
-            extra = world.beets_dir / "nonsecret-token.yaml"
-            extra.write_text(
-                "discogs:\n  user_token: outside-designated-secret\n",
-                encoding="utf-8",
-            )
-            world._write_main_config(
-                include=[str(extra), str(world.secret_include)]
-            )
-        world._seal("importer")
+        with BeetsContractWorld() as world:
+            world.unseal()
+            if source == "main":
+                world._write_main_config(
+                    discogs={"user_token": "outside-designated-secret"}
+                )
+            else:
+                extra = world.beets_dir / "nonsecret-token.yaml"
+                extra.write_text(
+                    "discogs:\n  user_token: outside-designated-secret\n",
+                    encoding="utf-8",
+                )
+                world._write_main_config(
+                    include=[str(extra), str(world.secret_include)]
+                )
+            world._seal("importer")
 
-        report = check_beets_config(world.cfg(), role="importer")
+            report = check_beets_config(world.cfg(), role="importer")
 
-        assert_hard_code(
-            report.hard_failures,
-            "discogs_token_outside_secret_include",
-        )
+            assert_hard_code(
+                report.hard_failures,
+                "discogs_token_outside_secret_include",
+            )
 
     @given(st.sampled_from((
         ("absent", "state_not_regular"),
@@ -655,29 +631,28 @@ class TestGeneratedEffectiveSettings(unittest.TestCase):
         case: tuple[str, str],
     ) -> None:
         mutation, expected_code = case
-        world = BeetsContractWorld(
+        with BeetsContractWorld(
             role="web" if mutation == "importer_readonly" else "importer"
-        )
-        self.addCleanup(world.close)
-        if mutation in {"absent", "nonregular", "inside_config"}:
-            world.unseal()
-            if mutation == "absent":
-                state = world.state_dir / "absent-state.pickle"
-            elif mutation == "nonregular":
-                state = world.state_dir / "state-directory"
-                state.mkdir()
-            else:
-                state = world.beets_dir / "state.pickle"
-                state.write_bytes(b"state")
-            world._write_runtime_config(state_file=str(state))
-            world._write_main_config(statefile=str(state))
-            world._seal("importer")
-        elif mutation == "unreadable":
-            world.set_state_mode(0)
+        ) as world:
+            if mutation in {"absent", "nonregular", "inside_config"}:
+                world.unseal()
+                if mutation == "absent":
+                    state = world.state_dir / "absent-state.pickle"
+                elif mutation == "nonregular":
+                    state = world.state_dir / "state-directory"
+                    state.mkdir()
+                else:
+                    state = world.beets_dir / "state.pickle"
+                    state.write_bytes(b"state")
+                world._write_runtime_config(state_file=str(state))
+                world._write_main_config(statefile=str(state))
+                world._seal("importer")
+            elif mutation == "unreadable":
+                world.set_state_mode(0)
 
-        report = check_beets_config(world.cfg(), role="importer")
+            report = check_beets_config(world.cfg(), role="importer")
 
-        assert_hard_code(report.hard_failures, expected_code)
+            assert_hard_code(report.hard_failures, expected_code)
 
     @given(st.sampled_from((
         "",
@@ -690,29 +665,27 @@ class TestGeneratedEffectiveSettings(unittest.TestCase):
         self,
         expected_endpoint: str,
     ) -> None:
-        world = BeetsContractWorld()
-        self.addCleanup(world.close)
-        report = check_beets_config(
-            replace(world.cfg(), musicbrainz_api_base=expected_endpoint),
-            role="importer",
-        )
+        with BeetsContractWorld() as world:
+            report = check_beets_config(
+                replace(world.cfg(), musicbrainz_api_base=expected_endpoint),
+                role="importer",
+            )
 
-        self.assertTrue(report.ok, report.hard_failures)
-        assert_hard_code(report.warnings, "musicbrainz_endpoint_drift")
+            self.assertTrue(report.ok, report.hard_failures)
+            assert_hard_code(report.warnings, "musicbrainz_endpoint_drift")
 
     @given(st.sampled_from(("main", "importer", "preview", "web")))
     def test_missing_main_config_never_reaches_effective_loading(
         self,
         role: BeetsRole,
     ) -> None:
-        world = BeetsContractWorld(role=role)
-        self.addCleanup(world.close)
-        world.unseal()
-        world.main_config.unlink()
-        world._seal(role)
+        with BeetsContractWorld(role=role) as world:
+            world.unseal()
+            world.main_config.unlink()
+            world._seal(role)
 
-        with self.assertRaisesRegex(BeetsConfigError, "config.yaml"):
-            check_beets_config(world.cfg(), role=role)
+            with self.assertRaisesRegex(BeetsConfigError, "config.yaml"):
+                check_beets_config(world.cfg(), role=role)
 
     @given(
         additionally_absent=st.sets(
@@ -723,18 +696,17 @@ class TestGeneratedEffectiveSettings(unittest.TestCase):
         self,
         additionally_absent: set[str],
     ) -> None:
-        world = BeetsContractWorld()
-        self.addCleanup(world.close)
-        available_without_musicbrainz = frozenset(
-            name for name in BASELINE_PLUGINS if name != "musicbrainz"
-        ) - additionally_absent
-        report = check_beets_config(
-            world.cfg(),
-            role="importer",
-            available_plugins=lambda: available_without_musicbrainz,
-        )
+        with BeetsContractWorld() as world:
+            available_without_musicbrainz = frozenset(
+                name for name in BASELINE_PLUGINS if name != "musicbrainz"
+            ) - additionally_absent
+            report = check_beets_config(
+                world.cfg(),
+                role="importer",
+                available_plugins=lambda: available_without_musicbrainz,
+            )
 
-        assert_hard_code(report.hard_failures, "plugin_unavailable")
+            assert_hard_code(report.hard_failures, "plugin_unavailable")
 
     @given(
         keys=st.lists(
@@ -752,17 +724,16 @@ class TestGeneratedEffectiveSettings(unittest.TestCase):
         self,
         keys: list[str],
     ) -> None:
-        world = BeetsContractWorld()
-        self.addCleanup(world.close)
-        world.unseal()
-        config = yaml.safe_load(world.main_config.read_text(encoding="utf-8"))
-        config["import"]["duplicate_keys"]["album"] = keys
-        world.main_config.write_text(yaml.safe_dump(config), encoding="utf-8")
-        world._seal("importer")
+        with BeetsContractWorld() as world:
+            world.unseal()
+            config = yaml.safe_load(world.main_config.read_text(encoding="utf-8"))
+            config["import"]["duplicate_keys"]["album"] = keys
+            world.main_config.write_text(yaml.safe_dump(config), encoding="utf-8")
+            world._seal("importer")
 
-        report = check_beets_config(world.cfg(), role="importer")
+            report = check_beets_config(world.cfg(), role="importer")
 
-        assert_hard_code(report.hard_failures, "duplicate_keys_unsafe")
+            assert_hard_code(report.hard_failures, "duplicate_keys_unsafe")
 
     @given(case=st.sampled_from((
         ("library", "missing", "library_not_regular"),
@@ -777,32 +748,31 @@ class TestGeneratedEffectiveSettings(unittest.TestCase):
         case: tuple[str, str, str],
     ) -> None:
         authority, object_kind, expected = case
-        world = BeetsContractWorld()
-        self.addCleanup(world.close)
-        target = (
-            world.library_db if authority == "library" else world.library_root
-        )
-        if object_kind in ("missing", "wrong_type"):
-            if target.is_dir():
-                target.rmdir()
-            else:
-                target.unlink()
-        if object_kind == "wrong_type":
-            if authority == "library":
-                target.mkdir()
-            else:
-                target.write_bytes(b"not a directory")
-        elif object_kind == "empty":
-            target.write_bytes(b"")
-        elif object_kind == "corrupt":
-            target.write_bytes(b"not sqlite")
+        with BeetsContractWorld() as world:
+            target = (
+                world.library_db if authority == "library" else world.library_root
+            )
+            if object_kind in ("missing", "wrong_type"):
+                if target.is_dir():
+                    target.rmdir()
+                else:
+                    target.unlink()
+            if object_kind == "wrong_type":
+                if authority == "library":
+                    target.mkdir()
+                else:
+                    target.write_bytes(b"not a directory")
+            elif object_kind == "empty":
+                target.write_bytes(b"")
+            elif object_kind == "corrupt":
+                target.write_bytes(b"not sqlite")
 
-        report = check_beets_config(world.cfg(), role="importer")
+            report = check_beets_config(world.cfg(), role="importer")
 
-        assert_hard_code(
-            report.hard_failures,
-            expected,
-        )
+            assert_hard_code(
+                report.hard_failures,
+                expected,
+            )
 
     @settings(max_examples=40)
     @given(
@@ -820,61 +790,57 @@ class TestGeneratedEffectiveSettings(unittest.TestCase):
         query_key: str,
         template: str,
     ) -> None:
-        world = BeetsContractWorld()
-        self.addCleanup(world.close)
-        world.unseal()
-        world._write_main_config(paths={
-            "default": SAFE_DEFAULT_PATH,
-            "singleton": SAFE_SINGLETON_PATH,
-            "comp": SAFE_COMP_PATH,
-            query_key: template,
-        })
-        world._seal("importer")
+        with BeetsContractWorld() as world:
+            world.unseal()
+            world._write_main_config(paths={
+                "default": SAFE_DEFAULT_PATH,
+                "singleton": SAFE_SINGLETON_PATH,
+                "comp": SAFE_COMP_PATH,
+                query_key: template,
+            })
+            world._seal("importer")
 
-        report = check_beets_config(world.cfg(), role="importer")
+            report = check_beets_config(world.cfg(), role="importer")
 
-        assert_hard_code(report.hard_failures, "paths_keys_unsupported")
+            assert_hard_code(report.hard_failures, "paths_keys_unsupported")
 
     @given(st.sampled_from(_SETTING_MUTANTS))
     def test_every_generated_effective_mutant_is_rejected(
         self, mutant: tuple[str, dict[str, object], str]
     ) -> None:
         _name, overrides, expected_code = mutant
-        world = BeetsContractWorld()
-        self.addCleanup(world.close)
-        world.unseal()
-        world._write_main_config(**overrides)
-        world._seal("importer")
+        with BeetsContractWorld() as world:
+            world.unseal()
+            world._write_main_config(**overrides)
+            world._seal("importer")
 
-        report = check_beets_config(world.cfg(), role="importer")
+            report = check_beets_config(world.cfg(), role="importer")
 
-        assert_hard_code(report.hard_failures, expected_code)
+            assert_hard_code(report.hard_failures, expected_code)
 
     _ROLES: tuple[BeetsRole, ...] = ("main", "preview", "web", "importer")
 
     @given(st.sampled_from(_ROLES))
     def test_each_role_gets_only_its_statefile_capability(self, role: BeetsRole) -> None:
-        world = BeetsContractWorld(role=role)
-        self.addCleanup(world.close)
-        report = check_beets_config(world.cfg(), role=role)
-        self.assertTrue(report.ok, report.hard_failures)
+        with BeetsContractWorld(role=role) as world:
+            report = check_beets_config(world.cfg(), role=role)
+            self.assertTrue(report.ok, report.hard_failures)
 
     @given(st.booleans())
     def test_endpoint_drift_is_warning_only(self, drifted: bool) -> None:
-        world = BeetsContractWorld()
-        self.addCleanup(world.close)
-        world.unseal()
-        world._write_main_config(
-            musicbrainz={
-                "host": "mirror.invalid" if drifted else "musicbrainz.org",
-                "https": True,
-            }
-        )
-        world._seal("importer")
-        report = check_beets_config(world.cfg(), role="importer")
-        self.assertTrue(report.ok, report.hard_failures)
-        warning_codes = [warning.code for warning in report.warnings]
-        self.assertEqual(warning_codes, ["musicbrainz_endpoint_drift"] if drifted else [])
+        with BeetsContractWorld() as world:
+            world.unseal()
+            world._write_main_config(
+                musicbrainz={
+                    "host": "mirror.invalid" if drifted else "musicbrainz.org",
+                    "https": True,
+                }
+            )
+            world._seal("importer")
+            report = check_beets_config(world.cfg(), role="importer")
+            self.assertTrue(report.ok, report.hard_failures)
+            warning_codes = [warning.code for warning in report.warnings]
+            self.assertEqual(warning_codes, ["musicbrainz_endpoint_drift"] if drifted else [])
 
     _FETCHART_SOURCE_NAMES: tuple[str, ...] = (
         "coverart", "cover_art_url", "itunes", "amazon", "albumart",
@@ -932,30 +898,29 @@ class TestGeneratedEffectiveSettings(unittest.TestCase):
         independently inactive) and asserts its warning emission agrees
         with an independently written oracle on every world, not merely the
         pinned ones."""
-        world = BeetsContractWorld()
-        self.addCleanup(world.close)
-        world.unseal()
-        fetchart_config: dict[str, object] = {"auto": True}
-        if sources is not None:
-            fetchart_config["sources"] = list(sources)
-        world._write_main_config(
-            plugins=[p for p in BASELINE_PLUGINS if p not in absent_plugins],
-            fetchart=fetchart_config,
-        )
-        world._seal("importer")
-
-        report = check_beets_config(world.cfg(), role="importer")
-
-        self.assertTrue(report.ok, report.hard_failures)
-        expected_warns = self._independent_oracle_expects_warning(
-            sources, absent_plugins
-        )
-        warning_codes = [warning.code for warning in report.warnings]
-        if expected_warns:
-            self.assertIn(
-                "fetchart_cover_art_url_ranked_after_itunes", warning_codes
+        with BeetsContractWorld() as world:
+            world.unseal()
+            fetchart_config: dict[str, object] = {"auto": True}
+            if sources is not None:
+                fetchart_config["sources"] = list(sources)
+            world._write_main_config(
+                plugins=[p for p in BASELINE_PLUGINS if p not in absent_plugins],
+                fetchart=fetchart_config,
             )
-        else:
-            self.assertNotIn(
-                "fetchart_cover_art_url_ranked_after_itunes", warning_codes
+            world._seal("importer")
+
+            report = check_beets_config(world.cfg(), role="importer")
+
+            self.assertTrue(report.ok, report.hard_failures)
+            expected_warns = self._independent_oracle_expects_warning(
+                sources, absent_plugins
             )
+            warning_codes = [warning.code for warning in report.warnings]
+            if expected_warns:
+                self.assertIn(
+                    "fetchart_cover_art_url_ranked_after_itunes", warning_codes
+                )
+            else:
+                self.assertNotIn(
+                    "fetchart_cover_art_url_ranked_after_itunes", warning_codes
+                )

--- a/tests/test_beets_config_contract_regressions_generated.py
+++ b/tests/test_beets_config_contract_regressions_generated.py
@@ -217,162 +217,153 @@ class TestGeneratedIntegrationRegressions(unittest.TestCase):
     ) -> None:
         assert_write_probe_errno_contract(_can_open_for_write, error_number)
 
-        world = BeetsContractWorld()
-        self.addCleanup(world.close)
-        error = OSError(error_number, os.strerror(error_number))
-        with patch("os.open", side_effect=error):
-            if error_number in _WRITE_DENIAL_ERRNOS:
-                report = check_beets_config(world.cfg(), role="importer")
-                assert_hard_code(
-                    report.hard_failures,
-                    "state_not_writable_by_importer",
-                )
-            else:
-                with self.assertRaisesRegex(
-                    BeetsConfigError,
-                    "cannot determine whether Beets authority is writable",
-                ):
-                    check_beets_config(world.cfg(), role="importer")
+        with BeetsContractWorld() as world:
+            error = OSError(error_number, os.strerror(error_number))
+            with patch("os.open", side_effect=error):
+                if error_number in _WRITE_DENIAL_ERRNOS:
+                    report = check_beets_config(world.cfg(), role="importer")
+                    assert_hard_code(
+                        report.hard_failures,
+                        "state_not_writable_by_importer",
+                    )
+                else:
+                    with self.assertRaisesRegex(
+                        BeetsConfigError,
+                        "cannot determine whether Beets authority is writable",
+                    ):
+                        check_beets_config(world.cfg(), role="importer")
 
     @settings(max_examples=40)
     @given(st.text(alphabet="abcdefghijklmnopqrstuvwxyz", min_size=1, max_size=24))
     def test_any_nonempty_pluginpath_is_rejected_without_owned_output_leak(
         self, suffix: str
     ) -> None:
-        world = BeetsContractWorld()
-        self.addCleanup(world.close)
-        world.unseal()
-        token = f"SECRET-pluginpath-{suffix}-TOKEN"
-        plugin_dir = world.root / token
-        plugin_dir.mkdir()
-        world._write_main_config(pluginpath=[str(plugin_dir)])
-        world._seal("importer")
-        report = check_beets_config(world.cfg(), role="importer")
-        assert_hard_code(report.hard_failures, "pluginpath_unsupported")
-        assert_token_absent_from_owned_report(
-            msgspec.json.encode(report).decode(), token
-        )
+        with BeetsContractWorld() as world:
+            world.unseal()
+            token = f"SECRET-pluginpath-{suffix}-TOKEN"
+            plugin_dir = world.root / token
+            plugin_dir.mkdir()
+            world._write_main_config(pluginpath=[str(plugin_dir)])
+            world._seal("importer")
+            report = check_beets_config(world.cfg(), role="importer")
+            assert_hard_code(report.hard_failures, "pluginpath_unsupported")
+            assert_token_absent_from_owned_report(
+                msgspec.json.encode(report).decode(), token
+            )
 
     @given(st.sampled_from(("runtime", "main", "include", "secret")))
     def test_writable_ordinary_ancestors_are_always_rejected(
         self, kind: str
     ) -> None:
-        world = BeetsContractWorld()
-        self.addCleanup(world.close)
-        expected = world.put_authority_behind_writable_ancestor(kind)
-        report = check_beets_config(world.cfg(), role="importer")
-        assert_hard_code(report.hard_failures, expected)
+        with BeetsContractWorld() as world:
+            expected = world.put_authority_behind_writable_ancestor(kind)
+            report = check_beets_config(world.cfg(), role="importer")
+            assert_hard_code(report.hard_failures, expected)
 
     @given(st.sampled_from((*REQUIRED_PLUGINS, "convert")))
     def test_disabled_plugins_are_absent_from_the_active_contract(
         self, plugin: str
     ) -> None:
-        world = BeetsContractWorld()
-        self.addCleanup(world.close)
-        world.unseal()
-        world._write_main_config(
-            plugins=[*BASELINE_PLUGINS, "convert"],
-            disabled_plugins=[plugin],
-            convert={"auto": True, "auto_keep": True},
-        )
-        world._seal("importer")
-        report = check_beets_config(world.cfg(), role="importer")
-        if plugin == "convert":
-            self.assertNotIn(
-                "convert_auto_conflict",
-                [finding.code for finding in report.hard_failures],
+        with BeetsContractWorld() as world:
+            world.unseal()
+            world._write_main_config(
+                plugins=[*BASELINE_PLUGINS, "convert"],
+                disabled_plugins=[plugin],
+                convert={"auto": True, "auto_keep": True},
             )
-        else:
-            assert_hard_code(report.hard_failures, f"{plugin}_plugin_missing")
+            world._seal("importer")
+            report = check_beets_config(world.cfg(), role="importer")
+            if plugin == "convert":
+                self.assertNotIn(
+                    "convert_auto_conflict",
+                    [finding.code for finding in report.hard_failures],
+                )
+            else:
+                assert_hard_code(report.hard_failures, f"{plugin}_plugin_missing")
 
     @settings(max_examples=40)
     @given(st.text(min_size=1, max_size=40).map(lambda text: f"SECRET::{text}::TOKEN"))
     def test_arbitrary_plugin_names_never_reach_owned_output(self, token: str) -> None:
-        world = BeetsContractWorld()
-        self.addCleanup(world.close)
-        world.unseal()
-        world._write_main_config(
-            plugins=[*BASELINE_PLUGINS, token]
-        )
-        world._seal("importer")
-        encoded = msgspec.json.encode(
-            check_beets_config(world.cfg(), role="importer")
-        ).decode()
-        assert_token_absent_from_owned_report(encoded, token)
+        with BeetsContractWorld() as world:
+            world.unseal()
+            world._write_main_config(
+                plugins=[*BASELINE_PLUGINS, token]
+            )
+            world._seal("importer")
+            encoded = msgspec.json.encode(
+                check_beets_config(world.cfg(), role="importer")
+            ).decode()
+            assert_token_absent_from_owned_report(encoded, token)
 
     @given(st.sampled_from(("redirect.yaml", "nested.yaml", "another.yaml")))
     def test_included_include_redirects_are_always_rejected(self, name: str) -> None:
-        world = BeetsContractWorld()
-        self.addCleanup(world.close)
-        world.unseal()
-        immutable_dir = world.beets_dir / "redirect-source"
-        immutable_dir.mkdir()
-        included = immutable_dir / "included.yaml"
-        included.write_text(f"include:\n  - {name}\n", encoding="utf-8")
-        included.chmod(stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
-        immutable_dir.chmod(
-            stat.S_IRUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP
-            | stat.S_IROTH | stat.S_IXOTH
-        )
-        world._write_main_config(include=[str(included), str(world.secret_include)])
-        world._seal("importer")
-        report = check_beets_config(world.cfg(), role="importer")
-        assert_hard_code(report.hard_failures, "included_include_forbidden")
+        with BeetsContractWorld() as world:
+            world.unseal()
+            immutable_dir = world.beets_dir / "redirect-source"
+            immutable_dir.mkdir()
+            included = immutable_dir / "included.yaml"
+            included.write_text(f"include:\n  - {name}\n", encoding="utf-8")
+            included.chmod(stat.S_IRUSR | stat.S_IRGRP | stat.S_IROTH)
+            immutable_dir.chmod(
+                stat.S_IRUSR | stat.S_IXUSR | stat.S_IRGRP | stat.S_IXGRP
+                | stat.S_IROTH | stat.S_IXOTH
+            )
+            world._write_main_config(include=[str(included), str(world.secret_include)])
+            world._seal("importer")
+            report = check_beets_config(world.cfg(), role="importer")
+            assert_hard_code(report.hard_failures, "included_include_forbidden")
 
     @given(st.sampled_from(("runtime", "secret")))
     def test_writable_lexical_symlink_parents_are_rejected(self, authority: str) -> None:
-        world = BeetsContractWorld()
-        self.addCleanup(world.close)
-        world.unseal()
-        if authority == "runtime":
-            target = world.contract_dir / "target.ini"
-            world.runtime_config.replace(target)
-            target.chmod(stat.S_IRUSR)
-            world.contract_dir.chmod(stat.S_IRUSR | stat.S_IXUSR)
-            link = world.runtime_dir / "runtime-link.ini"
-            link.symlink_to(target)
-            world.runtime_config = link
-            expected = "mutable_runtime_config"
-        else:
-            link = world.runtime_dir / "secret-link.yaml"
-            link.symlink_to(world.secret_include)
-            world._write_main_config(include=[str(link)])
-            world._seal("importer")
-            expected = "mutable_secret_include"
-        report = check_beets_config(world.cfg(), role="importer")
-        assert_hard_code(report.hard_failures, expected)
+        with BeetsContractWorld() as world:
+            world.unseal()
+            if authority == "runtime":
+                target = world.contract_dir / "target.ini"
+                world.runtime_config.replace(target)
+                target.chmod(stat.S_IRUSR)
+                world.contract_dir.chmod(stat.S_IRUSR | stat.S_IXUSR)
+                link = world.runtime_dir / "runtime-link.ini"
+                link.symlink_to(target)
+                world.runtime_config = link
+                expected = "mutable_runtime_config"
+            else:
+                link = world.runtime_dir / "secret-link.yaml"
+                link.symlink_to(world.secret_include)
+                world._write_main_config(include=[str(link)])
+                world._seal("importer")
+                expected = "mutable_secret_include"
+            report = check_beets_config(world.cfg(), role="importer")
+            assert_hard_code(report.hard_failures, expected)
 
     @given(st.sampled_from((
         "../runtime/state.pickle", "state.pickle", "~/state.pickle",
         "~root/state.pickle",
     )))
     def test_all_effective_relative_statefiles_are_rejected(self, value: str) -> None:
-        world = BeetsContractWorld()
-        self.addCleanup(world.close)
-        world.unseal()
-        world._write_main_config(statefile=value)
-        world._seal("importer")
-        report = check_beets_config(world.cfg(), role="importer")
-        assert_hard_code(report.hard_failures, "effective_state_relative")
+        with BeetsContractWorld() as world:
+            world.unseal()
+            world._write_main_config(statefile=value)
+            world._seal("importer")
+            report = check_beets_config(world.cfg(), role="importer")
+            assert_hard_code(report.hard_failures, "effective_state_relative")
 
     @given(st.one_of(st.none(), st.booleans()))
     def test_convert_defaults_false_but_explicit_true_conflicts(
         self, configured: bool | None
     ) -> None:
-        world = BeetsContractWorld()
-        self.addCleanup(world.close)
-        world.unseal()
-        convert = {} if configured is None else {"auto": configured, "auto_keep": False}
-        world._write_main_config(
-            plugins=[*BASELINE_PLUGINS, "convert"],
-            convert=convert,
-        )
-        world._seal("importer")
-        report = check_beets_config(world.cfg(), role="importer")
-        if configured:
-            assert_hard_code(report.hard_failures, "convert_auto_conflict")
-        else:
-            self.assertTrue(report.ok, report.hard_failures)
+        with BeetsContractWorld() as world:
+            world.unseal()
+            convert = {} if configured is None else {"auto": configured, "auto_keep": False}
+            world._write_main_config(
+                plugins=[*BASELINE_PLUGINS, "convert"],
+                convert=convert,
+            )
+            world._seal("importer")
+            report = check_beets_config(world.cfg(), role="importer")
+            if configured:
+                assert_hard_code(report.hard_failures, "convert_auto_conflict")
+            else:
+                self.assertTrue(report.ok, report.hard_failures)
 
 
 if __name__ == "__main__":

--- a/tests/test_beets_config_startup_generated.py
+++ b/tests/test_beets_config_startup_generated.py
@@ -46,66 +46,65 @@ class TestGeneratedStartupBoundary(unittest.TestCase):
         role: BeetsRole,
         outcome: str,
     ) -> None:
-        world = BeetsContractWorld(role=role)
-        self.addCleanup(world.close)
-        if outcome != "admitted":
-            world.unseal()
-        if outcome == "warning":
-            world._write_main_config(
-                musicbrainz={"host": "mirror.invalid", "https": True},
-            )
-        elif outcome == "hard":
-            world._write_main_config(**{
-                "import": {
-                    "autotag": True,
-                    "move": True,
-                    "write": False,
-                    "duplicate_keys": {
-                        "album": ["mb_albumid", "discogs_albumid"],
+        with BeetsContractWorld(role=role) as world:
+            if outcome != "admitted":
+                world.unseal()
+            if outcome == "warning":
+                world._write_main_config(
+                    musicbrainz={"host": "mirror.invalid", "https": True},
+                )
+            elif outcome == "hard":
+                world._write_main_config(**{
+                    "import": {
+                        "autotag": True,
+                        "move": True,
+                        "write": False,
+                        "duplicate_keys": {
+                            "album": ["mb_albumid", "discogs_albumid"],
+                        },
                     },
-                },
-            })
-        elif outcome == "load_error":
-            world.runtime_config.write_text(
-                "[Beets\nbroken = [\n",
-                encoding="utf-8",
-            )
-        elif outcome == "load_value_error":
-            world.runtime_config.write_text(
-                "[Search Settings]\nnumber_of_albums_to_grab = many\n",
-                encoding="utf-8",
-            )
-        if outcome != "admitted":
-            world._seal(role)
+                })
+            elif outcome == "load_error":
+                world.runtime_config.write_text(
+                    "[Beets\nbroken = [\n",
+                    encoding="utf-8",
+                )
+            elif outcome == "load_value_error":
+                world.runtime_config.write_text(
+                    "[Search Settings]\nnumber_of_albums_to_grab = many\n",
+                    encoding="utf-8",
+                )
+            if outcome != "admitted":
+                world._seal(role)
 
-        startup_logger = logging.getLogger("test.generated-beets-startup")
-        with (
-            _isolated_installed_authority(),
-            patch.object(startup_logger, "disabled", True),
-        ):
-            if outcome in ("hard", "load_error", "load_value_error"):
-                with self.assertRaises(BeetsStartupError):
-                    enforce_beets_startup(
+            startup_logger = logging.getLogger("test.generated-beets-startup")
+            with (
+                _isolated_installed_authority(),
+                patch.object(startup_logger, "disabled", True),
+            ):
+                if outcome in ("hard", "load_error", "load_value_error"):
+                    with self.assertRaises(BeetsStartupError):
+                        enforce_beets_startup(
+                            role=role,
+                            config_path=str(world.runtime_config),
+                            runtime_dir=str(world.runtime_dir),
+                            logger=startup_logger,
+                        )
+                else:
+                    admitted = enforce_beets_startup(
                         role=role,
                         config_path=str(world.runtime_config),
                         runtime_dir=str(world.runtime_dir),
                         logger=startup_logger,
                     )
-            else:
-                admitted = enforce_beets_startup(
-                    role=role,
-                    config_path=str(world.runtime_config),
-                    runtime_dir=str(world.runtime_dir),
-                    logger=startup_logger,
-                )
-                self.assertEqual(
-                    admitted.beets_config_dir,
-                    str(world.beets_dir),
-                )
-                self.assertEqual(
-                    admitted.beets_library_db,
-                    str(world.library_db),
-                )
+                    self.assertEqual(
+                        admitted.beets_config_dir,
+                        str(world.beets_dir),
+                    )
+                    self.assertEqual(
+                        admitted.beets_library_db,
+                        str(world.library_db),
+                    )
 
     @given(case=st.sampled_from(_RESTART_CASES))
     def test_every_real_entrypoint_restarts_after_contract_correction(
@@ -133,61 +132,60 @@ class TestGeneratedStartupBoundary(unittest.TestCase):
         suffix: str,
     ) -> None:
         token = f"PLANTED_TOKEN_759_{suffix}"
-        world = BeetsContractWorld(role=role)
-        self.addCleanup(world.close)
-        world.unseal()
-        if malformed_source == "runtime":
-            world.runtime_config.write_text(
-                f"[Beets\nuser_token = [{token}\n",
-                encoding="utf-8",
-            )
-        elif malformed_source == "secret":
-            world.secret_include.write_text(
-                f"discogs:\n  user_token: [{token}\n",
-                encoding="utf-8",
-            )
-        else:
-            world.main_config.write_text(
-                f"plugins: [musicbrainz, {token}\n",
-                encoding="utf-8",
-            )
-        world._seal(role)
-
-        if adapter == "startup":
-            logger = logging.getLogger("test.generated-beets-redaction")
-            with (
-                _isolated_installed_authority(),
-                self.assertLogs(logger, level="ERROR") as captured,
-                self.assertRaises(BeetsStartupError),
-            ):
-                enforce_beets_startup(
-                    role=role,
-                    config_path=str(world.runtime_config),
-                    runtime_dir=str(world.runtime_dir),
-                    logger=logger,
+        with BeetsContractWorld(role=role) as world:
+            world.unseal()
+            if malformed_source == "runtime":
+                world.runtime_config.write_text(
+                    f"[Beets\nuser_token = [{token}\n",
+                    encoding="utf-8",
                 )
-            output = "\n".join(captured.output)
-        else:
-            proc = subprocess.run(
-                [
-                    sys.executable,
-                    "scripts/check_beets_config.py",
-                    "--config",
-                    str(world.runtime_config),
-                    "--runtime-dir",
-                    str(world.runtime_dir),
-                    "--role",
-                    role,
-                ],
-                cwd=Path(__file__).resolve().parent.parent,
-                text=True,
-                capture_output=True,
-                check=False,
-            )
-            self.assertNotEqual(proc.returncode, 0)
-            output = proc.stderr + proc.stdout
+            elif malformed_source == "secret":
+                world.secret_include.write_text(
+                    f"discogs:\n  user_token: [{token}\n",
+                    encoding="utf-8",
+                )
+            else:
+                world.main_config.write_text(
+                    f"plugins: [musicbrainz, {token}\n",
+                    encoding="utf-8",
+                )
+            world._seal(role)
 
-        assert_redacted_load_failure(output, token)
+            if adapter == "startup":
+                logger = logging.getLogger("test.generated-beets-redaction")
+                with (
+                    _isolated_installed_authority(),
+                    self.assertLogs(logger, level="ERROR") as captured,
+                    self.assertRaises(BeetsStartupError),
+                ):
+                    enforce_beets_startup(
+                        role=role,
+                        config_path=str(world.runtime_config),
+                        runtime_dir=str(world.runtime_dir),
+                        logger=logger,
+                    )
+                output = "\n".join(captured.output)
+            else:
+                proc = subprocess.run(
+                    [
+                        sys.executable,
+                        "scripts/check_beets_config.py",
+                        "--config",
+                        str(world.runtime_config),
+                        "--runtime-dir",
+                        str(world.runtime_dir),
+                        "--role",
+                        role,
+                    ],
+                    cwd=Path(__file__).resolve().parent.parent,
+                    text=True,
+                    capture_output=True,
+                    check=False,
+                )
+                self.assertNotEqual(proc.returncode, 0)
+                output = proc.stderr + proc.stdout
+
+            assert_redacted_load_failure(output, token)
 
     def test_known_bad_raw_parser_diagnostic_trips_redaction_checker(self) -> None:
         token = "PLANTED_TOKEN_759_KNOWN_BAD"

--- a/tests/test_beets_contract_world_lifetime.py
+++ b/tests/test_beets_contract_world_lifetime.py
@@ -16,20 +16,46 @@ Bug recap: every production site used to construct the fixture as
 inside an @given-decorated method. addCleanup fires once per test METHOD,
 but Hypothesis re-executes the method body once per EXAMPLE, so every
 example before the last leaked a live world (two real tmpfs trees) until
-the method finally returned. All 45 leaking call sites found across
-tests/ (40 in the original two beets_config_contract files, plus 5 more
-found widening the same check to other resources/files) now use
-`with BeetsContractWorld() as world:` (or an equivalent locally-scoped
-context manager for their own resource), and BeetsContractWorld gained
-__enter__/__exit__ (tests/fakes/beets_contract.py) so __exit__ closes the
-world -- and releases its tmpfs trees -- at the end of the `with` block,
-i.e. at the end of the EXAMPLE, not the method.
+the method finally returned. 45 leaking call sites were found across
+tests/: 42 used this direct shape (31 in
+tests/test_beets_config_contract_generated.py, 9 in
+tests/test_beets_config_contract_regressions_generated.py, 2 in
+tests/test_beets_config_startup_generated.py) and now use
+`with BeetsContractWorld(...) as world:`; 3 more were found widening the
+same check to a helper-mediated shape (a resource built in a plain helper
+METHOD that a @given body merely calls by name --
+tests/test_import_queue.py, tests/test_mbid_replace_service.py,
+tests/test_automation_recovery_debris_generated.py) and now use an
+equivalent locally-scoped context manager for their own resource.
+BeetsContractWorld itself gained __enter__/__exit__
+(tests/fakes/beets_contract.py) so __exit__ closes the world -- and
+releases its tmpfs trees -- at the end of the `with` block, i.e. at the end
+of the EXAMPLE, not the method.
+
+Why this pin holds a live reference to every world it creates (issue #1214
+review finding F2): BeetsContractWorld's authority tree is chown'd to a
+subordinate uid while sealed (`_seal`), so an unremovable-until-unseal
+directory plus CPython's refcount-triggered `tempfile.TemporaryDirectory`
+finalizer can, by ACCIDENT, clean up both tmp trees the moment a world
+becomes unreachable -- regardless of whether `close()` (and therefore
+`__exit__`) ever ran, or ran only partially. A pin that lets each `world`
+go out of scope at the end of its own Hypothesis call therefore cannot
+tell "the fixture explicitly released its resources" from "CPython
+happened to garbage-collect them anyway": `__exit__ -> self.unseal();
+return` (no `close()` at all) and `close()`'s `finally` cleaning only one
+of the two tmp trees both still pass, because unsealing plus the world
+becoming unreachable is sufficient for the finalizers to do the fixture's
+job for it. Keeping every `world` strongly referenced in `created` for the
+entire test (never letting one go out of scope) removes that confound
+categorically: with a live reference held throughout, the ONLY way a
+world's tmp trees can disappear from disk is `BeetsContractWorld.close()`
+actually running to completion and calling `.cleanup()` on both
+`TemporaryDirectory` objects itself.
 """
 
 from __future__ import annotations
 
 import unittest
-from pathlib import Path
 
 from hypothesis import given, settings
 from hypothesis import strategies as st
@@ -48,7 +74,10 @@ class TestBeetsContractWorldLifetimeBoundToExample(unittest.TestCase):
     """A world's tmpfs trees never outlive the example that created them."""
 
     def test_resident_world_count_stays_bounded_across_examples(self) -> None:
-        created: list[tuple[Path, Path]] = []
+        # Every world is kept alive here for the whole test (see module
+        # docstring) so CPython's own refcount-triggered cleanup can never
+        # be mistaken for BeetsContractWorld.close() actually running.
+        created: list[BeetsContractWorld] = []
         alive_at_each_example: list[int] = []
 
         @settings(max_examples=_EXAMPLE_COUNT, deadline=None)
@@ -62,17 +91,23 @@ class TestBeetsContractWorldLifetimeBoundToExample(unittest.TestCase):
             # examples. st.integers over a wide range has no such
             # exhaustion shortcut, so every one of _EXAMPLE_COUNT examples
             # actually calls this function. seed is a real drawn input
-            # (referenced below), not decorative -- it selects role the
-            # exact way every one of the fixed production sites varies it.
+            # (referenced below), not decorative -- role is illustrative
+            # variation only, not a reproduction of any production site's
+            # own strategy: of the 42 real `with BeetsContractWorld(...)`
+            # call sites this issue fixed, 34 pass no role at all, 1 passes
+            # a fixed literal ("importer"), and 7 vary it via a
+            # Hypothesis-drawn `st.sampled_from(...)` role strategy -- none
+            # use a modulo-4 index. seed % 4 here is just a cheap way to
+            # touch all four roles across the run.
             role = ("importer", "preview", "web", "main")[seed % 4]
             with BeetsContractWorld(role=role) as world:
-                created.append((world.root, world.authority_root))
+                created.append(world)
                 world.cfg()
                 alive_at_each_example.append(
                     sum(
                         1
-                        for tmp_root, authority_root in created
-                        if tmp_root.exists() or authority_root.exists()
+                        for w in created
+                        if w.root.exists() or w.authority_root.exists()
                     )
                 )
 
@@ -83,26 +118,33 @@ class TestBeetsContractWorldLifetimeBoundToExample(unittest.TestCase):
             "Hypothesis did not actually run every example",
         )
         # The whole point of the fix: at the moment each example's world is
-        # constructed, every EARLIER example's world is already closed, so
-        # exactly one world -- never more -- is ever concurrently resident.
-        # Under the pre-#1214 addCleanup-per-method shape this would instead
-        # count 1, 2, 3, ... _EXAMPLE_COUNT (linear growth with the example
-        # index), never staying at 1.
+        # constructed, every EARLIER example's world has already had
+        # close() run against it (via __exit__), so exactly one world's
+        # tmp trees -- never more -- are ever concurrently resident on
+        # disk. Under the pre-#1214 addCleanup-per-method shape this would
+        # instead count 1, 2, 3, ... _EXAMPLE_COUNT (linear growth with the
+        # example index), never staying at 1.
         self.assertEqual(
             alive_at_each_example,
             [1] * _EXAMPLE_COUNT,
-            "resident BeetsContractWorld count grew with the example count "
-            "instead of staying bounded at 1 -- a world outlived its "
-            "example (issue #1214 regression)",
+            "resident BeetsContractWorld tmp-tree count grew with the "
+            "example count instead of staying bounded at 1 -- a world's "
+            "close() did not run (or did not fully run) before the next "
+            "example's world was constructed (issue #1214 regression)",
         )
-        # And after the whole run, nothing is left resident at all.
+        # And after the whole run, nothing is left resident at all --
+        # despite every world in `created` still being strongly referenced
+        # right here, so this can only be explicit close() having run for
+        # every one of them, never incidental garbage collection.
         self.assertTrue(
             all(
-                not tmp_root.exists() and not authority_root.exists()
-                for tmp_root, authority_root in created
+                not w.root.exists() and not w.authority_root.exists()
+                for w in created
             ),
             "a world's tmpfs trees were still on disk after its own "
-            "with-block exited",
+            "with-block exited, even though the world object itself was "
+            "kept alive throughout -- close() did not fully release both "
+            "trees",
         )
 
 

--- a/tests/test_beets_contract_world_lifetime.py
+++ b/tests/test_beets_contract_world_lifetime.py
@@ -95,10 +95,15 @@ class TestBeetsContractWorldLifetimeBoundToExample(unittest.TestCase):
             # variation only, not a reproduction of any production site's
             # own strategy: of the 42 real `with BeetsContractWorld(...)`
             # call sites this issue fixed, 34 pass no role at all, 1 passes
-            # a fixed literal ("importer"), and 7 vary it via a
-            # Hypothesis-drawn `st.sampled_from(...)` role strategy -- none
-            # use a modulo-4 index. seed % 4 here is just a cheap way to
-            # touch all four roles across the run.
+            # a fixed literal ("importer"), 6 pass `role=role` drawn
+            # directly from a Hypothesis `st.sampled_from(...)` role
+            # strategy, and 1 more derives role from a DIFFERENT drawn
+            # value via a conditional expression
+            # (`test_beets_config_contract_generated.py`'s
+            # `role="web" if mutation == "importer_readonly" else
+            # "importer"`) rather than a role strategy directly -- none use
+            # a modulo-4 index. seed % 4 here is just a cheap way to touch
+            # all four roles across the run.
             role = ("importer", "preview", "web", "main")[seed % 4]
             with BeetsContractWorld(role=role) as world:
                 created.append(world)

--- a/tests/test_beets_contract_world_lifetime.py
+++ b/tests/test_beets_contract_world_lifetime.py
@@ -1,0 +1,109 @@
+"""Regression pin for issue #1214: a BeetsContractWorld's tmpfs lifetime
+must be bound to the Hypothesis EXAMPLE that created it, not to the
+enclosing test METHOD.
+
+Test machinery -- deterministic only, per code-quality.md ("Never
+property-test the test machinery ... A regression in test infrastructure
+gets an exact pin and an end-to-end deterministic contract, not a
+pin/property pair"). This file therefore drives a small, self-contained
+@given body through the real Hypothesis machinery from inside one plain
+unittest test method, and asserts on the result afterward -- it is not
+itself a test_*_generated.py discovered fuzz target.
+
+Bug recap: every production site used to construct the fixture as
+    world = BeetsContractWorld()
+    self.addCleanup(world.close)
+inside an @given-decorated method. addCleanup fires once per test METHOD,
+but Hypothesis re-executes the method body once per EXAMPLE, so every
+example before the last leaked a live world (two real tmpfs trees) until
+the method finally returned. All 45 leaking call sites found across
+tests/ (40 in the original two beets_config_contract files, plus 5 more
+found widening the same check to other resources/files) now use
+`with BeetsContractWorld() as world:` (or an equivalent locally-scoped
+context manager for their own resource), and BeetsContractWorld gained
+__enter__/__exit__ (tests/fakes/beets_contract.py) so __exit__ closes the
+world -- and releases its tmpfs trees -- at the end of the `with` block,
+i.e. at the end of the EXAMPLE, not the method.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from tests.fakes.beets_contract import BeetsContractWorld
+
+#: >= 20 per the task brief; the real "resident worlds" production number
+#: this issue measured used CRATEDIGGER_FUZZ_MAX_EXAMPLES=2500 -- this pin
+#: only needs enough examples to prove the shape (bounded vs. growing), not
+#: to reproduce the exact production magnitude.
+_EXAMPLE_COUNT = 25
+
+
+class TestBeetsContractWorldLifetimeBoundToExample(unittest.TestCase):
+    """A world's tmpfs trees never outlive the example that created them."""
+
+    def test_resident_world_count_stays_bounded_across_examples(self) -> None:
+        created: list[tuple[Path, Path]] = []
+        alive_at_each_example: list[int] = []
+
+        @settings(max_examples=_EXAMPLE_COUNT, deadline=None)
+        @given(st.integers(min_value=0, max_value=10_000))
+        def drive_examples(seed: int) -> None:
+            # A plain st.sampled_from(ROLES) strategy has only 4 distinct
+            # outputs; Hypothesis special-cases that shape and can stop
+            # early once it believes the (tiny) space is exhausted, well
+            # short of _EXAMPLE_COUNT calls -- exactly the wrong behaviour
+            # for a pin whose whole point is running many sequential
+            # examples. st.integers over a wide range has no such
+            # exhaustion shortcut, so every one of _EXAMPLE_COUNT examples
+            # actually calls this function. seed is a real drawn input
+            # (referenced below), not decorative -- it selects role the
+            # exact way every one of the fixed production sites varies it.
+            role = ("importer", "preview", "web", "main")[seed % 4]
+            with BeetsContractWorld(role=role) as world:
+                created.append((world.root, world.authority_root))
+                world.cfg()
+                alive_at_each_example.append(
+                    sum(
+                        1
+                        for tmp_root, authority_root in created
+                        if tmp_root.exists() or authority_root.exists()
+                    )
+                )
+
+        drive_examples()
+
+        self.assertEqual(
+            len(created), _EXAMPLE_COUNT,
+            "Hypothesis did not actually run every example",
+        )
+        # The whole point of the fix: at the moment each example's world is
+        # constructed, every EARLIER example's world is already closed, so
+        # exactly one world -- never more -- is ever concurrently resident.
+        # Under the pre-#1214 addCleanup-per-method shape this would instead
+        # count 1, 2, 3, ... _EXAMPLE_COUNT (linear growth with the example
+        # index), never staying at 1.
+        self.assertEqual(
+            alive_at_each_example,
+            [1] * _EXAMPLE_COUNT,
+            "resident BeetsContractWorld count grew with the example count "
+            "instead of staying bounded at 1 -- a world outlived its "
+            "example (issue #1214 regression)",
+        )
+        # And after the whole run, nothing is left resident at all.
+        self.assertTrue(
+            all(
+                not tmp_root.exists() and not authority_root.exists()
+                for tmp_root, authority_root in created
+            ),
+            "a world's tmpfs trees were still on disk after its own "
+            "with-block exited",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_beets_contract_world_lifetime.py
+++ b/tests/test_beets_contract_world_lifetime.py
@@ -34,6 +34,7 @@ from pathlib import Path
 from hypothesis import given, settings
 from hypothesis import strategies as st
 
+import tests._hypothesis_profiles  # noqa: F401
 from tests.fakes.beets_contract import BeetsContractWorld
 
 #: >= 20 per the task brief; the real "resident worlds" production number

--- a/tests/test_given_body_cleanup_audit.py
+++ b/tests/test_given_body_cleanup_audit.py
@@ -1,40 +1,70 @@
-"""Audit: no ``self.addCleanup``/``self.enterContext`` lexically inside a
-function carrying a ``@given`` decorator.
+"""Audit: no resource lexically inside a function carrying a ``@given``
+decorator binds its lifetime to the enclosing test METHOD instead of the
+Hypothesis EXAMPLE.
 
 Issue #1214's root cause: ``BeetsContractWorld`` was constructed inside
 ``@given`` bodies with cleanup registered via ``self.addCleanup(world.close)``.
 ``addCleanup`` fires once per test METHOD; Hypothesis re-executes the method
 body once per EXAMPLE. So every example before the last leaked a live world
-(two real tmpfs trees) until the method finally returned -- measured at the
-daily gate's real budget, 2491 resident worlds / 1.59 GB from a single test
-class, reproducing a production ``cratedigger-daily-checks.service`` ENOSPC
-failure. The fix bound each resource's lifetime to the example that created
-it (``with BeetsContractWorld() as world:`` and equivalents) instead of the
-method. This audit is the missing other half of that fix per
+(two real tmpfs trees) until the method finally returned -- a fresh
+re-measurement at the daily gate's real budget
+(``CRATEDIGGER_FUZZ_MAX_EXAMPLES=2500``) found a peak of 2491 concurrently
+resident worlds / 1.59 GB within one test method's own run (issue #1214
+itself first measured 2469 worlds / 1576.99 MB from a slightly different
+run; both reproduce the same production ``cratedigger-daily-checks.service``
+failure: ``OSError: [Errno 28] No space left on device`` -- an ENOSPC
+exception, NOT a host OOM kill; issue #1214 states explicitly that no host
+OOM kill occurred). The fix bound each resource's lifetime to the example
+that created it (``with BeetsContractWorld() as world:`` and equivalents)
+instead of the method. This audit is the missing other half of that fix per
 ``code-quality.md``'s own authoring question -- "what one-line change to
 production would make this test fail?" -- applied to the FIX itself: without
 this audit, reverting any one of the converted call sites back to the
 addCleanup shape passes every other test in the suite untouched (issue #1214
 review finding F1).
 
-**Scope, precisely, and why it stops here.** This audit flags
-``self.addCleanup(...)``/``self.enterContext(...)`` (and their async twins,
-``self.addAsyncCleanup``/``self.enterAsyncContext`` -- unused in this repo
-today, per ``tests/test_beets_contract_world_lifetime.py``'s own docstring,
-but the grammar covers them so a future one is caught too) only when the call
-is a LEXICAL descendant of a function whose own decorator list carries
-``@given`` -- walking into ``with``/``for``/``if``/``try`` bodies, but
-stopping at any NESTED ``def``/``async def``/``lambda`` boundary, since that
-opens its own call frame with its own lifetime. It does **not** trace calls:
-a resource built and cleaned up inside a plain helper METHOD that a
-``@given`` body merely calls by name (``self._helper()``) is invisible to
-this audit, because resolving "does this call end up back inside a
-Hypothesis-driven loop" is call-graph/data-flow reasoning, which
-``.claude/rules/code-quality.md`` § "Semantic source scanners are prohibited"
-forbids. Three of the five extra leaks issue #1214 found and fixed while
-widening the check were exactly this helper-mediated shape
-(``tests/test_import_queue.py``'s ``_world``,
-``tests/test_mbid_replace_service.py``'s ``_patch_externals``,
+**Two clauses, each deliberately narrow.**
+
+1. **Registered-cleanup clause.** Flags ``self.addCleanup(...)``/
+   ``self.enterContext(...)`` (and their async twins,
+   ``self.addAsyncCleanup``/``self.enterAsyncContext`` -- a repo-wide grep
+   for either outside this audit module finds zero hits today, but the
+   grammar covers them so a future one is caught too) when the call is a
+   LEXICAL descendant of a function whose own decorator list carries
+   ``@given``.
+2. **Bare-construction clause (issue #1214 review finding A3).** The
+   registered-cleanup clause alone is blind to a STRICTLY WORSE shape: a
+   resource constructed inside a ``@given`` body with NO cleanup
+   registered at all -- no ``with``, no ``addCleanup``, nothing. That
+   shape is worse, not merely uncaught, because it strands the resource
+   for the rest of the PROCESS's life, not merely the rest of the test
+   METHOD (a bare ``BeetsContractWorld()`` construction whose seal is
+   never undone leaves an operator-unremovable ``/dev/shm`` directory
+   requiring the exact ``unshare --map-root-user --map-auto chown`` this
+   fixture itself uses to reclaim -- verified: ``cleanup()`` while sealed
+   raises ``PermissionError: [Errno 1] Operation not permitted``; the
+   directory survives that failed cleanup and is gone only after a real
+   ``close()``). This clause flags any call naming one of
+   ``BARE_CONSTRUCTION_RESOURCE_NAMES`` lexically inside a ``@given`` body
+   whose call node is not the ``context_expr`` of an enclosing ``with``/
+   ``async with`` statement. Deliberately a small, explicit, hand-maintained
+   name set -- not a general "infer which calls construct a resource"
+   scanner -- mirroring ``tests/_lambda_audit.py``'s
+   ``STRICT_RAISE_ADAPTER_KWARGS`` precedent for the same reason: the set
+   is reviewed by a human each time it grows, not inferred from source.
+
+**Both clauses stop at the same boundary, and it does NOT trace calls.**
+Each walks into ``with``/``for``/``if``/``try`` bodies, but stops at any
+NESTED ``def``/``async def``/``lambda`` boundary, since that opens its own
+call frame with its own lifetime. A resource built and cleaned up inside a
+plain helper METHOD that a ``@given`` body merely calls by name
+(``self._helper()``) is invisible to both clauses, because resolving "does
+this call end up back inside a Hypothesis-driven loop" is call-graph/
+data-flow reasoning, which ``.claude/rules/code-quality.md`` § "Semantic
+source scanners are prohibited" forbids. Three of the 45 leaking call sites
+issue #1214 found and fixed (42 direct-construction, 3 helper-mediated) were
+exactly this helper-mediated shape (``tests/test_import_queue.py``'s
+``_world``, ``tests/test_mbid_replace_service.py``'s ``_patch_externals``,
 ``tests/test_automation_recovery_debris_generated.py``'s cross-file
 ``_album_dir`` mixin call) -- this audit does not, and structurally cannot,
 catch that shape; it was found by a one-shot manual sweep, not committed
@@ -45,14 +75,20 @@ existing ``@given`` test.
 
 This audit reads decorators and calls with the stdlib ``ast`` and nothing
 else: no data flow, no alias tracking, no inference about runtime behaviour.
+The driver (``audit_tests_tree``/``iter_tests_tree_modules``) is proven
+end-to-end against real files on real disk, not only against synthetic
+source strings handed straight to the checker (issue #1214 review finding
+A1) -- see ``TestGivenBodyCleanupAuditDriverEndToEnd``.
 """
 
 from __future__ import annotations
 
 import ast
 import os
+import tempfile
 import unittest
 from dataclasses import dataclass
+from pathlib import Path
 
 TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
 
@@ -63,6 +99,13 @@ CLEANUP_METHODS = frozenset({
     "addCleanup", "addAsyncCleanup", "enterContext", "enterAsyncContext",
 })
 
+#: Deliberately small and explicit (issue #1214 review finding A3) -- the
+#: bare-construction clause only ever looks for calls naming one of these.
+#: Grow this set by hand, one reviewed entry at a time, when another
+#: resource earns the same "must always be `with`-bound" treatment; never
+#: infer membership from a call's arguments or return type.
+BARE_CONSTRUCTION_RESOURCE_NAMES = frozenset({"BeetsContractWorld"})
+
 
 class GivenBodyCleanupAuditError(Exception):
     """A tests-tree module could not be parsed, so it cannot be audited."""
@@ -70,23 +113,38 @@ class GivenBodyCleanupAuditError(Exception):
 
 @dataclass(frozen=True)
 class CleanupViolation:
-    """One ``self.<cleanup_method>(...)`` call found lexically inside a
-    ``@given``-decorated function."""
+    """One offending call found lexically inside a ``@given``-decorated
+    function -- either a ``self.<cleanup_method>(...)`` registration
+    (``kind="registered_cleanup"``, ``detail`` is the method name) or a bare
+    resource construction with no cleanup at all
+    (``kind="bare_construction"``, ``detail`` is the resource's name)."""
 
     relpath: str
     lineno: int
     function_name: str
-    cleanup_method: str
+    kind: str
+    detail: str
 
     def describe(self) -> str:
+        if self.kind == "registered_cleanup":
+            return (
+                f"{self.relpath}:{self.lineno}: `self.{self.detail}(...)` "
+                f"lexically inside @given-decorated `{self.function_name}` "
+                "-- addCleanup/enterContext (and their async twins) fire "
+                "once per test METHOD, but Hypothesis re-executes a @given "
+                "body once per EXAMPLE (issue #1214): bind the resource's "
+                "lifetime to the example instead (`with <resource>() as x:` "
+                "/ an equivalent context manager), not the method"
+            )
         return (
-            f"{self.relpath}:{self.lineno}: `self.{self.cleanup_method}(...)` "
-            f"lexically inside @given-decorated `{self.function_name}` -- "
-            "addCleanup/enterContext (and their async twins) fire once per "
-            "test METHOD, but Hypothesis re-executes a @given body once per "
-            "EXAMPLE (issue #1214): bind the resource's lifetime to the "
-            "example instead (`with <resource>() as x:` / an equivalent "
-            "context manager), not the method"
+            f"{self.relpath}:{self.lineno}: `{self.detail}(...)` "
+            f"constructed lexically inside @given-decorated "
+            f"`{self.function_name}` with NO `with` statement and no "
+            "cleanup registration at all -- worse than the "
+            "addCleanup/enterContext shape above, this strands the "
+            "resource for the rest of the process's life, not merely the "
+            "rest of the test METHOD (issue #1214 review finding A3): wrap "
+            f"the construction in `with {self.detail}(...) as x:`"
         )
 
 
@@ -126,14 +184,28 @@ def _is_self_cleanup_call(node: ast.Call) -> str | None:
     return None
 
 
+def _call_leaf_name(node: ast.Call) -> str | None:
+    """Return the leaf name/attribute this call's callee resolves to."""
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
 class _BoundedCallCollector(ast.NodeVisitor):
     """Collect ``ast.Call`` nodes without crossing a nested function/lambda
     boundary -- those open their own call frame with their own lifetime, so
-    a cleanup call inside one is not "lexically inside" the outer function
-    in the sense this audit polices."""
+    a call inside one is not "lexically inside" the outer function in the
+    sense this audit polices. Separately records which ``ast.Call`` node
+    ids appear as the ``context_expr`` of a ``with``/``async with`` item,
+    so the bare-construction clause can tell a `with`-bound construction
+    from a bare one without leaving this same bounded walk."""
 
     def __init__(self) -> None:
         self.calls: list[ast.Call] = []
+        self.with_context_call_ids: set[int] = set()
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
         return
@@ -144,16 +216,22 @@ class _BoundedCallCollector(ast.NodeVisitor):
     def visit_Lambda(self, node: ast.Lambda) -> None:
         return
 
+    def _mark_with_items(self, node: ast.With | ast.AsyncWith) -> None:
+        for item in node.items:
+            if isinstance(item.context_expr, ast.Call):
+                self.with_context_call_ids.add(id(item.context_expr))
+
+    def visit_With(self, node: ast.With) -> None:
+        self._mark_with_items(node)
+        self.generic_visit(node)
+
+    def visit_AsyncWith(self, node: ast.AsyncWith) -> None:
+        self._mark_with_items(node)
+        self.generic_visit(node)
+
     def visit_Call(self, node: ast.Call) -> None:
         self.calls.append(node)
         self.generic_visit(node)
-
-
-def _bounded_calls(body: list[ast.stmt]) -> list[ast.Call]:
-    collector = _BoundedCallCollector()
-    for stmt in body:
-        collector.visit(stmt)
-    return collector.calls
 
 
 def _function_violations(
@@ -161,15 +239,33 @@ def _function_violations(
 ) -> list[CleanupViolation]:
     if not _is_given_decorated(node):
         return []
+    collector = _BoundedCallCollector()
+    for stmt in node.body:
+        collector.visit(stmt)
+
     violations: list[CleanupViolation] = []
-    for call in _bounded_calls(node.body):
+    for call in collector.calls:
         method = _is_self_cleanup_call(call)
         if method is not None:
             violations.append(CleanupViolation(
                 relpath=relpath,
                 lineno=call.lineno,
                 function_name=node.name,
-                cleanup_method=method,
+                kind="registered_cleanup",
+                detail=method,
+            ))
+            continue
+        name = _call_leaf_name(call)
+        if (
+            name in BARE_CONSTRUCTION_RESOURCE_NAMES
+            and id(call) not in collector.with_context_call_ids
+        ):
+            violations.append(CleanupViolation(
+                relpath=relpath,
+                lineno=call.lineno,
+                function_name=node.name,
+                kind="bare_construction",
+                detail=name,
             ))
     return violations
 
@@ -218,7 +314,8 @@ def audit_tests_tree(root: str = TESTS_DIR) -> list[str]:
 
 
 class TestGivenBodyCleanupAudit(unittest.TestCase):
-    """No @given-decorated function registers cleanup that outlives it."""
+    """No @given-decorated function registers cleanup that outlives it, and
+    none constructs a policed resource with no cleanup at all."""
 
     def test_no_given_body_registers_cleanup_via_addcleanup_or_entercontext(
         self,
@@ -236,12 +333,75 @@ class TestGivenBodyCleanupAudit(unittest.TestCase):
 
     def test_scan_reaches_every_tests_subpackage(self) -> None:
         """Pin the recursive walk: a revert to a glob or ``os.listdir``
-        would silently drop the subpackages this audit must cover."""
+        would silently drop the subpackages this audit must cover. Also
+        pins a real ``*_generated.py`` module by name (issue #1214 review
+        finding A1): every one of the 42 real direct-construction
+        violations this audit exists to catch lives in a ``*_generated.py``
+        file, so a walk that silently excluded that name shape would defeat
+        the audit's entire practical purpose while every other pin here
+        (none of which name a ``*_generated.py`` module) stayed green."""
         relpaths = {relpath for relpath, _ in iter_tests_tree_modules()}
         self.assertIn("test_beets_contract_world_lifetime.py", relpaths)
+        self.assertIn("test_beets_config_contract_generated.py", relpaths)
         self.assertIn(os.path.join("web", "_harness.py"), relpaths)
         self.assertIn(os.path.join("world_model", "state_machine.py"), relpaths)
         self.assertIn(os.path.join("fakes", "beets_contract.py"), relpaths)
+
+
+class TestGivenBodyCleanupAuditDriverEndToEnd(unittest.TestCase):
+    """Issue #1214 review finding A1: prove ``audit_tests_tree``/
+    ``iter_tests_tree_modules`` actually read real file bytes from real
+    disk and walk every real filename shape -- not merely that
+    ``module_violations`` works correctly on synthetic source, which
+    ``TestGivenBodyCleanupCheckerTripsOnViolations`` already proves. Two
+    one-line mutants at the driver layer (replace the real file read with
+    an empty string; additionally skip any ``*_generated.py`` name) left
+    every other test in this module green -- see the issue #1214 kill
+    matrix. The planted files below are deliberately named
+    ``..._generated.py``: 42 of the 42 real violations this audit exists to
+    catch live in ``*_generated.py`` files, so a driver proof using any
+    other name would miss exactly the shape that matters most."""
+
+    def test_audit_tests_tree_finds_a_planted_violation_on_real_disk(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory(prefix="given-body-audit-e2e-") as tmp:
+            planted = Path(tmp) / "test_planted_violation_generated.py"
+            planted.write_text(
+                "import unittest\n"
+                "from hypothesis import given, strategies as st\n"
+                "\n"
+                "class T(unittest.TestCase):\n"
+                "    @given(n=st.integers())\n"
+                "    def test_x(self, n):\n"
+                "        self.addCleanup(lambda: None)\n",
+                encoding="utf-8",
+            )
+            offenders = audit_tests_tree(tmp)
+
+        self.assertEqual(len(offenders), 1, offenders)
+        self.assertIn("test_planted_violation_generated.py", offenders[0])
+        self.assertIn("addCleanup", offenders[0])
+
+    def test_audit_tests_tree_is_clean_on_a_planted_compliant_generated_file(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory(prefix="given-body-audit-e2e-") as tmp:
+            compliant = Path(tmp) / "test_planted_compliant_generated.py"
+            compliant.write_text(
+                "import unittest\n"
+                "from hypothesis import given, strategies as st\n"
+                "\n"
+                "class T(unittest.TestCase):\n"
+                "    @given(n=st.integers())\n"
+                "    def test_x(self, n):\n"
+                "        with open('/dev/null'):\n"
+                "            pass\n",
+                encoding="utf-8",
+            )
+            offenders = audit_tests_tree(tmp)
+
+        self.assertEqual(offenders, [])
 
 
 class TestGivenBodyCleanupCheckerTripsOnViolations(unittest.TestCase):
@@ -260,7 +420,8 @@ class TestGivenBodyCleanupCheckerTripsOnViolations(unittest.TestCase):
         )
         violations = module_violations(source, label="planted.py")
         self.assertEqual(len(violations), 1)
-        self.assertEqual(violations[0].cleanup_method, "addCleanup")
+        self.assertEqual(violations[0].kind, "registered_cleanup")
+        self.assertEqual(violations[0].detail, "addCleanup")
         self.assertEqual(violations[0].function_name, "test_x")
         self.assertIn("issue #1214", violations[0].describe())
 
@@ -276,7 +437,8 @@ class TestGivenBodyCleanupCheckerTripsOnViolations(unittest.TestCase):
         )
         violations = module_violations(source, label="planted.py")
         self.assertEqual(len(violations), 1)
-        self.assertEqual(violations[0].cleanup_method, "enterContext")
+        self.assertEqual(violations[0].kind, "registered_cleanup")
+        self.assertEqual(violations[0].detail, "enterContext")
 
     def test_addcleanup_inside_settings_plus_given_is_still_rejected(
         self,
@@ -309,10 +471,10 @@ class TestGivenBodyCleanupCheckerTripsOnViolations(unittest.TestCase):
         self,
     ) -> None:
         """Documents the audit's deliberate bound (see module docstring):
-        this is exactly the shape of 3 of the 5 helper-mediated leaks issue
-        #1214 found and fixed by manual sweep, not by static analysis --
-        the audit does not trace call graphs, so it cannot see through
-        ``self._helper()`` to the addCleanup inside ``_helper`` itself."""
+        this is exactly the shape of 3 of the 45 leaks issue #1214 found
+        and fixed by manual sweep, not by static analysis -- the audit does
+        not trace call graphs, so it cannot see through ``self._helper()``
+        to the addCleanup inside ``_helper`` itself."""
         source = (
             "import unittest\n"
             "from hypothesis import given, strategies as st\n"
@@ -362,6 +524,89 @@ class TestGivenBodyCleanupCheckerTripsOnViolations(unittest.TestCase):
     def test_unparseable_module_fails_closed(self) -> None:
         with self.assertRaises(GivenBodyCleanupAuditError):
             module_violations("def broken(:\n", label="planted.py")
+
+    def test_bare_construction_with_no_cleanup_at_all_is_rejected(
+        self,
+    ) -> None:
+        """Issue #1214 review finding A3: the strictly worse, previously
+        uncaught shape -- no `with`, no addCleanup, nothing."""
+        source = (
+            "import unittest\n"
+            "from hypothesis import given, strategies as st\n"
+            "from tests.fakes.beets_contract import BeetsContractWorld\n"
+            "\n"
+            "class T(unittest.TestCase):\n"
+            "    @given(n=st.integers())\n"
+            "    def test_x(self, n):\n"
+            "        world = BeetsContractWorld()\n"
+            "        world.cfg()\n"
+        )
+        violations = module_violations(source, label="planted.py")
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0].kind, "bare_construction")
+        self.assertEqual(violations[0].detail, "BeetsContractWorld")
+        self.assertIn("`with` statement", violations[0].describe())
+
+    def test_with_bound_construction_is_not_a_bare_construction_violation(
+        self,
+    ) -> None:
+        source = (
+            "import unittest\n"
+            "from hypothesis import given, strategies as st\n"
+            "from tests.fakes.beets_contract import BeetsContractWorld\n"
+            "\n"
+            "class T(unittest.TestCase):\n"
+            "    @given(n=st.integers())\n"
+            "    def test_x(self, n):\n"
+            "        with BeetsContractWorld() as world:\n"
+            "            world.cfg()\n"
+        )
+        self.assertEqual(module_violations(source, label="planted.py"), [])
+
+    def test_bare_construction_plus_addcleanup_reports_both_violations(
+        self,
+    ) -> None:
+        """The exact original #1214 defect shape trips BOTH clauses -- the
+        registered-cleanup clause (addCleanup fires per method) and the
+        bare-construction clause (the call itself is not `with`-bound).
+        Reporting both is intentional: each names a real, independently
+        true fact about the same site, and either fact alone is enough to
+        justify the fix."""
+        source = (
+            "import unittest\n"
+            "from hypothesis import given, strategies as st\n"
+            "from tests.fakes.beets_contract import BeetsContractWorld\n"
+            "\n"
+            "class T(unittest.TestCase):\n"
+            "    @given(n=st.integers())\n"
+            "    def test_x(self, n):\n"
+            "        world = BeetsContractWorld()\n"
+            "        self.addCleanup(world.close)\n"
+        )
+        violations = module_violations(source, label="planted.py")
+        self.assertEqual(len(violations), 2)
+        self.assertEqual(
+            {v.kind for v in violations},
+            {"registered_cleanup", "bare_construction"},
+        )
+
+    def test_bare_construction_of_an_unlisted_resource_is_not_flagged(
+        self,
+    ) -> None:
+        """The bare-construction clause is a small, explicit, hand-maintained
+        name set (see ``BARE_CONSTRUCTION_RESOURCE_NAMES``), not a general
+        "any resource" inference -- a call naming something else is not in
+        scope, however resource-shaped it looks."""
+        source = (
+            "import unittest\n"
+            "from hypothesis import given, strategies as st\n"
+            "\n"
+            "class T(unittest.TestCase):\n"
+            "    @given(n=st.integers())\n"
+            "    def test_x(self, n):\n"
+            "        handle = SomeOtherResource()\n"
+        )
+        self.assertEqual(module_violations(source, label="planted.py"), [])
 
 
 if __name__ == "__main__":

--- a/tests/test_given_body_cleanup_audit.py
+++ b/tests/test_given_body_cleanup_audit.py
@@ -1,0 +1,368 @@
+"""Audit: no ``self.addCleanup``/``self.enterContext`` lexically inside a
+function carrying a ``@given`` decorator.
+
+Issue #1214's root cause: ``BeetsContractWorld`` was constructed inside
+``@given`` bodies with cleanup registered via ``self.addCleanup(world.close)``.
+``addCleanup`` fires once per test METHOD; Hypothesis re-executes the method
+body once per EXAMPLE. So every example before the last leaked a live world
+(two real tmpfs trees) until the method finally returned -- measured at the
+daily gate's real budget, 2491 resident worlds / 1.59 GB from a single test
+class, reproducing a production ``cratedigger-daily-checks.service`` ENOSPC
+failure. The fix bound each resource's lifetime to the example that created
+it (``with BeetsContractWorld() as world:`` and equivalents) instead of the
+method. This audit is the missing other half of that fix per
+``code-quality.md``'s own authoring question -- "what one-line change to
+production would make this test fail?" -- applied to the FIX itself: without
+this audit, reverting any one of the converted call sites back to the
+addCleanup shape passes every other test in the suite untouched (issue #1214
+review finding F1).
+
+**Scope, precisely, and why it stops here.** This audit flags
+``self.addCleanup(...)``/``self.enterContext(...)`` (and their async twins,
+``self.addAsyncCleanup``/``self.enterAsyncContext`` -- unused in this repo
+today, per ``tests/test_beets_contract_world_lifetime.py``'s own docstring,
+but the grammar covers them so a future one is caught too) only when the call
+is a LEXICAL descendant of a function whose own decorator list carries
+``@given`` -- walking into ``with``/``for``/``if``/``try`` bodies, but
+stopping at any NESTED ``def``/``async def``/``lambda`` boundary, since that
+opens its own call frame with its own lifetime. It does **not** trace calls:
+a resource built and cleaned up inside a plain helper METHOD that a
+``@given`` body merely calls by name (``self._helper()``) is invisible to
+this audit, because resolving "does this call end up back inside a
+Hypothesis-driven loop" is call-graph/data-flow reasoning, which
+``.claude/rules/code-quality.md`` § "Semantic source scanners are prohibited"
+forbids. Three of the five extra leaks issue #1214 found and fixed while
+widening the check were exactly this helper-mediated shape
+(``tests/test_import_queue.py``'s ``_world``,
+``tests/test_mbid_replace_service.py``'s ``_patch_externals``,
+``tests/test_automation_recovery_debris_generated.py``'s cross-file
+``_album_dir`` mixin call) -- this audit does not, and structurally cannot,
+catch that shape; it was found by a one-shot manual sweep, not committed
+machinery (``.claude/rules/scope.md``). What this audit DOES catch, and
+permanently, is the direct-construction shape that was 42 of those 45 sites
+and is the one a future author is most likely to reintroduce by copying an
+existing ``@given`` test.
+
+This audit reads decorators and calls with the stdlib ``ast`` and nothing
+else: no data flow, no alias tracking, no inference about runtime behaviour.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import unittest
+from dataclasses import dataclass
+
+TESTS_DIR = os.path.dirname(os.path.abspath(__file__))
+
+#: The unittest cleanup-registration methods that bind a resource's release
+#: to the enclosing test METHOD rather than to whatever loop is re-running
+#: the function body.
+CLEANUP_METHODS = frozenset({
+    "addCleanup", "addAsyncCleanup", "enterContext", "enterAsyncContext",
+})
+
+
+class GivenBodyCleanupAuditError(Exception):
+    """A tests-tree module could not be parsed, so it cannot be audited."""
+
+
+@dataclass(frozen=True)
+class CleanupViolation:
+    """One ``self.<cleanup_method>(...)`` call found lexically inside a
+    ``@given``-decorated function."""
+
+    relpath: str
+    lineno: int
+    function_name: str
+    cleanup_method: str
+
+    def describe(self) -> str:
+        return (
+            f"{self.relpath}:{self.lineno}: `self.{self.cleanup_method}(...)` "
+            f"lexically inside @given-decorated `{self.function_name}` -- "
+            "addCleanup/enterContext (and their async twins) fire once per "
+            "test METHOD, but Hypothesis re-executes a @given body once per "
+            "EXAMPLE (issue #1214): bind the resource's lifetime to the "
+            "example instead (`with <resource>() as x:` / an equivalent "
+            "context manager), not the method"
+        )
+
+
+def _decorator_leaf_name(decorator: ast.expr) -> str | None:
+    """Return the leaf name/attribute a decorator resolves to, or None.
+
+    Handles both ``@given(...)`` (an ``ast.Call``) and a bare ``@given``
+    name/attribute, and both ``@given`` and ``@hypothesis.given``.
+    """
+    target = decorator.func if isinstance(decorator, ast.Call) else decorator
+    if isinstance(target, ast.Name):
+        return target.id
+    if isinstance(target, ast.Attribute):
+        return target.attr
+    return None
+
+
+def _is_given_decorated(
+    node: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> bool:
+    return any(
+        _decorator_leaf_name(decorator) == "given"
+        for decorator in node.decorator_list
+    )
+
+
+def _is_self_cleanup_call(node: ast.Call) -> str | None:
+    """Return the cleanup method name for a ``self.<method>(...)`` call."""
+    func = node.func
+    if (
+        isinstance(func, ast.Attribute)
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "self"
+        and func.attr in CLEANUP_METHODS
+    ):
+        return func.attr
+    return None
+
+
+class _BoundedCallCollector(ast.NodeVisitor):
+    """Collect ``ast.Call`` nodes without crossing a nested function/lambda
+    boundary -- those open their own call frame with their own lifetime, so
+    a cleanup call inside one is not "lexically inside" the outer function
+    in the sense this audit polices."""
+
+    def __init__(self) -> None:
+        self.calls: list[ast.Call] = []
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        return
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        return
+
+    def visit_Lambda(self, node: ast.Lambda) -> None:
+        return
+
+    def visit_Call(self, node: ast.Call) -> None:
+        self.calls.append(node)
+        self.generic_visit(node)
+
+
+def _bounded_calls(body: list[ast.stmt]) -> list[ast.Call]:
+    collector = _BoundedCallCollector()
+    for stmt in body:
+        collector.visit(stmt)
+    return collector.calls
+
+
+def _function_violations(
+    node: ast.FunctionDef | ast.AsyncFunctionDef, *, relpath: str,
+) -> list[CleanupViolation]:
+    if not _is_given_decorated(node):
+        return []
+    violations: list[CleanupViolation] = []
+    for call in _bounded_calls(node.body):
+        method = _is_self_cleanup_call(call)
+        if method is not None:
+            violations.append(CleanupViolation(
+                relpath=relpath,
+                lineno=call.lineno,
+                function_name=node.name,
+                cleanup_method=method,
+            ))
+    return violations
+
+
+def module_violations(source: str, *, label: str) -> list[CleanupViolation]:
+    """Return every violation in this module source, or raise on a parse
+    failure -- this audit never silently passes a module it could not read.
+    """
+    try:
+        tree = ast.parse(source, filename=label)
+    except SyntaxError as exc:
+        raise GivenBodyCleanupAuditError(
+            f"{label}: could not be parsed, so it cannot be audited for "
+            f"example-scoped cleanup: {exc}"
+        ) from exc
+
+    violations: list[CleanupViolation] = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            violations.extend(_function_violations(node, relpath=label))
+    return violations
+
+
+def iter_tests_tree_modules(root: str = TESTS_DIR) -> list[tuple[str, str]]:
+    """Yield ``(relpath, abspath)`` for every ``.py`` under ``root``."""
+    found: list[tuple[str, str]] = []
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = sorted(d for d in dirnames if d != "__pycache__")
+        for filename in sorted(filenames):
+            if not filename.endswith(".py"):
+                continue
+            path = os.path.join(dirpath, filename)
+            found.append((os.path.relpath(path, root), path))
+    return found
+
+
+def audit_tests_tree(root: str = TESTS_DIR) -> list[str]:
+    """Return one offender line per violation, sorted by discovery order."""
+    offenders: list[str] = []
+    for relpath, path in iter_tests_tree_modules(root):
+        with open(path, encoding="utf-8") as handle:
+            source = handle.read()
+        for violation in module_violations(source, label=relpath):
+            offenders.append(violation.describe())
+    return offenders
+
+
+class TestGivenBodyCleanupAudit(unittest.TestCase):
+    """No @given-decorated function registers cleanup that outlives it."""
+
+    def test_no_given_body_registers_cleanup_via_addcleanup_or_entercontext(
+        self,
+    ) -> None:
+        offenders = audit_tests_tree()
+        self.assertEqual(
+            offenders, [],
+            "A resource constructed directly inside a @given body must bind "
+            "its lifetime to the example (a `with` block), not the test "
+            "method -- addCleanup/enterContext fire once per method while "
+            "Hypothesis re-executes the body once per example (issue "
+            "#1214). Offenders (paths relative to tests/):\n  "
+            + "\n  ".join(offenders),
+        )
+
+    def test_scan_reaches_every_tests_subpackage(self) -> None:
+        """Pin the recursive walk: a revert to a glob or ``os.listdir``
+        would silently drop the subpackages this audit must cover."""
+        relpaths = {relpath for relpath, _ in iter_tests_tree_modules()}
+        self.assertIn("test_beets_contract_world_lifetime.py", relpaths)
+        self.assertIn(os.path.join("web", "_harness.py"), relpaths)
+        self.assertIn(os.path.join("world_model", "state_machine.py"), relpaths)
+        self.assertIn(os.path.join("fakes", "beets_contract.py"), relpaths)
+
+
+class TestGivenBodyCleanupCheckerTripsOnViolations(unittest.TestCase):
+    """Known-bad self-tests: the checker must reject planted module shapes,
+    and must not flag shapes it deliberately does not cover."""
+
+    def test_addcleanup_directly_in_a_given_body_is_rejected(self) -> None:
+        source = (
+            "import unittest\n"
+            "from hypothesis import given, strategies as st\n"
+            "\n"
+            "class T(unittest.TestCase):\n"
+            "    @given(n=st.integers())\n"
+            "    def test_x(self, n):\n"
+            "        self.addCleanup(lambda: None)\n"
+        )
+        violations = module_violations(source, label="planted.py")
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0].cleanup_method, "addCleanup")
+        self.assertEqual(violations[0].function_name, "test_x")
+        self.assertIn("issue #1214", violations[0].describe())
+
+    def test_entercontext_directly_in_a_given_body_is_rejected(self) -> None:
+        source = (
+            "import unittest\n"
+            "from hypothesis import given, strategies as st\n"
+            "\n"
+            "class T(unittest.TestCase):\n"
+            "    @given(n=st.integers())\n"
+            "    def test_x(self, n):\n"
+            "        world = self.enterContext(open('/dev/null'))\n"
+        )
+        violations = module_violations(source, label="planted.py")
+        self.assertEqual(len(violations), 1)
+        self.assertEqual(violations[0].cleanup_method, "enterContext")
+
+    def test_addcleanup_inside_settings_plus_given_is_still_rejected(
+        self,
+    ) -> None:
+        """A ``@settings(...)`` decorator stacked above ``@given`` must not
+        blind the check to the ``given``-carrying function underneath."""
+        source = (
+            "import unittest\n"
+            "from hypothesis import given, settings, strategies as st\n"
+            "\n"
+            "class T(unittest.TestCase):\n"
+            "    @settings(max_examples=5)\n"
+            "    @given(n=st.integers())\n"
+            "    def test_x(self, n):\n"
+            "        self.addCleanup(lambda: None)\n"
+        )
+        violations = module_violations(source, label="planted.py")
+        self.assertEqual(len(violations), 1)
+
+    def test_addcleanup_in_a_plain_non_given_method_is_accepted(self) -> None:
+        source = (
+            "import unittest\n"
+            "class T(unittest.TestCase):\n"
+            "    def test_x(self):\n"
+            "        self.addCleanup(lambda: None)\n"
+        )
+        self.assertEqual(module_violations(source, label="planted.py"), [])
+
+    def test_addcleanup_in_a_helper_called_from_a_given_body_is_not_caught(
+        self,
+    ) -> None:
+        """Documents the audit's deliberate bound (see module docstring):
+        this is exactly the shape of 3 of the 5 helper-mediated leaks issue
+        #1214 found and fixed by manual sweep, not by static analysis --
+        the audit does not trace call graphs, so it cannot see through
+        ``self._helper()`` to the addCleanup inside ``_helper`` itself."""
+        source = (
+            "import unittest\n"
+            "from hypothesis import given, strategies as st\n"
+            "\n"
+            "class T(unittest.TestCase):\n"
+            "    def _helper(self):\n"
+            "        self.addCleanup(lambda: None)\n"
+            "\n"
+            "    @given(n=st.integers())\n"
+            "    def test_x(self, n):\n"
+            "        self._helper()\n"
+        )
+        self.assertEqual(module_violations(source, label="planted.py"), [])
+
+    def test_addcleanup_inside_a_nested_def_within_a_given_body_is_not_caught(
+        self,
+    ) -> None:
+        """A nested ``def``/``lambda`` opens its own frame; a cleanup call
+        inside one is out of scope for this audit's bounded walk."""
+        source = (
+            "import unittest\n"
+            "from hypothesis import given, strategies as st\n"
+            "\n"
+            "class T(unittest.TestCase):\n"
+            "    @given(n=st.integers())\n"
+            "    def test_x(self, n):\n"
+            "        def _inner():\n"
+            "            self.addCleanup(lambda: None)\n"
+            "        _inner()\n"
+        )
+        self.assertEqual(module_violations(source, label="planted.py"), [])
+
+    def test_addcleanup_on_a_plain_object_is_not_flagged(self) -> None:
+        """Only ``self.<method>(...)`` is in scope -- an unrelated object
+        that happens to expose an ``addCleanup``-named method is not."""
+        source = (
+            "import unittest\n"
+            "from hypothesis import given, strategies as st\n"
+            "\n"
+            "class T(unittest.TestCase):\n"
+            "    @given(n=st.integers())\n"
+            "    def test_x(self, n):\n"
+            "        other.addCleanup(lambda: None)\n"
+        )
+        self.assertEqual(module_violations(source, label="planted.py"), [])
+
+    def test_unparseable_module_fails_closed(self) -> None:
+        with self.assertRaises(GivenBodyCleanupAuditError):
+            module_violations("def broken(:\n", label="planted.py")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_import_queue.py
+++ b/tests/test_import_queue.py
@@ -10,7 +10,7 @@ import tempfile
 import threading
 import time
 import unittest
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterator, Mapping
 from contextlib import AbstractContextManager, contextmanager
 from dataclasses import replace as dataclass_replace
 from datetime import UTC, datetime, timedelta
@@ -10509,133 +10509,136 @@ class TestForceWrongMatchReceiptStartupReplayGenerated(unittest.TestCase):
     have selected and replayed against live production data.
     """
 
+    @contextmanager
     def _world(
         self,
         outcome: str,
         *,
         source_already_deleted: bool,
-    ) -> tuple[FakePipelineDB, str, ImportJob]:
+    ) -> Iterator[tuple[FakePipelineDB, str, ImportJob]]:
         db = FakePipelineDB()
         root, source = _make_failed_import_source()
-        self.addCleanup(shutil.rmtree, root, ignore_errors=True)
-        with open(os.path.join(source, "01.mp3"), "wb") as handle:
-            handle.write(b"generated wrong-match audio")
-        db.seed_request(make_request_row(id=42, status="wanted"))
-        db.log_download(
-            42,
-            soulseek_username="alice",
-            outcome="rejected",
-            validation_result={
-                "scenario": "high_distance", "failed_path": source,
-            },
-        )
-        log_id = db.download_logs[-1].id
-        job = db.enqueue_import_job(
-            IMPORT_JOB_FORCE,
-            request_id=42,
-            dedupe_key=(
-                f"generated-wrong-match:{outcome}:{source_already_deleted}"
-            ),
-            payload=force_import_payload(
-                download_log_id=log_id, failed_path=source,
-            ),
-        )
-
-        if outcome in _WRONG_MATCH_REPLAY_OUTCOMES:
-            status, result, error = _wrong_match_replay_terminal_result(
-                outcome,
+        try:
+            with open(os.path.join(source, "01.mp3"), "wb") as handle:
+                handle.write(b"generated wrong-match audio")
+            db.seed_request(make_request_row(id=42, status="wanted"))
+            db.log_download(
+                42,
+                soulseek_username="alice",
+                outcome="rejected",
+                validation_result={
+                    "scenario": "high_distance", "failed_path": source,
+                },
             )
-            message = str(result["message"])
-            if status == "completed":
+            log_id = db.download_logs[-1].id
+            job = db.enqueue_import_job(
+                IMPORT_JOB_FORCE,
+                request_id=42,
+                dedupe_key=(
+                    f"generated-wrong-match:{outcome}:{source_already_deleted}"
+                ),
+                payload=force_import_payload(
+                    download_log_id=log_id, failed_path=source,
+                ),
+            )
+
+            if outcome in _WRONG_MATCH_REPLAY_OUTCOMES:
+                status, result, error = _wrong_match_replay_terminal_result(
+                    outcome,
+                )
+                message = str(result["message"])
+                if status == "completed":
+                    db.mark_import_job_completed(
+                        job.id, result=result, message=message,
+                    )
+                else:
+                    db.mark_import_job_failed(
+                        job.id, error=error, result=result, message=message,
+                    )
+            elif outcome == "historical_completed_no_marker":
+                # Live-row evidence: 477 of the 619 pre-feature rows doc2
+                # measured were exactly this shape — a 'completed' force job
+                # from before ``_job_result`` ever wrote the era marker. The
+                # measured live shape is the older three-key
+                # ``{deferred, message, success}`` payload (review round 3,
+                # MINOR-2), not a bare ``{"success": True}`` — selection is
+                # identical either way (both lack the marker), but the fixture
+                # should say what was actually measured.
                 db.mark_import_job_completed(
-                    job.id, result=result, message=message,
+                    job.id,
+                    result={
+                        "deferred": False, "message": "imported",
+                        "success": True,
+                    },
+                    message="imported",
                 )
-            else:
+            elif outcome == "historical_executor_crash":
+                # The literal shape ``process_claimed_job``'s own top-level
+                # exception handler writes (``scripts/importer.py``, BEFORE
+                # ``_job_result`` is ever computed) — constructed directly
+                # rather than driving that call chain live, since doing so
+                # would need a new ``cast(Any, ...)`` escape hatch for one
+                # shape a deterministic pin in this same file
+                # (``test_crashed_force_job_is_failed_not_parked``) already
+                # exercises end-to-end through the real code path.
                 db.mark_import_job_failed(
-                    job.id, error=error, result=result, message=message,
+                    job.id, error="RuntimeError: generated executor crash",
+                    result={"success": False},
                 )
-        elif outcome == "historical_completed_no_marker":
-            # Live-row evidence: 477 of the 619 pre-feature rows doc2
-            # measured were exactly this shape — a 'completed' force job
-            # from before ``_job_result`` ever wrote the era marker. The
-            # measured live shape is the older three-key
-            # ``{deferred, message, success}`` payload (review round 3,
-            # MINOR-2), not a bare ``{"success": True}`` — selection is
-            # identical either way (both lack the marker), but the fixture
-            # should say what was actually measured.
-            db.mark_import_job_completed(
-                job.id,
-                result={
-                    "deferred": False, "message": "imported",
-                    "success": True,
-                },
-                message="imported",
-            )
-        elif outcome == "historical_executor_crash":
-            # The literal shape ``process_claimed_job``'s own top-level
-            # exception handler writes (``scripts/importer.py``, BEFORE
-            # ``_job_result`` is ever computed) — constructed directly
-            # rather than driving that call chain live, since doing so
-            # would need a new ``cast(Any, ...)`` escape hatch for one
-            # shape a deterministic pin in this same file
-            # (``test_crashed_force_job_is_failed_not_parked``) already
-            # exercises end-to-end through the real code path.
-            db.mark_import_job_failed(
-                job.id, error="RuntimeError: generated executor crash",
-                result={"success": False},
-            )
-        elif outcome == "historical_operator_cleanup":
-            # Real producer: the actual ``mark_import_job_failed`` DB
-            # method, called directly with no ``result`` kwarg — mirrors
-            # ``tests/test_wrong_matches_cleanup.py``'s own "operator
-            # cancelled" pattern for an ad hoc administrative
-            # terminalization outside the adjudicating decision path.
-            db.mark_import_job_failed(job.id, error="operator cancelled")
-        elif outcome == "historical_preview_shape":
-            # Real producer (review round 3, MEDIUM-1 corrected a false
-            # "no current producer" claim): TWO live paths write the
-            # literal ``{"preview": <preview_result>}`` shape into
-            # ``result`` —
-            # ``lib/pipeline_db/import_jobs.py::mark_import_job_preview_failed``
-            # (called from ``scripts/import_preview_worker.py``'s
-            # ``job.request_id is None or request is None`` branch) and
-            # ``lib/pipeline_db/terminal_outcomes.py::
-            # persist_preview_terminal_outcome``'s non-automation branch
-            # (called via ``lib.dispatch._record_preview_measurement_failed``,
-            # ``import_preview_worker.py:952``). Live proof: force job
-            # 59313 (2026-07-25). Driven directly through the simpler of
-            # the two real producers — the write method itself decides
-            # the exact ``result`` shape, so calling it directly is the
-            # real producer, not a stand-in for it (freshly enqueued
-            # ``job`` is already ``status='queued',
-            # preview_status='waiting'``, exactly this method's
-            # precondition).
-            db.mark_import_job_preview_failed(
-                job.id,
-                preview_status="measurement_failed",
-                error="measurement_crashed",
-                preview_result={
-                    "reason": "measurement_crashed",
-                    "detail": "measurement_failed",
-                    "source_path": "",
-                },
-                message="Preview measurement failed: measurement_crashed",
-            )
-        elif outcome == "historical_null_result":
-            # A genuinely NULL ``result`` column has no public-API
-            # constructor — reach into the fake's own row store directly,
-            # mirroring the real-PG test's raw ``UPDATE ... result = NULL``.
-            db.mark_import_job_failed(job.id, error="unknown")
-            for row in db._import_jobs:
-                if row["id"] == job.id:
-                    row["result"] = None
-                    break
-        else:
-            raise AssertionError(f"unrecognised outcome {outcome!r}")
+            elif outcome == "historical_operator_cleanup":
+                # Real producer: the actual ``mark_import_job_failed`` DB
+                # method, called directly with no ``result`` kwarg — mirrors
+                # ``tests/test_wrong_matches_cleanup.py``'s own "operator
+                # cancelled" pattern for an ad hoc administrative
+                # terminalization outside the adjudicating decision path.
+                db.mark_import_job_failed(job.id, error="operator cancelled")
+            elif outcome == "historical_preview_shape":
+                # Real producer (review round 3, MEDIUM-1 corrected a false
+                # "no current producer" claim): TWO live paths write the
+                # literal ``{"preview": <preview_result>}`` shape into
+                # ``result`` —
+                # ``lib/pipeline_db/import_jobs.py::mark_import_job_preview_failed``
+                # (called from ``scripts/import_preview_worker.py``'s
+                # ``job.request_id is None or request is None`` branch) and
+                # ``lib/pipeline_db/terminal_outcomes.py::
+                # persist_preview_terminal_outcome``'s non-automation branch
+                # (called via ``lib.dispatch._record_preview_measurement_failed``,
+                # ``import_preview_worker.py:952``). Live proof: force job
+                # 59313 (2026-07-25). Driven directly through the simpler of
+                # the two real producers — the write method itself decides
+                # the exact ``result`` shape, so calling it directly is the
+                # real producer, not a stand-in for it (freshly enqueued
+                # ``job`` is already ``status='queued',
+                # preview_status='waiting'``, exactly this method's
+                # precondition).
+                db.mark_import_job_preview_failed(
+                    job.id,
+                    preview_status="measurement_failed",
+                    error="measurement_crashed",
+                    preview_result={
+                        "reason": "measurement_crashed",
+                        "detail": "measurement_failed",
+                        "source_path": "",
+                    },
+                    message="Preview measurement failed: measurement_crashed",
+                )
+            elif outcome == "historical_null_result":
+                # A genuinely NULL ``result`` column has no public-API
+                # constructor — reach into the fake's own row store directly,
+                # mirroring the real-PG test's raw ``UPDATE ... result = NULL``.
+                db.mark_import_job_failed(job.id, error="unknown")
+                for row in db._import_jobs:
+                    if row["id"] == job.id:
+                        row["result"] = None
+                        break
+            else:
+                raise AssertionError(f"unrecognised outcome {outcome!r}")
 
-        if source_already_deleted:
-            shutil.rmtree(source)
-        return db, source, job
+            if source_already_deleted:
+                shutil.rmtree(source)
+            yield db, source, job
+        finally:
+            shutil.rmtree(root, ignore_errors=True)
 
     @given(
         outcome=st.sampled_from(_WRONG_MATCH_REPLAY_ALL_WORLDS),
@@ -10648,31 +10651,31 @@ class TestForceWrongMatchReceiptStartupReplayGenerated(unittest.TestCase):
     ) -> None:
         from scripts import importer
 
-        db, source, job = self._world(
+        with self._world(
             outcome, source_already_deleted=source_already_deleted,
-        )
-        source_existed_before = os.path.isdir(source)
+        ) as (db, source, job):
+            source_existed_before = os.path.isdir(source)
 
-        importer.recover_abandoned_running_jobs(db)
+            importer.recover_abandoned_running_jobs(db)
 
-        converged = db.get_import_job(job.id)
-        assert converged is not None
-        result = converged.result or {}
-        raw_wrong_match_dismissal = result.get("wrong_match_dismissal")
-        raw_cleanup = result.get("cleanup")
-        raw_receipt = (
-            raw_wrong_match_dismissal
-            if raw_wrong_match_dismissal is not None else raw_cleanup
-        )
-        receipt = raw_receipt if isinstance(raw_receipt, dict) else None
-        violations = wrong_match_replay_violations(
-            outcome=outcome,
-            source_existed_before_replay=source_existed_before,
-            source_exists_after_replay=os.path.exists(source),
-            wrong_match_visible_after_replay=bool(db.get_wrong_matches()),
-            receipt=receipt,
-        )
-        self.assertEqual(violations, [], violations)
+            converged = db.get_import_job(job.id)
+            assert converged is not None
+            result = converged.result or {}
+            raw_wrong_match_dismissal = result.get("wrong_match_dismissal")
+            raw_cleanup = result.get("cleanup")
+            raw_receipt = (
+                raw_wrong_match_dismissal
+                if raw_wrong_match_dismissal is not None else raw_cleanup
+            )
+            receipt = raw_receipt if isinstance(raw_receipt, dict) else None
+            violations = wrong_match_replay_violations(
+                outcome=outcome,
+                source_existed_before_replay=source_existed_before,
+                source_exists_after_replay=os.path.exists(source),
+                wrong_match_visible_after_replay=bool(db.get_wrong_matches()),
+                receipt=receipt,
+            )
+            self.assertEqual(violations, [], violations)
 
 
 class TestWrongMatchReplayViolationsTripOnViolations(unittest.TestCase):

--- a/tests/test_mbid_replace_service.py
+++ b/tests/test_mbid_replace_service.py
@@ -1371,20 +1371,33 @@ class TestReplaceHappyPath(_ServiceCase):
         space, Replace always routes a uniquely resolved current album through
         pinned exact deletion. Status is lifecycle; displacement keys on the
         fresh identity snapshot."""
-        self._patch_externals()
-        beets = self._installed_beets()
-        exact_delete = MagicMock(side_effect=self._completed_delete)
-        _db, _, svc = self._replace(
-            old_status=old_status,
-            beets_db_factory=lambda: beets,
-            beets_delete_fn=exact_delete,
-        )
-        result = svc.replace_request_mbid(
-            42, target_mb_release_id=NEW_MBID,
-        )
-        self.assertEqual(result.outcome, RESULT_REPLACED)
-        exact_delete.assert_called_once()
-        self.assertEqual(exact_delete.call_args.args[0].album_id, 77)
+        # Scoped locally (not via self._patch_externals()/addCleanup) --
+        # Hypothesis re-executes this method body once per example, and
+        # addCleanup only fires once per method (issue #1214 defect class).
+        with (
+            patch(
+                "lib.mbid_replace_service.delete_wrong_match_group",
+                MagicMock(side_effect=_empty_wrong_match_summary),
+            ),
+            patch("lib.mbid_replace_service.trigger_plex_scan", MagicMock()),
+            patch(
+                "lib.mbid_replace_service.trigger_jellyfin_scan",
+                MagicMock(),
+            ),
+        ):
+            beets = self._installed_beets()
+            exact_delete = MagicMock(side_effect=self._completed_delete)
+            _db, _, svc = self._replace(
+                old_status=old_status,
+                beets_db_factory=lambda: beets,
+                beets_delete_fn=exact_delete,
+            )
+            result = svc.replace_request_mbid(
+                42, target_mb_release_id=NEW_MBID,
+            )
+            self.assertEqual(result.outcome, RESULT_REPLACED)
+            exact_delete.assert_called_once()
+            self.assertEqual(exact_delete.call_args.args[0].album_id, 77)
 
     def test_happy_path_downloading_skips_staging_logs_warning(self):
         self._patch_externals()

--- a/tests/test_mbid_replace_service.py
+++ b/tests/test_mbid_replace_service.py
@@ -11,6 +11,8 @@ import os
 import sys
 import tempfile
 import unittest
+from collections.abc import Iterator
+from contextlib import ExitStack, contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
@@ -290,16 +292,19 @@ class _ServiceCase(unittest.TestCase):
             preserved_paths=(),
         )
 
-    def _patch_externals(self):
-        """Patch wrong-match cleanup and the two rescan notifiers.
-
-        Beets deletion is injected through the service constructor; missing
-        current authority is the ordinary no-op default for unrelated tests.
-        Register cleanup via
-        ``self.addCleanup``. Returns the patched mocks as a list so tests
-        can assert on them. Scoped per-test — unlike ``patch.stopall``
-        which would stop EVERY active patch in the process."""
-        patches = [
+    @staticmethod
+    def _external_patches():
+        """The three service-boundary patches every _replace() run needs:
+        wrong-match cleanup and the two rescan notifiers. The ONLY source
+        location that spells these three patch() calls -- both
+        _patch_externals (addCleanup-scoped, per test METHOD) and
+        _patch_externals_scoped (context-manager-scoped, per Hypothesis
+        EXAMPLE, issue #1214) start this SAME list rather than each writing
+        their own patch() calls, so tests/_mock_audit_scanner.py's
+        MULTILINE_PATCH_BASELINE ratchet for
+        lib.mbid_replace_service.delete_wrong_match_group sees exactly one
+        occurrence here, not two."""
+        return [
             patch(
                 "lib.mbid_replace_service.delete_wrong_match_group",
                 MagicMock(side_effect=_empty_wrong_match_summary),
@@ -310,11 +315,33 @@ class _ServiceCase(unittest.TestCase):
                 MagicMock(),
             ),
         ]
+
+    def _patch_externals(self):
+        """Patch wrong-match cleanup and the two rescan notifiers.
+
+        Beets deletion is injected through the service constructor; missing
+        current authority is the ordinary no-op default for unrelated tests.
+        Register cleanup via
+        ``self.addCleanup``. Returns the patched mocks as a list so tests
+        can assert on them. Scoped per-test — unlike ``patch.stopall``
+        which would stop EVERY active patch in the process."""
         mocks = []
-        for p in patches:
+        for p in self._external_patches():
             mocks.append(p.start())
             self.addCleanup(p.stop)
         return mocks
+
+    @contextmanager
+    def _patch_externals_scoped(self) -> Iterator[list[MagicMock]]:
+        """Same three patches as _patch_externals, scoped to a with-block
+        instead of self.addCleanup. addCleanup fires once per test METHOD;
+        Hypothesis re-executes an @given method body once per EXAMPLE, so a
+        helper using addCleanup from inside such a body leaves every
+        earlier example's patches stacked until the whole method returns
+        (issue #1214 defect class). Use this from an @given body instead."""
+        with ExitStack() as stack:
+            mocks = [stack.enter_context(p) for p in self._external_patches()]
+            yield mocks
 
     def _assert_slskd_untouched(self, slskd: object) -> None:
         """Assert FakeSlskdAPI recorded zero calls across every surface.
@@ -1373,18 +1400,11 @@ class TestReplaceHappyPath(_ServiceCase):
         fresh identity snapshot."""
         # Scoped locally (not via self._patch_externals()/addCleanup) --
         # Hypothesis re-executes this method body once per example, and
-        # addCleanup only fires once per method (issue #1214 defect class).
-        with (
-            patch(
-                "lib.mbid_replace_service.delete_wrong_match_group",
-                MagicMock(side_effect=_empty_wrong_match_summary),
-            ),
-            patch("lib.mbid_replace_service.trigger_plex_scan", MagicMock()),
-            patch(
-                "lib.mbid_replace_service.trigger_jellyfin_scan",
-                MagicMock(),
-            ),
-        ):
+        # addCleanup only fires once per method (issue #1214 defect class):
+        # _patch_externals_scoped() shares its patch() calls with
+        # _patch_externals() (see _external_patches) but stops them at the
+        # end of this with-block instead.
+        with self._patch_externals_scoped():
             beets = self._installed_beets()
             exact_delete = MagicMock(side_effect=self._completed_delete)
             _db, _, svc = self._replace(

--- a/tests/test_mbid_replace_service.py
+++ b/tests/test_mbid_replace_service.py
@@ -295,15 +295,20 @@ class _ServiceCase(unittest.TestCase):
     @staticmethod
     def _external_patches():
         """The three service-boundary patches every _replace() run needs:
-        wrong-match cleanup and the two rescan notifiers. The ONLY source
-        location that spells these three patch() calls -- both
-        _patch_externals (addCleanup-scoped, per test METHOD) and
-        _patch_externals_scoped (context-manager-scoped, per Hypothesis
-        EXAMPLE, issue #1214) start this SAME list rather than each writing
-        their own patch() calls, so tests/_mock_audit_scanner.py's
-        MULTILINE_PATCH_BASELINE ratchet for
-        lib.mbid_replace_service.delete_wrong_match_group sees exactly one
-        occurrence here, not two."""
+        wrong-match cleanup and the two rescan notifiers. The one shared
+        source location _patch_externals (addCleanup-scoped, per test
+        METHOD) and _patch_externals_scoped (context-manager-scoped, per
+        Hypothesis EXAMPLE, issue #1214) both start from, rather than each
+        writing their own patch() calls -- so adding
+        _patch_externals_scoped did not add a second new patch() occurrence
+        of the delete_wrong_match_group target for
+        tests/_mock_audit_scanner.py's MULTILINE_PATCH_BASELINE ratchet to
+        count. That same target is also patched inline, pre-existing and
+        unrelated to this helper, at several other sites in this file
+        (already counted in the ratchet's baseline of 9) -- this docstring
+        is about the two Hypothesis-era callers of _external_patches, not a
+        claim that no other patch of this target exists anywhere in the
+        file."""
         return [
             patch(
                 "lib.mbid_replace_service.delete_wrong_match_group",
@@ -356,6 +361,48 @@ class _ServiceCase(unittest.TestCase):
         self.assertEqual(slskd.transfers.get_all_downloads_calls, [])
         self.assertEqual(slskd.users.directory_calls, [])
         self.assertEqual(slskd.users.status_calls, [])
+
+
+class TestPatchExternalsScopedPatchesTheSameTargets(_ServiceCase):
+    """Issue #1214 review finding F3: prove ``_patch_externals_scoped()``
+    patches the SAME three module attributes ``_patch_externals()`` does,
+    not merely that both call ``_external_patches()`` by construction.
+    Two mutants at ``_external_patches()``/``_patch_externals_scoped()``
+    left every other test in this module green (review finding F3):
+    dropping the ``delete_wrong_match_group`` entry from the shared list,
+    and making the scoped helper yield fresh, never-entered ``MagicMock()``
+    objects. This test fails on both -- see the issue #1214 kill matrix."""
+
+    def test_patch_externals_scoped_patches_the_same_three_targets(
+        self,
+    ) -> None:
+        import lib.mbid_replace_service as svc_mod
+
+        original_delete = svc_mod.delete_wrong_match_group
+        original_plex = svc_mod.trigger_plex_scan
+        original_jellyfin = svc_mod.trigger_jellyfin_scan
+
+        with self._patch_externals_scoped() as mocks:
+            self.assertEqual(len(mocks), 3)
+            # Each module attribute really was replaced by the SAME mock
+            # _patch_externals_scoped() handed back -- not three fresh,
+            # disconnected MagicMock()s nothing ever entered.
+            self.assertIs(svc_mod.delete_wrong_match_group, mocks[0])
+            self.assertIs(svc_mod.trigger_plex_scan, mocks[1])
+            self.assertIs(svc_mod.trigger_jellyfin_scan, mocks[2])
+            self.assertIsNot(svc_mod.delete_wrong_match_group, original_delete)
+            self.assertIsNot(svc_mod.trigger_plex_scan, original_plex)
+            self.assertIsNot(svc_mod.trigger_jellyfin_scan, original_jellyfin)
+            # The delete_wrong_match_group mock keeps _external_patches()'s
+            # own side_effect -- proves this came from the SAME shared list
+            # _patch_externals() uses, not an independently-invented patch.
+            self.assertIs(mocks[0].side_effect, _empty_wrong_match_summary)
+
+        # Restored after the with-block exits -- the same contract
+        # _patch_externals() gives via self.addCleanup(p.stop).
+        self.assertIs(svc_mod.delete_wrong_match_group, original_delete)
+        self.assertIs(svc_mod.trigger_plex_scan, original_plex)
+        self.assertIs(svc_mod.trigger_jellyfin_scan, original_jellyfin)
 
 
 class TestReplaceOutcomeMatrix(_ServiceCase):


### PR DESCRIPTION
Closes #1214 (root cause + the guard that stops it recurring).

## What broke

`cratedigger-daily-checks.service` failed 2026-08-20 05:05 on tmpfs ENOSPC during the generated fuzz burst — `1368 completed of 4586; 3218 not started; property verdict invalid`, unit peak `26.4G`.

## Root cause

`BeetsContractWorld` was constructed **inside `@given` bodies** with cleanup registered via `unittest`'s `addCleanup`:

```python
world = BeetsContractWorld()
self.addCleanup(world.close)
```

Hypothesis re-executes the body once per example; `addCleanup` fires once per **test method**. Every example therefore leaked a live world until the method returned, and each world holds *two* `tempfile.TemporaryDirectory` trees — one under `TMPDIR`, one under `/dev/shm`.

Because cgroup v2 `memory.peak` counts tmpfs pages, this presented as a *memory* problem: on 2026-08-19 the fuzz phase's `shmem_at_memory_current_peak` was 14.82 GB of a 21.39 GB peak — **69% of "memory" was the scratch tree**.

## Measured effect

One test class at the daily gate's real per-shard budget (`CRATEDIGGER_FUZZ_MAX_EXAMPLES=2500`):

| | peak resident worlds | peak bytes |
|---|---|---|
| before | 2491 (+2492 in `/dev/shm`) | **1.59 GB** |
| after | **1** | **0.64 MB** |

Independently reproduced by review at 300 examples: base 299 worlds / 182.20 MB → HEAD 1 world / 0.61 MB, with `/dev/shm` confirming at most one world sealed at a time.

## The fix

Every leaking site now binds the world's lifetime to the example that created it (`with BeetsContractWorld() as world:`). **42 direct sites** converted (31 in `test_beets_config_contract_generated.py`, 9 in `..._regressions_generated.py`, 2 in `test_beets_config_startup_generated.py`), plus **3 helper-mediated instances** of the same defect class found by widening the sweep:

- `tests/test_import_queue.py::_world` → `@contextmanager` with `try/finally`
- `tests/test_mbid_replace_service.py::_patch_externals` → `_patch_externals_scoped()` via `ExitStack`
- `tests/test_automation_recovery_debris_generated.py` → locally-scoped `TemporaryDirectory` (shared mixin left untouched for its ~15 other callers)

Review verified by AST canonicalisation that **no assertion changed meaning** across all conversions.

## The guard

`tests/test_given_body_cleanup_audit.py` — a bounded, fail-closed AST audit with two clauses:

1. no `self.addCleanup`/`self.enterContext` (and async twins) lexically inside a `@given`-decorated function;
2. no bare construction of a policed resource inside a `@given` body with no cleanup at all — a *strictly worse* shape, since an unsealed `BeetsContractWorld` strands an operator-unremovable `/dev/shm` directory (`cleanup()` while sealed raises `PermissionError`; only a real `close()` removes it).

Deliberately bounded: it does not trace calls (that would be the prohibited semantic-scanner shape), and the docstring states that bound. Deterministic-only per `code-quality.md` — test machinery gets an exact pin plus an end-to-end contract, never a Hypothesis property.

## Kill matrix

| Site (assertion / clause / constant) | One-line mutant | Test that goes RED | Result |
| --- | --- | --- | --- |
| `tests/fakes/beets_contract.py::__exit__` | body → `pass` | `test_beets_contract_world_lifetime` | RED |
| `tests/fakes/beets_contract.py::close` finally | drop `self._authority_tmp.cleanup()` (leak `/dev/shm` half only) | `test_beets_contract_world_lifetime` | RED |
| `tests/fakes/beets_contract.py::close` finally | drop `self._tmp.cleanup()` | `test_beets_contract_world_lifetime` | RED |
| `tests/fakes/beets_contract.py::__exit__` | `unseal()` only, never `close()` | `test_beets_contract_world_lifetime` | RED |
| same mutant vs the **pre-correction** pin | — | old pin | **passes** — proves the strong-reference correction was load-bearing |
| `test_beets_config_contract_generated.py:186` | revert one site to `world = ...; self.addCleanup(world.close)` | `test_given_body_cleanup_audit` | RED, names the exact site |
| `audit_tests_tree` | audit an empty source string | planted-violation driver test | RED |
| `iter_tests_tree_modules` | skip `*_generated.py` | `*_generated.py` walk-coverage pin | RED |
| `_ServiceCase._external_patches` | drop the `delete_wrong_match_group` entry | `TestPatchExternalsScopedPatchesTheSameTargets` | RED (`2 != 3`) |
| `_ServiceCase._patch_externals_scoped` | yield fresh unentered `MagicMock()`s | `TestPatchExternalsScopedPatchesTheSameTargets` | RED (`assertIs`) |
| `_ServiceCase._patch_externals_scoped` | `p.start()` without stop (no restore) | `TestPatchExternalsScopedPatchesTheSameTargets` | RED |
| bare-construction clause | construct a policed resource with no cleanup | `test_bare_construction_with_no_cleanup_at_all_is_rejected` | RED |

## Review

Two independent reviews (three rounds). Round 2 found the pin patrolled the fixture's *protocol* rather than its *usage* — reverting a converted call site left the module green; that produced the AST audit. Round 3 found the audit's own driver unguarded (two one-line mutants left a real reintroduced violation green), a false OOM characterisation of the incident, and the blind spot that became clause 2.

## Accepted residual

A hard SIGKILL between `_seal()` and `unseal()` strands ~16 KB per world in `/dev/shm`, owner-unremovable without `unshare --map-root-user --map-auto chown`. Reclaiming needs the privilege escalation that lives in this fixture, so no reaper can own it. Structural: `lib/beets_config_contract.py::_has_app_owned_component` walks every path component and returns True on the first euid-owned entry, so any real-user-owned buffer directory would break the sealed/admitted baseline the contract tests depend on. Exposure is now capped at **one** sealed world at a time (was up to 2500). The 2026-08-20 incident itself was an ENOSPC *exception*, which unwinds `with` blocks — so `__exit__ → close() → unseal()` runs and this path handles it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
