### PR TITLE
fix(#1208): reap leaked test scratch under an ownership marker, and retire final-gate receipts

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -468,6 +468,31 @@ override and the reaper looks in a different directory than the scratch
 trees it exists to reap. Latent: nothing in this repository sets that
 override outside tests and one doc recipe.
 
+Two more known residuals of the same design (issue #1208 review D-F4,
+D-F6):
+
+- The recursive walk (`_scratch_tree_last_activity`) only helps when a
+  descendant WRITES within `max_age_seconds`. A descendant that is alive
+  but genuinely quiet — a shell blocked on `read`/`sleep`, holding the
+  tree open with nothing touching any mtime — falls back to exactly the
+  mtime heuristic this design otherwise argues against; the owner-death
+  marker distinguishes "abandoned" from "idle" for the SHELL itself, but
+  says nothing about a live-but-quiet descendant of an already-dead
+  owner. Reproduced directly: a real SIGKILLed owner whose `bash`/`sleep`
+  descendants were still alive and holding `$TMPDIR` was reaped anyway,
+  because they were quiet.
+- **Operationally important**: every `cratedigger-tests.*` tree created
+  by a shell running BEFORE this fix lands has no `.owner` marker at
+  all — fail-closed means such a tree is never reaped, forever, by this
+  mechanism (a missing marker is "unknown", never "abandoned"). The
+  founding incident's own leaked-tree cohort is exactly this shape.
+  Deploying this fix does not retroactively clean up that cohort; it
+  only stops the leak going forward. A one-time manual sweep of
+  markerless `cratedigger-tests.*` trees whose owning shell is
+  genuinely gone (per scope.md: an operator/agent-run one-shot, never
+  committed machinery) clears the pre-existing backlog once, after this
+  lands.
+
 The 4-hour floor protects the bundle's detailed EVIDENCE (per-phase logs,
 summary.md), not receipt reuse itself: `run_final_gate.sh status` checks a
 receipt's `bundle` FILE (a path string) and now separately stats the

--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -428,29 +428,60 @@ legitimately needs to nest.) Only a genuinely interactive `nix-shell` entry,
 started outside any suite run, never has this var set and keeps its entry
 guard.
 
-Once admitted, `run_suite` best-effort reaps scratch directories nothing can
-still be writing (`reap_stale_check_bundles`, prefix set
-`_REAPABLE_PREFIXES`: `cratedigger-checks.*` bundles plus this test-infra
-change's own `cratedigger-{suite,admission,reap,headroom}-test-*` fixture
-directories, so a killed test process can't leak one forever) idle past
+Once admitted, `run_suite` first retires eligible final-gate receipts
+(`reap_stale_final_gate_receipts`, issue #1208 item 4), THEN best-effort
+reaps scratch directories nothing can still be writing
+(`reap_stale_check_bundles`, prefix set `_REAPABLE_PREFIXES`:
+`cratedigger-checks.*` bundles, this test-infra change's own
+`cratedigger-{suite,admission,reap,headroom}-test-*` fixture directories,
+and the dev shell's OWN main scratch `TMPDIR` (`SCRATCH_TREE_PREFIX`,
+`cratedigger-tests.*`, issue #1208 item 1) idle past
 `DEFAULT_STALE_BUNDLE_MAX_AGE_SECONDS` — safe for another `run_suite`'s own
 bundles specifically, because reaping happens exclusively under the same
 lock every `run_suite` call takes; it is NOT a claim about every possible
 creator of a matching prefix — `tests/test_final_gate_receipt.py` constructs
 a `cratedigger-checks.*` fixture directly, outside `run_suite` and outside
-the lock, and the age gate (not lock exclusivity) is what protects it. The
-4-hour floor protects the bundle's detailed EVIDENCE (per-phase logs,
+the lock, and the age gate (not lock exclusivity) is what protects it.
+
+`SCRATCH_TREE_PREFIX` is the one prefix the age gate alone does NOT protect:
+`scripts/test_tmpfs.sh` creates it at `nix-shell` entry, outside the
+admission lock, and cleans it up only via a shell EXIT trap — SIGTERM,
+SIGINT, and SIGHUP all run that trap correctly; only SIGKILL (the OOM
+killer, `kill -9`, host loss) skips it and leaks the tree forever, and a
+busy suite's own scratch root can go quiet (old mtime) for hours while very
+much in use, so mtime cannot distinguish "abandoned" from "just idle". A
+prior attempt reaped this prefix on mtime alone and was reverted after
+review found it reaping LIVE trees. The shipped design instead requires
+`_scratch_tree_owner_dead` to PROVE the owning shell process is gone before
+the age gate ever applies to a `cratedigger-tests.*` entry: `test_tmpfs.sh`
+writes a `.owner` marker (`"<pid> <ticks>\n"`, same content shape as the
+admission-lock holder identity below) immediately after `mktemp`, and
+`_scratch_tree_owner_dead` verifies it with the same pid-reuse-safe
+`_proc_start_ticks` comparison. A live owner is never touched regardless of
+age; a missing or malformed marker fails closed (treated as "unknown,
+never reap", not "abandoned") rather than falling back to age alone.
+
+The 4-hour floor protects the bundle's detailed EVIDENCE (per-phase logs,
 summary.md), not receipt reuse itself: `run_final_gate.sh status` checks a
 receipt's `bundle` FILE (a path string) and now separately stats the
 directory it names, failing visibly when it is gone rather than silently
 reporting `pass` over evidence that no longer exists — a receipt's own
 `terminal` verdict was always durable regardless of this floor. Before the
 age gate ever applies, `_receipt_protected_bundles` excludes any bundle path
-still named by a `cratedigger-final-gate.*/bundle` file (receipts are never
-themselves reaped — a different, unlisted prefix) — so a bundle a live
-receipt still references survives regardless of age, preserving both the
-verdict and its evidence for a long-running review (issue #1111 review
-m13). A receipt whose protected bundle turns out to be missing anyway is a
+still named by a `cratedigger-final-gate.*/bundle` file — so a bundle a
+still-present receipt still references survives regardless of age,
+preserving both the verdict and its evidence for a long-running review
+(issue #1111 review m13). Receipts are no longer permanently unreaped:
+`reap_stale_final_gate_receipts` deletes one once its `terminal` file
+exists OR its recorded helper/gate pid+start-ticks identities are
+conclusively dead — never one still live — AND it is older than
+`DEFAULT_RECEIPT_RETIREMENT_MAX_AGE_SECONDS` (a fixed 7-day constant, not
+an env-overridable knob). A retired receipt is gone from disk before
+`_receipt_protected_bundles` glob-scans `cratedigger-final-gate.*` on this
+same admitted pass, so retirement lapses that receipt's own bundle
+protection immediately, with no second cleanup path: the now-unprotected
+bundle ages out through this function's ordinary path like any other. A
+receipt whose protected bundle turns out to be missing anyway is a
 genuinely dangling receipt; the protection does not paper over that —
 `status`'s own stat check surfaces it, and the honest response is to
 re-run.

--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -460,6 +460,13 @@ admission-lock holder identity below) immediately after `mktemp`, and
 `_proc_start_ticks` comparison. A live owner is never touched regardless of
 age; a missing or malformed marker fails closed (treated as "unknown,
 never reap", not "abandoned") rather than falling back to age alone.
+Known residual (issue #1208 review D7): the reaper resolves its runtime
+root from `XDG_RUNTIME_DIR` only (`private_runtime_dir`), while
+`_check_suite_headroom` below and `scripts/test_tmpfs.sh`'s own scratch-
+tree parent both honor a `CRATEDIGGER_TEST_RAM_ROOT` override — set that
+override and the reaper looks in a different directory than the scratch
+trees it exists to reap. Latent: nothing in this repository sets that
+override outside tests and one doc recipe.
 
 The 4-hour floor protects the bundle's detailed EVIDENCE (per-phase logs,
 summary.md), not receipt reuse itself: `run_final_gate.sh status` checks a

--- a/.claude/skills/check/SKILL.md
+++ b/.claude/skills/check/SKILL.md
@@ -39,14 +39,18 @@ atomically writes `terminal` only after the command exits. The bundle — while
 it still exists — contains the typed summaries and complete per-phase logs.
 A second concurrently-launched canonical suite on this shared host waits on
 `run_suite`'s own admission lock rather than colliding with this one; once
-admitted it best-effort reaps check bundles idle past ~4 hours
-(`scripts/run_test_suite.py::DEFAULT_STALE_BUNDLE_MAX_AGE_SECONDS`), but never
-one this receipt still references — `status` (below) still stats the bundle
-path and fails visibly rather than silently reporting `pass` over evidence
-that no longer exists. A dangling receipt (bundle gone despite that
-protection) means something genuinely unusual happened to it outside the
-normal reap path — the honest response is to re-run the gate, not to trust
-the stale `terminal` verdict.
+admitted it first retires eligible receipts
+(`scripts/run_test_suite.py::reap_stale_final_gate_receipts`, issue #1208
+item 4 — a receipt whose lifecycle is provably over, `terminal` present or
+its recorded helper/gate process identities conclusively dead, AND older
+than a fixed 7-day floor), then best-effort reaps check bundles idle past
+~4 hours (`DEFAULT_STALE_BUNDLE_MAX_AGE_SECONDS`), but never one a still-
+present receipt references — `status` (below) still stats the bundle path
+and fails visibly rather than silently reporting `pass` over evidence that
+no longer exists. A dangling receipt (bundle gone despite that protection)
+means something genuinely unusual happened to it outside the normal reap
+path — the honest response is to re-run the gate, not to trust the stale
+`terminal` verdict.
 
 If the client detaches, recover the exact invocation from the same committed clean
 worktree:
@@ -58,7 +62,10 @@ still match; recover it rather than launching a duplicate. `pass` and `fail` are
 terminal; `incomplete` means no terminal result was recorded. A matching `pass`
 receipt prevents rerunning that unchanged gate. Never treat `fail` or
 `incomplete` as green; choose the next action explicitly. Receipts are never
-retried or deleted automatically.
+retried automatically, and a live or recent one is never deleted automatically
+either — only a receipt that is both conclusively finished-or-dead AND older
+than the 7-day retirement floor above is ever removed, and only by a later
+admitted suite run's own reap pass (issue #1208 item 4).
 
 The isolated final-gate worktree must remain exclusively owned for the entire
 gate. The receipt rechecks its HEAD and clean state immediately before terminal

--- a/scripts/run_test_suite.py
+++ b/scripts/run_test_suite.py
@@ -236,7 +236,19 @@ def dirty_state_fingerprint(repo_root: Path) -> tuple[bool, str]:
 
 
 def private_runtime_dir(candidate: Path | None = None) -> Path:
-    """Resolve and validate the caller-owned runtime tmpfs."""
+    """Resolve and validate the caller-owned runtime tmpfs.
+
+    Issue #1208 review D7 (documented, not changed here to avoid a merge
+    collision with concurrent headroom-logic work in this same file): this
+    reads ``XDG_RUNTIME_DIR`` only, with no ``CRATEDIGGER_TEST_RAM_ROOT``
+    override — unlike ``_check_suite_headroom`` below and
+    ``scripts/test_tmpfs.sh``'s own scratch-tree parent, both of which DO
+    honor that override. With ``CRATEDIGGER_TEST_RAM_ROOT`` set, the
+    reaper (this module) and the scratch trees it exists to reap
+    (``scripts/test_tmpfs.sh``) would resolve to DIFFERENT directories,
+    so item 1's fix would not apply at all. Latent today: nothing in this
+    repository sets that override outside tests and one doc recipe.
+    """
     runtime = candidate or Path(
         os.environ.get("XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}")
     )
@@ -312,19 +324,69 @@ def admission_lock_path(runtime: Path) -> Path:
     return runtime / ".cratedigger-test-admission.lock"
 
 
-def _proc_start_ticks(pid: int) -> str | None:
-    """Field 22 of /proc/<pid>/stat — mirrors run_final_gate.sh's proc_start_ticks."""
+def _read_proc_stat(pid: int) -> str:
+    """Real ``/proc/<pid>/stat`` reader — the sole production default for
+    ``_proc_stat_start_ticks`` below."""
+    return Path(f"/proc/{pid}/stat").read_text()
+
+
+def _proc_stat_start_ticks(
+    pid: int, *, read_stat: Callable[[int], str] = _read_proc_stat
+) -> tuple[bool, str | None]:
+    """(confirmed_absent, start_ticks) for /proc/<pid>/stat — field 22.
+
+    Three real outcomes, not two: the pid is CONFIRMED gone (``ENOENT`` —
+    the kernel's own proof no such process exists); the pid exists and its
+    start ticks were read and parsed; or the read failed for some OTHER
+    reason (a permission boundary, e.g. a restrictive ``hidepid`` mount, or
+    a malformed stat line) and liveness could not be determined AT ALL.
+    Only the first case returns ``confirmed_absent=True`` — every other
+    failure mode, including a failed read, returns ``False`` there, because
+    "cannot verify" is never the same fact as "confirmed gone" (issue
+    #1208 review D4).
+
+    ``_proc_start_ticks`` below collapses the second and third outcomes
+    into one ``None`` — the right posture for its own callers (the
+    admission-lock holder identity, receipt liveness): "unverified"
+    already degrades to "not live" there, and the worst consequence is a
+    wrong display name or an unretired receipt. ``_scratch_tree_owner_dead``
+    needs the finer distinction, because ITS decision is deletion: treating
+    "cannot verify" as "provably dead" there is exactly the conflation
+    issue #1208 review D4 named, so it calls this function directly
+    instead of going through the collapsed wrapper.
+
+    ``read_stat`` is a kwarg-DI seam (code-quality.md "Picking a
+    strategy" #2): production always uses the real default
+    (``_read_proc_stat``); tests inject a fake to exercise the
+    non-``FileNotFoundError`` OSError branch and the malformed-content
+    branch, neither of which is constructible against a real ``/proc``
+    entry without root or a user-namespace remap.
+    """
     try:
-        raw = Path(f"/proc/{pid}/stat").read_text()
+        raw = read_stat(pid)
+    except FileNotFoundError:
+        return True, None
     except OSError:
-        return None
+        return False, None
     close = raw.rfind(")")
     if close == -1:
-        return None
+        return False, None
     fields = raw[close + 2 :].split()
     if len(fields) < 20:
-        return None
-    return fields[19]
+        return False, None
+    return False, fields[19]
+
+
+def _proc_start_ticks(pid: int) -> str | None:
+    """Field 22 of /proc/<pid>/stat — mirrors run_final_gate.sh's proc_start_ticks.
+
+    A thin wrapper over ``_proc_stat_start_ticks`` that collapses "confirmed
+    gone" and "cannot verify" into the same ``None`` — see that function's
+    docstring for why that collapse is correct for THIS function's callers
+    but not for ``_scratch_tree_owner_dead``.
+    """
+    _confirmed_absent, ticks = _proc_stat_start_ticks(pid)
+    return ticks
 
 
 def _write_lock_holder_identity(descriptor: int) -> None:
@@ -481,6 +543,52 @@ def _bundle_last_activity(bundle: Path) -> float:
         return 0.0
 
 
+def _scratch_tree_last_activity(tree: Path) -> float:
+    """Most recent mtime anywhere WITHIN ``tree``, not just its own top-level dir.
+
+    ``_bundle_last_activity`` (above) is right for a ``run_suite`` check
+    bundle: ``run_suite`` is the bundle's only writer, and it writes
+    ``summary.json`` at the top level as its very last act, so the bundle's
+    own dirent set is exactly what changes as work happens.
+
+    A dev-shell scratch tree (``SCRATCH_TREE_PREFIX``) has no such shape
+    (issue #1208 review D3). Its own top-level directory mtime is bumped
+    only by a DIRECT child dirent change (create/delete/rename of an
+    immediate child) — a process writing INTO an existing nested
+    subdirectory never touches it. The owning shell's own children, or an
+    orphaned descendant that outlives the shell itself (e.g. issue #1214's
+    fuzz burst, which takes neither the admission lock nor a headroom
+    guard), can write deep inside the tree for the whole run without the
+    top-level dir's own mtime ever moving — so an age gate keyed on that
+    one timestamp can silently stop tracking real activity long before
+    writing actually stops, exactly the "mtime cannot distinguish
+    abandoned from just idle" argument the ownership-marker design itself
+    makes, just one level deeper. Walks the whole tree and returns the
+    maximum mtime observed on any entry (falling back to the tree's own
+    mtime on an empty tree or any walk error), so ongoing nested activity
+    is never mistaken for staleness. Deliberately does NOT check
+    ``summary.json`` — nothing writes one inside a scratch tree today, and
+    checking it here would silently key the age gate on a file that
+    happens to share a name with an unrelated concept.
+    """
+    latest = 0.0
+    try:
+        latest = tree.stat().st_mtime
+    except OSError:
+        pass
+    try:
+        for root, dirs, files in os.walk(tree, onerror=lambda _exc: None):
+            for name in (*dirs, *files):
+                try:
+                    entry_mtime = os.lstat(os.path.join(root, name)).st_mtime
+                except OSError:
+                    continue
+                latest = max(latest, entry_mtime)
+    except OSError:
+        pass
+    return latest
+
+
 #: Directory-name prefixes the reaper protects the shared runtime tmpfs from
 #: leaking forever: ``run_suite``'s own check bundles, plus this test-infra
 #: change's own per-test scratch directories (``tests/test_suite_coordinator.py``)
@@ -530,19 +638,30 @@ _REAPABLE_PREFIXES = (
 SCRATCH_TREE_OWNER_MARKER_NAME = ".owner"
 
 
-def _scratch_tree_owner_dead(tree: Path) -> bool:
+def _scratch_tree_owner_dead(
+    tree: Path,
+    *,
+    proc_stat: Callable[[int], tuple[bool, str | None]] = _proc_stat_start_ticks,
+) -> bool:
     """True only when ``tree``'s recorded pid+start-ticks owner is PROVABLY gone.
 
     Returns ``False`` — never eligible for reaping by this signal — for
     every case that is not a proven death: a missing marker file (the
     shell died before ``mktemp`` returned, or in the brief window before
-    the marker write in ``scripts/test_tmpfs.sh``), unreadable content, or
-    a malformed pid/ticks pair. ``False`` here means "unknown", not
-    "alive"; the caller must treat unknown exactly like alive. Only a
-    syntactically well-formed marker whose ``_proc_start_ticks(pid) !=
-    ticks`` (the process is gone, or — since start ticks make pid reuse
-    detectable, the same precedent ``_read_lock_holder_identity`` already
-    relies on — a different, unrelated process now holds that pid)
+    the marker write in ``scripts/test_tmpfs.sh``), unreadable content, a
+    malformed pid/ticks pair, or a ``/proc`` read that failed for a reason
+    OTHER than the pid being confirmed gone (issue #1208 review D4 — a
+    permission boundary such as a restrictive ``hidepid`` mount, or a
+    malformed stat line, is "cannot verify", never "provably dead"; this
+    calls ``_proc_stat_start_ticks`` directly, not the collapsed
+    ``_proc_start_ticks`` wrapper, specifically to keep that distinction —
+    see its docstring). ``False`` here means "unknown", not "alive"; the
+    caller must treat unknown exactly like alive. Only a syntactically
+    well-formed marker naming a pid the kernel CONFIRMS is gone, or one
+    whose current start ticks were read successfully and differ from the
+    recorded value (the process is gone, or — since start ticks make pid
+    reuse detectable, the same precedent ``_read_lock_holder_identity``
+    already relies on — a different, unrelated process now holds that pid)
     returns ``True``.
 
     This is the fail-closed half of issue #1208 item 1's ownership-marker
@@ -558,7 +677,12 @@ def _scratch_tree_owner_dead(tree: Path) -> bool:
     if len(parts) != 2 or not all(part.isdigit() for part in parts):
         return False
     pid_str, ticks = parts
-    return _proc_start_ticks(int(pid_str)) != ticks
+    confirmed_absent, current_ticks = proc_stat(int(pid_str))
+    if confirmed_absent:
+        return True
+    if current_ticks is None:
+        return False
+    return current_ticks != ticks
 
 
 def _receipt_protected_bundles(runtime: Path) -> frozenset[Path]:
@@ -613,7 +737,14 @@ def _receipt_last_activity(receipt: Path) -> float:
     finished and the tree-match check has passed — so its mtime is the true
     "this receipt became final" timestamp for a completed run. A receipt
     that never reached that point (crashed, interrupted) falls back to the
-    receipt directory's own mtime, which only ever gets older.
+    receipt directory's own mtime — issue #1208 review D8: that is NOT a
+    timestamp that "only ever gets older". ``run_gate`` writes roughly ten
+    files into the receipt over the run (``repo_root``, ``head``, ``clean``,
+    ``command``, ``helper_pid``, ``helper_start_ticks``, ``output.log``,
+    ``gate_pid``, ``gate_start_ticks``, ...), and each new dirent bumps the
+    directory's own mtime — the true claim is only that it stops moving
+    once nothing more is written into it, which for a crashed or
+    interrupted run is exactly when the crash happened.
     """
     try:
         return (receipt / "terminal").stat().st_mtime
@@ -745,7 +876,13 @@ def reap_stale_check_bundles(
     treated as unknown liveness, never as abandoned. Every other prefix
     keeps the pure age gate described above; only this one has a
     provable-death precondition, because only this one has an owning
-    process capable of writing it one.
+    process capable of writing it one. Its age itself is also computed
+    differently (``_scratch_tree_last_activity``, not
+    ``_bundle_last_activity``): a scratch tree's own top-level directory
+    mtime does not move when something writes into an existing nested
+    subdirectory, so an owner-dead-but-still-being-written-by-a-descendant
+    tree (issue #1208 review D3) is protected by walking the whole tree
+    for its true most recent activity, not just its top-level dirent.
     """
     reference = reference_time if reference_time is not None else time.time()
     protected = _receipt_protected_bundles(runtime)
@@ -768,11 +905,15 @@ def reap_stale_check_bundles(
             continue
         if info.st_uid != os.getuid():
             continue
-        if candidate.name.startswith(
-            SCRATCH_TREE_PREFIX
-        ) and not _scratch_tree_owner_dead(candidate):
+        is_scratch_tree = candidate.name.startswith(SCRATCH_TREE_PREFIX)
+        if is_scratch_tree and not _scratch_tree_owner_dead(candidate):
             continue
-        age = reference - _bundle_last_activity(candidate)
+        last_activity = (
+            _scratch_tree_last_activity(candidate)
+            if is_scratch_tree
+            else _bundle_last_activity(candidate)
+        )
+        age = reference - last_activity
         if age < max_age_seconds:
             continue
         try:

--- a/scripts/run_test_suite.py
+++ b/scripts/run_test_suite.py
@@ -326,8 +326,18 @@ def admission_lock_path(runtime: Path) -> Path:
 
 def _read_proc_stat(pid: int) -> str:
     """Real ``/proc/<pid>/stat`` reader — the sole production default for
-    ``_proc_stat_start_ticks`` below."""
-    return Path(f"/proc/{pid}/stat").read_text()
+    ``_proc_stat_start_ticks`` below.
+
+    Issue #1208 review D-F7: ``Path.read_text()`` with the default codec
+    can raise ``UnicodeDecodeError`` — a ``ValueError``, not an
+    ``OSError`` — which would escape ``_proc_stat_start_ticks``'s
+    ``except OSError`` and abort the whole suite rather than degrading to
+    "cannot verify" like every other read failure here.
+    ``errors="replace"`` makes a decode failure produce mangled-but-valid
+    text instead (which then correctly fails the caller's field-count /
+    digit checks), never an exception this reader's caller cannot catch.
+    """
+    return Path(f"/proc/{pid}/stat").read_text(errors="replace")
 
 
 def _proc_stat_start_ticks(
@@ -361,6 +371,19 @@ def _proc_stat_start_ticks(
     non-``FileNotFoundError`` OSError branch and the malformed-content
     branch, neither of which is constructible against a real ``/proc``
     entry without root or a user-namespace remap.
+
+    Acknowledged residual (issue #1208 review D6 follow-up): ``ENOENT``
+    means "no such pid IN THIS PROCESS'S OWN PID NAMESPACE" — an owner
+    process alive in a DIFFERENT pid namespace (one this reader cannot
+    see into) would read as ``ENOENT`` here too, and be treated as
+    ``confirmed_absent=True`` exactly like a genuinely dead process.
+    Unreachable today: nothing in this repository ever enters a pid
+    namespace (the ``unshare`` calls elsewhere in this test suite remap
+    USER namespaces only, for uid manipulation — a completely different
+    namespace kind — never pid namespaces), so every real caller and
+    every real owning shell share the host's single pid namespace. Stated
+    here rather than defended against, since there is nothing in this
+    codebase that could construct the scenario to defend against.
     """
     try:
         raw = read_stat(pid)
@@ -563,13 +586,28 @@ def _scratch_tree_last_activity(tree: Path) -> float:
     one timestamp can silently stop tracking real activity long before
     writing actually stops, exactly the "mtime cannot distinguish
     abandoned from just idle" argument the ownership-marker design itself
-    makes, just one level deeper. Walks the whole tree and returns the
-    maximum mtime observed on any entry (falling back to the tree's own
-    mtime on an empty tree or any walk error), so ongoing nested activity
-    is never mistaken for staleness. Deliberately does NOT check
-    ``summary.json`` — nothing writes one inside a scratch tree today, and
-    checking it here would silently key the age gate on a file that
-    happens to share a name with an unrelated concept.
+    makes, just one level deeper. Walks the whole tree, seeds ``latest``
+    with the tree's own top-level mtime, and takes the maximum observed
+    across every entry, so ongoing nested activity that WRITES within
+    ``max_age_seconds`` is never mistaken for staleness.
+
+    Stated limitation (issue #1208 review D-F4): this only helps when a
+    descendant WRITES. A descendant that is alive but genuinely quiet — a
+    shell blocked on ``read``/``sleep`` while holding the tree open, with
+    nothing touching any mtime — falls back to exactly the mtime
+    heuristic this rationale argues against; the owner-death marker is
+    what actually distinguishes "abandoned" from "idle" for the SHELL
+    itself, but says nothing about a descendant of a dead owner that is
+    still alive and simply not writing. Reproduced directly: a real
+    SIGKILLed owner whose ``bash``/``sleep`` descendants were still alive
+    and holding ``$TMPDIR`` was reaped anyway, because they were quiet.
+    Not a defect this function can fix on its own — recorded as a known
+    residual of the composed design.
+
+    Deliberately does NOT check ``summary.json`` — nothing writes one
+    inside a scratch tree today, and checking it here would silently key
+    the age gate on a file that happens to share a name with an unrelated
+    concept.
     """
     latest = 0.0
     try:
@@ -674,7 +712,11 @@ def _scratch_tree_owner_dead(
     except OSError:
         return False
     parts = content.split()
-    if len(parts) != 2 or not all(part.isdigit() for part in parts):
+    # issue #1208 review D-F7: isdigit() (not isdecimal()) would accept
+    # e.g. the superscript "²" — True for isdigit(), but int("²") raises
+    # ValueError, escaping uncaught and aborting the whole suite.
+    # isdecimal() is the correct predicate for "int() can parse this".
+    if len(parts) != 2 or not all(part.isdecimal() for part in parts):
         return False
     pid_str, ticks = parts
     confirmed_absent, current_ticks = proc_stat(int(pid_str))
@@ -769,11 +811,13 @@ def _receipt_process_field_live(
     ``_read_lock_holder_identity`` already takes for the admission lock.
     """
     try:
-        pid_text = (receipt / pid_field).read_text().strip()
-        ticks_text = (receipt / ticks_field).read_text().strip()
+        pid_text = (receipt / pid_field).read_text(errors="replace").strip()
+        ticks_text = (receipt / ticks_field).read_text(errors="replace").strip()
     except OSError:
         return False
-    if not pid_text.isdigit() or not ticks_text.isdigit():
+    # issue #1208 review D-F7: isdecimal(), not isdigit() — see
+    # _scratch_tree_owner_dead's identical fix for why.
+    if not pid_text.isdecimal() or not ticks_text.isdecimal():
         return False
     return _proc_start_ticks(int(pid_text)) == ticks_text
 
@@ -875,8 +919,10 @@ def reap_stale_check_bundles(
     never reaped regardless of age, and a missing/malformed marker is
     treated as unknown liveness, never as abandoned. Every other prefix
     keeps the pure age gate described above; only this one has a
-    provable-death precondition, because only this one has an owning
-    process capable of writing it one. Its age itself is also computed
+    provable-death precondition (issue #1208 review D-F8: every prefix's
+    creator is, in principle, a process capable of writing an ownership
+    marker — this one is simply the only prefix whose creator actually
+    DOES). Its age itself is also computed
     differently (``_scratch_tree_last_activity``, not
     ``_bundle_last_activity``): a scratch tree's own top-level directory
     mtime does not move when something writes into an existing nested

--- a/scripts/run_test_suite.py
+++ b/scripts/run_test_suite.py
@@ -488,27 +488,99 @@ def _bundle_last_activity(bundle: Path) -> float:
 #: fixture before ``tearDown`` can remove it, in the exact directory this PR
 #: exists to keep clean. Age-gated the same way as check bundles; a fresh
 #: fixture belonging to a currently-running test is never touched.
+#:
+#: ``SCRATCH_TREE_PREFIX`` (issue #1208 item 1) is the dev shell's OWN main
+#: scratch ``TMPDIR``: ``scripts/test_tmpfs.sh``'s ``setup_cratedigger_test_
+#: tmpfs`` creates it at ``nix-shell`` entry with
+#: ``mktemp -d "$parent/cratedigger-tests.XXXXXX"``, OUTSIDE the admission
+#: lock, and cleans it up only via a shell EXIT trap — SIGTERM/SIGINT/SIGHUP
+#: all run that trap correctly; only SIGKILL (the OOM killer, ``kill -9``,
+#: host loss) skips it and leaks the tree forever. Live incident
+#: 2026-08-19: two leaked trees (910M, 339M) starved a 3.1G RAM root to
+#: 1.9G free at idle and deterministically failed a headroom-measuring test
+#: on three consecutive otherwise-green gate runs.
+#:
+#: This prefix is deliberately NOT reaped on age alone. A prior attempt
+#: used directory mtime as the liveness signal and was reverted after
+#: review found it reaps LIVE trees: a busy suite's scratch root can go
+#: quiet (old mtime) for hours while very much in use, so mtime cannot
+#: distinguish "abandoned" from "just idle". Instead
+#: ``reap_stale_check_bundles`` requires ``_scratch_tree_owner_dead`` to
+#: PROVE the owning shell process is gone (pid+start-ticks, same
+#: pid-reuse-safe ``_proc_start_ticks`` precedent as the admission-lock
+#: holder identity and ``run_final_gate.sh``'s own helper/gate identity)
+#: before the age gate ever applies to a ``cratedigger-tests.*`` entry —
+#: a live owner is never touched regardless of age, and a missing or
+#: malformed marker fails closed (treated as "unknown, never reap", not
+#: "abandoned").
+SCRATCH_TREE_PREFIX = "cratedigger-tests."
 _REAPABLE_PREFIXES = (
     "cratedigger-checks.",
     "cratedigger-suite-test-",
     "cratedigger-admission-test-",
     "cratedigger-reap-test-",
     "cratedigger-headroom-test-",
+    SCRATCH_TREE_PREFIX,
 )
+
+#: Name of the ownership-marker file ``scripts/test_tmpfs.sh`` writes inside
+#: its own ``cratedigger-tests.*`` scratch tree, immediately after
+#: ``mktemp`` — same "<pid> <ticks>\n" content shape as the admission-lock
+#: holder identity file.
+SCRATCH_TREE_OWNER_MARKER_NAME = ".owner"
+
+
+def _scratch_tree_owner_dead(tree: Path) -> bool:
+    """True only when ``tree``'s recorded pid+start-ticks owner is PROVABLY gone.
+
+    Returns ``False`` — never eligible for reaping by this signal — for
+    every case that is not a proven death: a missing marker file (the
+    shell died before ``mktemp`` returned, or in the brief window before
+    the marker write in ``scripts/test_tmpfs.sh``), unreadable content, or
+    a malformed pid/ticks pair. ``False`` here means "unknown", not
+    "alive"; the caller must treat unknown exactly like alive. Only a
+    syntactically well-formed marker whose ``_proc_start_ticks(pid) !=
+    ticks`` (the process is gone, or — since start ticks make pid reuse
+    detectable, the same precedent ``_read_lock_holder_identity`` already
+    relies on — a different, unrelated process now holds that pid)
+    returns ``True``.
+
+    This is the fail-closed half of issue #1208 item 1's ownership-marker
+    design: the reverted mtime-based attempt reaped live trees because an
+    idle mtime is not a liveness signal. Here, "cannot prove dead" always
+    wins over "looks stale".
+    """
+    try:
+        content = (tree / SCRATCH_TREE_OWNER_MARKER_NAME).read_text().strip()
+    except OSError:
+        return False
+    parts = content.split()
+    if len(parts) != 2 or not all(part.isdigit() for part in parts):
+        return False
+    pid_str, ticks = parts
+    return _proc_start_ticks(int(pid_str)) != ticks
 
 
 def _receipt_protected_bundles(runtime: Path) -> frozenset[Path]:
     """Bundle paths a run_final_gate.sh receipt still references.
 
-    ``cratedigger-final-gate.*`` receipts are never themselves in
-    ``_REAPABLE_PREFIXES`` (a different prefix, never reaped), so protecting
-    the bundle path they name preserves both the pass/fail verdict AND its
-    evidence for a long-running review (issue #1111 review m13) — without
-    this, a review that outlives the age floor would lose the bundle out
-    from under a still-valid receipt. If a protected bundle is somehow gone
-    anyway, that is a genuinely dangling receipt; this function's exclusion
-    does not paper over it — ``run_final_gate.sh status``'s own stat check
-    (issue #1111 review m5) is what surfaces that honestly.
+    ``cratedigger-final-gate.*`` receipts are not in ``_REAPABLE_PREFIXES``
+    (a different prefix, not reaped by this function) — they have their own
+    age-gated retirement pass, ``reap_stale_final_gate_receipts`` (issue
+    #1208 item 4), which ``run_suite`` calls before this function on every
+    admitted run. A receipt still on disk when THIS function runs — whether
+    fresh, or old but not yet retired because its recorded helper/gate
+    process is still live — protects the bundle path it names, preserving
+    both the pass/fail verdict AND its evidence for a long-running review
+    (issue #1111 review m13) — without this, a review that outlives the age
+    floor would lose the bundle out from under a still-valid receipt.
+    Retiring a receipt (deleting it) naturally lapses this protection on the
+    very next call, with no second cleanup path: an unprotected bundle then
+    ages out through this function's ordinary age gate like any other. If a
+    protected bundle is somehow gone anyway, that is a genuinely dangling
+    receipt; this function's exclusion does not paper over it —
+    ``run_final_gate.sh status``'s own stat check (issue #1111 review m5) is
+    what surfaces that honestly.
     """
     protected: set[Path] = set()
     for receipt in sorted(runtime.glob("cratedigger-final-gate.*")):
@@ -519,6 +591,129 @@ def _receipt_protected_bundles(runtime: Path) -> frozenset[Path]:
         if content:
             protected.add(Path(content))
     return frozenset(protected)
+
+
+#: A run_final_gate.sh receipt survives at least this long before admission-
+#: time retirement may remove it (issue #1208 item 4) — well past any
+#: realistic review horizon. Unlike ``DEFAULT_STALE_BUNDLE_MAX_AGE_SECONDS``
+#: this is a fixed constant, not an env-overridable knob: shrinking receipt
+#: retention is not something an ambient env var should be able to do by
+#: accident. Before this, "Receipts are never retried or deleted
+#: automatically" (the ``check`` skill) was true without qualification —
+#: 61 of 68 receipts were pinning a bundle against the reaper in perpetuity
+#: on the live 2026-08-20 root, with no exit path at all.
+DEFAULT_RECEIPT_RETIREMENT_MAX_AGE_SECONDS = 7 * 24 * 60 * 60
+
+
+def _receipt_last_activity(receipt: Path) -> float:
+    """The receipt's most recent completion evidence, or its own mtime.
+
+    Mirrors ``_bundle_last_activity``'s shape. ``run_final_gate.sh``'s
+    ``run_gate`` writes ``terminal`` LAST, only after the suite itself has
+    finished and the tree-match check has passed — so its mtime is the true
+    "this receipt became final" timestamp for a completed run. A receipt
+    that never reached that point (crashed, interrupted) falls back to the
+    receipt directory's own mtime, which only ever gets older.
+    """
+    try:
+        return (receipt / "terminal").stat().st_mtime
+    except OSError:
+        pass
+    try:
+        return receipt.stat().st_mtime
+    except OSError:
+        return 0.0
+
+
+def _receipt_process_field_live(
+    receipt: Path, pid_field: str, ticks_field: str
+) -> bool:
+    """True only when the named pid+ticks pair names a process still alive.
+
+    Same shape ``run_final_gate.sh``'s own ``status_receipt`` uses
+    (``_proc_start_ticks(pid) == ticks``, defined above). A missing,
+    unreadable, or malformed identity is never treated as live — it is not
+    evidence a process is running, so it cannot block retirement either;
+    it is exactly the same "unverified is not live" posture
+    ``_read_lock_holder_identity`` already takes for the admission lock.
+    """
+    try:
+        pid_text = (receipt / pid_field).read_text().strip()
+        ticks_text = (receipt / ticks_field).read_text().strip()
+    except OSError:
+        return False
+    if not pid_text.isdigit() or not ticks_text.isdigit():
+        return False
+    return _proc_start_ticks(int(pid_text)) == ticks_text
+
+
+def _receipt_is_retirable(receipt: Path) -> bool:
+    """A receipt's lifecycle is provably over — the age gate decides the rest.
+
+    A ``terminal`` file is ``run_final_gate.sh``'s own completion marker,
+    written last; its mere presence is definitive, exactly as
+    ``status_receipt`` treats it (it never re-checks process liveness once
+    ``terminal`` exists). Without a ``terminal`` file the receipt is either
+    still an in-progress run or one that crashed before finishing —
+    retirement is safe only when BOTH its recorded helper
+    (``run_final_gate.sh`` itself) and gate (the ``nix-shell`` suite child)
+    process identities are conclusively not live. Either one still live
+    blocks retirement (issue #1208 item 4).
+    """
+    if (receipt / "terminal").exists():
+        return True
+    return not (
+        _receipt_process_field_live(receipt, "helper_pid", "helper_start_ticks")
+        or _receipt_process_field_live(receipt, "gate_pid", "gate_start_ticks")
+    )
+
+
+def reap_stale_final_gate_receipts(
+    runtime: Path,
+    *,
+    max_age_seconds: float = DEFAULT_RECEIPT_RETIREMENT_MAX_AGE_SECONDS,
+    reference_time: float | None = None,
+) -> tuple[Path, ...]:
+    """Age-gated retirement of run_final_gate.sh receipts (issue #1208 item 4).
+
+    Only ever called from ``run_suite``, while holding
+    ``acquire_suite_admission`` exclusively, and BEFORE
+    ``reap_stale_check_bundles`` — the same ownership precondition that
+    function documents for itself. Retiring a receipt here deletes it from
+    disk, so ``_receipt_protected_bundles``'s very next glob (inside
+    ``reap_stale_check_bundles``) naturally no longer sees it: a retired
+    receipt's bundle protection lapses on the same admitted pass, and the
+    now-unprotected bundle ages out through that function's ordinary path.
+    No second cleanup path exists for either receipts or bundles — this is
+    the one lifecycle owner for both.
+
+    A receipt is eligible only when ``_receipt_is_retirable`` proves its
+    lifecycle is over AND it is older than ``max_age_seconds``. Both
+    conditions are required: an old-but-still-live receipt is never touched,
+    and a dead-but-fresh receipt waits out the floor like everything else.
+    """
+    reference = reference_time if reference_time is not None else time.time()
+    retired: list[Path] = []
+    for candidate in sorted(runtime.glob("cratedigger-final-gate.*")):
+        try:
+            info = candidate.lstat()
+        except OSError:
+            continue
+        if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+            continue
+        if info.st_uid != os.getuid():
+            continue
+        if not _receipt_is_retirable(candidate):
+            continue
+        age = reference - _receipt_last_activity(candidate)
+        if age < max_age_seconds:
+            continue
+        try:
+            shutil.rmtree(candidate)
+        except OSError:
+            continue
+        retired.append(candidate)
+    return tuple(retired)
 
 
 def reap_stale_check_bundles(
@@ -543,6 +738,14 @@ def reap_stale_check_bundles(
     prefixes above — a killed test process can leak one with no
     ``run_suite`` involved at all. A bundle a live receipt still references
     (``_receipt_protected_bundles``) is never reaped regardless of age.
+
+    ``SCRATCH_TREE_PREFIX`` (``cratedigger-tests.*``, issue #1208 item 1) is
+    additionally gated on ``_scratch_tree_owner_dead`` — a live owner is
+    never reaped regardless of age, and a missing/malformed marker is
+    treated as unknown liveness, never as abandoned. Every other prefix
+    keeps the pure age gate described above; only this one has a
+    provable-death precondition, because only this one has an owning
+    process capable of writing it one.
     """
     reference = reference_time if reference_time is not None else time.time()
     protected = _receipt_protected_bundles(runtime)
@@ -564,6 +767,10 @@ def reap_stale_check_bundles(
         if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
             continue
         if info.st_uid != os.getuid():
+            continue
+        if candidate.name.startswith(
+            SCRATCH_TREE_PREFIX
+        ) and not _scratch_tree_owner_dead(candidate):
             continue
         age = reference - _bundle_last_activity(candidate)
         if age < max_age_seconds:
@@ -1453,10 +1660,11 @@ def run_suite(
     """Admit one canonical suite at a time, then run every phase (issue #1111).
 
     Validates the runtime tmpfs, then acquires the exclusive admission lock
-    (bounded wait, reported progress), reaps stale check bundles, and checks
-    headroom — all BEFORE any phase runs, so an unready environment fails
-    once, immediately, with its real reason instead of tripping deep into a
-    run after earlier phases already passed.
+    (bounded wait, reported progress), retires stale final-gate receipts,
+    reaps stale check bundles (and leaked scratch/test-fixture directories),
+    and checks headroom — all BEFORE any phase runs, so an unready
+    environment fails once, immediately, with its real reason instead of
+    tripping deep into a run after earlier phases already passed.
     """
     output = stream if stream is not None else sys.stdout
     root = repo_root.resolve(strict=True)
@@ -1476,6 +1684,19 @@ def run_suite(
         poll_seconds=admission_poll_seconds,
         progress_interval_seconds=admission_progress_interval_seconds,
     ):
+        # Retire eligible final-gate receipts BEFORE reaping check bundles:
+        # a retired receipt's own directory is gone from disk by the time
+        # reap_stale_check_bundles computes _receipt_protected_bundles, so
+        # its bundle protection lapses on this same admitted pass (issue
+        # #1208 item 4).
+        retired_receipts = reap_stale_final_gate_receipts(runtime)
+        if retired_receipts:
+            output.write(
+                f"retired {len(retired_receipts)} stale final-gate receipt(s): "
+                + ", ".join(str(path) for path in retired_receipts)
+                + "\n"
+            )
+            output.flush()
         reaped = reap_stale_check_bundles(
             runtime,
             max_age_seconds=reap_max_age_seconds,

--- a/scripts/targeted_test_selection.py
+++ b/scripts/targeted_test_selection.py
@@ -112,6 +112,18 @@ EXACT_PATH_NEIGHBOURS: dict[str, tuple[str, ...]] = {
     "scripts/test.sh": (
         "tests.test_targeted_test_selection",
     ),
+    "scripts/test_tmpfs.sh": (
+        # Issue #1208 review D1: this file had NO entry at all — a solo
+        # producer-side edit here (the /proc field index, $$ vs $PPID, the
+        # marker filename/delimiter) selected nothing, so the two mutants
+        # review found surviving were also unreachable by targeted
+        # selection, not just by the test suite's own coverage.
+        # tests.test_test_tmpfs drives this file's real
+        # setup_cratedigger_test_tmpfs end to end, including the real
+        # ".owner" marker round-tripped through
+        # scripts.run_test_suite._scratch_tree_owner_dead.
+        "tests.test_test_tmpfs",
+    ),
     # Shared tests/ infrastructure (issue #1081): none of these are
     # discoverable test modules themselves, so each needs an explicit
     # mapping to the test(s) that actually exercise it. tests/structural_audits/

--- a/scripts/test_tmpfs.sh
+++ b/scripts/test_tmpfs.sh
@@ -150,11 +150,18 @@ setup_cratedigger_test_tmpfs() {
         # `>file 2>/dev/null` order does NOT suppress a failed open of
         # `file` — bash reports that diagnostic on the still-live original
         # stderr before the `2>/dev/null` redirection is even installed.
-        # Reproduced on a full/permission-denied tmpfs: every dev-shell
-        # entry printed an unexplained "Permission denied" naming this
-        # hidden dotfile. `2>/dev/null` FIRST makes stderr point at
-        # /dev/null before the `>` open is attempted, so its failure
-        # diagnostic (like everything else here) is genuinely silent.
+        # Issue #1208 review D-F5: this ".owner" write is new in this PR
+        # and has never actually run in a real dev shell in the failing
+        # state described below — the finding is a controlled
+        # reproduction, not observed production history. Forcing the
+        # write to fail (a read-only scratch tree) with the OLD ordering
+        # printed an unexplained "Permission denied" naming this hidden
+        # dotfile on real stderr; shell entry itself still succeeded
+        # (TMPDIR still exported) either way. `2>/dev/null` FIRST makes
+        # stderr point at /dev/null before the `>` open is attempted, so
+        # that failure diagnostic (like everything else here) is
+        # genuinely silent — verified the same way, with the corrected
+        # ordering.
         printf '%s %s\n' "$$" "$_cratedigger_test_tmpfs_owner_ticks" \
             2>/dev/null >"$_CRATEDIGGER_TEST_TMPDIR/.owner" || true
     fi

--- a/scripts/test_tmpfs.sh
+++ b/scripts/test_tmpfs.sh
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
 # Allocate one isolated RAM-backed scratch directory for the dev shell.
 
+# Field 22 of /proc/<pid>/stat (process start time in clock ticks since
+# boot) — same shape as scripts/run_final_gate.sh's proc_start_ticks and
+# scripts/run_test_suite.py's _proc_start_ticks, kept as its own copy here
+# since no shared shell lib exists yet in this repo.
+_cratedigger_test_tmpfs_proc_start_ticks() {
+    local pid=$1 stat
+    [[ -r "/proc/$pid/stat" ]] || return 1
+    stat=$(<"/proc/$pid/stat")
+    stat=${stat##*) }
+    awk '{print $20}' <<<"$stat"
+}
+
 _cleanup_cratedigger_test_tmpfs() {
     local scratch="${_CRATEDIGGER_TEST_TMPDIR:-}"
     local parent="${_CRATEDIGGER_TEST_TMP_PARENT:-}"
@@ -41,6 +53,7 @@ setup_cratedigger_test_tmpfs() {
     local filesystem_type
     local available_bytes
     local mode
+    local _cratedigger_test_tmpfs_owner_ticks
 
     if [[ ! "$minimum_bytes" =~ ^[0-9]+$ ]]; then
         echo "CRATEDIGGER_TEST_RAM_MIN_BYTES must be a non-negative integer" >&2
@@ -112,5 +125,27 @@ setup_cratedigger_test_tmpfs() {
         mktemp -d "$parent/cratedigger-tests.XXXXXX"
     )" || return 1
     export TMPDIR="$_CRATEDIGGER_TEST_TMPDIR"
+
+    # Ownership marker (issue #1208 item 1): a "<pid> <ticks>\n" pair naming
+    # THIS shell process, written immediately after mktemp so the window
+    # during which the directory exists with no marker at all is as small
+    # as possible. Same content shape as scripts/run_test_suite.py's
+    # admission-lock holder identity and scripts/run_final_gate.sh's own
+    # helper/gate identity. scripts/run_test_suite.py::_scratch_tree_owner_dead
+    # reads it on the reaping side and verifies liveness with the same
+    # pid-reuse-safe start-ticks comparison those two already use — never
+    # on readability alone. A missing or unparseable marker (this write
+    # failing, or a reap racing the tiny window before it lands) is read
+    # as "unknown, never reap", not "abandoned" — fail closed, not fail
+    # open, which is why this write is best-effort: a lost write leaves
+    # the tree unreaped forever rather than wrongly reaped while live.
+    _cratedigger_test_tmpfs_owner_ticks="$(
+        _cratedigger_test_tmpfs_proc_start_ticks "$$" 2>/dev/null
+    )" || _cratedigger_test_tmpfs_owner_ticks=""
+    if [[ -n "$_cratedigger_test_tmpfs_owner_ticks" ]]; then
+        printf '%s %s\n' "$$" "$_cratedigger_test_tmpfs_owner_ticks" \
+            >"$_CRATEDIGGER_TEST_TMPDIR/.owner" 2>/dev/null || true
+    fi
+
     trap _exit_cratedigger_test_tmpfs EXIT
 }

--- a/scripts/test_tmpfs.sh
+++ b/scripts/test_tmpfs.sh
@@ -129,10 +129,13 @@ setup_cratedigger_test_tmpfs() {
     # Ownership marker (issue #1208 item 1): a "<pid> <ticks>\n" pair naming
     # THIS shell process, written immediately after mktemp so the window
     # during which the directory exists with no marker at all is as small
-    # as possible. Same content shape as scripts/run_test_suite.py's
-    # admission-lock holder identity and scripts/run_final_gate.sh's own
-    # helper/gate identity. scripts/run_test_suite.py::_scratch_tree_owner_dead
-    # reads it on the reaping side and verifies liveness with the same
+    # as possible. Same content shape as scripts/run_test_suite.py's own
+    # admission-lock holder identity (issue #1208 review D8: NOT the same
+    # shape as scripts/run_final_gate.sh's helper/gate identity, which
+    # stores pid and start-ticks in two SEPARATE files rather than one
+    # "<pid> <ticks>" line — an earlier version of this comment claimed
+    # otherwise). scripts/run_test_suite.py::_scratch_tree_owner_dead reads
+    # it on the reaping side and verifies liveness with the same
     # pid-reuse-safe start-ticks comparison those two already use — never
     # on readability alone. A missing or unparseable marker (this write
     # failing, or a reap racing the tiny window before it lands) is read
@@ -143,8 +146,17 @@ setup_cratedigger_test_tmpfs() {
         _cratedigger_test_tmpfs_proc_start_ticks "$$" 2>/dev/null
     )" || _cratedigger_test_tmpfs_owner_ticks=""
     if [[ -n "$_cratedigger_test_tmpfs_owner_ticks" ]]; then
+        # Issue #1208 review D5: redirections apply LEFT TO RIGHT, so a
+        # `>file 2>/dev/null` order does NOT suppress a failed open of
+        # `file` — bash reports that diagnostic on the still-live original
+        # stderr before the `2>/dev/null` redirection is even installed.
+        # Reproduced on a full/permission-denied tmpfs: every dev-shell
+        # entry printed an unexplained "Permission denied" naming this
+        # hidden dotfile. `2>/dev/null` FIRST makes stderr point at
+        # /dev/null before the `>` open is attempted, so its failure
+        # diagnostic (like everything else here) is genuinely silent.
         printf '%s %s\n' "$$" "$_cratedigger_test_tmpfs_owner_ticks" \
-            >"$_CRATEDIGGER_TEST_TMPDIR/.owner" 2>/dev/null || true
+            2>/dev/null >"$_CRATEDIGGER_TEST_TMPDIR/.owner" || true
     fi
 
     trap _exit_cratedigger_test_tmpfs EXIT

--- a/tests/test_suite_coordinator.py
+++ b/tests/test_suite_coordinator.py
@@ -39,6 +39,7 @@ from scripts.run_test_suite import (
     _default_min_headroom_bytes,
     _default_phases,
     _proc_start_ticks,
+    _proc_stat_start_ticks,
     _read_lock_holder_identity,
     _scratch_tree_owner_dead,
     acquire_suite_admission,
@@ -1129,11 +1130,25 @@ class StaleCheckBundleReapTestCase(unittest.TestCase):
     def test_scratch_tree_prefix_matches_test_tmpfs_shs_own_mktemp_template(
         self,
     ) -> None:
-        """scripts/test_tmpfs.sh's setup_cratedigger_test_tmpfs creates its
-        scratch tree with `mktemp -d "$parent/cratedigger-tests.XXXXXX"` —
-        a hand-typed literal there, not a value either side imports. This
-        pin is the only thing that would catch the constant here drifting
-        away from that literal."""
+        """Issue #1208 review D2: an earlier version of this docstring
+        falsely claimed this pin "is the only thing that would catch the
+        constant here drifting" and, implicitly, that it binds this
+        constant to the producer. Neither is true — both sides of this
+        equality are hand-typed literals (this one, and
+        scripts/test_tmpfs.sh's own `mktemp -d
+        "$parent/cratedigger-tests.XXXXXX"` template), so this is a
+        same-repo consistency check between two independently-written
+        strings, not a producer binding. Real producer-side drift is
+        caught elsewhere, against the REAL shell function:
+        `tests.test_test_tmpfs.TestTmpfsSetup.test_allocates_isolated_
+        tmpfs_directory_and_cleans_it_on_exit` (asserts the real created
+        directory's name against its own hand-typed "cratedigger-tests."
+        literal) and
+        `tests.test_test_tmpfs.ScratchTreeOwnershipMarkerTestCase`'s real
+        SIGKILL round trip (drives the real setup function end to end).
+        This pin is kept anyway because it fails fast and names the exact
+        drifted value if the two literals here and in run_test_suite.py
+        ever disagree with each other — it does not replace those."""
         self.assertEqual(SCRATCH_TREE_PREFIX, "cratedigger-tests.")
 
     def _scratch_tree(self, name: str, *, age_seconds: float, now: float) -> Path:
@@ -1200,6 +1215,78 @@ class StaleCheckBundleReapTestCase(unittest.TestCase):
 
         self.assertTrue(_scratch_tree_owner_dead(tree))
 
+    # --- Issue #1208 review D4: "cannot verify" must never collapse into
+    # "provably dead". A permission boundary (e.g. a restrictive `hidepid`
+    # mount) or a malformed /proc/<pid>/stat line is not constructible
+    # against a REAL /proc entry without root or a user-namespace remap,
+    # so these use the kwarg-DI seam _proc_stat_start_ticks and
+    # _scratch_tree_owner_dead both accept (`read_stat=` / `proc_stat=`) —
+    # production always uses the real default; only tests inject.
+
+    def test_proc_stat_start_ticks_confirms_absence_only_on_file_not_found(
+        self,
+    ) -> None:
+        def _raise(exc: BaseException) -> str:
+            raise exc
+
+        CASES = (
+            (
+                "process confirmed gone (ENOENT)",
+                lambda pid: _raise(FileNotFoundError()),
+                (True, None),
+            ),
+            (
+                "permission boundary (a real, non-ENOENT OSError)",
+                lambda pid: _raise(PermissionError()),
+                (False, None),
+            ),
+            (
+                "malformed content: no comm-field close paren",
+                lambda pid: "not a real stat line",
+                (False, None),
+            ),
+            (
+                "malformed content: too few fields after comm",
+                lambda pid: "12345 (bash) R 1 2 3",
+                (False, None),
+            ),
+        )
+        for desc, read_stat, expected in CASES:
+            with self.subTest(desc=desc):
+                self.assertEqual(
+                    _proc_stat_start_ticks(12345, read_stat=read_stat),
+                    expected,
+                )
+
+    def test_proc_stat_start_ticks_reads_real_ticks_on_success(self) -> None:
+        """The happy path, still through the real default reader — proves
+        the DI seam's default is wired to the real function, not just
+        that the seam itself can be overridden."""
+        confirmed_absent, ticks = _proc_stat_start_ticks(os.getpid())
+
+        self.assertFalse(confirmed_absent)
+        self.assertEqual(ticks, _proc_start_ticks(os.getpid()))
+
+    def test_scratch_tree_owner_dead_is_false_when_liveness_cannot_be_verified(
+        self,
+    ) -> None:
+        """THE outermost real adapter for this decision: a marker naming
+        a pid whose /proc read fails for a reason OTHER than confirmed
+        absence must never be treated as dead — "unknown" degrades to
+        "alive", the fail-closed half of the ownership-marker design, now
+        proven for the /proc-read failure mode specifically (not just the
+        marker-file failure modes the earlier tests in this class cover)."""
+        tree = self._scratch_tree(
+            "cratedigger-tests.unverifiable", age_seconds=1, now=time.time()
+        )
+        self._write_owner_marker(tree, 999999999, "123456")
+
+        self.assertFalse(
+            _scratch_tree_owner_dead(
+                tree, proc_stat=lambda pid: (False, None)
+            )
+        )
+
     @staticmethod
     def _observed_start_ticks(pid: int) -> str:
         ticks = _proc_start_ticks(pid)
@@ -1226,10 +1313,13 @@ class StaleCheckBundleReapTestCase(unittest.TestCase):
             )
             self._write_owner_marker(tree, proc.pid, ticks)
             # Writing the marker just now bumped the directory's own mtime
-            # to "now" (a new dirent updates the parent dir's mtime) —
-            # restore the staleness so the age gate alone could NOT be
-            # what is protecting this tree; only the live-owner check may.
-            os.utime(tree, (stamp, stamp))
+            # AND gave the .owner file itself a fresh mtime —
+            # _scratch_tree_last_activity (issue #1208 review D3) walks
+            # the WHOLE tree, so restamping only the top-level dir is not
+            # enough: without restamping the marker file too, the age
+            # gate alone (not the live-owner check) would be what keeps
+            # this test green, defeating the point of the test.
+            self._restamp_recursive(tree, stamp)
 
             reaped = reap_stale_check_bundles(
                 self.runtime, max_age_seconds=100, reference_time=now
@@ -1256,10 +1346,11 @@ class StaleCheckBundleReapTestCase(unittest.TestCase):
             "cratedigger-tests.deadchild", age_seconds=999, now=now
         )
         self._write_owner_marker(tree, pid, ticks)
-        # Writing the marker just now bumped the directory's own mtime to
-        # "now" (a new dirent updates the parent dir's mtime) — restore
-        # the staleness _bundle_last_activity's fallback will read.
-        os.utime(tree, (stamp, stamp))
+        # Writing the marker just now bumped the directory's own mtime AND
+        # gave the .owner file itself a fresh mtime — _scratch_tree_last_
+        # activity (issue #1208 review D3) walks the WHOLE tree, so both
+        # need restoring to genuine staleness, not just the top-level dir.
+        self._restamp_recursive(tree, stamp)
 
         reaped = reap_stale_check_bundles(
             self.runtime, max_age_seconds=100, reference_time=now
@@ -1303,6 +1394,69 @@ class StaleCheckBundleReapTestCase(unittest.TestCase):
 
         self.assertEqual(reaped, ())
         self.assertTrue(tree.exists())
+
+    # --- Issue #1208 review D3: the age gate must walk the WHOLE tree,
+    # not just its top-level directory mtime. A write into an EXISTING
+    # nested subdirectory never bumps the top-level dir's own mtime, so
+    # an orphaned descendant of the (now dead) owning shell — e.g. issue
+    # #1214's fuzz burst, which takes neither the admission lock nor a
+    # headroom guard — could keep a tree genuinely in use while its
+    # top-level dirent looked stale for hours.
+
+    @staticmethod
+    def _restamp_recursive(path: Path, stamp: float) -> None:
+        for root, dirs, files in os.walk(path):
+            for name in (*dirs, *files):
+                os.utime(os.path.join(root, name), (stamp, stamp))
+        os.utime(path, (stamp, stamp))
+
+    def test_reap_keeps_a_dead_owned_tree_with_recent_nested_activity(
+        self,
+    ) -> None:
+        now = time.time()
+        old = now - 999
+        tree = self._scratch_tree(
+            "cratedigger-tests.orphanwriting", age_seconds=999, now=now
+        )
+        self._write_owner_marker(tree, 999999999, "123456")
+        nested = tree / "nested"
+        nested.mkdir()
+        self._restamp_recursive(tree, old)
+        # Created AFTER the restamp above, so its mtime (and its parent
+        # nested/'s) is genuinely recent — an orphaned descendant still
+        # writing, exactly the scenario the top-level-only check misses.
+        (nested / "still-writing.tmp").write_text("x")
+
+        reaped = reap_stale_check_bundles(
+            self.runtime, max_age_seconds=100, reference_time=now
+        )
+
+        self.assertEqual(reaped, ())
+        self.assertTrue(tree.exists())
+
+    def test_reap_removes_a_dead_owned_tree_once_all_nested_activity_is_stale(
+        self,
+    ) -> None:
+        """Converse of the above: once every entry in the tree — not just
+        the top-level dir — is genuinely stale, the dead-owned tree is
+        reaped."""
+        now = time.time()
+        old = now - 999
+        tree = self._scratch_tree(
+            "cratedigger-tests.trulystale", age_seconds=999, now=now
+        )
+        self._write_owner_marker(tree, 999999999, "123456")
+        nested = tree / "nested"
+        nested.mkdir()
+        (nested / "old.tmp").write_text("x")
+        self._restamp_recursive(tree, old)
+
+        reaped = reap_stale_check_bundles(
+            self.runtime, max_age_seconds=100, reference_time=now
+        )
+
+        self.assertEqual(reaped, (tree,))
+        self.assertFalse(tree.exists())
 
 
 class FinalGateReceiptRetirementTestCase(unittest.TestCase):
@@ -1529,6 +1683,63 @@ class FinalGateReceiptRetirementTestCase(unittest.TestCase):
 
         self.assertEqual(reaped, (bundle,))
         self.assertFalse(bundle.exists())
+
+    # --- Issue #1208 review D6: per-clause coverage for
+    # reap_stale_final_gate_receipts's non-dir/symlink and foreign-uid
+    # guards — untested gaps review found by planting mutants that
+    # survived. Recorded honestly: for THESE two clauses specifically,
+    # shutil.rmtree already refuses to operate on a symlink or a
+    # non-directory (raises OSError, caught by this function's own
+    # `except OSError: continue`), so removing either guard clause does
+    # NOT change the observable `retired` return value or which entities
+    # survive on disk — the tests below pin that real end-to-end safety
+    # property (proven empirically: shutil.rmtree(symlink) raises
+    # "Cannot call rmtree on a symbolic link", shutil.rmtree(regular_file)
+    # raises NotADirectoryError), not the specific guard-clause mutant,
+    # which this composition genuinely cannot distinguish from "no guard
+    # at all". They still matter as regression coverage: if a future
+    # change ever replaced shutil.rmtree with something that lacks its
+    # built-in refusal, these would be the tests that catch it.
+
+    def test_never_retires_a_symlink_named_like_a_receipt(self) -> None:
+        now = time.time()
+        real_target = self.runtime / "not-actually-a-receipt"
+        real_target.mkdir(mode=0o700)
+        (real_target / "terminal").write_text("pass 0\n")
+        stamp = now - 999
+        os.utime(real_target / "terminal", (stamp, stamp))
+        link = self.runtime / "cratedigger-final-gate.symlink"
+        link.symlink_to(real_target)
+
+        retired = reap_stale_final_gate_receipts(
+            self.runtime, max_age_seconds=100, reference_time=now
+        )
+
+        self.assertEqual(retired, ())
+        self.assertTrue(link.exists())
+        self.assertTrue(real_target.exists())
+
+    def test_never_retires_a_non_directory_named_like_a_receipt(self) -> None:
+        now = time.time()
+        stray_file = self.runtime / "cratedigger-final-gate.strayfile"
+        stray_file.write_text("not a receipt directory\n")
+        stamp = now - 999
+        os.utime(stray_file, (stamp, stamp))
+
+        retired = reap_stale_final_gate_receipts(
+            self.runtime, max_age_seconds=100, reference_time=now
+        )
+
+        self.assertEqual(retired, ())
+        self.assertTrue(stray_file.exists())
+
+    # The third guard clause (`info.st_uid != os.getuid()`) has no test
+    # here: constructing a receipt-shaped directory genuinely owned by a
+    # DIFFERENT real uid requires root or a user-namespace remap, neither
+    # available to this test user. Recorded as an honest, stated residual
+    # (issue #1208 review D6) rather than a fabricated or skipped test —
+    # `reap_stale_check_bundles` carries the identical, equally untested
+    # clause already, so this is not a new gap.
 
     def test_default_retirement_floor_is_seven_days(self) -> None:
         """Pins the documented constant directly — a change here is a

--- a/tests/test_suite_coordinator.py
+++ b/tests/test_suite_coordinator.py
@@ -963,6 +963,83 @@ class SuiteAdmissionTestCase(unittest.TestCase):
         self.assertEqual(lock_path.read_text().strip(), "")
 
 
+def _chown_via_user_namespace(
+    path: Path, owner: str, *, recursive: bool = False
+) -> None:
+    """Remap ``path``'s ownership through an unprivileged user namespace.
+
+    Issue #1208 review D-F1: an earlier version of the foreign-uid guard
+    tests here (and this commit's own message) claimed constructing a
+    genuinely foreign-uid directory "requires root or a user-namespace
+    remap, neither available to this test user" — false. The remap IS
+    available: this is the exact ``unshare --map-root-user --map-auto
+    chown`` technique ``tests/fakes/beets_contract.py``'s ``_chown_path``
+    already uses, load-bearing, on every run of this suite. ``owner``
+    values are uid:gid pairs INSIDE the namespace — ``--map-root-user``
+    maps namespace uid 0 back to this process's own real uid, so
+    ``"0:0"`` restores real ownership (the unseal direction) and any
+    other pair (e.g. ``"1:1"``) lands on a genuinely different,
+    auto-allocated subordinate uid outside the namespace — no root
+    required, matching the review's own reproduction (``st_uid=100000``
+    from ``chown -R 1:1``).
+    """
+    recursive_flag = ["-R"] if recursive else []
+    subprocess.run(
+        [
+            "unshare", "--map-root-user", "--map-auto", "chown",
+            *recursive_flag, owner, str(path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _run_in_uid_remapped_namespace(script: str) -> subprocess.CompletedProcess[str]:
+    """Run ``script`` (a self-contained Python source string) as fake-root
+    inside a fresh, unprivileged user namespace.
+
+    Issue #1208 review D-F1, second correction: a delete attempt run from
+    a NORMAL (non-namespaced) process against a directory chowned via
+    ``_chown_via_user_namespace`` above is invisible to the foreign-uid
+    guard clause, because ordinary POSIX permission bits (mode 0700,
+    foreign owner) already block ``shutil.rmtree`` with a plain
+    ``PermissionError`` before the software guard is ever reached —
+    empirically verified: this repository's own reap functions catch
+    that ``OSError`` and silently continue, so the guard-removed mutant
+    is unobservable that way, the same redundancy D6 already documented
+    honestly for the symlink/non-directory clauses. That is NOT the
+    world the review's own reproduction table describes.
+
+    The actual discriminating world: `unshare --map-root-user` makes the
+    CALLING process uid 0 (fake-root) WITHIN the new namespace, and
+    Linux root has ``DAC_OVERRIDE`` for any file owned by a uid the
+    namespace's own mapping covers — so a directory chowned to a
+    DIFFERENT in-namespace uid (``os.chown(path, 1, 1)``, run from
+    inside this same namespace) is fully readable, writable, and
+    deletable by that fake-root process. There, POSIX permissions grant
+    NOTHING — the software guard (``info.st_uid != os.getuid()``) is the
+    ONLY thing between it and deletion. Verified directly: inside such a
+    namespace, ``os.getuid()`` reads 0, a directory chowned to uid 1
+    reports ``st_uid=1``, and ``shutil.rmtree`` on it succeeds outright
+    (no exception at all) — the exact shape a caller of this reaper
+    could produce by never having remapped uid 1 to anything, or a
+    future refactor that lost the guard.
+
+    This runs the real reap function inside exactly that world and
+    reports a ``RESULT:PASS``/``RESULT:FAIL`` marker on stdout so the
+    caller can assert on it without itself needing namespace access.
+    """
+    return subprocess.run(
+        ["unshare", "--map-root-user", "--map-auto", sys.executable, "-c", script],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+
 class StaleCheckBundleReapTestCase(unittest.TestCase):
     """Contracts for admission-time cleanup of stale check bundles (#1111)."""
 
@@ -1120,6 +1197,49 @@ class StaleCheckBundleReapTestCase(unittest.TestCase):
         self.assertTrue(referenced.exists())
         self.assertFalse(unreferenced.exists())
 
+    def test_never_reaps_a_bundle_owned_by_a_foreign_uid(self) -> None:
+        """Issue #1208 review D-F1: the foreign-uid guard
+        (``info.st_uid != os.getuid()``) here — see
+        ``_run_in_uid_remapped_namespace`` for why the delete attempt
+        must run INSIDE the same user namespace that performed the
+        chown to actually exercise this clause (a normal-process delete
+        attempt is already blocked by ordinary POSIX permissions,
+        vacuously)."""
+        bundle = self.runtime / "cratedigger-checks.foreignowner"
+        script = (
+            "import os\n"
+            "import time\n"
+            "from pathlib import Path\n"
+            "from scripts.run_test_suite import reap_stale_check_bundles\n"
+            "\n"
+            f"runtime = Path({str(self.runtime)!r})\n"
+            f"bundle = Path({str(bundle)!r})\n"
+            "bundle.mkdir(mode=0o700)\n"
+            "summary = bundle / 'summary.json'\n"
+            "summary.write_text('{}\\n')\n"
+            "now = time.time()\n"
+            "stamp = now - 999\n"
+            "os.utime(summary, (stamp, stamp))\n"
+            "os.chown(bundle, 1, 1)\n"
+            "\n"
+            "reaped = reap_stale_check_bundles(\n"
+            "    runtime, max_age_seconds=100, reference_time=now\n"
+            ")\n"
+            "ok = reaped == () and bundle.exists()\n"
+            "print('RESULT:' + ('PASS' if ok else 'FAIL'))\n"
+        )
+        try:
+            completed = _run_in_uid_remapped_namespace(script)
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertIn(
+                "RESULT:PASS",
+                completed.stdout,
+                f"stdout={completed.stdout!r} stderr={completed.stderr!r}",
+            )
+        finally:
+            if bundle.exists():
+                _chown_via_user_namespace(bundle, "0:0", recursive=True)
+
     # --- Issue #1208 item 1: ownership-marker liveness for
     # SCRATCH_TREE_PREFIX ("cratedigger-tests.*"), the dev shell's own main
     # scratch TMPDIR. A prior attempt reaped these on mtime alone and was
@@ -1183,6 +1303,12 @@ class StaleCheckBundleReapTestCase(unittest.TestCase):
             ("three fields", "12345 6789 extra"),
             ("non-digit pid", "abc 6789"),
             ("non-digit ticks", "12345 abc"),
+            # issue #1208 review D-F7: a superscript "\u00b9" IS
+            # str.isdigit() (True) but is NOT str.isdecimal() (False) and
+            # int("\u00b9") raises ValueError — the guard must use
+            # isdecimal(), or this case crashes the whole suite instead
+            # of degrading to "not dead".
+            ("unicode digit that int() cannot parse", "\u00b9 6789"),
         )
         for index, (desc, content) in enumerate(CASES):
             with self.subTest(desc=desc):
@@ -1259,13 +1385,39 @@ class StaleCheckBundleReapTestCase(unittest.TestCase):
                 )
 
     def test_proc_stat_start_ticks_reads_real_ticks_on_success(self) -> None:
-        """The happy path, still through the real default reader — proves
-        the DI seam's default is wired to the real function, not just
-        that the seam itself can be overridden."""
+        """The happy path, through the real default reader. Issue #1208
+        review D-F2: an earlier version of this docstring claimed this
+        "proves the DI seam's default is wired to the real function" —
+        false. It compared against ``_proc_start_ticks``, which shares
+        the exact SAME ``_read_proc_stat`` default, so a fake reader
+        returning a constant stat line would pass both sides identically
+        in isolation — agree-by-construction, not proof. That real
+        producer-vs-reader binding is already proven by
+        ``test_real_marker_reports_alive_then_dead_across_a_real_sigkill``
+        in ``tests/test_test_tmpfs.py`` (an independent awk-based
+        producer). This test instead compares against a genuinely
+        independent oracle — bash + awk reading the same ``/proc`` entry,
+        not Python, and not this module's own parsing code."""
+        independent = subprocess.run(
+            [
+                "bash",
+                "-c",
+                (
+                    f'stat=$(cat /proc/{os.getpid()}/stat); '
+                    'stat=${stat##*) }; '
+                    "awk '{print $20}' <<<\"$stat\""
+                ),
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        expected = independent.stdout.strip()
+
         confirmed_absent, ticks = _proc_stat_start_ticks(os.getpid())
 
         self.assertFalse(confirmed_absent)
-        self.assertEqual(ticks, _proc_start_ticks(os.getpid()))
+        self.assertEqual(ticks, expected)
 
     def test_scratch_tree_owner_dead_is_false_when_liveness_cannot_be_verified(
         self,
@@ -1457,6 +1609,76 @@ class StaleCheckBundleReapTestCase(unittest.TestCase):
 
         self.assertEqual(reaped, (tree,))
         self.assertFalse(tree.exists())
+
+    def test_reap_keeps_a_dead_owned_tree_when_a_recent_entry_precedes_stale_ones_in_walk_order(
+        self,
+    ) -> None:
+        """Issue #1208 review D-F3: a ``latest = entry_mtime`` mutant
+        (last-entry-wins, not ``max()``) is invisible if the fixture's
+        only recent entry happens to be visited LAST in ``os.walk``'s
+        traversal order — the earlier two D3 tests both had that shape
+        by accident. ``os.walk`` in topdown mode (the default, used here)
+        guarantees a directory's own direct children are yielded in ONE
+        tuple BEFORE any subdirectory's contents are yielded in a LATER
+        tuple — so a recent entry placed directly in ``tree`` (yielded
+        first) followed by a stale entry nested one level deeper (yielded
+        later) deterministically orders "recent, then stale" regardless
+        of within-directory listing order, which "last wins" gets
+        backwards."""
+        now = time.time()
+        old = now - 999
+        tree = self._scratch_tree(
+            "cratedigger-tests.recentfirst", age_seconds=999, now=now
+        )
+        self._write_owner_marker(tree, 999999999, "123456")
+        nested = tree / "nested"
+        nested.mkdir()
+        (nested / "old.tmp").write_text("x")
+        self._restamp_recursive(tree, old)
+        # Created AFTER the restamp, directly inside `tree` — visited in
+        # os.walk's FIRST yield, strictly before `nested`'s own contents
+        # in a later yield. Genuinely recent.
+        (tree / "recent.tmp").write_text("x")
+
+        reaped = reap_stale_check_bundles(
+            self.runtime, max_age_seconds=100, reference_time=now
+        )
+
+        self.assertEqual(reaped, ())
+        self.assertTrue(tree.exists())
+
+    def test_reap_keeps_a_dead_owned_tree_whose_only_recent_entry_is_a_directory(
+        self,
+    ) -> None:
+        """Issue #1208 review D-F3: a ``for name in files`` mutant
+        (dropping directory names from the walk targets) is invisible if
+        the recent activity happens to also touch a surviving FILE. An
+        orphaned descendant that creates and deletes scratch files inside
+        a nested directory bumps only that DIRECTORY's own mtime — no
+        file with a recent mtime survives to be walked, so the recent
+        entry must be found among ``dirs``, not only ``files``."""
+        now = time.time()
+        old = now - 999
+        tree = self._scratch_tree(
+            "cratedigger-tests.dirchurn", age_seconds=999, now=now
+        )
+        self._write_owner_marker(tree, 999999999, "123456")
+        nested = tree / "nested"
+        nested.mkdir()
+        self._restamp_recursive(tree, old)
+        # Create then delete a scratch file inside `nested` — bumps ONLY
+        # `nested`'s own directory mtime to "now"; nothing recent
+        # survives as a walkable file.
+        churn_file = nested / "scratch.tmp"
+        churn_file.write_text("x")
+        churn_file.unlink()
+
+        reaped = reap_stale_check_bundles(
+            self.runtime, max_age_seconds=100, reference_time=now
+        )
+
+        self.assertEqual(reaped, ())
+        self.assertTrue(tree.exists())
 
 
 class FinalGateReceiptRetirementTestCase(unittest.TestCase):
@@ -1651,6 +1873,33 @@ class FinalGateReceiptRetirementTestCase(unittest.TestCase):
         self.assertEqual(retired, (receipt,))
         self.assertFalse(receipt.exists())
 
+    def test_retirement_does_not_crash_on_a_non_decimal_unicode_digit_identity(
+        self,
+    ) -> None:
+        """Issue #1208 review D-F7: the identical isdigit()-vs-isdecimal()
+        bug in ``_receipt_process_field_live`` — a superscript "\u00b9"
+        passes ``str.isdigit()`` but ``int("\u00b9")`` raises
+        ``ValueError``, which would abort the whole suite instead of
+        degrading to "not live", same as the fix for
+        ``_scratch_tree_owner_dead``. A malformed identity degrades
+        gracefully to "not live" (retirement proceeds), never crashes."""
+        now = time.time()
+        receipt = self._receipt(
+            "cratedigger-final-gate.baddigit",
+            age_seconds=999,
+            now=now,
+            terminal=False,
+            helper_identity=("\u00b9", "123456"),
+            gate_identity=self._dead_identity(),
+        )
+
+        retired = reap_stale_final_gate_receipts(
+            self.runtime, max_age_seconds=100, reference_time=now
+        )
+
+        self.assertEqual(retired, (receipt,))
+        self.assertFalse(receipt.exists())
+
     def test_retiring_a_receipt_releases_its_bundle_protection(self) -> None:
         """Retirement and bundle reaping run in the SAME admitted pass —
         run_suite calls reap_stale_final_gate_receipts before
@@ -1733,13 +1982,52 @@ class FinalGateReceiptRetirementTestCase(unittest.TestCase):
         self.assertEqual(retired, ())
         self.assertTrue(stray_file.exists())
 
-    # The third guard clause (`info.st_uid != os.getuid()`) has no test
-    # here: constructing a receipt-shaped directory genuinely owned by a
-    # DIFFERENT real uid requires root or a user-namespace remap, neither
-    # available to this test user. Recorded as an honest, stated residual
-    # (issue #1208 review D6) rather than a fabricated or skipped test —
-    # `reap_stale_check_bundles` carries the identical, equally untested
-    # clause already, so this is not a new gap.
+    def test_never_retires_a_receipt_owned_by_a_foreign_uid(self) -> None:
+        """Issue #1208 review D-F1: the third guard clause
+        (``info.st_uid != os.getuid()``) — D6 originally recorded this as
+        untestable without root; that claim was false, closed via
+        ``_chown_via_user_namespace``. A second correction: a delete
+        attempt run from a normal process against that chowned directory
+        is ALSO invisible to this specific clause, because ordinary
+        POSIX permissions already block it — see
+        ``_run_in_uid_remapped_namespace`` for the actual discriminating
+        world (the delete attempt run AS fake-root INSIDE the same
+        namespace that performed the chown, where only the software
+        guard stands between it and deletion)."""
+        receipt = self.runtime / "cratedigger-final-gate.foreignowner"
+        script = (
+            "import os\n"
+            "import time\n"
+            "from pathlib import Path\n"
+            "from scripts.run_test_suite import reap_stale_final_gate_receipts\n"
+            "\n"
+            f"runtime = Path({str(self.runtime)!r})\n"
+            f"receipt = Path({str(receipt)!r})\n"
+            "receipt.mkdir(mode=0o700)\n"
+            "terminal = receipt / 'terminal'\n"
+            "terminal.write_text('pass 0\\n')\n"
+            "now = time.time()\n"
+            "stamp = now - 999\n"
+            "os.utime(terminal, (stamp, stamp))\n"
+            "os.chown(receipt, 1, 1)\n"
+            "\n"
+            "retired = reap_stale_final_gate_receipts(\n"
+            "    runtime, max_age_seconds=100, reference_time=now\n"
+            ")\n"
+            "ok = retired == () and receipt.exists()\n"
+            "print('RESULT:' + ('PASS' if ok else 'FAIL'))\n"
+        )
+        try:
+            completed = _run_in_uid_remapped_namespace(script)
+            self.assertEqual(completed.returncode, 0, completed.stderr)
+            self.assertIn(
+                "RESULT:PASS",
+                completed.stdout,
+                f"stdout={completed.stdout!r} stderr={completed.stderr!r}",
+            )
+        finally:
+            if receipt.exists():
+                _chown_via_user_namespace(receipt, "0:0", recursive=True)
 
     def test_default_retirement_floor_is_seven_days(self) -> None:
         """Pins the documented constant directly — a change here is a

--- a/tests/test_suite_coordinator.py
+++ b/tests/test_suite_coordinator.py
@@ -24,7 +24,10 @@ from scripts.run_test_suite import (
     _HEADROOM_BASE_BYTES,
     _HEADROOM_PER_WORKER_BYTES,
     DEFAULT_MIN_HEADROOM_BYTES,
+    DEFAULT_RECEIPT_RETIREMENT_MAX_AGE_SECONDS,
     FAILURE_MARKER_PREFIX,
+    SCRATCH_TREE_OWNER_MARKER_NAME,
+    SCRATCH_TREE_PREFIX,
     TEST_RAM_ROOT_EXHAUSTED,
     CheckFailureMarker,
     CheckSummary,
@@ -37,10 +40,12 @@ from scripts.run_test_suite import (
     _default_phases,
     _proc_start_ticks,
     _read_lock_holder_identity,
+    _scratch_tree_owner_dead,
     acquire_suite_admission,
     admission_lock_path,
     dirty_state_fingerprint,
     reap_stale_check_bundles,
+    reap_stale_final_gate_receipts,
     run_suite,
 )
 
@@ -1011,8 +1016,13 @@ class StaleCheckBundleReapTestCase(unittest.TestCase):
         self.assertTrue(fresh.exists())
 
     def test_ignores_directories_matching_no_reapable_prefix(self) -> None:
+        # NOTE: this must NOT be a "cratedigger-tests." prefix — issue #1208
+        # item 1 registered that prefix precisely so it IS considered for
+        # reaping (see the ScratchTreeOwnershipTestCase-style methods below
+        # in this same class). This test instead proves a directory
+        # matching no registered prefix at all is left untouched.
         now = time.time()
-        unrelated = self.runtime / "cratedigger-tests.unrelated"
+        unrelated = self.runtime / "some-other-tool.unrelated"
         unrelated.mkdir(mode=0o700)
         stamp = now - 999
         os.utime(unrelated, (stamp, stamp))
@@ -1108,6 +1118,470 @@ class StaleCheckBundleReapTestCase(unittest.TestCase):
         self.assertEqual(reaped, (unreferenced,))
         self.assertTrue(referenced.exists())
         self.assertFalse(unreferenced.exists())
+
+    # --- Issue #1208 item 1: ownership-marker liveness for
+    # SCRATCH_TREE_PREFIX ("cratedigger-tests.*"), the dev shell's own main
+    # scratch TMPDIR. A prior attempt reaped these on mtime alone and was
+    # reverted after review found it reaps LIVE trees (a busy suite's
+    # scratch root can go quiet for hours while very much in use). These
+    # tests prove the replacement ownership-marker design instead.
+
+    def test_scratch_tree_prefix_matches_test_tmpfs_shs_own_mktemp_template(
+        self,
+    ) -> None:
+        """scripts/test_tmpfs.sh's setup_cratedigger_test_tmpfs creates its
+        scratch tree with `mktemp -d "$parent/cratedigger-tests.XXXXXX"` —
+        a hand-typed literal there, not a value either side imports. This
+        pin is the only thing that would catch the constant here drifting
+        away from that literal."""
+        self.assertEqual(SCRATCH_TREE_PREFIX, "cratedigger-tests.")
+
+    def _scratch_tree(self, name: str, *, age_seconds: float, now: float) -> Path:
+        assert name.startswith(SCRATCH_TREE_PREFIX)
+        tree = self.runtime / name
+        tree.mkdir(mode=0o700)
+        stamp = now - age_seconds
+        os.utime(tree, (stamp, stamp))
+        return tree
+
+    @staticmethod
+    def _write_owner_marker(tree: Path, pid: int, ticks: str) -> None:
+        (tree / SCRATCH_TREE_OWNER_MARKER_NAME).write_text(f"{pid} {ticks}\n")
+
+    def test_scratch_tree_owner_dead_is_false_for_a_missing_marker(self) -> None:
+        """Fail closed: no marker at all is "unknown", never "dead" — the
+        tiny post-mktemp race window, or any other cause, must not become
+        reap-eligible."""
+        tree = self._scratch_tree(
+            "cratedigger-tests.nomarker", age_seconds=1, now=time.time()
+        )
+
+        self.assertFalse(_scratch_tree_owner_dead(tree))
+
+    def test_scratch_tree_owner_dead_is_false_for_malformed_marker_content(
+        self,
+    ) -> None:
+        now = time.time()
+        CASES = (
+            ("empty", ""),
+            ("only a pid", "12345"),
+            ("three fields", "12345 6789 extra"),
+            ("non-digit pid", "abc 6789"),
+            ("non-digit ticks", "12345 abc"),
+        )
+        for index, (desc, content) in enumerate(CASES):
+            with self.subTest(desc=desc):
+                tree = self._scratch_tree(
+                    f"cratedigger-tests.malformed{index}", age_seconds=1, now=now
+                )
+                (tree / SCRATCH_TREE_OWNER_MARKER_NAME).write_text(content)
+
+                self.assertFalse(_scratch_tree_owner_dead(tree))
+
+    def test_scratch_tree_owner_dead_is_false_for_a_live_process(self) -> None:
+        """Uses our own real, currently-running process — same precedent
+        as test_read_lock_holder_identity_parses_well_formed_live_content."""
+        tree = self._scratch_tree(
+            "cratedigger-tests.livepid", age_seconds=1, now=time.time()
+        )
+        ticks = _proc_start_ticks(os.getpid())
+        assert ticks is not None
+        self._write_owner_marker(tree, os.getpid(), ticks)
+
+        self.assertFalse(_scratch_tree_owner_dead(tree))
+
+    def test_scratch_tree_owner_dead_is_true_for_a_guaranteed_dead_pid(self) -> None:
+        tree = self._scratch_tree(
+            "cratedigger-tests.deadpid", age_seconds=1, now=time.time()
+        )
+        # A PID far past any real process on this host; guaranteed dead —
+        # same precedent as test_read_lock_holder_identity_rejects_a_stale_dead_pid.
+        self._write_owner_marker(tree, 999999999, "123456")
+
+        self.assertTrue(_scratch_tree_owner_dead(tree))
+
+    @staticmethod
+    def _observed_start_ticks(pid: int) -> str:
+        ticks = _proc_start_ticks(pid)
+        deadline = time.monotonic() + 5.0
+        while ticks is None and time.monotonic() < deadline:
+            time.sleep(0.02)
+            ticks = _proc_start_ticks(pid)
+        assert ticks is not None, f"could not observe start ticks for pid {pid}"
+        return ticks
+
+    def test_reap_never_touches_a_live_owned_scratch_tree(self) -> None:
+        """THE most important contract in this PR (issue #1208): a live
+        owner is never reaped, however stale its directory mtime looks.
+        Proven against a REAL subprocess, not a mock or our own test
+        process — this is exactly the scenario the reverted mtime-based
+        attempt got wrong."""
+        proc = subprocess.Popen(["sleep", "30"])
+        try:
+            ticks = self._observed_start_ticks(proc.pid)
+            now = time.time()
+            stamp = now - 999
+            tree = self._scratch_tree(
+                "cratedigger-tests.livechild", age_seconds=999, now=now
+            )
+            self._write_owner_marker(tree, proc.pid, ticks)
+            # Writing the marker just now bumped the directory's own mtime
+            # to "now" (a new dirent updates the parent dir's mtime) —
+            # restore the staleness so the age gate alone could NOT be
+            # what is protecting this tree; only the live-owner check may.
+            os.utime(tree, (stamp, stamp))
+
+            reaped = reap_stale_check_bundles(
+                self.runtime, max_age_seconds=100, reference_time=now
+            )
+
+            self.assertEqual(reaped, ())
+            self.assertTrue(tree.exists())
+        finally:
+            proc.kill()
+            proc.wait(timeout=5)
+
+    def test_reap_removes_a_dead_owned_stale_scratch_tree(self) -> None:
+        """Converse of the above: once the real owning process is
+        provably gone AND the tree is stale, it is reaped."""
+        proc = subprocess.Popen(["sleep", "30"])
+        ticks = self._observed_start_ticks(proc.pid)
+        pid = proc.pid
+        proc.kill()
+        proc.wait(timeout=5)
+
+        now = time.time()
+        stamp = now - 999
+        tree = self._scratch_tree(
+            "cratedigger-tests.deadchild", age_seconds=999, now=now
+        )
+        self._write_owner_marker(tree, pid, ticks)
+        # Writing the marker just now bumped the directory's own mtime to
+        # "now" (a new dirent updates the parent dir's mtime) — restore
+        # the staleness _bundle_last_activity's fallback will read.
+        os.utime(tree, (stamp, stamp))
+
+        reaped = reap_stale_check_bundles(
+            self.runtime, max_age_seconds=100, reference_time=now
+        )
+
+        self.assertEqual(reaped, (tree,))
+        self.assertFalse(tree.exists())
+
+    def test_reap_keeps_a_dead_owned_scratch_tree_within_the_age_floor(
+        self,
+    ) -> None:
+        """The age gate still applies on top of provable death — a
+        process dying seconds ago does not make its tree fair game
+        immediately; both conditions are required."""
+        now = time.time()
+        tree = self._scratch_tree(
+            "cratedigger-tests.freshdead", age_seconds=1, now=now
+        )
+        self._write_owner_marker(tree, 999999999, "123456")
+
+        reaped = reap_stale_check_bundles(
+            self.runtime, max_age_seconds=100, reference_time=now
+        )
+
+        self.assertEqual(reaped, ())
+        self.assertTrue(tree.exists())
+
+    def test_reap_keeps_a_stale_scratch_tree_with_no_marker_at_all(self) -> None:
+        """Fail-closed exercised through the real reap entry point: a
+        directory with no ownership marker (the tiny post-mktemp race, or
+        anything else) is never reaped through this mechanism, however
+        old it looks — the reverted design's own failure mode inverted."""
+        now = time.time()
+        tree = self._scratch_tree(
+            "cratedigger-tests.unmarked", age_seconds=999, now=now
+        )
+
+        reaped = reap_stale_check_bundles(
+            self.runtime, max_age_seconds=100, reference_time=now
+        )
+
+        self.assertEqual(reaped, ())
+        self.assertTrue(tree.exists())
+
+
+class FinalGateReceiptRetirementTestCase(unittest.TestCase):
+    """Contracts for age-gated run_final_gate.sh receipt retirement (#1208 item 4)."""
+
+    def setUp(self) -> None:
+        shared = Path(
+            os.environ.get("XDG_RUNTIME_DIR", f"/run/user/{os.getuid()}")
+        )
+        self.assertTrue(
+            shared.is_dir(),
+            "private runtime tmpfs is required for this test",
+        )
+        self.runtime = Path(
+            tempfile.mkdtemp(dir=shared, prefix="cratedigger-reap-test-")
+        )
+
+    def tearDown(self) -> None:
+        shutil.rmtree(self.runtime, ignore_errors=True)
+
+    @staticmethod
+    def _live_identity() -> tuple[str, str]:
+        """This test process's own real pid+ticks pair — genuinely alive,
+        same precedent as test_read_lock_holder_identity_parses_well_
+        formed_live_content above."""
+        ticks = _proc_start_ticks(os.getpid())
+        assert ticks is not None
+        return str(os.getpid()), ticks
+
+    @staticmethod
+    def _dead_identity() -> tuple[str, str]:
+        """A syntactically well-formed but guaranteed-dead pid+ticks pair —
+        same precedent as test_read_lock_holder_identity_rejects_a_stale_
+        dead_pid above (a PID far past any real process on this host)."""
+        return "999999999", "123456"
+
+    def _receipt(
+        self,
+        name: str,
+        *,
+        age_seconds: float,
+        now: float,
+        terminal: bool,
+        helper_identity: tuple[str, str] | None = None,
+        gate_identity: tuple[str, str] | None = None,
+    ) -> Path:
+        receipt = self.runtime / name
+        receipt.mkdir(mode=0o700)
+        if helper_identity is not None:
+            (receipt / "helper_pid").write_text(f"{helper_identity[0]}\n")
+            (receipt / "helper_start_ticks").write_text(f"{helper_identity[1]}\n")
+        if gate_identity is not None:
+            (receipt / "gate_pid").write_text(f"{gate_identity[0]}\n")
+            (receipt / "gate_start_ticks").write_text(f"{gate_identity[1]}\n")
+        stamp = now - age_seconds
+        if terminal:
+            terminal_path = receipt / "terminal"
+            terminal_path.write_text("pass 0\n")
+            os.utime(terminal_path, (stamp, stamp))
+            # Deliberately leave the receipt directory's own mtime alone
+            # (fresh, "now" — it was just mkdir'd above): production
+            # creates the receipt directory BEFORE the run and writes
+            # `terminal` only at the end, so age_seconds should always be
+            # measured from the terminal file, never the directory.
+            # Backdating only the terminal file here proves
+            # _receipt_last_activity actually reads it, rather than
+            # accidentally passing because both timestamps happen to agree.
+        else:
+            os.utime(receipt, (stamp, stamp))
+        return receipt
+
+    def test_retires_a_terminal_receipt_older_than_the_floor(self) -> None:
+        now = time.time()
+        receipt = self._receipt(
+            "cratedigger-final-gate.done", age_seconds=999, now=now, terminal=True
+        )
+
+        retired = reap_stale_final_gate_receipts(
+            self.runtime, max_age_seconds=100, reference_time=now
+        )
+
+        self.assertEqual(retired, (receipt,))
+        self.assertFalse(receipt.exists())
+
+    def test_keeps_a_terminal_receipt_within_the_floor(self) -> None:
+        now = time.time()
+        receipt = self._receipt(
+            "cratedigger-final-gate.recent", age_seconds=10, now=now, terminal=True
+        )
+
+        retired = reap_stale_final_gate_receipts(
+            self.runtime, max_age_seconds=100, reference_time=now
+        )
+
+        self.assertEqual(retired, ())
+        self.assertTrue(receipt.exists())
+
+    def test_keeps_an_old_receipt_whose_gate_process_is_still_live(self) -> None:
+        """Never retire a receipt whose recorded gate identity is still
+        live, however old — an in-progress or genuinely long final gate."""
+        now = time.time()
+        receipt = self._receipt(
+            "cratedigger-final-gate.running",
+            age_seconds=999,
+            now=now,
+            terminal=False,
+            helper_identity=self._dead_identity(),
+            gate_identity=self._live_identity(),
+        )
+
+        retired = reap_stale_final_gate_receipts(
+            self.runtime, max_age_seconds=100, reference_time=now
+        )
+
+        self.assertEqual(retired, ())
+        self.assertTrue(receipt.exists())
+
+    def test_keeps_an_old_receipt_whose_helper_process_is_still_live(self) -> None:
+        """Symmetric to the gate check: EITHER recorded identity being live
+        blocks retirement, not only the gate (asymmetric-mutant guard)."""
+        now = time.time()
+        receipt = self._receipt(
+            "cratedigger-final-gate.wrapper-alive",
+            age_seconds=999,
+            now=now,
+            terminal=False,
+            helper_identity=self._live_identity(),
+            gate_identity=self._dead_identity(),
+        )
+
+        retired = reap_stale_final_gate_receipts(
+            self.runtime, max_age_seconds=100, reference_time=now
+        )
+
+        self.assertEqual(retired, ())
+        self.assertTrue(receipt.exists())
+
+    def test_retires_an_old_receipt_with_no_terminal_and_dead_processes(self) -> None:
+        now = time.time()
+        receipt = self._receipt(
+            "cratedigger-final-gate.crashed",
+            age_seconds=999,
+            now=now,
+            terminal=False,
+            helper_identity=self._dead_identity(),
+            gate_identity=self._dead_identity(),
+        )
+
+        retired = reap_stale_final_gate_receipts(
+            self.runtime, max_age_seconds=100, reference_time=now
+        )
+
+        self.assertEqual(retired, (receipt,))
+        self.assertFalse(receipt.exists())
+
+    def test_keeps_a_fresh_receipt_with_no_terminal_and_dead_processes(self) -> None:
+        """The age gate applies independently of liveness: dead recorded
+        processes alone are not sufficient — it must ALSO be old."""
+        now = time.time()
+        receipt = self._receipt(
+            "cratedigger-final-gate.fresh-crash",
+            age_seconds=1,
+            now=now,
+            terminal=False,
+            helper_identity=self._dead_identity(),
+            gate_identity=self._dead_identity(),
+        )
+
+        retired = reap_stale_final_gate_receipts(
+            self.runtime, max_age_seconds=100, reference_time=now
+        )
+
+        self.assertEqual(retired, ())
+        self.assertTrue(receipt.exists())
+
+    def test_retires_an_old_receipt_with_no_process_identity_recorded(self) -> None:
+        """A missing pid/ticks file (interrupted before the first write) is
+        "not live", never assumed live — same posture as
+        _read_lock_holder_identity's own unreadable-content fallback."""
+        now = time.time()
+        receipt = self._receipt(
+            "cratedigger-final-gate.no-identity",
+            age_seconds=999,
+            now=now,
+            terminal=False,
+        )
+
+        retired = reap_stale_final_gate_receipts(
+            self.runtime, max_age_seconds=100, reference_time=now
+        )
+
+        self.assertEqual(retired, (receipt,))
+        self.assertFalse(receipt.exists())
+
+    def test_retiring_a_receipt_releases_its_bundle_protection(self) -> None:
+        """Retirement and bundle reaping run in the SAME admitted pass —
+        run_suite calls reap_stale_final_gate_receipts before
+        reap_stale_check_bundles — so a retired receipt's bundle is no
+        longer protected on the very next reap call. One lifecycle owner,
+        no second cleanup path."""
+        now = time.time()
+        bundle = self.runtime / "cratedigger-checks.orphaned"
+        bundle.mkdir(mode=0o700)
+        summary = bundle / "summary.json"
+        summary.write_text("{}\n")
+        stamp = now - 999
+        os.utime(summary, (stamp, stamp))
+        receipt = self._receipt(
+            "cratedigger-final-gate.protecting",
+            age_seconds=999,
+            now=now,
+            terminal=True,
+        )
+        (receipt / "bundle").write_text(f"{bundle}\n")
+
+        retired = reap_stale_final_gate_receipts(
+            self.runtime, max_age_seconds=100, reference_time=now
+        )
+        self.assertEqual(retired, (receipt,))
+
+        reaped = reap_stale_check_bundles(
+            self.runtime, max_age_seconds=100, reference_time=now
+        )
+
+        self.assertEqual(reaped, (bundle,))
+        self.assertFalse(bundle.exists())
+
+    def test_default_retirement_floor_is_seven_days(self) -> None:
+        """Pins the documented constant directly — a change here is a
+        deliberate policy change, not an accident."""
+        self.assertEqual(
+            DEFAULT_RECEIPT_RETIREMENT_MAX_AGE_SECONDS, 7 * 24 * 60 * 60
+        )
+
+    def test_run_suite_retires_eligible_receipts_before_reaping_bundles(
+        self,
+    ) -> None:
+        """Wiring pin: run_suite's own admitted pass must actually call
+        reap_stale_final_gate_receipts, and BEFORE reap_stale_check_bundles
+        — proven end-to-end through the real run_suite entry point (a
+        headroom failure short-circuits before any phase runs, so this
+        never executes the real suite)."""
+        now = time.time()
+        bundle = self.runtime / "cratedigger-checks.orphaned"
+        bundle.mkdir(mode=0o700)
+        summary = bundle / "summary.json"
+        summary.write_text("{}\n")
+        stale = now - (5 * 60 * 60)
+        os.utime(summary, (stale, stale))
+        receipt = self._receipt(
+            "cratedigger-final-gate.old",
+            age_seconds=8 * 24 * 60 * 60,
+            now=now,
+            terminal=True,
+        )
+        (receipt / "bundle").write_text(f"{bundle}\n")
+
+        phases = (
+            PhaseSpec(
+                "must-not-run", (sys.executable, "-c", "pass"), "n", "generic"
+            ),
+        )
+        stream = io.StringIO()
+
+        with self.assertRaises(RamRootExhaustedError):
+            run_suite(
+                repo_root=REPO_ROOT,
+                phases=phases,
+                runtime_dir=self.runtime,
+                stream=stream,
+                min_headroom_bytes=1 << 62,
+            )
+
+        self.assertFalse(receipt.exists(), "an eligible receipt must retire")
+        self.assertFalse(
+            bundle.exists(),
+            "its now-unprotected bundle must reap in the same admitted pass",
+        )
+        self.assertIn("retired 1 stale final-gate receipt(s)", stream.getvalue())
 
 
 class SuiteHeadroomPreconditionTestCase(unittest.TestCase):

--- a/tests/test_test_tmpfs.py
+++ b/tests/test_test_tmpfs.py
@@ -5,13 +5,20 @@ from __future__ import annotations
 import ast
 import os
 import re
+import shutil
 import stat
 import subprocess
 import tempfile
+import time
 import unittest
 from collections.abc import Mapping
 from pathlib import Path
 
+from scripts.run_test_suite import (
+    SCRATCH_TREE_OWNER_MARKER_NAME,
+    SCRATCH_TREE_PREFIX,
+    _scratch_tree_owner_dead,
+)
 from tests._source_pins import pinned_source
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -19,6 +26,10 @@ TMPFS_SETUP = REPO_ROOT / "scripts" / "test_tmpfs.sh"
 NIX_SHELL = REPO_ROOT / "nix" / "shell.nix"
 TMPFS_SETUP_AND_PRINT_TMPDIR = (
     'source "$1" && setup_cratedigger_test_tmpfs && printf "%s" "$TMPDIR"'
+)
+TMPFS_SETUP_AND_HOLD = (
+    'source "$1" && setup_cratedigger_test_tmpfs '
+    '&& printf "%s\n" "$TMPDIR" && read -r _cratedigger_test_tmpfs_hold_line'
 )
 LOW_HEADROOM_MINIMUM_BYTES = 1 << 50
 
@@ -41,6 +52,36 @@ def run_tmpfs_setup_and_print_tmpdir(
         capture_output=True,
         text=True,
         check=False,
+    )
+
+
+def run_tmpfs_setup_and_hold(
+    *,
+    env: Mapping[str, str] | None = None,
+) -> subprocess.Popen[str]:
+    """Drive the real shell helper and keep the owning shell alive, blocked
+    on stdin, until the caller lets it proceed.
+
+    Issue #1208 review D1: ``run_tmpfs_setup_and_print_tmpdir`` prints
+    TMPDIR then lets the whole script exit immediately, firing the EXIT
+    trap before a caller can observe anything about the still-live tree —
+    useless for proving the ownership marker's PRODUCER (this file) agrees
+    with its READER (``scripts.run_test_suite._scratch_tree_owner_dead``).
+    This variant blocks on a `read` after allocation so a test can inspect
+    the real ``.owner`` marker the real ``setup_cratedigger_test_tmpfs``
+    wrote, and the real process it names, while genuinely alive — then
+    either release it (closing stdin lets `read` return and the script
+    exit normally, EXIT trap fires) or SIGKILL it (trap skipped, matching
+    the founding incident).
+    """
+    return subprocess.Popen(
+        ["bash", "-c", TMPFS_SETUP_AND_HOLD, "bash", str(TMPFS_SETUP)],
+        cwd=REPO_ROOT,
+        env=env,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
     )
 
 
@@ -286,6 +327,183 @@ class TestTmpfsSetup(unittest.TestCase):
 
         self.assertIn("scripts/test_tmpfs.sh", source)
         self.assertIn("setup_cratedigger_test_tmpfs", source)
+
+
+class ScratchTreeOwnershipMarkerTestCase(unittest.TestCase):
+    """Issue #1208 review D1: nothing bound the ``.owner`` PRODUCER (this
+    file, ``scripts/test_tmpfs.sh``) to its READER
+    (``scripts.run_test_suite._scratch_tree_owner_dead``). Every existing
+    test of the reader hand-typed the marker content
+    (``tests/test_suite_coordinator.py``'s ``_write_owner_marker``), so a
+    one-character producer edit — the wrong ``/proc`` field, ``$$`` ->
+    ``$PPID``, the marker filename, the "<pid> <ticks>" delimiter — was
+    invisible to the whole suite. This class drives the REAL
+    ``setup_cratedigger_test_tmpfs`` and feeds the marker IT wrote
+    straight into the real reader (test-fidelity.md Rule C: the trigger
+    must come from the producer, never a literal)."""
+
+    def test_real_marker_reports_alive_then_dead_across_a_real_sigkill(
+        self,
+    ) -> None:
+        """THE producer<->reader binding proof. While the real owning
+        shell (blocked on `read`, genuinely alive) holds the tree,
+        ``_scratch_tree_owner_dead`` must read its real ``.owner`` marker
+        as NOT dead. SIGKILLing that same shell — the founding incident,
+        and the only signal that skips the EXIT trap — must flip the same
+        function's verdict to dead, proven against the real process the
+        marker actually names, not a hand-typed pid+ticks pair."""
+        proc = run_tmpfs_setup_and_hold(env=allocation_environment())
+        tree: Path | None = None
+        try:
+            assert proc.stdout is not None
+            tmpdir_line = proc.stdout.readline()
+            if not tmpdir_line:
+                # Only read stderr on the failure path: the child is still
+                # alive and blocked on `read` at this point on the happy
+                # path, so an unconditional proc.stderr.read() here would
+                # block until EOF — i.e. until the child exits, which it
+                # never will while blocked. An f-string argument to
+                # assertTrue is evaluated eagerly regardless of the
+                # assertion's outcome, so that shape deadlocks even when
+                # tmpdir_line IS truthy; this explicit branch is required,
+                # not stylistic.
+                self.fail(
+                    "no TMPDIR line from the real setup function; "
+                    f"stderr={proc.stderr.read() if proc.stderr else ''!r}"
+                )
+            tree = Path(tmpdir_line.strip())
+            self.assertTrue(tree.name.startswith(SCRATCH_TREE_PREFIX))
+
+            marker = tree / SCRATCH_TREE_OWNER_MARKER_NAME
+            deadline = time.monotonic() + 5.0
+            while not marker.exists() and time.monotonic() < deadline:
+                time.sleep(0.02)
+            self.assertTrue(
+                marker.exists(),
+                "the real setup_cratedigger_test_tmpfs never wrote .owner",
+            )
+
+            self.assertFalse(
+                _scratch_tree_owner_dead(tree),
+                "the real owning shell is alive but the real marker it "
+                "wrote was read as dead",
+            )
+
+            proc.kill()
+            proc.wait(timeout=5)
+
+            self.assertTrue(
+                tree.exists(),
+                "SIGKILL must skip the EXIT trap, exactly like the "
+                "founding incident (only SIGKILL does)",
+            )
+            self.assertTrue(
+                _scratch_tree_owner_dead(tree),
+                "the real owning shell is confirmed dead (SIGKILLed and "
+                "reaped by wait()) but the real marker it wrote was read "
+                "as alive",
+            )
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+            for pipe in (proc.stdin, proc.stdout, proc.stderr):
+                if pipe is not None:
+                    pipe.close()
+            if tree is not None:
+                shutil.rmtree(tree, ignore_errors=True)
+
+    def test_owner_marker_write_failure_does_not_leak_a_stray_diagnostic(
+        self,
+    ) -> None:
+        """Issue #1208 review D5: bash redirections apply LEFT TO RIGHT,
+        so a naive ``>file 2>/dev/null`` order does NOT suppress a failed
+        OPEN of ``file`` — the diagnostic prints on the still-live
+        original stderr before ``2>/dev/null`` is even installed.
+        Overrides ``mktemp`` to chmod the real scratch tree read-only the
+        instant it is created, forcing the real ``.owner`` write inside
+        ``setup_cratedigger_test_tmpfs`` to fail exactly the way a
+        full/permission-denied tmpfs does — reproduced against the real
+        function, not a snippet in isolation. Uses the same held-shell
+        pattern as the round-trip test above (not a plain
+        ``subprocess.run``): the EXIT trap removes the read-only-but-empty
+        tree the instant the script would otherwise exit, so the marker's
+        absence can only be observed while the shell is still genuinely
+        alive and deliberately blocked before that point."""
+        override_mktemp_readonly = (
+            "mktemp() {\n"
+            "    local real_dir\n"
+            '    real_dir=$(command mktemp "$@") || return 1\n'
+            '    chmod 500 "$real_dir"\n'
+            '    printf "%s\\n" "$real_dir"\n'
+            "}\n"
+            "export -f mktemp\n"
+        )
+        proc = subprocess.Popen(
+            [
+                "bash",
+                "-c",
+                override_mktemp_readonly + TMPFS_SETUP_AND_HOLD,
+                "bash",
+                str(TMPFS_SETUP),
+            ],
+            cwd=REPO_ROOT,
+            env=allocation_environment(),
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        tree: Path | None = None
+        try:
+            assert proc.stdout is not None
+            tmpdir_line = proc.stdout.readline()
+            if not tmpdir_line:
+                self.fail(
+                    "no TMPDIR line from the real setup function; "
+                    f"stderr={proc.stderr.read() if proc.stderr else ''!r}"
+                )
+            tree = Path(tmpdir_line.strip())
+
+            # The shell is still blocked at `read` here — genuinely alive
+            # and holding the read-only tree open — so this observes the
+            # write's real outcome, not the EXIT trap's aftermath.
+            self.assertTrue(tree.exists())
+            self.assertFalse(
+                (tree / SCRATCH_TREE_OWNER_MARKER_NAME).exists(),
+                "the marker write should have failed on the read-only tree",
+            )
+
+            # A blank line, not a bare close: bash's `read` returns
+            # non-zero on EOF-without-a-line, which the EXIT trap would
+            # then propagate as this script's own exit status — nothing
+            # to do with the diagnostic-suppression fix under test, but a
+            # real newline lets `read` succeed normally so the script's
+            # actual exit code reflects the setup itself, not this
+            # release mechanism's own plumbing.
+            assert proc.stdin is not None
+            proc.stdin.write("\n")
+            proc.stdin.close()
+            stderr_output = proc.stderr.read() if proc.stderr else ""
+            proc.wait(timeout=5)
+
+            self.assertEqual(proc.returncode, 0, stderr_output)
+            self.assertEqual(
+                stderr_output,
+                "",
+                "the failed .owner write leaked a diagnostic instead of "
+                "being silently suppressed",
+            )
+        finally:
+            if proc.poll() is None:
+                proc.kill()
+                proc.wait(timeout=5)
+            for pipe in (proc.stdin, proc.stdout, proc.stderr):
+                if pipe is not None:
+                    pipe.close()
+            if tree is not None and tree.exists():
+                tree.chmod(0o700)
+                shutil.rmtree(tree, ignore_errors=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #1208 items 1 and 4.

Authority for reopening these two items, which a prior ruling had declined as "machinery":

> "the reaper i was talking about was for worktrees, if there's a ram reaper we probably need to fix this."

— operator, verbatim, 2026-08-20. The earlier ruling covered **worktree** cleanup only; worktree hygiene remains policy-only, unchanged.

## The defects

**Item 1** — `_REAPABLE_PREFIXES` did not cover `cratedigger-tests.*`, the suite's own scratch tree created by `scripts/test_tmpfs.sh` and exported as `TMPDIR`. In the founding incident two OOM-killed runs stranded 910 M and 339 M trees, which then deterministically failed a named test on three consecutive later gate runs.

**Item 4** — receipts pinned bundles against the reaper forever. Measured on the live root: 68 bundles, 68 receipts, **61 pinned — effective reaper coverage ~7 of 68 and shrinking**.

## Why the previous attempt was reverted, and how this differs

The prior attempt used **directory mtime** as the liveness signal and was reverted after review proved it reaped **live** trees. This one requires positive proof of death:

`scripts/test_tmpfs.sh` writes a `.owner` marker (`"<pid> <ticks>"`) into its own scratch tree immediately after `mktemp`; `_scratch_tree_owner_dead` verifies death with the pid-reuse-safe `_proc_start_ticks(pid) != ticks` comparison already used by the admission lock and `run_final_gate.sh`. **Every ambiguous case fails closed** — missing marker, unreadable marker, malformed content, or any non-`ENOENT` `/proc` error all mean "not dead", so "cannot prove dead" always beats "looks stale".

Reproduced end-to-end: a real backgrounded `nix-shell`, its real marker, `kill -9` on the owning shell (EXIT trap skipped — only SIGKILL defeats it; SIGTERM/SIGINT/SIGHUP all clean up), tree survives on disk, then correctly reported dead and reaped once aged past the floor.

Receipt retirement: a receipt retires only once `terminal` exists (or both recorded identities are conclusively dead) **and** it is older than a fixed 7-day floor, called before bundle reaping so a retired receipt's protection lapses in the same pass. `run_final_gate.sh status` on a retired receipt fails visibly rather than reporting a stale verdict.

## Kill matrix

| Site (assertion / clause / constant) | One-line mutant | Test that goes RED | Result |
| --- | --- | --- | --- |
| `test_tmpfs.sh` ticks field | `awk '{print $20}'` → `$21` | `test_real_marker_reports_alive_then_dead_across_a_real_sigkill` | RED (**deletes a live tree** without this) |
| `test_tmpfs.sh` pid | `"$$"` → `"$PPID"` | same | RED |
| `test_tmpfs.sh` marker name | `.owner` → `.owner-v2` | same | RED |
| `run_test_suite.py` reader marker name | drift from producer | same | RED |
| `reap_stale_check_bundles` scratch gate | drop `not _scratch_tree_owner_dead(...)` (the reverted design) | `test_reap_never_touches_a_live_owned_scratch_tree` | RED |
| `_scratch_tree_owner_dead` compare | `!=` → `==` | live/dead pid tests | RED |
| `_scratch_tree_owner_dead` missing marker | `return False` → `True` (fail-open) | missing-marker + no-marker tests | RED |
| `_scratch_tree_owner_dead` grammar | `all(...)` → `any(...)` | malformed-marker test | RED |
| `_proc_stat_start_ticks` non-ENOENT | `OSError` → `(True, None)` | `…confirms_absence_only_on_file_not_found` | RED |
| `_proc_stat_start_ticks` ENOENT | → `(False, None)` | same | RED |
| `_scratch_tree_last_activity` | revert recursive walk | `…keeps_a_dead_owned_tree_with_recent_nested_activity` | RED |
| `_scratch_tree_last_activity` | `max(latest, e)` → `e` (last-wins) | walk-order fixture | RED |
| `_scratch_tree_last_activity` | `(*dirs, *files)` → `files` | directory-mtime fixture | RED |
| `reap_stale_final_gate_receipts` uid guard | drop `st_uid != getuid()` | uid-remapped-namespace test | RED (**deletes a foreign-uid dir** without it) |
| `reap_stale_check_bundles` uid guard | same | same | RED |
| `_receipt_is_retirable` | `or` → `and` | live-identity tests | RED |
| `_receipt_is_retirable` | always retirable | retirement tests | RED |
| receipt age floor | removed | floor tests | RED |
| `run_suite` ordering | bundles before receipts | ordering test | RED |
| `.owner` write redirection | revert `2>/dev/null >file` order | `…does_not_leak_a_stray_diagnostic` | RED |
| pid/ticks parse | `isdecimal()` → `isdigit()` | non-ASCII-digit test | RED (uncaught `ValueError` aborts the suite) |

## Review

Two independent reviews. The first found the code correct **today** but the producer (`scripts/test_tmpfs.sh`) entirely untested — every `.owner` input in the suite was a hand-typed literal, and a one-character producer edit was proven to delete a live tree (test-fidelity Rule C). The second returned **"safe to ship as a deletion mechanism"** — no world could be constructed where a live tree is reaped — with four claim/coverage gaps, all closed here.

Notable self-correction: the first attempt at the foreign-uid test built the fixture with `unshare` but ran the *delete attempt* from a normal process, where ordinary POSIX permissions already block it — vacuous. It now runs inside the same uid-remapped namespace, where the process is fake-root with `DAC_OVERRIDE` and the software guard is the sole protection.

## Operator action required after merge

Every `cratedigger-tests.*` tree created by a **pre-merge** shell is markerless, and fail-closed means those are **never reaped**. The founding incident's own cohort therefore needs one manual sweep after this lands. Documented in the code rather than weakened into an mtime heuristic.

## Stated residuals

- A live-but-**quiet** orphaned descendant of a SIGKILLed owner is invisible to the recursive walk (reproduced); for that case the design falls back to the mtime heuristic. Documented next to the rationale.
- An owner in a different PID namespace would read `ENOENT` as confirmed-dead. Unreachable today — nothing in the repo enters a PID namespace. Noted in the docstring.
- `private_runtime_dir` ignores `CRATEDIGGER_TEST_RAM_ROOT` while the headroom check and `test_tmpfs.sh` honour it; coverage gap only, no deletion risk. Documented.

No deploy: test-infrastructure, dev-shell, docs and rules only — zero doc2 runtime delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
