### PR TITLE
fix(#1156): bound the fuzz lane and stop disguising memory exhaustion as ordinary test failures

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -546,36 +546,59 @@ A target whose failures are ENTIRELY disk-full returns
 `infrastructure-failure`, not an ordinary `failed`, without touching
 `scripts/run_test_suite.py`'s generic phase-state derivation.
 `scripts/fuzz_burst.sh` (`scripts/run_fuzz_tests.py`) and
-`scripts/run_world_model_burst.py` deliberately do NOT take
-`acquire_suite_admission`'s exclusive lock or `reap_stale_check_bundles`'s
-scratch reaping (issue #1156 items 1-3): both are long-running,
-variable-duration bursts (minutes interactively, up to the full overnight
-`CRATEDIGGER_FUZZ_MAX_EXAMPLES` budget in the daily gate), and folding them
-into the SAME exclusive queue an ordinary, quick `scripts/test.sh` dev-loop
-run waits on would starve that bounded wait, or force raising its timeout
-for everyone. They DO each now run their own analogous headroom
-precondition — `headroom_floor_bytes`/`_check_suite_headroom`, called once
-before any work and again inside their own admission loop before every new
-target — closing the #1111-era residual for the fail-fast half. Both pass
-`worker_count=1` (the flat, override-respecting `DEFAULT_MIN_HEADROOM_BYTES`
-floor), not a worker-scaled one: neither burst has a MEASURED per-worker
-tmpfs footprint the way the deterministic suite's #1131 model does — a
-worker-scaled attempt sized by the fuzz burst's own default worker count
-(up to 60 on a 30-core host) demanded over 4 GiB, more than a normal
-interactive dev tmpfs actually has free (see `headroom_floor_bytes`'s
-docstring). `recommended_fuzz_jobs` also gained a ceiling
-(`MAX_FUZZ_JOBS`), the only worker formula in the repo that previously had
-none. Separately, `run_python_tests.py`'s worker-death classifier
+`scripts/run_world_model_burst.py` each now run their own analogous
+headroom precondition (issue #1156 item 3) — `headroom_floor_bytes`/
+`_check_suite_headroom`, called once before any work and again once per
+admission CYCLE inside their own admission loop (a cycle can admit up to
+`worker_count` targets at once, so this is not a per-target check).
+Honestly stated (independent review F6/F7): in the daily gate specifically
+this preflight is a near-duplicate of a check that already ran seconds
+earlier — `scripts/daily_flake_update.sh` scopes
+`CRATEDIGGER_SUITE_OWNS_HEADROOM=1` to its `deterministic_suite` stage
+only, so the `world_model`/`generated_fuzz`/`mirror_harness` stages still
+hit `scripts/test_tmpfs.sh`'s shell-entry guard on the SAME root with the
+SAME env var and the SAME flat 1 GiB default before either coordinator's
+own `main` ever runs. The coordinator-level preflight's real added value
+is for a SECOND invocation inside an already-entered shell (interactive
+dev use, or any caller that skips the wrapper `.sh` and its shellHook),
+where nothing else re-checks headroom between shell entry and that call.
+Neither burst takes `acquire_suite_admission`'s exclusive lock or
+`reap_stale_check_bundles`'s scratch reaping; each `main`'s own docstring
+records the reasoning (both are long-running, variable-duration bursts
+that would starve or force raising the timeout on the bounded queue an
+ordinary `scripts/test.sh` dev-loop run waits on). Both pass
+`worker_count=1` to `headroom_floor_bytes`
+(the flat, override-respecting `DEFAULT_MIN_HEADROOM_BYTES` floor), not a
+worker-scaled one: neither burst has a MEASURED per-worker tmpfs footprint
+the way the deterministic suite's #1131 model does — a worker-scaled
+attempt sized by the fuzz burst's own default worker count (up to 60 on a
+30-core host) demanded over 4 GiB, more than a normal interactive dev
+tmpfs actually has free (see `headroom_floor_bytes`'s docstring). Tripping
+either guard stops ADMISSION only — already-running targets keep
+consuming the reserve regardless, so this is a correct label and exit code
+on the way out, not prevention, and the abort is one-way with no
+hysteresis. `recommended_fuzz_jobs` separately gained a ceiling
+(`MAX_FUZZ_JOBS` = 64, issue #1214 "Contributing gaps" item 1, NOT #1156
+item 1): it is inert on hosts measured to date (doc1 at 30 cores computes
+60, well under 64) and would not by itself have prevented the 2026-08-20
+incident (60 was already the number that overflowed) — it is fail-closed
+legislation for a future, larger host. Separately,
+`run_python_tests.py`'s worker-death classifier
 (`_classify_target_infrastructure_failure`) now also folds a worker killed
 by the OOM killer — exception shape `BrokenProcessPool`, corroborated by
-measured `/proc/meminfo` `MemAvailable` below
-`CRATEDIGGER_TEST_MEMORY_MIN_BYTES` — into ONE named
-`test host memory exhausted` marker (`TEST_HOST_MEMORY_EXHAUSTED` /
-`_collapse_memory_exhausted_failures`), the same N-disguises fix
-`TEST_RAM_ROOT_EXHAUSTED` above already gave disk-full. A DIFFERENT
-resource (system memory, not the tmpfs RAM root) gets a DIFFERENT identity
-and exit code (`TEST_HOST_MEMORY_EXHAUSTED_EXIT_CODE`), never folded into
-the disk-full bucket.
+measured `/proc/meminfo` `MemAvailable` below the env-overridable
+`CRATEDIGGER_TEST_MEMORY_MIN_BYTES` (mirroring `CRATEDIGGER_TEST_RAM_MIN_BYTES`'s
+own override pattern) — into ONE named `test host memory exhausted` marker
+(`TEST_HOST_MEMORY_EXHAUSTED` / `_collapse_memory_exhausted_failures`), the
+same N-disguises fix `TEST_RAM_ROOT_EXHAUSTED` above already gave
+disk-full. A DIFFERENT resource (system memory, not the tmpfs RAM root)
+gets a DIFFERENT identity and exit code
+(`TEST_HOST_MEMORY_EXHAUSTED_EXIT_CODE`), never folded into the disk-full
+bucket. If BOTH a disk-full marker and a memory-exhausted marker occur in
+the same run (different targets), the phase reports an ordinary failed
+rather than promoting to infrastructure-failure — a known, accepted
+residual (independent review F10), not a claim that the two never
+co-occur.
 
 **Generated (property-based) production tests**
 (`tests/test_*_generated.py`, Hypothesis)

--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -563,10 +563,18 @@ is for a SECOND invocation inside an already-entered shell (interactive
 dev use, or any caller that skips the wrapper `.sh` and its shellHook),
 where nothing else re-checks headroom between shell entry and that call.
 Neither burst takes `acquire_suite_admission`'s exclusive lock or
-`reap_stale_check_bundles`'s scratch reaping; each `main`'s own docstring
-records the reasoning (both are long-running, variable-duration bursts
-that would starve or force raising the timeout on the bounded queue an
-ordinary `scripts/test.sh` dev-loop run waits on). Both pass
+`reap_stale_check_bundles`'s scratch reaping. Independent review B-4 (third
+round, issue #1156): these are two SEPARATE decisions, and only the lock one
+is where this paragraph previously claimed both were -- each `main`'s own
+docstring records the lock reasoning (both are long-running, variable-
+duration bursts that would starve or force raising the timeout on the
+bounded queue an ordinary `scripts/test.sh` dev-loop run waits on); neither
+docstring mentions `reap_stale_check_bundles` at all. The reaping decision
+is simpler and stated here instead: `reap_stale_check_bundles` only reaps
+`cratedigger-checks.*`/fixture-prefixed scratch under the ADMISSION LOCK
+(`scripts/run_test_suite.py::run_suite`, called for neither burst), so a
+burst that never takes that lock has no reap call to make in the first
+place -- there is no burst-specific tradeoff to document. Both pass
 `worker_count=1` to `headroom_floor_bytes`
 (the flat, override-respecting `DEFAULT_MIN_HEADROOM_BYTES` floor), not a
 worker-scaled one: neither burst has a MEASURED per-worker tmpfs footprint

--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -545,9 +545,37 @@ A target whose failures are ENTIRELY disk-full returns
 `TEST_RAM_ROOT_EXHAUSTED_EXIT_CODE` so the phase (and the suite) reports
 `infrastructure-failure`, not an ordinary `failed`, without touching
 `scripts/run_test_suite.py`'s generic phase-state derivation.
-`scripts/fuzz_burst.sh` and `scripts/run_world_model_burst.py` remain
-entirely outside this gate — a known, stated residual, part of #1111's own
-incident set, not a hidden gap.
+`scripts/fuzz_burst.sh` (`scripts/run_fuzz_tests.py`) and
+`scripts/run_world_model_burst.py` deliberately do NOT take
+`acquire_suite_admission`'s exclusive lock or `reap_stale_check_bundles`'s
+scratch reaping (issue #1156 items 1-3): both are long-running,
+variable-duration bursts (minutes interactively, up to the full overnight
+`CRATEDIGGER_FUZZ_MAX_EXAMPLES` budget in the daily gate), and folding them
+into the SAME exclusive queue an ordinary, quick `scripts/test.sh` dev-loop
+run waits on would starve that bounded wait, or force raising its timeout
+for everyone. They DO each now run their own analogous headroom
+precondition — `headroom_floor_bytes`/`_check_suite_headroom`, called once
+before any work and again inside their own admission loop before every new
+target — closing the #1111-era residual for the fail-fast half. Both pass
+`worker_count=1` (the flat, override-respecting `DEFAULT_MIN_HEADROOM_BYTES`
+floor), not a worker-scaled one: neither burst has a MEASURED per-worker
+tmpfs footprint the way the deterministic suite's #1131 model does — a
+worker-scaled attempt sized by the fuzz burst's own default worker count
+(up to 60 on a 30-core host) demanded over 4 GiB, more than a normal
+interactive dev tmpfs actually has free (see `headroom_floor_bytes`'s
+docstring). `recommended_fuzz_jobs` also gained a ceiling
+(`MAX_FUZZ_JOBS`), the only worker formula in the repo that previously had
+none. Separately, `run_python_tests.py`'s worker-death classifier
+(`_classify_target_infrastructure_failure`) now also folds a worker killed
+by the OOM killer — exception shape `BrokenProcessPool`, corroborated by
+measured `/proc/meminfo` `MemAvailable` below
+`CRATEDIGGER_TEST_MEMORY_MIN_BYTES` — into ONE named
+`test host memory exhausted` marker (`TEST_HOST_MEMORY_EXHAUSTED` /
+`_collapse_memory_exhausted_failures`), the same N-disguises fix
+`TEST_RAM_ROOT_EXHAUSTED` above already gave disk-full. A DIFFERENT
+resource (system memory, not the tmpfs RAM root) gets a DIFFERENT identity
+and exit code (`TEST_HOST_MEMORY_EXHAUSTED_EXIT_CODE`), never folded into
+the disk-full bucket.
 
 **Generated (property-based) production tests**
 (`tests/test_*_generated.py`, Hypothesis)

--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -572,7 +572,9 @@ ordinary `scripts/test.sh` dev-loop run waits on). Both pass
 worker-scaled one: neither burst has a MEASURED per-worker tmpfs footprint
 the way the deterministic suite's #1131 model does — a worker-scaled
 attempt sized by the fuzz burst's own default worker count (up to 60 on a
-30-core host) demanded over 4 GiB, more than a normal interactive dev
+30-core host) demanded EXACTLY 4 GiB (256 MiB base + 64 MiB/worker * 60
+workers = 4096 MiB, independent review B7 item 2 — "over 4 GiB" overstated
+it), more than a normal interactive dev
 tmpfs actually has free (see `headroom_floor_bytes`'s docstring). Tripping
 either guard stops ADMISSION only — already-running targets keep
 consuming the reserve regardless, so this is a correct label and exit code

--- a/docs/generated-testing.md
+++ b/docs/generated-testing.md
@@ -399,7 +399,16 @@ coordinator-owned ephemeral PostgreSQL cluster is migrated once, then every
 active target gets a distinct cloned database. Each target also runs in a fresh
 interpreter with private Beets and Hypothesis paths. Ambient `TEST_DB_DSN` is
 replaced with an owned clone DSN and children cannot stop the shared cluster.
-The mirror-harness engine remains separately capped at two jobs.
+The mirror-harness engine remains separately capped at two jobs. A shared
+tmpfs-headroom precondition (`headroom_floor_bytes`/`_check_suite_headroom`,
+the same primitives `scripts/run_test_suite.py::run_suite` and the fuzz burst
+use) runs once before any work and again inside the admission loop before
+every new target; either trip aborts the run under the `test RAM root
+exhausted` identity rather than surfacing as an opaque coordinator crash
+(issue #1156 item 3). Like the fuzz burst, it uses the flat, override-
+respecting default floor (`CRATEDIGGER_TEST_RAM_MIN_BYTES`), not one scaled
+by its own job count: no MEASURED per-worker tmpfs footprint exists for this
+coordinator's own worker pool.
 
 Every run prints a random 64-bit root seed before storage starts; `--seed`
 recreates that schedule. Target seeds derive only from the root seed, logical
@@ -563,13 +572,24 @@ the module's other properties or pins. An exact-budget check rejects any
 schedule that omits a test, repeats a pin, changes a property's combined example
 count, exceeds a resource shard limit, or invents an ID.
 
-The queue defaults to twice the host's core count because these targets mix
-Python with subprocess and filesystem waits. PostgreSQL-backed targets have a
+The queue defaults to twice the host's core count, capped at `MAX_FUZZ_JOBS`
+(64) regardless of host size (issue #1156 item 1 — the only worker formula in
+the repository with no prior ceiling), because these targets mix Python with
+subprocess and filesystem waits. PostgreSQL-backed targets have a
 separate bounded lane (24 targets on doc1's 30-core host); admission fills that
 lane before ordinary capacity so PostgreSQL work cannot accumulate into a
 low-utilization tail. Any `ENOSPC`, PostgreSQL `DiskFull`, or unexpected loss of
 an ephemeral database aborts further admission and reports that the property
-verdict is invalid. Set `CRATEDIGGER_FUZZ_JOBS` to cap all concurrent processes,
+verdict is invalid. A shared tmpfs-headroom precondition
+(`headroom_floor_bytes`/`_check_suite_headroom`, the same primitives
+`scripts/run_test_suite.py::run_suite` uses) runs once before any work and
+again inside the admission loop before every new target; either trip aborts
+the same way, under the `test RAM root exhausted` identity, before the burst
+can silently ENOSPC deep into a run (issue #1156 item 3). Unlike the
+deterministic suite's own worker-scaled floor, the fuzz burst uses the flat,
+override-respecting default (`CRATEDIGGER_TEST_RAM_MIN_BYTES`): there is no
+equivalent measured per-worker tmpfs footprint for its own, much larger and
+differently-shaped worker pool. Set `CRATEDIGGER_FUZZ_JOBS` to cap all concurrent processes,
 `CRATEDIGGER_FUZZ_POSTGRES_JOBS` to cap the PostgreSQL lane, or
 `CRATEDIGGER_FUZZ_PROPERTY_SHARDS` to override automatic entropy fan-out. On
 doc1's 30-core VM on 2026-07-23, the complete 71-module,

--- a/docs/generated-testing.md
+++ b/docs/generated-testing.md
@@ -402,13 +402,20 @@ replaced with an owned clone DSN and children cannot stop the shared cluster.
 The mirror-harness engine remains separately capped at two jobs. A shared
 tmpfs-headroom precondition (`headroom_floor_bytes`/`_check_suite_headroom`,
 the same primitives `scripts/run_test_suite.py::run_suite` and the fuzz burst
-use) runs once before any work and again inside the admission loop before
-every new target; either trip aborts the run under the `test RAM root
+use) runs once before any work and again once per admission CYCLE inside the
+admission loop (a cycle can admit up to `jobs` targets at once, so this is
+not a per-target check); either trip aborts the run under the `test RAM root
 exhausted` identity rather than surfacing as an opaque coordinator crash
 (issue #1156 item 3). Like the fuzz burst, it uses the flat, override-
 respecting default floor (`CRATEDIGGER_TEST_RAM_MIN_BYTES`), not one scaled
 by its own job count: no MEASURED per-worker tmpfs footprint exists for this
-coordinator's own worker pool.
+coordinator's own worker pool. Same daily-gate redundancy caveat as the fuzz
+burst below: `scripts/daily_flake_update.sh` only sets
+`CRATEDIGGER_SUITE_OWNS_HEADROOM=1` for its deterministic-suite stage, so
+this coordinator's `world_model`/`mirror_harness` stages still hit
+`scripts/test_tmpfs.sh`'s own shell-entry guard on the same root moments
+earlier — the mid-run half, not the preflight half, is this change's
+genuinely new protection.
 
 Every run prints a random 64-bit root seed before storage starts; `--seed`
 recreates that schedule. Target seeds derive only from the root seed, logical
@@ -573,9 +580,9 @@ schedule that omits a test, repeats a pin, changes a property's combined example
 count, exceeds a resource shard limit, or invents an ID.
 
 The queue defaults to twice the host's core count, capped at `MAX_FUZZ_JOBS`
-(64) regardless of host size (issue #1156 item 1 — the only worker formula in
-the repository with no prior ceiling), because these targets mix Python with
-subprocess and filesystem waits. PostgreSQL-backed targets have a
+(64) regardless of host size (issue #1214 "Contributing gaps" item 1 — NOT
+#1156 item 1, a different, unrelated finding), because these targets mix
+Python with subprocess and filesystem waits. PostgreSQL-backed targets have a
 separate bounded lane (24 targets on doc1's 30-core host); admission fills that
 lane before ordinary capacity so PostgreSQL work cannot accumulate into a
 low-utilization tail. Any `ENOSPC`, PostgreSQL `DiskFull`, or unexpected loss of
@@ -583,13 +590,39 @@ an ephemeral database aborts further admission and reports that the property
 verdict is invalid. A shared tmpfs-headroom precondition
 (`headroom_floor_bytes`/`_check_suite_headroom`, the same primitives
 `scripts/run_test_suite.py::run_suite` uses) runs once before any work and
-again inside the admission loop before every new target; either trip aborts
-the same way, under the `test RAM root exhausted` identity, before the burst
-can silently ENOSPC deep into a run (issue #1156 item 3). Unlike the
-deterministic suite's own worker-scaled floor, the fuzz burst uses the flat,
-override-respecting default (`CRATEDIGGER_TEST_RAM_MIN_BYTES`): there is no
-equivalent measured per-worker tmpfs footprint for its own, much larger and
-differently-shaped worker pool. Set `CRATEDIGGER_FUZZ_JOBS` to cap all concurrent processes,
+again once per admission CYCLE inside the admission loop (a cycle can admit
+up to `worker_count` targets at once, so this is not a per-target check);
+either trip aborts the same way, under the `test RAM root exhausted`
+identity, before the burst can silently ENOSPC deep into a run (issue #1156
+item 3). The MID-RUN half is the genuinely new protection; the PREFLIGHT
+half is a near-duplicate in the daily gate specifically, where
+`scripts/daily_flake_update.sh` only sets `CRATEDIGGER_SUITE_OWNS_HEADROOM=1`
+for its deterministic-suite stage, so `scripts/test_tmpfs.sh`'s own
+shell-entry guard already checked the SAME root with the SAME flat 1 GiB
+default moments earlier — the preflight's real added value is a SECOND
+invocation inside an already-entered shell. Unlike the deterministic suite's
+own worker-scaled floor, the fuzz
+burst uses the flat, override-respecting default
+(`CRATEDIGGER_TEST_RAM_MIN_BYTES`): there is no equivalent measured
+per-worker tmpfs footprint for its own, much larger and differently-shaped
+worker pool. Tripping the guard stops ADMISSION only -- already-running
+targets keep consuming the reserve regardless, so this is a correct label
+and exit code on the way out, not prevention, and the abort is one-way with
+no hysteresis (a single transient dip abandons every not-yet-started
+target). Separately (and NOT part of this headroom precondition): when the
+deterministic suite's own Python-phase worker pool runs a generated-test
+module deterministically (`run_python_tests.py`'s own `ProcessPoolExecutor`
+scheduling, not this randomized nightly burst -- the burst spawns each
+target's own subprocess directly via `subprocess.run` and so can never
+raise `BrokenProcessPool`), a worker killed by the OOM killer is classified
+honestly rather than reported as an ordinary per-target failure:
+`_classify_target_infrastructure_failure` recognizes the `BrokenProcessPool`
+shape, corroborated by measured `/proc/meminfo` `MemAvailable` below the
+env-overridable `CRATEDIGGER_TEST_MEMORY_MIN_BYTES` (mirroring
+`CRATEDIGGER_TEST_RAM_MIN_BYTES`'s own override pattern), and folds every
+such worker death into one `test host memory exhausted` marker instead of
+N separately-indexed disguises (issue #1156 item 2). Set
+`CRATEDIGGER_FUZZ_JOBS` to cap all concurrent processes,
 `CRATEDIGGER_FUZZ_POSTGRES_JOBS` to cap the PostgreSQL lane, or
 `CRATEDIGGER_FUZZ_PROPERTY_SHARDS` to override automatic entropy fan-out. On
 doc1's 30-core VM on 2026-07-23, the complete 71-module,

--- a/scripts/run_fuzz_tests.py
+++ b/scripts/run_fuzz_tests.py
@@ -12,7 +12,7 @@ import tempfile
 import time
 import unittest
 from collections import Counter
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from concurrent.futures import (
     FIRST_COMPLETED,
     Future,
@@ -33,6 +33,7 @@ if str(REPO_ROOT) not in sys.path:
 from scripts.run_python_tests import (
     HOTSPOT_SHARD_POLICIES,
     STRATEGY_SPACE_EXHAUSTED,
+    TEST_RAM_ROOT_EXHAUSTED_EXIT_CODE,
     ChildTargetResult,
     HypothesisPropertyStats,
     TestModule,
@@ -42,6 +43,13 @@ from scripts.run_python_tests import (
     resolve_hypothesis_settings,
     settings_max_examples,
     shard_test_ids,
+)
+from scripts.run_test_suite import (
+    TEST_RAM_ROOT_EXHAUSTED,
+    RamRootExhaustedError,
+    _check_suite_headroom,
+    headroom_floor_bytes,
+    private_runtime_dir,
 )
 from tests.finite_domain_metadata import (
     FINITE_DOMAIN_ATTRIBUTE,
@@ -163,6 +171,11 @@ class FuzzTargetBatch:
     results: tuple[FuzzRunResult, ...]
     infrastructure_failures: tuple[FuzzInfrastructureFailure, ...]
     not_started: tuple[FuzzTarget, ...]
+    #: Set when the coordinator's own mid-run headroom check (issue #1156
+    #: item 3) tripped, rather than any individual target — a coordinator-
+    #: level abort, not a per-target infrastructure failure, so it is kept
+    #: out of ``infrastructure_failures``.
+    headroom_exhausted: bool = False
 
 
 class PersistedFuzzTarget(msgspec.Struct, frozen=True):
@@ -905,12 +918,31 @@ def run_fuzz_targets(
     postgres_worker_count: int,
     environment: Mapping[str, str],
     log_directory: Path,
+    check_headroom: Callable[[], None],
 ) -> FuzzTargetBatch:
-    """Run a bounded queue and stop admission after infrastructure loss."""
+    """Run a bounded queue and stop admission after infrastructure loss.
+
+    ``check_headroom`` is called once per admission cycle, right before any
+    new target would be admitted (issue #1156 item 3): the production
+    caller (``main`` below) binds it to the same
+    ``_check_suite_headroom``/``headroom_floor_bytes`` precondition the
+    coordinator already ran once, before any work, so a run admitted at
+    floor+ε does not silently ENOSPC deep into the burst — it aborts here,
+    under the same named identity, instead of surfacing as an opaque
+    per-target subprocess crash. A ``RamRootExhaustedError`` stops
+    admission exactly like an infrastructure failure (already-running
+    targets are drained, nothing new starts), but is reported through
+    ``FuzzTargetBatch.headroom_exhausted`` rather than
+    ``infrastructure_failures`` — it is a coordinator-level abort, not an
+    individual target's failure. No default: the real closure needs a
+    resolved runtime path only ``main`` owns; tests inject a controlled
+    fake.
+    """
     results: list[FuzzRunResult] = []
     infrastructure_failures: list[FuzzInfrastructureFailure] = []
     pending = list(enumerate(targets))
     infrastructure_aborted = False
+    headroom_exhausted = False
     completed_count = 0
     with ThreadPoolExecutor(max_workers=worker_count) as executor:
         futures: dict[
@@ -919,33 +951,40 @@ def run_fuzz_targets(
         ] = {}
         while futures or (pending and not infrastructure_aborted):
             if not infrastructure_aborted:
-                active = tuple(target for _index, target in futures.values())
-                admitted_positions = select_fuzz_admissions(
-                    tuple(target for _index, target in pending),
-                    active,
-                    worker_count=worker_count,
-                    postgres_worker_count=postgres_worker_count,
-                )
-                admitted_position_set = set(admitted_positions)
-                admitted = tuple(
-                    item
-                    for position, item in enumerate(pending)
-                    if position in admitted_position_set
-                )
-                pending = [
-                    item
-                    for position, item in enumerate(pending)
-                    if position not in admitted_position_set
-                ]
-                for index, target in admitted:
-                    future = executor.submit(
-                        _execute_fuzz_target,
-                        index,
-                        target,
-                        environment=environment,
-                        log_directory=log_directory,
+                try:
+                    check_headroom()
+                except RamRootExhaustedError as exc:
+                    infrastructure_aborted = True
+                    headroom_exhausted = True
+                    print(f"RAM ROOT EXHAUSTED mid-run: {exc}", flush=True)
+                else:
+                    active = tuple(target for _index, target in futures.values())
+                    admitted_positions = select_fuzz_admissions(
+                        tuple(target for _index, target in pending),
+                        active,
+                        worker_count=worker_count,
+                        postgres_worker_count=postgres_worker_count,
                     )
-                    futures[future] = (index, target)
+                    admitted_position_set = set(admitted_positions)
+                    admitted = tuple(
+                        item
+                        for position, item in enumerate(pending)
+                        if position in admitted_position_set
+                    )
+                    pending = [
+                        item
+                        for position, item in enumerate(pending)
+                        if position not in admitted_position_set
+                    ]
+                    for index, target in admitted:
+                        future = executor.submit(
+                            _execute_fuzz_target,
+                            index,
+                            target,
+                            environment=environment,
+                            log_directory=log_directory,
+                        )
+                        futures[future] = (index, target)
             if not futures:
                 break
 
@@ -996,6 +1035,7 @@ def run_fuzz_targets(
         results=tuple(results),
         infrastructure_failures=tuple(infrastructure_failures),
         not_started=tuple(target for _index, target in pending),
+        headroom_exhausted=headroom_exhausted,
     )
 
 
@@ -1094,11 +1134,31 @@ def _parse_positive_int(value: str) -> int:
     return parsed
 
 
+#: Hard ceiling stacked on top of the doubling formula below (issue #1156
+#: item 1). Mixed subprocess/I/O fuzz targets tolerate CPU oversubscription
+#: far better than the deterministic suite's in-process workers, so
+#: ``recommended_worker_count``'s audited three-quarters-of-cores contract
+#: does not apply here — but nothing bounded the DOUBLING itself, so an
+#: arbitrarily large host could mint an arbitrarily large number of
+#: concurrent fuzz-target subprocesses, each importing its own Python
+#: interpreter and Hypothesis, and (for ephemeral-postgres targets,
+#: separately capped at ``EPHEMERAL_POSTGRES_TARGET_LIMIT``) test
+#: fixtures. Mirrors ``run_world_model_burst.py::IN_PROCESS_JOB_CAP``'s
+#: same shape — a flat ceiling stacked on top of a per-core formula — for
+#: the same reason: an unattended overnight/daily run has no operator
+#: watching worker counts climb. Chosen comfortably above every host
+#: measured in this repository's fleet to date (doc1 at 30 cores computes
+#: 60, well under this ceiling, so it never engages on hardware seen so
+#: far) — this exists for the next, larger host, not to shrink today's
+#: number.
+MAX_FUZZ_JOBS = 64
+
+
 def recommended_fuzz_jobs(cpu_count: int) -> int:
-    """Keep mixed subprocess/I/O targets runnable at twice host cores."""
+    """Keep mixed subprocess/I/O targets runnable at twice host cores, bounded."""
     if cpu_count < 1:
         raise ValueError("cpu_count must be at least 1")
-    return cpu_count * 2
+    return min(cpu_count * 2, MAX_FUZZ_JOBS)
 
 
 def recommended_postgres_jobs(cpu_count: int, worker_count: int) -> int:
@@ -1203,13 +1263,50 @@ def _parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    check_headroom: Callable[[], None] | None = None,
+) -> int:
+    """Run the fuzz burst.
+
+    ``check_headroom`` mirrors ``run_world_model_burst.py::main``'s own DI
+    seam (issue #1156 item 3): ``None`` (the production default) builds the
+    real ``_check_suite_headroom``/``headroom_floor_bytes`` closure below;
+    tests inject a controlled fake so BOTH the preflight call and the
+    SAME callable threaded into ``run_fuzz_targets`` for the mid-run
+    admission-loop check can be driven deterministically end-to-end,
+    including through this function's own post-run reporting.
+    """
     args = _parser().parse_args(argv)
     module_names = tuple(args.modules) or _default_modules()
     if not module_names:
         print("No generated fuzz modules found", file=sys.stderr)
         return 2
     worker_count = min(args.jobs, max(1, len(module_names)))
+
+    if check_headroom is None:
+        runtime = private_runtime_dir()
+        # worker_count=1 deliberately, not args.jobs: see
+        # headroom_floor_bytes's docstring (issue #1156 item 3) for why
+        # the fuzz burst does not extend the suite's per-worker multiplier
+        # to itself.
+        headroom_minimum = headroom_floor_bytes(1)
+        check_headroom = lambda: _check_suite_headroom(
+            runtime, minimum_bytes=headroom_minimum
+        )
+    try:
+        check_headroom()
+    except RamRootExhaustedError as exc:
+        print(f"fuzz burst: {exc}", file=sys.stderr)
+        return TEST_RAM_ROOT_EXHAUSTED_EXIT_CODE
+    except (OSError, RuntimeError, ValueError) as exc:
+        print(
+            f"fuzz burst: infrastructure precondition failed: {exc}",
+            file=sys.stderr,
+        )
+        return 2
+
     persistent_database = _persistent_path(
         os.environ.get("HYPOTHESIS_STORAGE_DIRECTORY"),
         REPO_ROOT / ".hypothesis",
@@ -1294,13 +1391,21 @@ def main(argv: Sequence[str] | None = None) -> int:
             ),
             environment=child_environment,
             log_directory=log_directory,
+            check_headroom=check_headroom,
         )
         results = batch.results
         infrastructure_failures = batch.infrastructure_failures
         wall_seconds = time.monotonic() - started_at
 
+        # NOTE(#1156 item 3): batch.headroom_exhausted and
+        # infrastructure_failures are NOT mutually exclusive -- a target
+        # already admitted before the mid-run headroom check tripped can
+        # ALSO fail independently (e.g. its own worker crash) in the same
+        # drain. Both are folded into the SAME reporting block below so
+        # neither swallows the other's detail, mirroring
+        # _collapse_disk_full_failures's own "two separate entries" rule.
         failed_results = [result for result in results if not result.successful]
-        if not infrastructure_failures:
+        if not infrastructure_failures and not batch.headroom_exhausted:
             for result in sorted(
                 results,
                 key=lambda item: item.elapsed_seconds,
@@ -1319,8 +1424,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                 )
             ):
                 print(line)
-        if failed_results or infrastructure_failures:
-            if infrastructure_failures:
+        if failed_results or infrastructure_failures or batch.headroom_exhausted:
+            if infrastructure_failures or batch.headroom_exhausted:
                 if failed_results:
                     print(
                         f"\n{len(failed_results)} unittest-failed "
@@ -1340,7 +1445,14 @@ def main(argv: Sequence[str] | None = None) -> int:
             ):
                 print(f"\n--- INFRASTRUCTURE FAIL {failure.target.label} ---")
                 print(failure.detail)
-            if not infrastructure_failures:
+            if batch.headroom_exhausted:
+                print(f"\n--- {TEST_RAM_ROOT_EXHAUSTED} (mid-run) ---")
+                print(
+                    "the coordinator's own headroom precondition tripped "
+                    "during admission; already-running targets were "
+                    "drained and no new target was started"
+                )
+            if not infrastructure_failures and not batch.headroom_exhausted:
                 _persist_failure_database(
                     active_database,
                     persistent_database,
@@ -1353,6 +1465,14 @@ def main(argv: Sequence[str] | None = None) -> int:
                 )
                 print(f"fuzz burst: complete module logs retained at {retained}")
             completed_targets = len(results) + len(infrastructure_failures)
+            if batch.headroom_exhausted:
+                print(
+                    f"fuzz burst: {TEST_RAM_ROOT_EXHAUSTED} mid-run after "
+                    f"{wall_seconds:.1f}s ({completed_targets} completed of "
+                    f"{len(targets)}; {len(batch.not_started)} not started; "
+                    "property verdict invalid)"
+                )
+                return TEST_RAM_ROOT_EXHAUSTED_EXIT_CODE
             if infrastructure_failures:
                 print(
                     f"fuzz burst: INFRASTRUCTURE ABORT after "

--- a/scripts/run_fuzz_tests.py
+++ b/scripts/run_fuzz_tests.py
@@ -922,8 +922,14 @@ def run_fuzz_targets(
 ) -> FuzzTargetBatch:
     """Run a bounded queue and stop admission after infrastructure loss.
 
-    ``check_headroom`` is called once per admission cycle, right before any
-    new target would be admitted (issue #1156 item 3): the production
+    ``check_headroom`` is called once per outer admission-loop iteration,
+    while ``pending`` is still non-empty (issue #1156 item 3) — NOT only on
+    a cycle that goes on to actually admit a new target. Independent
+    review B7: with the worker pool already full (or every pending target
+    blocked on the separate PostgreSQL ceiling),
+    ``select_fuzz_admissions`` can legitimately return zero admissions for
+    a cycle, and this check still fires that cycle; "right before any new
+    target would be admitted" overstated the guarantee. The production
     caller (``main`` below) binds it to the same
     ``_check_suite_headroom``/``headroom_floor_bytes`` precondition the
     coordinator already ran once, before any work, so a run admitted at

--- a/scripts/run_fuzz_tests.py
+++ b/scripts/run_fuzz_tests.py
@@ -950,7 +950,7 @@ def run_fuzz_targets(
             tuple[int, FuzzTarget],
         ] = {}
         while futures or (pending and not infrastructure_aborted):
-            if not infrastructure_aborted:
+            if pending and not infrastructure_aborted:
                 try:
                     check_headroom()
                 except RamRootExhaustedError as exc:
@@ -1134,8 +1134,10 @@ def _parse_positive_int(value: str) -> int:
     return parsed
 
 
-#: Hard ceiling stacked on top of the doubling formula below (issue #1156
-#: item 1). Mixed subprocess/I/O fuzz targets tolerate CPU oversubscription
+#: Hard ceiling stacked on top of the doubling formula below (issue #1214,
+#: "Contributing gaps" item 1 -- NOT #1156 item 1, which is a different,
+#: unrelated finding about test_nix_module world-level sharding). Mixed
+#: subprocess/I/O fuzz targets tolerate CPU oversubscription
 #: far better than the deterministic suite's in-process workers, so
 #: ``recommended_worker_count``'s audited three-quarters-of-cores contract
 #: does not apply here — but nothing bounded the DOUBLING itself, so an
@@ -1277,6 +1279,19 @@ def main(
     SAME callable threaded into ``run_fuzz_targets`` for the mid-run
     admission-loop check can be driven deterministically end-to-end,
     including through this function's own post-run reporting.
+
+    Design note (issue #1156, task scoping explicitly left this call): this
+    coordinator does NOT take ``scripts/run_test_suite.py::
+    acquire_suite_admission``'s exclusive lock. It is long-running and
+    variable-duration (minutes interactively, up to the full overnight
+    ``CRATEDIGGER_FUZZ_MAX_EXAMPLES`` budget in the daily gate); folding it
+    into the SAME exclusive queue an ordinary, quick ``scripts/test.sh``
+    dev-loop run waits on (bounded at ``DEFAULT_ADMISSION_TIMEOUT_SECONDS``)
+    would either starve that bounded wait or force raising the timeout for
+    everyone. It gets its own independent headroom precondition instead —
+    real, but narrower in scope than full admission: it does not serialize
+    against a concurrently-running deterministic suite the way the lock
+    would.
     """
     args = _parser().parse_args(argv)
     module_names = tuple(args.modules) or _default_modules()
@@ -1285,17 +1300,27 @@ def main(
         return 2
     worker_count = min(args.jobs, max(1, len(module_names)))
 
-    if check_headroom is None:
-        runtime = private_runtime_dir()
-        # worker_count=1 deliberately, not args.jobs: see
-        # headroom_floor_bytes's docstring (issue #1156 item 3) for why
-        # the fuzz burst does not extend the suite's per-worker multiplier
-        # to itself.
-        headroom_minimum = headroom_floor_bytes(1)
-        check_headroom = lambda: _check_suite_headroom(
-            runtime, minimum_bytes=headroom_minimum
-        )
+    # issue #1156 review F3: private_runtime_dir() must be called INSIDE
+    # the try below, not before it -- it is the one production call site
+    # that can raise the plain RuntimeError this except tuple exists to
+    # catch (e.g. XDG_RUNTIME_DIR unset/non-tmpfs/wrong-owner), and a
+    # RuntimeError raised one line above a try is never caught by it.
+    # An unavailable runtime dir aborts loudly here (exit 2) rather than
+    # silently degrading and running without the guard -- matching
+    # run_test_suite.py::main's own top-level precondition for the exact
+    # same failure shape; silently skipping the guard when its own
+    # prerequisite is broken would defeat the guard's purpose.
     try:
+        if check_headroom is None:
+            runtime = private_runtime_dir()
+            # worker_count=1 deliberately, not args.jobs: see
+            # headroom_floor_bytes's docstring (issue #1156 item 3) for why
+            # the fuzz burst does not extend the suite's per-worker
+            # multiplier to itself.
+            headroom_minimum = headroom_floor_bytes(1)
+            check_headroom = lambda: _check_suite_headroom(
+                runtime, minimum_bytes=headroom_minimum
+            )
         check_headroom()
     except RamRootExhaustedError as exc:
         print(f"fuzz burst: {exc}", file=sys.stderr)

--- a/scripts/run_python_tests.py
+++ b/scripts/run_python_tests.py
@@ -1622,7 +1622,31 @@ def _parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    run_targets_fn: Callable[
+        ...,
+        tuple[tuple[TargetRunResult, ...], tuple[TargetInfrastructureFailure, ...]],
+    ] = _run_targets,
+) -> int:
+    """Run the deterministic Python suite phase's CLI entry point.
+
+    ``run_targets_fn`` mirrors the ``check_headroom`` DI seam on the fuzz
+    and world-model bursts' own ``main`` functions (issue #1156 item 3):
+    ``_run_targets`` (the production default) is the ONE real boundary that
+    talks to a genuine ``ProcessPoolExecutor`` and its subprocess-level
+    worker-death semantics -- a worker dying poisons the WHOLE pool for
+    every still-tracked future, so two independently-classified real
+    deaths (one disk_full, one memory_exhausted) cannot be produced
+    deterministically in a single real run. Independent review B-3 (third
+    round): the two-clause promotion guard below needs exactly that
+    heterogeneous-marker scenario to prove its own `is None` clauses are
+    load-bearing; the test seeds it by replacing this ONE real boundary
+    with pre-built results, while every other line of `main` -- CLI
+    parsing, discovery, scheduling, the collapse helpers, printing, exit
+    code selection -- runs for real, unmocked.
+    """
     args = _parser().parse_args(argv)
     top = args.top_level_directory.resolve()
     start = args.start_directory
@@ -1672,7 +1696,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         f"({sharded_target_count} audited hotspot targets)"
     )
     started_at = time.monotonic()
-    results, infrastructure_failures = _run_targets(
+    results, infrastructure_failures = run_targets_fn(
         schedule,
         worker_count=worker_count,
         top_level_directory=top,

--- a/scripts/run_python_tests.py
+++ b/scripts/run_python_tests.py
@@ -17,6 +17,7 @@ import unittest
 from collections import Counter
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from concurrent.futures import ProcessPoolExecutor, as_completed
+from concurrent.futures.process import BrokenProcessPool
 from dataclasses import dataclass, replace
 from pathlib import Path
 from types import TracebackType
@@ -62,6 +63,20 @@ _SCHEMA_READY_ENV = "CRATEDIGGER_TEST_SCHEMA_READY"
 #: the phase — and the whole suite — out of an ordinary "failed" state,
 #: without touching that generic logic.
 TEST_RAM_ROOT_EXHAUSTED_EXIT_CODE = 4
+
+#: Issue #1156 item 2: a worker killed by the OOM killer raises the SAME
+#: BrokenProcessPool shape this module already catches for every
+#: outstanding future in a broken ProcessPoolExecutor, but the disk-full
+#: classifier above measures the wrong resource for it (tmpfs, not system
+#: memory) — so it always fell through as disk_full=False and reported as
+#: N ordinary worker failures, each named after a different innocent test
+#: (the same N-disguises shape issue #1111 fixed for disk-full). This is a
+#: DIFFERENT resource than the tmpfs RAM root, so it gets its OWN identity
+#: and exit code rather than being folded into TEST_RAM_ROOT_EXHAUSTED —
+#: conflating the two would undo the honesty this classification exists
+#: for.
+TEST_HOST_MEMORY_EXHAUSTED = "test host memory exhausted"
+TEST_HOST_MEMORY_EXHAUSTED_EXIT_CODE = 5
 WORLD_MODEL_MODULE = "tests.world_model.state_machine"
 # Method profiling showed the dominant Nix evaluation was otherwise admitted
 # late enough to become the deterministic suite's tail.
@@ -173,6 +188,7 @@ class TargetInfrastructureFailure:
     target: TestTarget
     detail: str
     disk_full: bool = False
+    memory_exhausted: bool = False
 
 
 class HypothesisPropertyStats(msgspec.Struct, frozen=True):
@@ -324,6 +340,62 @@ def _measure_tempdir_available_bytes() -> int | None:
         return shutil.disk_usage(tempfile.gettempdir()).free
     except OSError:
         return None
+
+
+#: Deliberately conservative floor for the OOM classifier below (issue
+#: #1156 item 2) — unlike the tmpfs floor, which run_suite's own
+#: precondition already pins to a specific, worker-aware value, there is
+#: no equivalent configured "expected system memory headroom" anywhere in
+#: this repository; 256 MiB is chosen to sit comfortably below what any
+#: live, unstressed host is expected to have free, minimizing the chance
+#: an ordinary transient dip gets misclassified as exhaustion. See
+#: ``_classify_target_infrastructure_failure``'s docstring for the
+#: measurement-timing residual this floor cannot close.
+_MIN_VALID_MEMORY_HEADROOM_BYTES = 256 * 1024 * 1024
+
+
+def _measure_available_memory_bytes() -> int | None:
+    """Best-effort system memory availability right now, via /proc/meminfo.
+
+    ``MemAvailable`` (not ``MemFree``) is the kernel's own estimate of what
+    a new allocation could get without swapping — closer to what actually
+    drives OOM-kill decisions than raw free pages, which undercounts
+    reclaimable page cache. Linux-only, matching every other resource
+    guard in this module; returns ``None`` when unreadable (missing file,
+    unexpected format) so the caller degrades to "cannot classify" rather
+    than guessing.
+    """
+    try:
+        with open("/proc/meminfo", encoding="utf-8") as handle:
+            for line in handle:
+                if line.startswith("MemAvailable:"):
+                    return int(line.split()[1]) * 1024
+    except (OSError, ValueError, IndexError):
+        return None
+    return None
+
+
+def _default_min_memory_headroom_bytes() -> int:
+    """The OOM classifier's floor: env-overridable, mirroring
+    ``CRATEDIGGER_TEST_RAM_MIN_BYTES``'s own override pattern for the
+    tmpfs floor. This is also the seam that makes the classifier's
+    positive case testable end-to-end: a test can set this to a value no
+    real host's ``MemAvailable`` can exceed — the identical trick
+    ``TestRunTargetsWorkerExceptionWiring``'s own docstring already
+    documents for the disk-full floor.
+    """
+    raw = os.environ.get("CRATEDIGGER_TEST_MEMORY_MIN_BYTES")
+    if raw is not None:
+        try:
+            value = int(raw)
+        except ValueError:
+            value = -1
+        if value < 0:
+            raise ValueError(
+                "CRATEDIGGER_TEST_MEMORY_MIN_BYTES must be a non-negative integer"
+            )
+        return value
+    return _MIN_VALID_MEMORY_HEADROOM_BYTES
 
 
 def _classify_test_infrastructure_error(
@@ -1226,6 +1298,8 @@ def _classify_target_infrastructure_failure(
     *,
     available_bytes: Callable[[], int | None] = _measure_tempdir_available_bytes,
     minimum_bytes: int | None = None,
+    available_memory_bytes: Callable[[], int | None] = _measure_available_memory_bytes,
+    minimum_memory_bytes: int | None = None,
 ) -> TargetInfrastructureFailure:
     """Classify a worker's own crash by measuring free bytes right now.
 
@@ -1253,14 +1327,62 @@ def _classify_target_infrastructure_failure(
     It can never fold a genuine code defect INTO this bucket and hide it:
     nothing here suppresses a failure, only relabels ones it can prove are
     environmental.
+
+    Issue #1156 item 2: an OOM-killed worker raises ``BrokenProcessPool``,
+    not an ENOSPC-shaped exception, and the disk-full check above measures
+    the wrong resource for it — so it always fell through as an ordinary,
+    unclassified worker failure, one ``CheckFailureMarker`` per target,
+    each named after a different innocent test (the same N-disguises shape
+    issue #1111 fixed for disk-full). Classified the same "measured state"
+    way, narrowed by exception SHAPE rather than left as a bare threshold
+    check: ``isinstance(exc, BrokenProcessPool)`` is the specific signal
+    every outstanding future in a ``ProcessPoolExecutor`` receives when one
+    of its workers vanishes unexpectedly, and
+    ``available_memory_bytes() < minimum_memory_bytes`` is the
+    corroborating measured state — never a scan of ``exc``'s text. Only
+    evaluated when the disk check already came back negative, since a
+    target cannot plausibly be both.
+
+    Residual, stated honestly (worse than the tmpfs case): an OOM kill
+    FREES the killed worker's memory immediately, so by the time this
+    classifier runs — after ``ProcessPoolExecutor`` has already detected
+    the broken pool and raised — available memory may have already
+    recovered above the floor. That reads as an ordinary worker failure,
+    the same miss the disk-full branch already accepts for its own
+    measurement-timing window, just more likely to occur here. It can
+    never fold a genuine code defect into this bucket: a
+    ``BrokenProcessPool`` with healthy measured memory stays an ordinary
+    infrastructure failure, and any exception OTHER than
+    ``BrokenProcessPool`` is never reclassified as memory exhaustion no
+    matter how little memory is measured.
     """
     available = available_bytes()
     floor = minimum_bytes if minimum_bytes is not None else _default_min_headroom_bytes()
     disk_full = available is not None and available < floor
+    memory_exhausted = False
+    available_memory: int | None = None
+    if not disk_full and isinstance(exc, BrokenProcessPool):
+        memory_floor = (
+            minimum_memory_bytes
+            if minimum_memory_bytes is not None
+            else _default_min_memory_headroom_bytes()
+        )
+        available_memory = available_memory_bytes()
+        memory_exhausted = (
+            available_memory is not None
+            and available_memory < memory_floor
+        )
     detail = f"{type(exc).__name__}: {exc}"
     if disk_full:
         detail = f"temporary filesystem has {available} bytes free; {detail}"
-    return TargetInfrastructureFailure(target=target, detail=detail, disk_full=disk_full)
+    elif memory_exhausted:
+        detail = f"system memory has {available_memory} bytes available; {detail}"
+    return TargetInfrastructureFailure(
+        target=target,
+        detail=detail,
+        disk_full=disk_full,
+        memory_exhausted=memory_exhausted,
+    )
 
 
 def _run_targets(
@@ -1378,6 +1500,46 @@ def _collapse_disk_full_failures(
         test_ids=tuple(combined_ids),
     )
     return tuple(remaining_results), tuple(remaining_infrastructure), marker
+
+
+def _collapse_memory_exhausted_failures(
+    infrastructure_failures: Sequence[TargetInfrastructureFailure],
+) -> tuple[tuple[TargetInfrastructureFailure, ...], CheckFailureMarker | None]:
+    """Fold every OOM-classified worker death into one named marker.
+
+    Mirrors ``_collapse_disk_full_failures`` for a DIFFERENT resource
+    (issue #1156 item 2), not a copy of its decision: memory exhaustion is
+    detectable only at the WORKER-death level
+    (``TargetInfrastructureFailure.memory_exhausted`` —
+    ``BrokenProcessPool`` means the whole pool broke, not that a
+    still-alive worker's specific test raised), so unlike the disk-full
+    fold there is no ``failed_results`` half to fold here; a target that
+    finished, however it finished, never carries this kind of failure.
+    """
+    remaining: list[TargetInfrastructureFailure] = []
+    combined_ids: list[str] = []
+    combined_details: list[str] = []
+    for failure in infrastructure_failures:
+        if failure.memory_exhausted:
+            combined_ids.append(failure.target.test_name)
+            combined_details.append(failure.detail)
+        else:
+            remaining.append(failure)
+
+    if not combined_ids:
+        return tuple(remaining), None
+
+    marker = CheckFailureMarker(
+        identity=TEST_HOST_MEMORY_EXHAUSTED,
+        owner="",
+        detail=(
+            f"{len(combined_ids)} target(s) failed while the host's "
+            "available system memory was exhausted; sample: "
+            f"{combined_details[0] if combined_details else 'no detail'}"
+        ),
+        test_ids=tuple(combined_ids),
+    )
+    return tuple(remaining), marker
 
 
 def _failure_diagnostics(output: str) -> str:
@@ -1510,6 +1672,10 @@ def main(argv: Sequence[str] | None = None) -> int:
             remaining_infrastructure_failures,
             ram_root_marker,
         ) = _collapse_disk_full_failures(failed_results, infrastructure_failures)
+        (
+            remaining_infrastructure_failures,
+            memory_marker,
+        ) = _collapse_memory_exhausted_failures(remaining_infrastructure_failures)
         for result in sorted(
             remaining_failed_results,
             key=lambda item: item.target.test_name,
@@ -1567,11 +1733,22 @@ def main(argv: Sequence[str] | None = None) -> int:
                 f"({len(ram_root_marker.test_ids)} target(s)/test(s)) ---"
             )
             print(ram_root_marker.detail)
+        if memory_marker is not None:
+            # Issue #1156 item 2: every OOM-classified worker death is ONE
+            # named entry here, never N separately-indexed disguises.
+            print(FAILURE_MARKER_PREFIX + msgspec.json.encode(memory_marker).decode())
+            print(
+                "\n--- FAIL: "
+                f"{TEST_HOST_MEMORY_EXHAUSTED} "
+                f"({len(memory_marker.test_ids)} target(s)) ---"
+            )
+            print(memory_marker.detail)
         known_count = sum(result.tests_run for result in results)
         failed_targets = (
             len(remaining_failed_results)
             + len(remaining_infrastructure_failures)
             + (1 if ram_root_marker is not None else 0)
+            + (1 if memory_marker is not None else 0)
         )
         print(
             METRICS_MARKER_PREFIX
@@ -1591,8 +1768,16 @@ def main(argv: Sequence[str] | None = None) -> int:
             not remaining_failed_results
             and not remaining_infrastructure_failures
             and ram_root_marker is not None
+            and memory_marker is None
         ):
             return TEST_RAM_ROOT_EXHAUSTED_EXIT_CODE
+        if (
+            not remaining_failed_results
+            and not remaining_infrastructure_failures
+            and memory_marker is not None
+            and ram_root_marker is None
+        ):
+            return TEST_HOST_MEMORY_EXHAUSTED_EXIT_CODE
         return 1
 
     total_tests = sum(result.tests_run for result in results)

--- a/scripts/run_python_tests.py
+++ b/scripts/run_python_tests.py
@@ -1348,8 +1348,19 @@ def _classify_target_infrastructure_failure(
     of its workers vanishes unexpectedly, and
     ``available_memory_bytes() < minimum_memory_bytes`` is the
     corroborating measured state — never a scan of ``exc``'s text. Only
-    evaluated when the disk check already came back negative, since a
-    target cannot plausibly be both.
+    evaluated when the disk check already came back negative — a DELIBERATE
+    ORDERING CHOICE, not a claim that the two are physically distinct
+    (independent review B2, issue #1156): on a host where the shared tmpfs
+    RAM root is itself what "memory" mostly consists of (issue #1214's own
+    measurement — cgroup v2 ``memory.peak`` counts tmpfs pages, 69% of the
+    fuzz phase's peak was scratch tmpfs), genuine system-wide memory
+    pressure usually manifests as tmpfs exhaustion FIRST, so the disk-full
+    branch wins and this memory branch is largely inert under exactly the
+    pressure it exists to name. ``scripts/run_python_tests.py``'s own
+    `main` wiring below (issue #1156 review F10) already states the
+    correct, weaker fact: nothing stops a disk-full marker and a
+    memory-exhausted marker from BOTH occurring in the same run (on
+    different targets); this docstring must not contradict it.
 
     Residual, stated honestly (worse than the tmpfs case): an OOM kill
     FREES the killed worker's memory immediately, so by the time this

--- a/scripts/run_python_tests.py
+++ b/scripts/run_python_tests.py
@@ -354,7 +354,9 @@ def _measure_tempdir_available_bytes() -> int | None:
 _MIN_VALID_MEMORY_HEADROOM_BYTES = 256 * 1024 * 1024
 
 
-def _measure_available_memory_bytes() -> int | None:
+def _measure_available_memory_bytes(
+    meminfo_path: Path = Path("/proc/meminfo"),
+) -> int | None:
     """Best-effort system memory availability right now, via /proc/meminfo.
 
     ``MemAvailable`` (not ``MemFree``) is the kernel's own estimate of what
@@ -364,9 +366,15 @@ def _measure_available_memory_bytes() -> int | None:
     guard in this module; returns ``None`` when unreadable (missing file,
     unexpected format) so the caller degrades to "cannot classify" rather
     than guessing.
+
+    ``meminfo_path`` defaults to the real file so every production caller
+    is unaffected; it exists so a test can pin the ``MemAvailable`` line
+    and its ``* 1024`` (kB -> bytes) conversion against a KNOWN fixture
+    (issue #1156 review F4) — /proc/meminfo cannot otherwise be forced to
+    a controlled value.
     """
     try:
-        with open("/proc/meminfo", encoding="utf-8") as handle:
+        with meminfo_path.open(encoding="utf-8") as handle:
             for line in handle:
                 if line.startswith("MemAvailable:"):
                     return int(line.split()[1]) * 1024
@@ -1349,12 +1357,21 @@ def _classify_target_infrastructure_failure(
     the broken pool and raised — available memory may have already
     recovered above the floor. That reads as an ordinary worker failure,
     the same miss the disk-full branch already accepts for its own
-    measurement-timing window, just more likely to occur here. It can
-    never fold a genuine code defect into this bucket: a
+    measurement-timing window, just more likely to occur here.
+
+    This one is NOT one-directional the way the disk-full branch's own
+    claim is (independent review F5(e), issue #1156): a genuine code
+    defect whose crash happens to raise a real ``BrokenProcessPool``
+    (e.g. a segfault in a C extension the pool worker was running) WHILE
+    measured memory genuinely reads below the floor at that exact moment
+    WOULD be folded into "memory exhausted" and reported as
+    environmental rather than a real bug. What is still true: a
     ``BrokenProcessPool`` with healthy measured memory stays an ordinary
     infrastructure failure, and any exception OTHER than
     ``BrokenProcessPool`` is never reclassified as memory exhaustion no
-    matter how little memory is measured.
+    matter how little memory is measured — the exception-shape gate
+    narrows the false-positive window to "the pool broke AND memory is
+    genuinely low right now," not "any bug at all."
     """
     available = available_bytes()
     floor = minimum_bytes if minimum_bytes is not None else _default_min_headroom_bytes()
@@ -1764,6 +1781,19 @@ def main(argv: Sequence[str] | None = None) -> int:
             f"\nFAILED: {failed_targets} of {len(schedule)} targets; "
             f"Ran {known_count} reported tests in {wall_seconds:.1f}s"
         )
+        # Promotion requires a HOMOGENEOUS failure set: exactly one
+        # environmental cause and nothing else unexplained. If BOTH
+        # ram_root_marker and memory_marker are present (two DIFFERENT
+        # targets independently classified disk_full and memory_exhausted
+        # in the same run -- a per-target classification is mutually
+        # exclusive between the two, but nothing stops different targets
+        # in the same run from landing on different sides), neither
+        # condition below matches and this falls through to the ordinary
+        # `return 1`. Both markers are still printed above with their
+        # correct identities; only the infrastructure-failure PROMOTION is
+        # skipped. Stated honestly (independent review F10, issue #1156):
+        # this is a known, accepted residual, not a claim that the two
+        # causes can never co-occur in one run.
         if (
             not remaining_failed_results
             and not remaining_infrastructure_failures

--- a/scripts/run_test_suite.py
+++ b/scripts/run_test_suite.py
@@ -1094,8 +1094,9 @@ def headroom_floor_bytes(worker_count: int) -> int:
     suite's own multiplier to them would be an unjustified guess dressed
     up as a measurement — confirmed live: sizing the fuzz burst's floor by
     its own default worker count (up to 60 on a 30-core host) demanded
-    over 4 GiB, more than this repository's own 3.1 GiB interactive dev
-    tmpfs actually has free. Reusing the SAME flat floor
+    EXACTLY 4 GiB (256 MiB base + 64 MiB/worker * 60 workers = 4096 MiB,
+    independent review B7 item 2 — "over 4 GiB" overstated it), more than
+    this repository's own 3.1 GiB interactive dev tmpfs actually has free. Reusing the SAME flat floor
     ``scripts/test_tmpfs.sh``'s shell-entry guard already enforces for
     them today just moves the check from "one-shot at shell entry" to "a
     real coordinator precondition, with a mid-run recheck," without
@@ -1151,10 +1152,16 @@ def _check_suite_headroom(runtime: Path, *, minimum_bytes: int) -> None:
     ONLY, a trip fails the whole suite once and never mid-run. Issue #1156
     item 3: the fuzz burst (``scripts/run_fuzz_tests.py``) and the
     world-model burst (``scripts/run_world_model_burst.py``) also call
-    this SAME function, but each one calls it TWICE per coordinator run —
-    once as their own preflight, and again inside their own admission
-    loop, genuinely mid-run — so "never mid-run" is a property of
-    ``run_suite``'s own call site, not of this function itself.
+    this SAME function, but NOT exactly twice per coordinator run
+    (independent review B7 item 1 — corrected): each makes exactly one
+    preflight call, plus one call per outer admission-loop iteration for
+    as long as ``pending`` remains non-empty — as few as one such mid-run
+    call when the whole pool is admitted in a single cycle (two calls
+    total), or several more when admission is staggered across multiple
+    cycles because the worker pool or the separate PostgreSQL ceiling is
+    already full. What stays true regardless of the exact count: "never
+    mid-run" is a property of ``run_suite``'s own call site, not of this
+    function itself.
     """
     target = Path(os.environ.get("CRATEDIGGER_TEST_RAM_ROOT") or runtime)
     available = shutil.disk_usage(target).free

--- a/scripts/run_test_suite.py
+++ b/scripts/run_test_suite.py
@@ -1063,27 +1063,46 @@ _HEADROOM_BASE_BYTES = 256 * 1024 * 1024
 _HEADROOM_PER_WORKER_BYTES = 64 * 1024 * 1024
 
 
-def _default_min_headroom_bytes() -> int:
-    """Read the same env var scripts/test_tmpfs.sh uses; the DEFAULT (no
-    override) scales with the Python phase's own expected worker count.
+def headroom_floor_bytes(worker_count: int) -> int:
+    """Worker-aware headroom floor, shared by every coordinator on this tmpfs.
 
-    Issue #1131 review N1: raising the default worker count means more
-    concurrent ephemeral PostgreSQL clusters, so a flat 1 GiB floor no
-    longer bounds a run's OWN peak tmpfs on a tight host — doc1 (30
-    cores, 3.2 GB root) measured a 1178 MB peak at 22 workers, above the
-    flat 1 GiB (1073.7 MB) floor a run could previously have been
-    admitted under. The unset-default floor is now
+    Reads the same ``CRATEDIGGER_TEST_RAM_MIN_BYTES`` env var
+    ``scripts/test_tmpfs.sh``'s own shell-entry guard uses; an EXPLICIT
+    override is honored exactly as given, with no worker-aware adjustment.
+    The unset-default floor is
     ``max(DEFAULT_MIN_HEADROOM_BYTES, _HEADROOM_BASE_BYTES +
-    _HEADROOM_PER_WORKER_BYTES * _expected_worker_count())`` — see
-    ``recommended_worker_count``'s docstring for the measured evidence.
-    An EXPLICIT ``CRATEDIGGER_TEST_RAM_MIN_BYTES`` override is still
-    respected exactly as given, with no worker-aware adjustment: this
-    scaling only fills in the unset default. ``scripts/test_tmpfs.sh``'s
-    own shell-entry guard deliberately stays a flat 1 GiB for the
-    DIFFERENT case it covers — a bare interactive ``nix-shell`` entry,
-    skipped entirely once ``CRATEDIGGER_SUITE_OWNS_HEADROOM`` is set,
-    where no worker count is even known yet.
+    _HEADROOM_PER_WORKER_BYTES * worker_count)`` — see
+    ``recommended_worker_count``'s docstring for the measured evidence this
+    per-worker term is sized against: the deterministic suite's own
+    ephemeral-PostgreSQL worker footprint.
+
+    Issue #1156 item 3: this function takes a plain, explicit
+    ``worker_count`` rather than reading a suite-specific global, so every
+    coordinator that admits its own pool of processes onto the shared
+    tmpfs can call it. The deterministic suite passes its own predicted
+    worker count (``_expected_worker_count``, via
+    ``_default_min_headroom_bytes`` below) because issue #1131 measured
+    that specific per-worker footprint. The fuzz burst
+    (``scripts/run_fuzz_tests.py``) and the world-model burst
+    (``scripts/run_world_model_burst.py``) instead call this with
+    ``worker_count=1`` — i.e. the flat ``DEFAULT_MIN_HEADROOM_BYTES``,
+    still override-respecting — because there is no equivalent MEASURED
+    per-worker footprint for either burst's own, differently-shaped worker
+    pool (up to several dozen short-lived fuzz targets, vs. the suite's
+    handful of ephemeral-PostgreSQL-backed workers), and issue #1214 is
+    concurrently changing what that footprint even is. Extending the
+    suite's own multiplier to them would be an unjustified guess dressed
+    up as a measurement — confirmed live: sizing the fuzz burst's floor by
+    its own default worker count (up to 60 on a 30-core host) demanded
+    over 4 GiB, more than this repository's own 3.1 GiB interactive dev
+    tmpfs actually has free. Reusing the SAME flat floor
+    ``scripts/test_tmpfs.sh``'s shell-entry guard already enforces for
+    them today just moves the check from "one-shot at shell entry" to "a
+    real coordinator precondition, with a mid-run recheck," without
+    inventing a number nothing measures.
     """
+    if worker_count < 1:
+        raise ValueError("worker_count must be at least 1")
     raw = os.environ.get("CRATEDIGGER_TEST_RAM_MIN_BYTES")
     if raw is not None:
         try:
@@ -1097,8 +1116,26 @@ def _default_min_headroom_bytes() -> int:
         return value
     return max(
         DEFAULT_MIN_HEADROOM_BYTES,
-        _HEADROOM_BASE_BYTES + _HEADROOM_PER_WORKER_BYTES * _expected_worker_count(),
+        _HEADROOM_BASE_BYTES + _HEADROOM_PER_WORKER_BYTES * worker_count,
     )
+
+
+def _default_min_headroom_bytes() -> int:
+    """The deterministic suite's own floor: ``headroom_floor_bytes`` sized by
+    the Python phase's own expected worker count (``_expected_worker_count``).
+
+    Issue #1131 review N1: raising the default worker count means more
+    concurrent ephemeral PostgreSQL clusters, so a flat 1 GiB floor no
+    longer bounds a run's OWN peak tmpfs on a tight host — doc1 (30
+    cores, 3.2 GB root) measured a 1178 MB peak at 22 workers, above the
+    flat 1 GiB (1073.7 MB) floor a run could previously have been
+    admitted under. ``scripts/test_tmpfs.sh``'s own shell-entry guard
+    deliberately stays a flat 1 GiB for the DIFFERENT case it covers — a
+    bare interactive ``nix-shell`` entry, skipped entirely once
+    ``CRATEDIGGER_SUITE_OWNS_HEADROOM`` is set, where no worker count is
+    even known yet.
+    """
+    return headroom_floor_bytes(_expected_worker_count())
 
 
 def _check_suite_headroom(runtime: Path, *, minimum_bytes: int) -> None:

--- a/scripts/run_test_suite.py
+++ b/scripts/run_test_suite.py
@@ -1139,11 +1139,22 @@ def _default_min_headroom_bytes() -> int:
 
 
 def _check_suite_headroom(runtime: Path, *, minimum_bytes: int) -> None:
-    """Fail the whole suite once, immediately — never mid-run (issue #1111).
+    """One measured headroom check against the shared tmpfs root, raising
+    ``RamRootExhaustedError`` on insufficient free bytes.
 
     Measures the same root scripts/test_tmpfs.sh's shell-entry guard does:
     ``CRATEDIGGER_TEST_RAM_ROOT`` when an operator has overridden it, else
     the validated ``runtime`` this suite was actually admitted under.
+
+    The deterministic suite (``run_suite`` below) calls this exactly once,
+    immediately, before any phase runs (issue #1111) — for that caller
+    ONLY, a trip fails the whole suite once and never mid-run. Issue #1156
+    item 3: the fuzz burst (``scripts/run_fuzz_tests.py``) and the
+    world-model burst (``scripts/run_world_model_burst.py``) also call
+    this SAME function, but each one calls it TWICE per coordinator run —
+    once as their own preflight, and again inside their own admission
+    loop, genuinely mid-run — so "never mid-run" is a property of
+    ``run_suite``'s own call site, not of this function itself.
     """
     target = Path(os.environ.get("CRATEDIGGER_TEST_RAM_ROOT") or runtime)
     available = shutil.disk_usage(target).free

--- a/scripts/run_world_model_burst.py
+++ b/scripts/run_world_model_burst.py
@@ -1013,6 +1013,26 @@ def main(
     replace_canonical: _ReplaceCanonical = replace_canonical_database,
     check_headroom: Callable[[], None] | None = None,
 ) -> int:
+    """Run the world-model burst.
+
+    ``check_headroom`` mirrors ``run_fuzz_tests.py::main``'s own DI seam
+    (issue #1156 item 3): ``None`` (the production default) builds the
+    real ``_check_suite_headroom``/``headroom_floor_bytes`` closure below;
+    tests inject a controlled fake so both the preflight call and the
+    mid-run admission-loop check can be driven deterministically.
+
+    Design note (issue #1156, task scoping explicitly left this call): this
+    coordinator does NOT take ``scripts/run_test_suite.py::
+    acquire_suite_admission``'s exclusive lock. It is long-running and
+    variable-duration (minutes interactively, up to the full overnight
+    budget in the daily gate); folding it into the SAME exclusive queue an
+    ordinary, quick ``scripts/test.sh`` dev-loop run waits on (bounded at
+    ``DEFAULT_ADMISSION_TIMEOUT_SECONDS``) would either starve that bounded
+    wait or force raising the timeout for everyone. It gets its own
+    independent headroom precondition instead — real, but narrower in
+    scope than full admission: it does not serialize against a
+    concurrently-running deterministic suite the way the lock would.
+    """
     os.environ.pop("TEST_DB_DSN", None)
     os.environ.pop(_SCHEMA_READY_ENV, None)
     args = _parser().parse_args(argv)
@@ -1045,16 +1065,27 @@ def main(
         print(f"output_dir={args.output_dir}")
         return 0
 
-    if check_headroom is None:
-        runtime = private_runtime_dir()
-        # worker_count=1 deliberately, not jobs: see headroom_floor_bytes's
-        # docstring (issue #1156 item 3) for why the world-model burst does
-        # not extend the suite's per-worker multiplier to itself.
-        headroom_minimum = headroom_floor_bytes(1)
-        check_headroom = lambda: _check_suite_headroom(
-            runtime, minimum_bytes=headroom_minimum
-        )
+    # issue #1156 review F3: private_runtime_dir() must be called INSIDE
+    # the try below, not before it -- it is the one production call site
+    # that can raise the plain RuntimeError this except tuple exists to
+    # catch (e.g. XDG_RUNTIME_DIR unset/non-tmpfs/wrong-owner), and a
+    # RuntimeError raised one line above a try is never caught by it.
+    # An unavailable runtime dir aborts loudly here (exit 2) rather than
+    # silently degrading and running without the guard -- matching
+    # run_test_suite.py::main's own top-level precondition for the exact
+    # same failure shape; silently skipping the guard when its own
+    # prerequisite is broken would defeat the guard's purpose.
     try:
+        if check_headroom is None:
+            runtime = private_runtime_dir()
+            # worker_count=1 deliberately, not jobs: see
+            # headroom_floor_bytes's docstring (issue #1156 item 3) for why
+            # the world-model burst does not extend the suite's per-worker
+            # multiplier to itself.
+            headroom_minimum = headroom_floor_bytes(1)
+            check_headroom = lambda: _check_suite_headroom(
+                runtime, minimum_bytes=headroom_minimum
+            )
         check_headroom()
     except RamRootExhaustedError as error:
         print(f"world-model burst: {error}", file=sys.stderr)

--- a/scripts/run_world_model_burst.py
+++ b/scripts/run_world_model_burst.py
@@ -38,7 +38,17 @@ if str(REPO_ROOT) not in sys.path:
 
 from lib.ephemeral_postgres import EphemeralPostgres
 from lib.migrator import apply_migrations
-from scripts.run_python_tests import RecordingTextTestResult
+from scripts.run_python_tests import (
+    TEST_RAM_ROOT_EXHAUSTED_EXIT_CODE,
+    RecordingTextTestResult,
+)
+from scripts.run_test_suite import (
+    TEST_RAM_ROOT_EXHAUSTED,
+    RamRootExhaustedError,
+    _check_suite_headroom,
+    headroom_floor_bytes,
+    private_runtime_dir,
+)
 
 DEFAULT_EXAMPLES = 25
 DEFAULT_STEPS = 100
@@ -1001,6 +1011,7 @@ def main(
     argv: Sequence[str] | None = None,
     *,
     replace_canonical: _ReplaceCanonical = replace_canonical_database,
+    check_headroom: Callable[[], None] | None = None,
 ) -> int:
     os.environ.pop("TEST_DB_DSN", None)
     os.environ.pop(_SCHEMA_READY_ENV, None)
@@ -1034,6 +1045,27 @@ def main(
         print(f"output_dir={args.output_dir}")
         return 0
 
+    if check_headroom is None:
+        runtime = private_runtime_dir()
+        # worker_count=1 deliberately, not jobs: see headroom_floor_bytes's
+        # docstring (issue #1156 item 3) for why the world-model burst does
+        # not extend the suite's per-worker multiplier to itself.
+        headroom_minimum = headroom_floor_bytes(1)
+        check_headroom = lambda: _check_suite_headroom(
+            runtime, minimum_bytes=headroom_minimum
+        )
+    try:
+        check_headroom()
+    except RamRootExhaustedError as error:
+        print(f"world-model burst: {error}", file=sys.stderr)
+        return TEST_RAM_ROOT_EXHAUSTED_EXIT_CODE
+    except (OSError, RuntimeError, ValueError) as error:
+        print(
+            f"world-model burst: infrastructure precondition failed: {error}",
+            file=sys.stderr,
+        )
+        return 2
+
     canonical_database = _resolved_path(args.database)
     output_root = _resolved_path(args.output_dir)
     output_root.mkdir(parents=True, exist_ok=True)
@@ -1046,6 +1078,7 @@ def main(
     planned_targets: tuple[WorldTarget, ...] = ()
     admission_aborted = False
     coordinator_error: str | None = None
+    ram_root_exhausted = False
     try:
         prepare_canonical_database(canonical_database)
         with tempfile.TemporaryDirectory(prefix="cratedigger_world_burst_") as temporary_name:
@@ -1071,6 +1104,8 @@ def main(
                 with ThreadPoolExecutor(max_workers=jobs) as executor:
                     active: dict[Future[TargetOutcome], tuple[int, WorldTarget]] = {}
                     while active or (pending and not admission_aborted):
+                        if pending and not admission_aborted:
+                            check_headroom()
                         while pending and len(active) < jobs and not admission_aborted:
                             index, target = pending.pop(0)
                             future = executor.submit(
@@ -1127,6 +1162,14 @@ def main(
                         tuple(outcome.database_path for outcome in outcomes),
                         owned_key_paths,
                     )
+    except RamRootExhaustedError as error:
+        coordinator_error = f"{TEST_RAM_ROOT_EXHAUSTED}: {error}"
+        admission_aborted = True
+        ram_root_exhausted = True
+        (logs / "coordinator-error.log").write_text(
+            traceback.format_exc(), encoding="utf-8"
+        )
+        print(f"world-model burst: {coordinator_error}", file=sys.stderr)
     except Exception as error:  # noqa: BLE001 - coordinator fail-closed boundary
         coordinator_error = f"{type(error).__name__}: {error}"
         admission_aborted = True
@@ -1190,12 +1233,13 @@ def main(
     )
     _write_replay_receipt(run_directory / "replay.json", replay)
     if coordinator_error is not None:
+        label = TEST_RAM_ROOT_EXHAUSTED if ram_root_exhausted else "INFRASTRUCTURE ABORT"
         print(
-            f"world-model burst: INFRASTRUCTURE ABORT after {elapsed:.1f}s "
+            f"world-model burst: {label} after {elapsed:.1f}s "
             f"({len(outcomes)} completed; {len(not_started)} not started; "
             f"receipts={run_directory})"
         )
-        return 1
+        return TEST_RAM_ROOT_EXHAUSTED_EXIT_CODE if ram_root_exhausted else 1
     if failures:
         infra = any(outcome.outcome == "infrastructure_error" for outcome in failures)
         properties = any(

--- a/tests/test_discogs_artist_concurrency.py
+++ b/tests/test_discogs_artist_concurrency.py
@@ -131,16 +131,23 @@ class TestDiscogsArtistGlobalConcurrency(unittest.TestCase):
         self.assertEqual(attempts, ["discogs", "discogs"])
 
     def test_three_top_level_artist_reads_share_one_two_request_budget(self) -> None:
-        # Issue #1156 item 6: this test predates #1175's handler_exit_delay
-        # fix and was left on the bare mechanism -- exposed to the exact
-        # same trailing-teardown counted-window symptom #1175 fixed for
-        # test_slow_handler_teardown_does_not_inflate_the_measured_window
-        # below, just without that test's own name calling it out. At 20-24
-        # workers on a 16-thread host this failed reproducibly (a degenerate
-        # counted window reading 1 instead of 2, or a scheduling-starved
-        # reader failing to overlap at all). handler_exit_delay=0.02 mirrors
-        # #1175's own proven fix rather than loosening the assertion below.
-        mirror = self._run_calls(3, handler_exit_delay=0.02)
+        # Issue #1156 item 6: a prior round of this fix added
+        # handler_exit_delay=0.02 here on the theory that this test shared
+        # test_slow_handler_teardown_does_not_inflate_the_measured_window's
+        # #1175 counted-window symptom. Independent review (third round)
+        # traced _DiscogsMirror.do_GET and found that theory unsupported:
+        # leave() closes the counted window BEFORE send_response and is
+        # idempotent, so handler_exit_delay's sleep in the `finally` block
+        # only delays handler-thread TEARDOWN (which ThreadingHTTPServer
+        # does not serialize against) -- it cannot move mirror.max_active
+        # either way. An A/B load probe on a 30-core host was inconclusive
+        # (0/25 failures with the delay, 0/25 without), which is consistent
+        # with the delay being a no-op here, not evidence either way of the
+        # underlying flake reported in issue #1156 item 6. Left unchanged
+        # rather than keeping an unsubstantiated fix; the demonstrated,
+        # reproduced half of item 6 is the Node worker startup timeout in
+        # tests/test_node_jsonl_worker.py.
+        mirror = self._run_calls(3)
         # Saturation AND the cap in one assertion: with the budget honoured the
         # only value three concurrent readers can produce is the budget itself.
         # A degenerate counted window (reading 1) fails here just as a breached

--- a/tests/test_discogs_artist_concurrency.py
+++ b/tests/test_discogs_artist_concurrency.py
@@ -131,7 +131,16 @@ class TestDiscogsArtistGlobalConcurrency(unittest.TestCase):
         self.assertEqual(attempts, ["discogs", "discogs"])
 
     def test_three_top_level_artist_reads_share_one_two_request_budget(self) -> None:
-        mirror = self._run_calls(3)
+        # Issue #1156 item 6: this test predates #1175's handler_exit_delay
+        # fix and was left on the bare mechanism -- exposed to the exact
+        # same trailing-teardown counted-window symptom #1175 fixed for
+        # test_slow_handler_teardown_does_not_inflate_the_measured_window
+        # below, just without that test's own name calling it out. At 20-24
+        # workers on a 16-thread host this failed reproducibly (a degenerate
+        # counted window reading 1 instead of 2, or a scheduling-starved
+        # reader failing to overlap at all). handler_exit_delay=0.02 mirrors
+        # #1175's own proven fix rather than loosening the assertion below.
+        mirror = self._run_calls(3, handler_exit_delay=0.02)
         # Saturation AND the cap in one assertion: with the budget honoured the
         # only value three concurrent readers can produce is the budget itself.
         # A degenerate counted window (reading 1) fails here just as a breached

--- a/tests/test_fuzz_burst.py
+++ b/tests/test_fuzz_burst.py
@@ -781,14 +781,22 @@ class TestFuzzMainMidRunHeadroom(unittest.TestCase):
     def test_main_reports_a_mid_run_trip_through_the_ordinary_failure_path(
         self,
     ) -> None:
+        """Independent review B4 (HIGH): the fake used to raise
+        ``f"{TEST_RAM_ROOT_EXHAUSTED}: synthetic mid-run trip"`` -- an
+        identity string ALREADY embedded in the exception's own message --
+        so a loose ``assertIn`` matched ``run_fuzz_targets``'s OWN separate
+        admission-loop print (`scripts/run_fuzz_tests.py` line ~959,
+        ``print(f"RAM ROOT EXHAUSTED mid-run: {exc}")``) regardless of
+        whether ``main()``'s OWN reporting block (lines ~1473-1499) ever
+        ran at all. The fake below deliberately carries NEITHER
+        ``TEST_RAM_ROOT_EXHAUSTED`` NOR the word "mid-run", so the
+        assertions can only pass via strings ``main()`` itself composes."""
         calls = {"count": 0}
 
         def flaky_check_headroom() -> None:
             calls["count"] += 1
             if calls["count"] >= 3:
-                raise RamRootExhaustedError(
-                    f"{TEST_RAM_ROOT_EXHAUSTED}: synthetic mid-run trip"
-                )
+                raise RamRootExhaustedError("xyzzy-unrelated-probe-marker")
 
         stdout = io.StringIO()
         with contextlib.redirect_stdout(stdout):
@@ -799,8 +807,18 @@ class TestFuzzMainMidRunHeadroom(unittest.TestCase):
         output = stdout.getvalue()
 
         self.assertEqual(status, TEST_RAM_ROOT_EXHAUSTED_EXIT_CODE, output)
-        self.assertIn(TEST_RAM_ROOT_EXHAUSTED, output)
-        self.assertIn("mid-run", output)
+        # main()'s own header line (scripts/run_fuzz_tests.py:1474) -- no
+        # other print site in the module emits this exact banner.
+        self.assertIn(f"--- {TEST_RAM_ROOT_EXHAUSTED} (mid-run) ---", output)
+        # main()'s own unique explanatory sentence (line ~1476-1478) --
+        # not duplicated by run_fuzz_targets's admission-loop print.
+        self.assertIn(
+            "already-running targets were drained and no new target "
+            "was started",
+            output,
+        )
+        # main()'s own terminal summary line (line ~1494-1499).
+        self.assertIn("property verdict invalid", output)
         self.assertGreaterEqual(calls["count"], 3)
 
     def test_unavailable_runtime_dir_aborts_cleanly_not_as_a_raw_traceback(
@@ -816,13 +834,18 @@ class TestFuzzMainMidRunHeadroom(unittest.TestCase):
         fake in test_preflight_non_ram_root_error_returns_two only proves
         the except clause's own handling, never the real raise site.
         """
-        # dir=REPO_ROOT deliberately: TMPDIR is itself tmpfs inside this
+        # dir="/var/tmp" deliberately: TMPDIR is itself tmpfs inside this
         # nix-shell (scripts/test_tmpfs.sh's own shell-entry scratch), so a
         # bare tempfile.TemporaryDirectory() would land ON tmpfs and never
-        # trip the check this test exists to prove. The repo checkout
-        # itself is real disk-backed storage (ext4 on doc1 and in this
-        # worktree), guaranteed non-tmpfs.
-        with tempfile.TemporaryDirectory(dir=str(REPO_ROOT)) as fake_runtime_dir:
+        # trip the check this test exists to prove. /var/tmp is real
+        # disk-backed storage (ext4 on doc1 and in this worktree),
+        # guaranteed non-tmpfs -- AND, unlike an earlier version of this
+        # test that used dir=REPO_ROOT, it is NOT inside the git-tracked
+        # checkout (independent review B9): a hard kill mid-test (the
+        # TemporaryDirectory context manager's own cleanup never runs on
+        # SIGKILL) used to risk leaving a stray directory inside the repo
+        # worktree; /var/tmp is real disk but outside anything git tracks.
+        with tempfile.TemporaryDirectory(dir="/var/tmp") as fake_runtime_dir:
             original = os.environ.get("XDG_RUNTIME_DIR")
             os.environ["XDG_RUNTIME_DIR"] = fake_runtime_dir
             try:
@@ -1087,6 +1110,24 @@ class TestBurstDepthReport(unittest.TestCase):
 
 class TestFuzzRunnerProcess(unittest.TestCase):
     def setUp(self) -> None:
+        # Independent review B1 (BLOCKING): main()'s production default
+        # (check_headroom=None) now calls the REAL private_runtime_dir()/
+        # _check_suite_headroom() with a flat 1 GiB floor. Every subprocess
+        # test in this class that does not deliberately test headroom
+        # inherited a live ambient-free-space precondition, coupling them
+        # to whatever the shared tmpfs root happens to have free at test
+        # time -- reproduced live (4/460 targets failed on doc1 with
+        # 1002692608 bytes free, needs 1073741824). Pin the floor to "0"
+        # (always satisfied, real code path, no DI) for the whole class;
+        # the one test that is actually ABOUT headroom
+        # (test_preflight_headroom_exhaustion_aborts_before_any_discovery)
+        # overrides it back to an impossible value in its OWN env dict,
+        # which wins over this class-level default.
+        self._original_ram_min_bytes = os.environ.get(
+            "CRATEDIGGER_TEST_RAM_MIN_BYTES"
+        )
+        os.environ["CRATEDIGGER_TEST_RAM_MIN_BYTES"] = "0"
+        self.addCleanup(self._restore_ram_min_bytes)
         self.tempdir = tempfile.TemporaryDirectory()
         self.addCleanup(self.tempdir.cleanup)
         self.root = Path(self.tempdir.name)
@@ -1231,6 +1272,12 @@ class TestFuzzRunnerProcess(unittest.TestCase):
         self.database = self.root / "persistent-database"
         self.database.mkdir()
         (self.database / "seed-marker").write_text("seed", encoding="utf-8")
+
+    def _restore_ram_min_bytes(self) -> None:
+        if self._original_ram_min_bytes is None:
+            os.environ.pop("CRATEDIGGER_TEST_RAM_MIN_BYTES", None)
+        else:
+            os.environ["CRATEDIGGER_TEST_RAM_MIN_BYTES"] = self._original_ram_min_bytes
 
     def run_burst(self, *, failing: bool) -> subprocess.CompletedProcess[str]:
         env = {

--- a/tests/test_fuzz_burst.py
+++ b/tests/test_fuzz_burst.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import contextlib
+import io
 import os
 import subprocess
 import sys
@@ -12,6 +14,7 @@ from pathlib import Path
 from scripts.run_fuzz_tests import (
     DEPTH_REPORT_LIMIT,
     EPHEMERAL_POSTGRES_TARGET_LIMIT,
+    MAX_FUZZ_JOBS,
     FuzzModuleManifest,
     FuzzPropertyManifest,
     FuzzTarget,
@@ -24,16 +27,20 @@ from scripts.run_fuzz_tests import (
     discover_fuzz_manifests,
     format_depth_report,
     is_structurally_shallow,
+    main,
     property_profile_max_examples,
     recommended_fuzz_jobs,
     recommended_postgres_jobs,
     recommended_property_shards,
+    run_fuzz_targets,
     select_fuzz_admissions,
 )
 from scripts.run_python_tests import (
     STRATEGY_SPACE_EXHAUSTED,
+    TEST_RAM_ROOT_EXHAUSTED_EXIT_CODE,
     HypothesisPropertyStats,
 )
+from scripts.run_test_suite import TEST_RAM_ROOT_EXHAUSTED, RamRootExhaustedError
 from tests._source_pins import pinned_source
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -486,6 +493,15 @@ class TestFuzzTargetPlanning(unittest.TestCase):
         self.assertEqual(workers, 60)
         self.assertEqual(recommended_postgres_jobs(30, workers), 24)
 
+    def test_worker_formula_is_capped_regardless_of_host_size(self) -> None:
+        """Issue #1156 item 1: recommended_fuzz_jobs was the only worker
+        formula in the repo with no ceiling; MAX_FUZZ_JOBS bounds it on an
+        arbitrarily large host without moving today's measured 30-core
+        number (60, well under the 64 ceiling)."""
+        self.assertEqual(recommended_fuzz_jobs(40), MAX_FUZZ_JOBS)
+        self.assertLess(recommended_fuzz_jobs(40), 40 * 2)
+        self.assertEqual(recommended_fuzz_jobs(1000), MAX_FUZZ_JOBS)
+
     def test_discovered_profile_budget_ignores_explicit_properties(self) -> None:
         manifest = FuzzModuleManifest(
             module_name="tests.test_generated_world",
@@ -566,6 +582,184 @@ class TestFuzzTargetPlanning(unittest.TestCase):
 
         self.assertTrue(manifest.uses_ephemeral_postgres)
         self.assertNotIn("TEST_DB_DSN", environment)
+
+
+class TestFuzzTargetsMidRunHeadroom(unittest.TestCase):
+    """``run_fuzz_targets``'s own admission-loop headroom check (issue
+    #1156 item 3) -- distinct from the preflight check ``main`` also runs
+    (covered end-to-end in ``TestFuzzRunnerProcess`` below). Both call
+    sites use the identical real ``_check_suite_headroom`` measurement
+    against the same shared tmpfs, so a static real-disk threshold cannot
+    tell them apart; a controlled ``check_headroom`` fake proves the loop
+    consults it a SECOND time, mid-run, not just once at the top.
+    """
+
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.root = Path(self.tempdir.name)
+        package = self.root / "midrun_fixture"
+        package.mkdir()
+        (package / "__init__.py").write_text("", encoding="utf-8")
+        (package / "test_pins.py").write_text(
+            "import unittest\n\n"
+            "class PinWorld(unittest.TestCase):\n"
+            "    def test_a(self):\n"
+            "        self.assertTrue(True)\n\n"
+            "    def test_b(self):\n"
+            "        self.assertTrue(True)\n\n"
+            "    def test_c(self):\n"
+            "        self.assertTrue(True)\n",
+            encoding="utf-8",
+        )
+        self.module = "midrun_fixture.test_pins"
+        self.log_directory = self.root / "logs"
+        self.log_directory.mkdir()
+        self.environment = {
+            **os.environ,
+            "PYTHONPATH": os.pathsep.join(
+                (str(self.root), str(REPO_ROOT), os.environ.get("PYTHONPATH", ""))
+            ),
+        }
+
+    def _target(self, letter: str) -> FuzzTarget:
+        return FuzzTarget(
+            label=letter,
+            module_name=self.module,
+            load_names=(self.module,),
+            expected_test_ids=(f"{self.module}.PinWorld.test_{letter}",),
+        )
+
+    def test_trip_aborts_admission_without_starting_the_rest(self) -> None:
+        calls = {"count": 0}
+
+        def flaky_check_headroom() -> None:
+            calls["count"] += 1
+            if calls["count"] >= 2:
+                raise RamRootExhaustedError(
+                    f"{TEST_RAM_ROOT_EXHAUSTED}: synthetic mid-run trip"
+                )
+
+        targets = (self._target("a"), self._target("b"), self._target("c"))
+
+        batch = run_fuzz_targets(
+            targets,
+            worker_count=1,
+            postgres_worker_count=1,
+            environment=self.environment,
+            log_directory=self.log_directory,
+            check_headroom=flaky_check_headroom,
+        )
+
+        self.assertTrue(batch.headroom_exhausted)
+        self.assertEqual(batch.infrastructure_failures, ())
+        self.assertEqual(len(batch.results), 1)
+        self.assertTrue(batch.results[0].successful)
+        self.assertEqual(len(batch.not_started), 2)
+        self.assertGreaterEqual(calls["count"], 2)
+
+    def test_never_tripping_runs_every_target_normally(self) -> None:
+        targets = (self._target("a"), self._target("b"), self._target("c"))
+
+        batch = run_fuzz_targets(
+            targets,
+            worker_count=2,
+            postgres_worker_count=2,
+            environment=self.environment,
+            log_directory=self.log_directory,
+            check_headroom=lambda: None,
+        )
+
+        self.assertFalse(batch.headroom_exhausted)
+        self.assertEqual(batch.infrastructure_failures, ())
+        self.assertEqual(len(batch.results), 3)
+        self.assertTrue(all(result.successful for result in batch.results))
+        self.assertEqual(batch.not_started, ())
+
+
+class TestFuzzMainMidRunHeadroom(unittest.TestCase):
+    """``main``'s own POST-run reporting of a mid-run trip (issue #1156
+    item 3) -- distinct from TestFuzzTargetsMidRunHeadroom above, which
+    only proves ``run_fuzz_targets``'s admission loop stops correctly.
+    This drives the real CLI entry point in-process (the ``check_headroom``
+    DI seam mirrors ``run_world_model_burst.py::main``'s own) so the
+    unified failed_results/infrastructure_failures/headroom_exhausted
+    reporting block -- the code that used to silently drop other targets'
+    detail when it early-returned before printing them -- is exercised
+    end-to-end, not just unit-tested in isolation.
+    """
+
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.root = Path(self.tempdir.name)
+        package = self.root / "main_midrun_fixture"
+        package.mkdir()
+        (package / "__init__.py").write_text("", encoding="utf-8")
+        (package / "test_alpha.py").write_text(
+            "import unittest\n\n"
+            "class Alpha(unittest.TestCase):\n"
+            "    def test_pin(self):\n"
+            "        self.assertTrue(True)\n",
+            encoding="utf-8",
+        )
+        (package / "test_beta.py").write_text(
+            "import unittest\n\n"
+            "class Beta(unittest.TestCase):\n"
+            "    def test_pin(self):\n"
+            "        self.assertTrue(True)\n",
+            encoding="utf-8",
+        )
+        self.module_a = "main_midrun_fixture.test_alpha"
+        self.module_b = "main_midrun_fixture.test_beta"
+        self.database = self.root / "database"
+        self.database.mkdir()
+        original_pythonpath = os.environ.get("PYTHONPATH")
+        os.environ["PYTHONPATH"] = os.pathsep.join(
+            (str(self.root), original_pythonpath or "")
+        )
+        original_hsd = os.environ.pop("HYPOTHESIS_STORAGE_DIRECTORY", None)
+        os.environ["HYPOTHESIS_STORAGE_DIRECTORY"] = str(self.database)
+        original_output_dir = os.environ.pop("CRATEDIGGER_FUZZ_OUTPUT_DIR", None)
+
+        def _restore() -> None:
+            if original_pythonpath is None:
+                os.environ.pop("PYTHONPATH", None)
+            else:
+                os.environ["PYTHONPATH"] = original_pythonpath
+            if original_hsd is None:
+                os.environ.pop("HYPOTHESIS_STORAGE_DIRECTORY", None)
+            else:
+                os.environ["HYPOTHESIS_STORAGE_DIRECTORY"] = original_hsd
+            if original_output_dir is not None:
+                os.environ["CRATEDIGGER_FUZZ_OUTPUT_DIR"] = original_output_dir
+
+        self.addCleanup(_restore)
+
+    def test_main_reports_a_mid_run_trip_through_the_ordinary_failure_path(
+        self,
+    ) -> None:
+        calls = {"count": 0}
+
+        def flaky_check_headroom() -> None:
+            calls["count"] += 1
+            if calls["count"] >= 3:
+                raise RamRootExhaustedError(
+                    f"{TEST_RAM_ROOT_EXHAUSTED}: synthetic mid-run trip"
+                )
+
+        stdout = io.StringIO()
+        with contextlib.redirect_stdout(stdout):
+            status = main(
+                (self.module_a, self.module_b, "--jobs", "1", "--profile", "suite"),
+                check_headroom=flaky_check_headroom,
+            )
+        output = stdout.getvalue()
+
+        self.assertEqual(status, TEST_RAM_ROOT_EXHAUSTED_EXIT_CODE, output)
+        self.assertIn(TEST_RAM_ROOT_EXHAUSTED, output)
+        self.assertIn("mid-run", output)
+        self.assertGreaterEqual(calls["count"], 3)
 
 
 class TestFuzzProfileBudget(unittest.TestCase):
@@ -1267,6 +1461,55 @@ class TestFuzzRunnerProcess(unittest.TestCase):
             "supported only by the fuzz profile",
             completed.stderr,
         )
+
+    def test_preflight_headroom_exhaustion_aborts_before_any_discovery(
+        self,
+    ) -> None:
+        """Issue #1156 item 3: the fail-fast, before-any-work precondition.
+
+        CRATEDIGGER_TEST_RAM_MIN_BYTES set to a value no real host's free
+        bytes can exceed is the same deterministic trick
+        TestRunTargetsWorkerExceptionWiring already documents for the
+        suite's own classifier -- real headroom_floor_bytes/
+        _check_suite_headroom, genuinely tripped, no fake disk.
+        """
+        env = {
+            **os.environ,
+            "PYTHONPATH": os.pathsep.join(
+                (str(self.root), str(REPO_ROOT), os.environ.get("PYTHONPATH", ""))
+            ),
+            "HYPOTHESIS_STORAGE_DIRECTORY": str(self.database),
+            "CRATEDIGGER_FUZZ_OUTPUT_DIR": str(self.output_dir),
+            "CRATEDIGGER_TEST_RAM_MIN_BYTES": str(10**18),
+        }
+
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(RUNNER),
+                "--jobs",
+                "1",
+                "--profile",
+                "suite",
+                self.module,
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        self.assertEqual(
+            completed.returncode,
+            TEST_RAM_ROOT_EXHAUSTED_EXIT_CODE,
+            completed.stdout + completed.stderr,
+        )
+        self.assertIn(
+            TEST_RAM_ROOT_EXHAUSTED, completed.stdout + completed.stderr
+        )
+        self.assertFalse(self.output_dir.exists())
+        self.assertNotIn("targets (", completed.stdout)
 
     def test_wrapper_delegates_to_the_exact_coverage_runner(self) -> None:
         source = pinned_source(WRAPPER)

--- a/tests/test_fuzz_burst.py
+++ b/tests/test_fuzz_burst.py
@@ -494,10 +494,11 @@ class TestFuzzTargetPlanning(unittest.TestCase):
         self.assertEqual(recommended_postgres_jobs(30, workers), 24)
 
     def test_worker_formula_is_capped_regardless_of_host_size(self) -> None:
-        """Issue #1156 item 1: recommended_fuzz_jobs was the only worker
-        formula in the repo with no ceiling; MAX_FUZZ_JOBS bounds it on an
-        arbitrarily large host without moving today's measured 30-core
-        number (60, well under the 64 ceiling)."""
+        """Issue #1214 "Contributing gaps" item 1 (independent review F5(b):
+        NOT #1156 item 1, a different, unrelated finding): recommended_
+        fuzz_jobs had no ceiling; MAX_FUZZ_JOBS bounds it on an arbitrarily
+        large host without moving today's measured 30-core number (60,
+        well under the 64 ceiling)."""
         self.assertEqual(recommended_fuzz_jobs(40), MAX_FUZZ_JOBS)
         self.assertLess(recommended_fuzz_jobs(40), 40 * 2)
         self.assertEqual(recommended_fuzz_jobs(1000), MAX_FUZZ_JOBS)
@@ -676,6 +677,47 @@ class TestFuzzTargetsMidRunHeadroom(unittest.TestCase):
         self.assertTrue(all(result.successful for result in batch.results))
         self.assertEqual(batch.not_started, ())
 
+    def test_drain_phase_never_calls_check_headroom_once_pending_is_empty(
+        self,
+    ) -> None:
+        """Independent review F1 (BLOCKING): the mid-run check used to sit
+        inside ``if not infrastructure_aborted:`` with no ``pending`` gate,
+        so it kept firing on every drain iteration after the LAST target
+        was already admitted -- when there is nothing left to admit. A
+        free-space dip at that exact moment reported a fully green burst
+        ("2 completed of 2, 0 not started") as an infrastructure failure.
+        worker_count >= len(targets) admits everything in the first
+        iteration; the poison pill below (a RamRootExhaustedError on every
+        call after the first) proves check_headroom is never consulted
+        again during the drain that follows.
+        """
+        calls = {"count": 0}
+
+        def check_headroom() -> None:
+            calls["count"] += 1
+            if calls["count"] > 1:
+                raise RamRootExhaustedError(
+                    f"{TEST_RAM_ROOT_EXHAUSTED}: must never fire once "
+                    "pending is empty"
+                )
+
+        targets = (self._target("a"), self._target("b"), self._target("c"))
+
+        batch = run_fuzz_targets(
+            targets,
+            worker_count=3,
+            postgres_worker_count=3,
+            environment=self.environment,
+            log_directory=self.log_directory,
+            check_headroom=check_headroom,
+        )
+
+        self.assertFalse(batch.headroom_exhausted)
+        self.assertEqual(batch.infrastructure_failures, ())
+        self.assertEqual(len(batch.results), 3)
+        self.assertTrue(all(result.successful for result in batch.results))
+        self.assertEqual(batch.not_started, ())
+
 
 class TestFuzzMainMidRunHeadroom(unittest.TestCase):
     """``main``'s own POST-run reporting of a mid-run trip (issue #1156
@@ -760,6 +802,46 @@ class TestFuzzMainMidRunHeadroom(unittest.TestCase):
         self.assertIn(TEST_RAM_ROOT_EXHAUSTED, output)
         self.assertIn("mid-run", output)
         self.assertGreaterEqual(calls["count"], 3)
+
+    def test_unavailable_runtime_dir_aborts_cleanly_not_as_a_raw_traceback(
+        self,
+    ) -> None:
+        """Independent review F3 (MEDIUM): private_runtime_dir() used to be
+        called ONE LINE ABOVE the try/except that exists to catch its own
+        RuntimeError, so it escaped as an unhandled traceback instead of
+        the intended "infrastructure precondition failed" exit 2. Drives
+        the REAL production private_runtime_dir() (check_headroom=None,
+        the default -- no injected fake), pointed at a real, non-tmpfs
+        directory via XDG_RUNTIME_DIR, matching test-fidelity Rule B: the
+        fake in test_preflight_non_ram_root_error_returns_two only proves
+        the except clause's own handling, never the real raise site.
+        """
+        # dir=REPO_ROOT deliberately: TMPDIR is itself tmpfs inside this
+        # nix-shell (scripts/test_tmpfs.sh's own shell-entry scratch), so a
+        # bare tempfile.TemporaryDirectory() would land ON tmpfs and never
+        # trip the check this test exists to prove. The repo checkout
+        # itself is real disk-backed storage (ext4 on doc1 and in this
+        # worktree), guaranteed non-tmpfs.
+        with tempfile.TemporaryDirectory(dir=str(REPO_ROOT)) as fake_runtime_dir:
+            original = os.environ.get("XDG_RUNTIME_DIR")
+            os.environ["XDG_RUNTIME_DIR"] = fake_runtime_dir
+            try:
+                stdout = io.StringIO()
+                stderr = io.StringIO()
+                with contextlib.redirect_stdout(stdout), contextlib.redirect_stderr(
+                    stderr
+                ):
+                    status = main((self.module_a, "--jobs", "1", "--profile", "suite"))
+            finally:
+                if original is None:
+                    os.environ.pop("XDG_RUNTIME_DIR", None)
+                else:
+                    os.environ["XDG_RUNTIME_DIR"] = original
+            output = stdout.getvalue() + stderr.getvalue()
+
+        self.assertEqual(status, 2, output)
+        self.assertIn("infrastructure precondition failed", output)
+        self.assertIn("not tmpfs", output)
 
 
 class TestFuzzProfileBudget(unittest.TestCase):

--- a/tests/test_fuzz_burst.py
+++ b/tests/test_fuzz_burst.py
@@ -819,6 +819,13 @@ class TestFuzzMainMidRunHeadroom(unittest.TestCase):
         )
         # main()'s own terminal summary line (line ~1494-1499).
         self.assertIn("property verdict invalid", output)
+        # Independent review B-2 (third round): the OTHER identity token in
+        # main()'s own terminal summary (line ~1500-1501) was previously
+        # unconstrained -- replacing TEST_RAM_ROOT_EXHAUSTED with a generic
+        # literal there survived every existing assertion above.
+        self.assertIn(
+            f"fuzz burst: {TEST_RAM_ROOT_EXHAUSTED} mid-run after", output
+        )
         self.assertGreaterEqual(calls["count"], 3)
 
     def test_unavailable_runtime_dir_aborts_cleanly_not_as_a_raw_traceback(

--- a/tests/test_node_jsonl_worker.py
+++ b/tests/test_node_jsonl_worker.py
@@ -159,6 +159,16 @@ async function handle() {
         self.assertFalse(worker.is_running)
 
     def test_blocked_request_write_consumes_the_transaction_deadline(self) -> None:
+        """Independent review B-1 (third round): `command=` overrides the
+        default Node spawn with a bare Python fake, so this test doesn't
+        carry the Node-startup fragility the sibling fixes above address --
+        it did not reproduce live -- but it shares the SAME shape (a tight
+        timeout_seconds plus an upper-bound wall-clock assertion on
+        termination promptness) and the reviewer's own note says use
+        judgement here. Widened proportionally so a slow SIGKILL-and-reap
+        under host CPU pressure has real headroom without weakening what
+        this test proves: that the deadline path returns control promptly,
+        nowhere near the child's deliberate 60s sleep."""
         command = self._fake_command(
             "import signal, time\n"
             "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
@@ -168,7 +178,7 @@ async function handle() {
         worker = NodeJsonlWorker(
             "",
             cwd=ROOT,
-            timeout_seconds=0.1,
+            timeout_seconds=0.5,
             command=command,
         )
         self.addCleanup(worker.close)
@@ -176,7 +186,7 @@ async function handle() {
         started = time.monotonic()
         with self.assertRaisesRegex(NodeJsonlWorkerError, "timed out") as caught:
             worker.request("blocked", {"text": "x" * (512 * 1024)})
-        self.assertLess(time.monotonic() - started, 0.75)
+        self.assertLess(time.monotonic() - started, 3.0)
         self.assertFalse(worker.is_running)
         with self.assertRaises(NodeJsonlWorkerError) as repeated:
             worker.request("blocked", {})
@@ -201,13 +211,24 @@ async function handle() {
         self.assertEqual(str(repeated.exception), str(caught.exception))
 
     def test_partial_line_times_out_instead_of_blocking_readline(self) -> None:
+        """Independent review B-1 (HIGH, third round): this test constructs
+        a real Node worker (no `command=` override) with the SAME
+        timeout_seconds=0.1 that test_timeout_terminates_child_and_fails_
+        closed above was widened for, and for the identical reason --
+        NodeJsonlWorker.__init__ reuses this budget for Node's own startup
+        handshake, not just the deliberate hang under test. Reproduced live
+        on doc1 at load ~19-89 (1/8, then 8/20 module/class runs failing
+        with "request 0 timed out after 0.1s" -- a construction-time
+        ERROR, not a clean assertion failure, since it happens before the
+        assertRaisesRegex block below is even entered). 2.0s matches the
+        sibling fix."""
         source = r"""
 async function handle(_operation, _payload) {
   process.stdout.write('{"id":');
   return await new Promise(() => {});
 }
 """
-        worker = NodeJsonlWorker(source, cwd=ROOT, timeout_seconds=0.1)
+        worker = NodeJsonlWorker(source, cwd=ROOT, timeout_seconds=2.0)
         self.addCleanup(worker.close)
 
         with self.assertRaisesRegex(NodeJsonlWorkerError, "timed out"):

--- a/tests/test_node_jsonl_worker.py
+++ b/tests/test_node_jsonl_worker.py
@@ -130,12 +130,27 @@ async function handle() {
         self.assertFalse(worker.is_running)
 
     def test_timeout_terminates_child_and_fails_closed(self) -> None:
+        """Issue #1156 item 6: the original 0.1s timeout_seconds governs
+        BOTH the deliberate hang below AND this worker's own Node startup
+        handshake (NodeJsonlWorker.__init__ reuses the same budget for the
+        "ready" response) -- at 20-24 workers on a 16-thread host, Node
+        interpreter startup alone can exceed 0.1s under real CPU
+        contention, raising NodeJsonlWorkerError OUT OF THE CONSTRUCTOR,
+        before the `with self.assertRaisesRegex(...)` block below is even
+        entered (it only wraps `worker.request`, not construction) --
+        reproducing exactly the "fails reproducibly past the worker knee"
+        symptom the issue names, as a raw ERROR rather than a clean
+        assertion failure. 2.0s (matching this file's own
+        test_stderr_flood_is_drained_without_deadlocking_response) gives
+        real startup headroom under load while the deliberate hang
+        (`await new Promise(() => {})`, which never resolves) still makes
+        the timeout the only possible outcome."""
         source = """
 async function handle() {
   await new Promise(() => {});
 }
 """
-        worker = NodeJsonlWorker(source, cwd=ROOT, timeout_seconds=0.1)
+        worker = NodeJsonlWorker(source, cwd=ROOT, timeout_seconds=2.0)
         self.addCleanup(worker.close)
 
         with self.assertRaisesRegex(NodeJsonlWorkerError, "timed out"):

--- a/tests/test_parallel_test_runner.py
+++ b/tests/test_parallel_test_runner.py
@@ -49,6 +49,7 @@ from scripts.run_python_tests import (
     _classify_test_infrastructure_error,
     _collapse_disk_full_failures,
     _collapse_memory_exhausted_failures,
+    _default_min_memory_headroom_bytes,
     _iter_test_cases,
     _measure_available_memory_bytes,
     _measure_tempdir_available_bytes,
@@ -214,7 +215,18 @@ class TestWorkerMemoryExhaustionClassification(unittest.TestCase):
     by exception SHAPE (BrokenProcessPool) narrowed by MEASURED system
     memory -- never a scan of the exception's text, and never triggered by
     measured state alone (unlike disk_full, which does not care what the
-    exception is)."""
+    exception is).
+
+    Independent review B2 (discovered while verifying the named fix):
+    every case below pins `minimum_bytes=0` explicitly. `_classify_target_
+    infrastructure_failure` checks disk_full BEFORE memory, and disk_full's
+    own floor falls back to the ambient CRATEDIGGER_TEST_RAM_MIN_BYTES when
+    no `minimum_bytes` is given -- so without the pin, a large-enough
+    ambient floor (e.g. a suite run forcing it to prove B2's OWN fix) makes
+    every `available_bytes=10 GiB` fixture here read as disk_full and
+    short-circuit the memory branch these tests exist to exercise. Pinning
+    the disk floor to 0 makes disk_full unreachable at 10 GiB regardless of
+    the ambient value, so only the memory branch under test is live."""
 
     def test_broken_process_pool_with_low_memory_is_memory_exhausted(
         self,
@@ -223,6 +235,7 @@ class TestWorkerMemoryExhaustionClassification(unittest.TestCase):
             _target("tests.test_alpha"),
             BrokenProcessPool("a worker was terminated abruptly"),
             available_bytes=lambda: 10 * 1024 * 1024 * 1024,
+            minimum_bytes=0,
             available_memory_bytes=lambda: 1,
         )
 
@@ -236,6 +249,7 @@ class TestWorkerMemoryExhaustionClassification(unittest.TestCase):
             _target("tests.test_alpha"),
             BrokenProcessPool("a worker was terminated abruptly"),
             available_bytes=lambda: 10 * 1024 * 1024 * 1024,
+            minimum_bytes=0,
             available_memory_bytes=lambda: 10 * 1024 * 1024 * 1024,
         )
 
@@ -251,14 +265,18 @@ class TestWorkerMemoryExhaustionClassification(unittest.TestCase):
             _target("tests.test_alpha"),
             RuntimeError("ordinary worker crash, unrelated to memory"),
             available_bytes=lambda: 10 * 1024 * 1024 * 1024,
+            minimum_bytes=0,
             available_memory_bytes=lambda: 1,
         )
 
         self.assertFalse(failure.memory_exhausted)
 
     def test_disk_full_takes_priority_over_memory_exhaustion(self) -> None:
-        """Mutual exclusivity: a target cannot plausibly be both, so the
-        disk check short-circuits the memory one."""
+        """The disk check short-circuits the memory one by construction
+        (a deliberate ORDERING choice in the classifier, not a claim the
+        two are physically distinct -- independent review B2: on this
+        host's own topology the tmpfs RAM root often IS memory pressure,
+        per issue #1214's own cgroup measurement)."""
         failure = _classify_target_infrastructure_failure(
             _target("tests.test_alpha"),
             BrokenProcessPool("a worker was terminated abruptly"),
@@ -274,6 +292,7 @@ class TestWorkerMemoryExhaustionClassification(unittest.TestCase):
             _target("tests.test_alpha"),
             BrokenProcessPool("a worker was terminated abruptly"),
             available_bytes=lambda: 10 * 1024 * 1024 * 1024,
+            minimum_bytes=0,
             available_memory_bytes=lambda: None,
         )
 
@@ -287,6 +306,7 @@ class TestWorkerMemoryExhaustionClassification(unittest.TestCase):
                 _target("tests.test_alpha"),
                 BrokenProcessPool("a worker was terminated abruptly"),
                 available_bytes=lambda: 10 * 1024 * 1024 * 1024,
+                minimum_bytes=0,
                 available_memory_bytes=lambda: 123455,
             )
         finally:
@@ -304,6 +324,7 @@ class TestWorkerMemoryExhaustionClassification(unittest.TestCase):
             _target("tests.test_alpha"),
             BrokenProcessPool("a worker was terminated abruptly"),
             available_bytes=lambda: 10 * 1024 * 1024 * 1024,
+            minimum_bytes=0,
             available_memory_bytes=lambda: 100 * 1024 * 1024,
             minimum_memory_bytes=10 * 1024 * 1024,
         )
@@ -326,6 +347,7 @@ class TestWorkerMemoryExhaustionClassification(unittest.TestCase):
                 _target("tests.test_alpha"),
                 BrokenProcessPool("a worker was terminated abruptly"),
                 available_bytes=lambda: 10 * 1024 * 1024 * 1024,
+                minimum_bytes=0,
                 available_memory_bytes=lambda: 200 * 1024 * 1024,
             )
         finally:
@@ -343,6 +365,7 @@ class TestWorkerMemoryExhaustionClassification(unittest.TestCase):
             _target("tests.test_alpha"),
             BrokenProcessPool("a worker was terminated abruptly"),
             available_bytes=lambda: 10 * 1024 * 1024 * 1024,
+            minimum_bytes=0,
             available_memory_bytes=lambda: 10 * 1024 * 1024,
             minimum_memory_bytes=10 * 1024 * 1024,
         )
@@ -359,6 +382,7 @@ class TestWorkerMemoryExhaustionClassification(unittest.TestCase):
             _target("tests.test_alpha"),
             BrokenProcessPool("a worker was terminated abruptly"),
             available_bytes=lambda: 10 * 1024 * 1024 * 1024,
+            minimum_bytes=0,
             available_memory_bytes=lambda: 0,
         )
 
@@ -410,6 +434,46 @@ class TestWorkerMemoryExhaustionClassification(unittest.TestCase):
         self.assertIsNotNone(result)
         assert result is not None
         self.assertGreater(result, 0)
+
+    def test_negative_memory_floor_override_fails_closed(self) -> None:
+        """Independent review B5 (MEDIUM): known-bad self-test for
+        `_default_min_memory_headroom_bytes`'s negative-override guard
+        clause, which shipped with no test at all -- mirroring the
+        sibling disk-floor guard's own message-asserting shape."""
+        original = os.environ.get("CRATEDIGGER_TEST_MEMORY_MIN_BYTES")
+        try:
+            os.environ["CRATEDIGGER_TEST_MEMORY_MIN_BYTES"] = "-1"
+            with self.assertRaisesRegex(
+                ValueError,
+                "CRATEDIGGER_TEST_MEMORY_MIN_BYTES must be a "
+                "non-negative integer",
+            ):
+                _default_min_memory_headroom_bytes()
+        finally:
+            if original is None:
+                os.environ.pop("CRATEDIGGER_TEST_MEMORY_MIN_BYTES", None)
+            else:
+                os.environ["CRATEDIGGER_TEST_MEMORY_MIN_BYTES"] = original
+
+    def test_non_integer_memory_floor_override_fails_closed(self) -> None:
+        """A malformed (non-integer) override is coerced to the same
+        fail-closed ValueError as an explicit negative one -- proving the
+        `except ValueError: value = -1` fallback actually reaches the
+        guard clause rather than silently returning a bogus floor."""
+        original = os.environ.get("CRATEDIGGER_TEST_MEMORY_MIN_BYTES")
+        try:
+            os.environ["CRATEDIGGER_TEST_MEMORY_MIN_BYTES"] = "not-a-number"
+            with self.assertRaisesRegex(
+                ValueError,
+                "CRATEDIGGER_TEST_MEMORY_MIN_BYTES must be a "
+                "non-negative integer",
+            ):
+                _default_min_memory_headroom_bytes()
+        finally:
+            if original is None:
+                os.environ.pop("CRATEDIGGER_TEST_MEMORY_MIN_BYTES", None)
+            else:
+                os.environ["CRATEDIGGER_TEST_MEMORY_MIN_BYTES"] = original
 
 
 class TestCollapseDiskFullFailures(unittest.TestCase):
@@ -1454,7 +1518,7 @@ class TestRunnerProcessContract(unittest.TestCase):
         )
 
     def _run_worker_death_fixture(
-        self, *, count: int = 2
+        self, *, count: int = 2, env_overrides: dict[str, str] | None = None
     ) -> subprocess.CompletedProcess[str]:
         """Kill `count` INDEPENDENT ProcessPoolExecutor worker processes
         (not the nested per-target subprocess `_run_test_target` spawns)
@@ -1467,6 +1531,15 @@ class TestRunnerProcessContract(unittest.TestCase):
         "folded into one marker" from "there was only ever one failure to
         report" -- count>1 real, independent deaths is required to prove
         the fold actually collapses N>1 into ONE.
+
+        Independent review B2 (HIGH): CRATEDIGGER_TEST_RAM_MIN_BYTES is
+        pinned to "0" by default -- disk_full is checked BEFORE memory in
+        `_classify_target_infrastructure_failure`, so leaving it ambient
+        left this fixture coupled to the host's own real free tmpfs bytes
+        (measured on doc1: the ambient worker-scaled floor, 1,744,830,464,
+        classified both deaths disk_full instead of memory_exhausted).
+        `env_overrides` lets callers (e.g. a pure disk-full scenario) flip
+        which resource actually trips.
         """
         with tempfile.TemporaryDirectory() as tempdir:
             root = Path(tempdir)
@@ -1485,7 +1558,9 @@ class TestRunnerProcessContract(unittest.TestCase):
                 )
             env = {
                 **os.environ,
+                "CRATEDIGGER_TEST_RAM_MIN_BYTES": "0",
                 "CRATEDIGGER_TEST_MEMORY_MIN_BYTES": str(10**18),
+                **(env_overrides or {}),
             }
             return subprocess.run(
                 [
@@ -1531,6 +1606,66 @@ class TestRunnerProcessContract(unittest.TestCase):
         )
         self.assertIn(TEST_HOST_MEMORY_EXHAUSTED, result.stdout)
         self.assertIn("BrokenProcessPool", result.stdout)
+        marker_line = next(
+            line
+            for line in result.stdout.splitlines()
+            if line.startswith(FAILURE_MARKER_PREFIX)
+        )
+        marker = msgspec.json.decode(
+            marker_line.removeprefix(FAILURE_MARKER_PREFIX),
+            type=CheckFailureMarker,
+        )
+        self.assertEqual(
+            set(marker.test_ids),
+            {"fixture_tests.test_alpha0", "fixture_tests.test_alpha1"},
+        )
+
+    def test_worker_deaths_classified_pure_disk_full_never_reach_the_memory_bucket(
+        self,
+    ) -> None:
+        """Independent review B3: the composition test in
+        TestCollapseMemoryExhaustedFailures (test_disk_full_and_memory_
+        exhausted_are_each_folded_exactly_once) reimplements main()'s own
+        wiring inline rather than driving it -- it would stay green even if
+        main() itself fed `_collapse_memory_exhausted_failures` the RAW
+        `infrastructure_failures` list instead of the disk-full-FILTERED
+        `remaining_infrastructure_failures` (line ~1706). This test drives
+        the real subprocess end-to-end instead: TWO real, independent
+        BrokenProcessPool deaths, both forced disk_full via an impossibly
+        high CRATEDIGGER_TEST_RAM_MIN_BYTES (the memory floor is left at
+        the fixture's own high default, but never evaluated -- disk_full
+        short-circuits the memory branch in _classify_target_infrastructure_
+        failure). Correct wiring: both fold into ONE ram-root marker, exit
+        TEST_RAM_ROOT_EXHAUSTED_EXIT_CODE, no memory marker at all. The
+        named mutant (raw list instead of the filtered remainder) would
+        instead leave both targets in `remaining_infrastructure_failures`
+        (since neither has memory_exhausted=True) -- printed a SECOND time
+        as ordinary per-target failures on top of the folded marker, and
+        the exit code would fall through to plain `1` because
+        `remaining_infrastructure_failures` is no longer empty."""
+        result = self._run_worker_death_fixture(
+            count=2,
+            env_overrides={"CRATEDIGGER_TEST_RAM_MIN_BYTES": str(10**18)},
+        )
+
+        self.assertEqual(
+            result.returncode,
+            TEST_RAM_ROOT_EXHAUSTED_EXIT_CODE,
+            result.stdout + result.stderr,
+        )
+        self.assertEqual(
+            result.stdout.count(FAILURE_MARKER_PREFIX),
+            1,
+            "both disk-full-classified deaths must fold into ONE marker, "
+            "never double-reported alongside an ordinary per-target entry",
+        )
+        self.assertIn(TEST_RAM_ROOT_EXHAUSTED, result.stdout)
+        self.assertNotIn(
+            TEST_HOST_MEMORY_EXHAUSTED,
+            result.stdout,
+            "disk_full short-circuits the memory branch -- no memory "
+            "marker should appear at all",
+        )
         marker_line = next(
             line
             for line in result.stdout.splitlines()

--- a/tests/test_parallel_test_runner.py
+++ b/tests/test_parallel_test_runner.py
@@ -50,6 +50,7 @@ from scripts.run_python_tests import (
     _collapse_disk_full_failures,
     _collapse_memory_exhausted_failures,
     _iter_test_cases,
+    _measure_available_memory_bytes,
     _measure_tempdir_available_bytes,
     _run_targets,
     assert_exact_schedule,
@@ -309,6 +310,107 @@ class TestWorkerMemoryExhaustionClassification(unittest.TestCase):
 
         self.assertFalse(failure.memory_exhausted)
 
+    def test_default_floor_uses_the_real_256mib_constant_not_env(self) -> None:
+        """Independent review F4 (MEDIUM): every other "low memory" test in
+        this class uses available_memory_bytes=lambda: 1 -- degenerate,
+        since 1 is below ANY plausible floor including a mutant of
+        _MIN_VALID_MEMORY_HEADROOM_BYTES collapsed to 2 (1 < 2 is still
+        True, so that mutant survives every other test here). A reading
+        comfortably under the real 256 MiB constant but far above a
+        near-zero mutant proves the CONSTANT itself, not just the env
+        override path (test_default_memory_floor_reads_the_configured_
+        env_var above), gates real classification."""
+        original = os.environ.pop("CRATEDIGGER_TEST_MEMORY_MIN_BYTES", None)
+        try:
+            failure = _classify_target_infrastructure_failure(
+                _target("tests.test_alpha"),
+                BrokenProcessPool("a worker was terminated abruptly"),
+                available_bytes=lambda: 10 * 1024 * 1024 * 1024,
+                available_memory_bytes=lambda: 200 * 1024 * 1024,
+            )
+        finally:
+            if original is not None:
+                os.environ["CRATEDIGGER_TEST_MEMORY_MIN_BYTES"] = original
+
+        self.assertTrue(failure.memory_exhausted)
+
+    def test_memory_exactly_at_the_floor_is_not_exhausted(self) -> None:
+        """Independent review F8: boundary. The classifier uses a strict
+        `<` comparison against the floor, matching the disk-full
+        classifier's own convention -- `<=` would misclassify a host
+        sitting exactly at the configured floor."""
+        failure = _classify_target_infrastructure_failure(
+            _target("tests.test_alpha"),
+            BrokenProcessPool("a worker was terminated abruptly"),
+            available_bytes=lambda: 10 * 1024 * 1024 * 1024,
+            available_memory_bytes=lambda: 10 * 1024 * 1024,
+            minimum_memory_bytes=10 * 1024 * 1024,
+        )
+
+        self.assertFalse(failure.memory_exhausted)
+
+    def test_zero_available_memory_is_still_exhausted(self) -> None:
+        """Independent review F8: boundary. 0 is a legitimate (falsy)
+        MemAvailable reading -- a genuinely exhausted host -- not the
+        unmeasurable (None) case; the classifier's `is not None` check
+        must not be weakened to a truthiness check that would silently
+        treat 0 the same as "cannot classify"."""
+        failure = _classify_target_infrastructure_failure(
+            _target("tests.test_alpha"),
+            BrokenProcessPool("a worker was terminated abruptly"),
+            available_bytes=lambda: 10 * 1024 * 1024 * 1024,
+            available_memory_bytes=lambda: 0,
+        )
+
+        self.assertTrue(failure.memory_exhausted)
+
+    def test_measure_available_memory_converts_kib_to_bytes(self) -> None:
+        """Independent review F4 (MEDIUM): MemAvailable in /proc/meminfo is
+        reported in KiB. Dropping the `* 1024` conversion would silently
+        read kB as bytes, misclassifying every real BrokenProcessPool as
+        memory-exhausted on a healthy multi-GB host -- worse than the
+        disguise this whole change exists to remove. A fake fixture file
+        proves the conversion since /proc/meminfo cannot be forced to a
+        known value."""
+        with tempfile.TemporaryDirectory() as tempdir:
+            fake_meminfo = Path(tempdir) / "meminfo"
+            fake_meminfo.write_text(
+                "MemTotal:       32865536 kB\n"
+                "MemFree:        10000000 kB\n"
+                "MemAvailable:   20000000 kB\n",
+                encoding="utf-8",
+            )
+            result = _measure_available_memory_bytes(fake_meminfo)
+
+        self.assertEqual(result, 20000000 * 1024)
+
+    def test_measure_available_memory_reads_memavailable_not_memfree(
+        self,
+    ) -> None:
+        """Independent review F4 (MEDIUM): must read MemAvailable, not
+        MemFree -- MemFree undercounts reclaimable page cache and would
+        report a healthy host as critically low."""
+        with tempfile.TemporaryDirectory() as tempdir:
+            fake_meminfo = Path(tempdir) / "meminfo"
+            fake_meminfo.write_text(
+                "MemTotal:       32865536 kB\n"
+                "MemFree:            1000 kB\n"
+                "MemAvailable:   20000000 kB\n",
+                encoding="utf-8",
+            )
+            result = _measure_available_memory_bytes(fake_meminfo)
+
+        self.assertEqual(result, 20000000 * 1024)
+
+    def test_measure_available_memory_reads_the_real_proc_meminfo(self) -> None:
+        """The default parameter value is wired to the REAL file on this
+        Linux host, not just the fixture-driven tests above."""
+        result = _measure_available_memory_bytes()
+
+        self.assertIsNotNone(result)
+        assert result is not None
+        self.assertGreater(result, 0)
+
 
 class TestCollapseDiskFullFailures(unittest.TestCase):
     """Issue #1111 item 2: N disk-full-classified failures fold into ONE
@@ -508,6 +610,41 @@ class TestCollapseMemoryExhaustedFailures(unittest.TestCase):
 
         self.assertEqual(remaining, (disk_full_failure,))
         self.assertIsNone(marker)
+
+    def test_disk_full_and_memory_exhausted_are_each_folded_exactly_once(
+        self,
+    ) -> None:
+        """Independent review F9: main()'s wiring MUST feed
+        _collapse_memory_exhausted_failures the DISK-FULL-FILTERED
+        remainder from _collapse_disk_full_failures, never the raw
+        infrastructure_failures list. Feeding the raw list would leave a
+        disk_full failure in BOTH ram_root_marker's folded set AND the
+        "remaining" list this composition proves must be empty --
+        double-reporting the same failure under two different markers
+        while ALSO printing it a third time as an ordinary per-target
+        detail."""
+        disk_full_failure = TargetInfrastructureFailure(
+            target=_target("tests.test_disk"), detail="disk", disk_full=True
+        )
+        memory_failure = TargetInfrastructureFailure(
+            target=_target("tests.test_memory"),
+            detail="BrokenProcessPool: a worker was terminated abruptly",
+            memory_exhausted=True,
+        )
+
+        _remaining_results, remaining_infra, ram_root_marker = (
+            _collapse_disk_full_failures([], [disk_full_failure, memory_failure])
+        )
+        remaining_infra, memory_marker = _collapse_memory_exhausted_failures(
+            remaining_infra
+        )
+
+        self.assertEqual(remaining_infra, ())
+        self.assertIsNotNone(ram_root_marker)
+        self.assertIsNotNone(memory_marker)
+        assert ram_root_marker is not None and memory_marker is not None
+        self.assertEqual(ram_root_marker.test_ids, ("tests.test_disk",))
+        self.assertEqual(memory_marker.test_ids, ("tests.test_memory",))
 
 
 class TestRunTargetsWorkerExceptionWiring(unittest.TestCase):
@@ -1316,29 +1453,36 @@ class TestRunnerProcessContract(unittest.TestCase):
             ("fixture_tests.test_alpha.Alpha.test_real_bug",),
         )
 
-    def _run_worker_death_fixture(self) -> subprocess.CompletedProcess[str]:
-        """Kill the ProcessPoolExecutor's OWN worker process (not the
-        nested per-target subprocess `_run_test_target` spawns) so the
-        parent's `future.result()` genuinely raises `BrokenProcessPool` --
-        the SAME exception shape an OOM kill produces. `os.getppid()`
-        inside the nested `--_run-target` child is the pool worker's PID:
-        killing IT (not the child's own PID) reproduces the real
-        production shape, confirmed live (issue #1156 item 2).
+    def _run_worker_death_fixture(
+        self, *, count: int = 2
+    ) -> subprocess.CompletedProcess[str]:
+        """Kill `count` INDEPENDENT ProcessPoolExecutor worker processes
+        (not the nested per-target subprocess `_run_test_target` spawns)
+        so the parent's `future.result()` genuinely raises
+        `BrokenProcessPool` for EACH ONE -- the SAME exception shape an
+        OOM kill produces. `os.getppid()` inside the nested `--_run-target`
+        child is the pool worker's PID: killing IT (not the child's own
+        PID) reproduces the real production shape, confirmed live (issue
+        #1156 item 2). Independent review F10: count=1 cannot distinguish
+        "folded into one marker" from "there was only ever one failure to
+        report" -- count>1 real, independent deaths is required to prove
+        the fold actually collapses N>1 into ONE.
         """
         with tempfile.TemporaryDirectory() as tempdir:
             root = Path(tempdir)
             tests_dir = root / "fixture_tests"
             tests_dir.mkdir()
             (tests_dir / "__init__.py").write_text("", encoding="utf-8")
-            (tests_dir / "test_alpha.py").write_text(
-                "import os\n"
-                "import signal\n"
-                "import unittest\n\n"
-                "class Alpha(unittest.TestCase):\n"
-                "    def test_worker_dies(self):\n"
-                "        os.kill(os.getppid(), signal.SIGKILL)\n",
-                encoding="utf-8",
-            )
+            for index in range(count):
+                (tests_dir / f"test_alpha{index}.py").write_text(
+                    "import os\n"
+                    "import signal\n"
+                    "import unittest\n\n"
+                    "class Alpha(unittest.TestCase):\n"
+                    "    def test_worker_dies(self):\n"
+                    "        os.kill(os.getppid(), signal.SIGKILL)\n",
+                    encoding="utf-8",
+                )
             env = {
                 **os.environ,
                 "CRATEDIGGER_TEST_MEMORY_MIN_BYTES": str(10**18),
@@ -1352,7 +1496,7 @@ class TestRunnerProcessContract(unittest.TestCase):
                     "--top-level-directory",
                     str(root),
                     "--jobs",
-                    "1",
+                    str(count),
                 ],
                 cwd=REPO_ROOT,
                 env=env,
@@ -1365,12 +1509,15 @@ class TestRunnerProcessContract(unittest.TestCase):
     def test_worker_death_under_exhausted_memory_floor_collapses_to_one_named_failure(
         self,
     ) -> None:
-        """End-to-end (issue #1156 item 2): a REAL BrokenProcessPool, not a
-        fake, folded into ONE marker instead of an ordinary per-target
-        disguise -- the CRATEDIGGER_TEST_MEMORY_MIN_BYTES override is the
-        same deterministic trick TestRunTargetsWorkerExceptionWiring
-        documents for the disk-full floor, applied to the memory one."""
-        result = self._run_worker_death_fixture()
+        """End-to-end (issue #1156 item 2): TWO REAL, INDEPENDENT
+        BrokenProcessPool deaths, not fakes, folded into ONE marker
+        instead of an ordinary per-target disguise -- the
+        CRATEDIGGER_TEST_MEMORY_MIN_BYTES override is the same
+        deterministic trick TestRunTargetsWorkerExceptionWiring documents
+        for the disk-full floor, applied to the memory one. Independent
+        review F10: N=2 (not 1) so "exactly one marker" actually proves
+        folding, not just that there was one failure to report."""
+        result = self._run_worker_death_fixture(count=2)
 
         self.assertEqual(
             result.returncode,
@@ -1384,7 +1531,19 @@ class TestRunnerProcessContract(unittest.TestCase):
         )
         self.assertIn(TEST_HOST_MEMORY_EXHAUSTED, result.stdout)
         self.assertIn("BrokenProcessPool", result.stdout)
-        self.assertIn("fixture_tests.test_alpha", result.stdout)
+        marker_line = next(
+            line
+            for line in result.stdout.splitlines()
+            if line.startswith(FAILURE_MARKER_PREFIX)
+        )
+        marker = msgspec.json.decode(
+            marker_line.removeprefix(FAILURE_MARKER_PREFIX),
+            type=CheckFailureMarker,
+        )
+        self.assertEqual(
+            set(marker.test_ids),
+            {"fixture_tests.test_alpha0", "fixture_tests.test_alpha1"},
+        )
 
     def test_each_module_gets_a_fresh_python_interpreter(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:

--- a/tests/test_parallel_test_runner.py
+++ b/tests/test_parallel_test_runner.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import datetime
 import errno
 import io
@@ -10,7 +11,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from concurrent.futures.process import BrokenProcessPool
 from dataclasses import replace
 from pathlib import Path
@@ -63,6 +64,7 @@ from scripts.run_python_tests import (
     hotspot_targets,
     hypothesis_example_budgets,
     list_module_test_ids,
+    main,
     recommended_worker_count,
     resolve_hypothesis_settings,
     schedule_modules,
@@ -152,10 +154,16 @@ class TestWorkerCrashClassification(unittest.TestCase):
         self.assertIn("FileNotFoundError", failure.detail)
 
     def test_ample_measured_headroom_is_an_ordinary_worker_failure(self) -> None:
+        # Independent review B-6 (third round): pins minimum_bytes=0 --
+        # the identical ambient-CRATEDIGGER_TEST_RAM_MIN_BYTES-coupling
+        # shape B2 fixed in TestWorkerMemoryExhaustionClassification next
+        # door. Without it, a large-enough ambient floor makes this
+        # available_bytes=10 GiB fixture read as disk_full too.
         failure = _classify_target_infrastructure_failure(
             _target("tests.test_alpha"),
             RuntimeError("target subprocess exited 1: traceback"),
             available_bytes=lambda: 10 * 1024 * 1024 * 1024,
+            minimum_bytes=0,
         )
 
         self.assertFalse(failure.disk_full)
@@ -1679,6 +1687,92 @@ class TestRunnerProcessContract(unittest.TestCase):
             set(marker.test_ids),
             {"fixture_tests.test_alpha0", "fixture_tests.test_alpha1"},
         )
+
+    def test_both_markers_present_falls_through_to_the_ordinary_failure_code(
+        self,
+    ) -> None:
+        """Independent review B-3 (third round): the two-clause promotion
+        guard in main() (`... and ram_root_marker is not None and
+        memory_marker is None` / the mirrored clause for memory) implements
+        the documented F10 residual -- BOTH markers present is a
+        HETEROGENEOUS failure set, so promotion is skipped and the run
+        falls through to plain `return 1`. Deleting either `is None` clause
+        survived every prior test, since none seeded BOTH markers in one
+        run.
+
+        A REAL subprocess reproduction of this scenario was tried first
+        and abandoned: a killed ProcessPoolExecutor worker poisons the
+        WHOLE pool for every future still tracked at that moment
+        (concurrent.futures' own documented semantics), including a
+        SEPARATE target's already-in-flight ENOSPC classification --
+        reproduced deterministically (3/3 runs, both --jobs 2 racing the
+        two targets and --jobs 1 sequencing them) as BOTH targets folding
+        into the SAME memory_exhausted marker, never the heterogeneous
+        scenario this guard exists to handle. `run_targets_fn` (mirroring
+        the burst `main`s' own `check_headroom` DI seam, issue #1156 item
+        3) replaces exactly that one real subprocess boundary with two
+        pre-built failures -- one disk_full, one memory_exhausted, using
+        the REAL schedule main() itself discovers -- while every other
+        line of main() (CLI parsing, discovery, scheduling, both collapse
+        helpers, printing, exit-code selection) runs unmocked."""
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            tests_dir = root / "fixture_tests"
+            tests_dir.mkdir()
+            (tests_dir / "__init__.py").write_text("", encoding="utf-8")
+            (tests_dir / "test_alpha.py").write_text(
+                "import unittest\n\n"
+                "class Alpha(unittest.TestCase):\n"
+                "    def test_ok(self):\n"
+                "        pass\n",
+                encoding="utf-8",
+            )
+            (tests_dir / "test_beta.py").write_text(
+                "import unittest\n\n"
+                "class Beta(unittest.TestCase):\n"
+                "    def test_ok(self):\n"
+                "        pass\n",
+                encoding="utf-8",
+            )
+
+            def seeded_run_targets(
+                schedule: Sequence[TestTarget], **_kwargs: object
+            ) -> tuple[
+                tuple[TargetRunResult, ...],
+                tuple[TargetInfrastructureFailure, ...],
+            ]:
+                targets = tuple(schedule)
+                self.assertEqual(len(targets), 2)
+                disk_failure = TargetInfrastructureFailure(
+                    target=targets[0],
+                    detail="temporary filesystem has 0 bytes free",
+                    disk_full=True,
+                )
+                memory_failure = TargetInfrastructureFailure(
+                    target=targets[1],
+                    detail=(
+                        "system memory has 0 bytes available; "
+                        "BrokenProcessPool: fake worker death"
+                    ),
+                    memory_exhausted=True,
+                )
+                return (), (disk_failure, memory_failure)
+
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                status = main(
+                    (
+                        "--start-directory", str(tests_dir),
+                        "--top-level-directory", str(root),
+                        "--jobs", "2",
+                    ),
+                    run_targets_fn=seeded_run_targets,
+                )
+            output = stdout.getvalue()
+
+        self.assertEqual(status, 1, output)
+        self.assertIn(TEST_RAM_ROOT_EXHAUSTED, output)
+        self.assertIn(TEST_HOST_MEMORY_EXHAUSTED, output)
 
     def test_each_module_gets_a_fresh_python_interpreter(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:

--- a/tests/test_parallel_test_runner.py
+++ b/tests/test_parallel_test_runner.py
@@ -11,6 +11,7 @@ import sys
 import tempfile
 import unittest
 from collections.abc import Callable
+from concurrent.futures.process import BrokenProcessPool
 from dataclasses import replace
 from pathlib import Path
 
@@ -31,6 +32,8 @@ from scripts.run_python_tests import (
     HOTSPOT_SHARD_POLICIES,
     HYPOTHESIS_CASE_STATUSES,
     STRATEGY_SPACE_EXHAUSTED,
+    TEST_HOST_MEMORY_EXHAUSTED,
+    TEST_HOST_MEMORY_EXHAUSTED_EXIT_CODE,
     TEST_RAM_ROOT_EXHAUSTED_EXIT_CODE,
     WORLD_MODEL_MODULE,
     ChildInfrastructureError,
@@ -45,6 +48,7 @@ from scripts.run_python_tests import (
     _classify_target_infrastructure_failure,
     _classify_test_infrastructure_error,
     _collapse_disk_full_failures,
+    _collapse_memory_exhausted_failures,
     _iter_test_cases,
     _measure_tempdir_available_bytes,
     _run_targets,
@@ -204,6 +208,108 @@ class TestWorkerCrashClassification(unittest.TestCase):
         self.assertFalse(failure.disk_full)
 
 
+class TestWorkerMemoryExhaustionClassification(unittest.TestCase):
+    """A worker killed by the OOM killer (issue #1156 item 2) is classified
+    by exception SHAPE (BrokenProcessPool) narrowed by MEASURED system
+    memory -- never a scan of the exception's text, and never triggered by
+    measured state alone (unlike disk_full, which does not care what the
+    exception is)."""
+
+    def test_broken_process_pool_with_low_memory_is_memory_exhausted(
+        self,
+    ) -> None:
+        failure = _classify_target_infrastructure_failure(
+            _target("tests.test_alpha"),
+            BrokenProcessPool("a worker was terminated abruptly"),
+            available_bytes=lambda: 10 * 1024 * 1024 * 1024,
+            available_memory_bytes=lambda: 1,
+        )
+
+        self.assertTrue(failure.memory_exhausted)
+        self.assertFalse(failure.disk_full)
+        self.assertIn("1 bytes available", failure.detail)
+        self.assertIn("BrokenProcessPool", failure.detail)
+
+    def test_broken_process_pool_with_ample_memory_is_ordinary(self) -> None:
+        failure = _classify_target_infrastructure_failure(
+            _target("tests.test_alpha"),
+            BrokenProcessPool("a worker was terminated abruptly"),
+            available_bytes=lambda: 10 * 1024 * 1024 * 1024,
+            available_memory_bytes=lambda: 10 * 1024 * 1024 * 1024,
+        )
+
+        self.assertFalse(failure.memory_exhausted)
+
+    def test_non_broken_process_pool_exception_is_never_memory_exhausted(
+        self,
+    ) -> None:
+        """Known-bad self-test: proves the classifier is gated by
+        exception SHAPE, not measured state alone -- a low memory reading
+        must never be enough by itself."""
+        failure = _classify_target_infrastructure_failure(
+            _target("tests.test_alpha"),
+            RuntimeError("ordinary worker crash, unrelated to memory"),
+            available_bytes=lambda: 10 * 1024 * 1024 * 1024,
+            available_memory_bytes=lambda: 1,
+        )
+
+        self.assertFalse(failure.memory_exhausted)
+
+    def test_disk_full_takes_priority_over_memory_exhaustion(self) -> None:
+        """Mutual exclusivity: a target cannot plausibly be both, so the
+        disk check short-circuits the memory one."""
+        failure = _classify_target_infrastructure_failure(
+            _target("tests.test_alpha"),
+            BrokenProcessPool("a worker was terminated abruptly"),
+            available_bytes=lambda: 1,
+            available_memory_bytes=lambda: 1,
+        )
+
+        self.assertTrue(failure.disk_full)
+        self.assertFalse(failure.memory_exhausted)
+
+    def test_unmeasurable_memory_never_claims_exhaustion(self) -> None:
+        failure = _classify_target_infrastructure_failure(
+            _target("tests.test_alpha"),
+            BrokenProcessPool("a worker was terminated abruptly"),
+            available_bytes=lambda: 10 * 1024 * 1024 * 1024,
+            available_memory_bytes=lambda: None,
+        )
+
+        self.assertFalse(failure.memory_exhausted)
+
+    def test_default_memory_floor_reads_the_configured_env_var(self) -> None:
+        original = os.environ.pop("CRATEDIGGER_TEST_MEMORY_MIN_BYTES", None)
+        try:
+            os.environ["CRATEDIGGER_TEST_MEMORY_MIN_BYTES"] = "123456"
+            failure = _classify_target_infrastructure_failure(
+                _target("tests.test_alpha"),
+                BrokenProcessPool("a worker was terminated abruptly"),
+                available_bytes=lambda: 10 * 1024 * 1024 * 1024,
+                available_memory_bytes=lambda: 123455,
+            )
+        finally:
+            if original is None:
+                os.environ.pop("CRATEDIGGER_TEST_MEMORY_MIN_BYTES", None)
+            else:
+                os.environ["CRATEDIGGER_TEST_MEMORY_MIN_BYTES"] = original
+
+        self.assertTrue(failure.memory_exhausted)
+
+    def test_explicit_minimum_memory_bytes_overrides_the_configured_default(
+        self,
+    ) -> None:
+        failure = _classify_target_infrastructure_failure(
+            _target("tests.test_alpha"),
+            BrokenProcessPool("a worker was terminated abruptly"),
+            available_bytes=lambda: 10 * 1024 * 1024 * 1024,
+            available_memory_bytes=lambda: 100 * 1024 * 1024,
+            minimum_memory_bytes=10 * 1024 * 1024,
+        )
+
+        self.assertFalse(failure.memory_exhausted)
+
+
 class TestCollapseDiskFullFailures(unittest.TestCase):
     """Issue #1111 item 2: N disk-full-classified failures fold into ONE
     named failure-index entry; anything else is reported unchanged."""
@@ -349,6 +455,58 @@ class TestCollapseDiskFullFailures(unittest.TestCase):
         )
 
         self.assertEqual(remaining_results, (result,))
+        self.assertIsNone(marker)
+
+
+class TestCollapseMemoryExhaustedFailures(unittest.TestCase):
+    """Issue #1156 item 2: N OOM-classified worker deaths fold into ONE
+    named failure-index entry, mirroring TestCollapseDiskFullFailures for
+    a different resource; anything else passes through unchanged."""
+
+    def test_no_memory_signal_passes_everything_through_unchanged(self) -> None:
+        infra = TargetInfrastructureFailure(
+            target=_target("tests.test_beta"), detail="segfault"
+        )
+
+        remaining, marker = _collapse_memory_exhausted_failures([infra])
+
+        self.assertEqual(remaining, (infra,))
+        self.assertIsNone(marker)
+
+    def test_memory_exhausted_worker_deaths_fold_into_one_marker(self) -> None:
+        crashed = TargetInfrastructureFailure(
+            target=_target("tests.test_gamma"),
+            detail="BrokenProcessPool: a worker was terminated abruptly",
+            memory_exhausted=True,
+        )
+        also_crashed = TargetInfrastructureFailure(
+            target=_target("tests.test_delta"),
+            detail="BrokenProcessPool: a worker was terminated abruptly",
+            memory_exhausted=True,
+        )
+
+        remaining, marker = _collapse_memory_exhausted_failures(
+            [crashed, also_crashed]
+        )
+
+        self.assertEqual(remaining, ())
+        self.assertIsNotNone(marker)
+        assert marker is not None
+        self.assertEqual(marker.identity, TEST_HOST_MEMORY_EXHAUSTED)
+        self.assertEqual(
+            set(marker.test_ids), {"tests.test_gamma", "tests.test_delta"}
+        )
+
+    def test_disk_full_failures_are_not_folded_by_this_function(self) -> None:
+        disk_full_failure = TargetInfrastructureFailure(
+            target=_target("tests.test_epsilon"), detail="disk", disk_full=True
+        )
+
+        remaining, marker = _collapse_memory_exhausted_failures(
+            [disk_full_failure]
+        )
+
+        self.assertEqual(remaining, (disk_full_failure,))
         self.assertIsNone(marker)
 
 
@@ -1157,6 +1315,76 @@ class TestRunnerProcessContract(unittest.TestCase):
             alpha_marker.test_ids,
             ("fixture_tests.test_alpha.Alpha.test_real_bug",),
         )
+
+    def _run_worker_death_fixture(self) -> subprocess.CompletedProcess[str]:
+        """Kill the ProcessPoolExecutor's OWN worker process (not the
+        nested per-target subprocess `_run_test_target` spawns) so the
+        parent's `future.result()` genuinely raises `BrokenProcessPool` --
+        the SAME exception shape an OOM kill produces. `os.getppid()`
+        inside the nested `--_run-target` child is the pool worker's PID:
+        killing IT (not the child's own PID) reproduces the real
+        production shape, confirmed live (issue #1156 item 2).
+        """
+        with tempfile.TemporaryDirectory() as tempdir:
+            root = Path(tempdir)
+            tests_dir = root / "fixture_tests"
+            tests_dir.mkdir()
+            (tests_dir / "__init__.py").write_text("", encoding="utf-8")
+            (tests_dir / "test_alpha.py").write_text(
+                "import os\n"
+                "import signal\n"
+                "import unittest\n\n"
+                "class Alpha(unittest.TestCase):\n"
+                "    def test_worker_dies(self):\n"
+                "        os.kill(os.getppid(), signal.SIGKILL)\n",
+                encoding="utf-8",
+            )
+            env = {
+                **os.environ,
+                "CRATEDIGGER_TEST_MEMORY_MIN_BYTES": str(10**18),
+            }
+            return subprocess.run(
+                [
+                    sys.executable,
+                    str(RUNNER),
+                    "--start-directory",
+                    str(tests_dir),
+                    "--top-level-directory",
+                    str(root),
+                    "--jobs",
+                    "1",
+                ],
+                cwd=REPO_ROOT,
+                env=env,
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+
+    def test_worker_death_under_exhausted_memory_floor_collapses_to_one_named_failure(
+        self,
+    ) -> None:
+        """End-to-end (issue #1156 item 2): a REAL BrokenProcessPool, not a
+        fake, folded into ONE marker instead of an ordinary per-target
+        disguise -- the CRATEDIGGER_TEST_MEMORY_MIN_BYTES override is the
+        same deterministic trick TestRunTargetsWorkerExceptionWiring
+        documents for the disk-full floor, applied to the memory one."""
+        result = self._run_worker_death_fixture()
+
+        self.assertEqual(
+            result.returncode,
+            TEST_HOST_MEMORY_EXHAUSTED_EXIT_CODE,
+            result.stdout + result.stderr,
+        )
+        self.assertEqual(
+            result.stdout.count(FAILURE_MARKER_PREFIX),
+            1,
+            "every memory-exhausted worker death must fold into ONE marker",
+        )
+        self.assertIn(TEST_HOST_MEMORY_EXHAUSTED, result.stdout)
+        self.assertIn("BrokenProcessPool", result.stdout)
+        self.assertIn("fixture_tests.test_alpha", result.stdout)
 
     def test_each_module_gets_a_fresh_python_interpreter(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:

--- a/tests/test_suite_coordinator.py
+++ b/tests/test_suite_coordinator.py
@@ -18,7 +18,11 @@ from unittest import mock
 
 import msgspec
 
-from scripts.run_python_tests import TEST_RAM_ROOT_EXHAUSTED_EXIT_CODE
+from scripts.run_python_tests import (
+    TEST_HOST_MEMORY_EXHAUSTED,
+    TEST_HOST_MEMORY_EXHAUSTED_EXIT_CODE,
+    TEST_RAM_ROOT_EXHAUSTED_EXIT_CODE,
+)
 from scripts.run_targeted_tests import targeted_phases
 from scripts.run_test_suite import (
     _HEADROOM_BASE_BYTES,
@@ -746,6 +750,88 @@ class SuiteCoordinatorTestCase(unittest.TestCase):
         self.assertEqual(summary.phases[0].state, "infrastructure-failure")
         self.assertEqual(
             summary.phases[0].failures[0].identity, TEST_RAM_ROOT_EXHAUSTED
+        )
+
+    def test_memory_exhausted_exit_code_is_not_an_ordinary_python_failure_code(
+        self,
+    ) -> None:
+        """Independent review F2 (BLOCKING): mirrors
+        test_ram_root_exhausted_exit_code_is_not_an_ordinary_python_
+        failure_code above for the SIBLING constant -- issue #1111 shipped
+        TWO guard tests for TEST_RAM_ROOT_EXHAUSTED_EXIT_CODE and this PR
+        mirrored neither for TEST_HOST_MEMORY_EXHAUSTED_EXIT_CODE.
+        Mutating 5 -> 1 (or -> 4, TEST_RAM_ROOT_EXHAUSTED_EXIT_CODE's own
+        value) used to leave 121 tests across this module and
+        test_parallel_test_runner green, because nothing asserted this
+        constant's VALUE against anything other than itself
+        (assertEqual(result.returncode, TEST_HOST_MEMORY_EXHAUSTED_EXIT_CODE)
+        is tautological — the exact anti-pattern code-quality.md records
+        from #1088/#1090). This test instead asserts the constant's value
+        stays OUTSIDE the "python" phase's declared failure_exit_codes in
+        BOTH _default_phases() and targeted_phases(), and stays DISTINCT
+        from its sibling constant.
+        """
+        self.assertNotEqual(
+            TEST_HOST_MEMORY_EXHAUSTED_EXIT_CODE, TEST_RAM_ROOT_EXHAUSTED_EXIT_CODE
+        )
+        canonical_python = next(
+            phase for phase in _default_phases() if phase.name == "python"
+        )
+        targeted_python = next(
+            phase
+            for phase in targeted_phases(("tests.test_typing_ratchet",))
+            if phase.name == "python"
+        )
+        for desc, phase in (
+            ("canonical _default_phases", canonical_python),
+            ("targeted targeted_phases", targeted_python),
+        ):
+            with self.subTest(desc=desc):
+                self.assertNotIn(
+                    TEST_HOST_MEMORY_EXHAUSTED_EXIT_CODE, phase.failure_exit_codes
+                )
+
+    def test_pure_memory_exhaustion_promotes_the_suite_to_infrastructure_failure(
+        self,
+    ) -> None:
+        """Independent review F2 (BLOCKING): mirrors
+        test_pure_ram_root_exhaustion_promotes_the_suite_to_infrastructure_
+        failure above -- a "python" phase that emits the collapsed
+        memory-exhaustion marker and exits
+        TEST_HOST_MEMORY_EXHAUSTED_EXIT_CODE must promote the whole suite
+        to infrastructure-failure (exit 2), not an ordinary failed
+        (exit 1)."""
+        marker = msgspec.json.encode(
+            CheckFailureMarker(
+                identity=TEST_HOST_MEMORY_EXHAUSTED,
+                owner="",
+                detail=(
+                    "1 target(s) failed while the host's available system "
+                    "memory was exhausted"
+                ),
+                test_ids=("tests.test_alpha",),
+            )
+        ).decode()
+        phases = (
+            PhaseSpec(
+                "python",
+                _python_command(
+                    f"{FAILURE_MARKER_PREFIX}{marker}",
+                    TEST_HOST_MEMORY_EXHAUSTED_EXIT_CODE,
+                ),
+                "python3 scripts/run_python_tests.py",
+                "python",
+            ),
+        )
+
+        result, _terminal = self._run(phases)
+        summary = decode_summary(result.bundle / "summary.json")
+
+        self.assertEqual(result.exit_code, 2)
+        self.assertEqual(summary.state, "infrastructure-failure")
+        self.assertEqual(summary.phases[0].state, "infrastructure-failure")
+        self.assertEqual(
+            summary.phases[0].failures[0].identity, TEST_HOST_MEMORY_EXHAUSTED
         )
 
 

--- a/tests/test_suite_coordinator.py
+++ b/tests/test_suite_coordinator.py
@@ -45,6 +45,7 @@ from scripts.run_test_suite import (
     acquire_suite_admission,
     admission_lock_path,
     dirty_state_fingerprint,
+    headroom_floor_bytes,
     reap_stale_check_bundles,
     reap_stale_final_gate_receipts,
     run_suite,
@@ -2226,6 +2227,54 @@ class SuiteHeadroomPreconditionTestCase(unittest.TestCase):
             os.environ["CRATEDIGGER_TEST_RAM_MIN_BYTES"] = "not-a-number"
             with self.assertRaises(ValueError):
                 _default_min_headroom_bytes()
+        finally:
+            if original is None:
+                os.environ.pop("CRATEDIGGER_TEST_RAM_MIN_BYTES", None)
+            else:
+                os.environ["CRATEDIGGER_TEST_RAM_MIN_BYTES"] = original
+
+    def test_headroom_floor_bytes_rejects_a_worker_count_below_one(self) -> None:
+        """Known-bad self-test for headroom_floor_bytes's own guard clause
+        (issue #1156 item 3): every OTHER clause in this function is
+        already covered indirectly via _default_min_headroom_bytes's own
+        tests below, but THIS clause only trips when a caller passes a
+        non-positive worker_count directly -- _default_min_headroom_bytes
+        can never reach it, since _expected_worker_count always returns at
+        least 1."""
+        original = os.environ.pop("CRATEDIGGER_TEST_RAM_MIN_BYTES", None)
+        try:
+            with self.assertRaisesRegex(
+                ValueError, "worker_count must be at least 1"
+            ):
+                headroom_floor_bytes(0)
+        finally:
+            if original is not None:
+                os.environ["CRATEDIGGER_TEST_RAM_MIN_BYTES"] = original
+
+    def test_headroom_floor_bytes_scales_with_the_given_worker_count(self) -> None:
+        """Issue #1156 item 3: headroom_floor_bytes is the SAME formula
+        _default_min_headroom_bytes wraps, but callable directly with an
+        explicit worker_count -- the fuzz and world-model bursts each size
+        their own floor this way rather than through the deterministic
+        suite's own worker-count prediction."""
+        original = os.environ.pop("CRATEDIGGER_TEST_RAM_MIN_BYTES", None)
+        try:
+            self.assertEqual(
+                headroom_floor_bytes(40),
+                _HEADROOM_BASE_BYTES + _HEADROOM_PER_WORKER_BYTES * 40,
+            )
+            self.assertEqual(headroom_floor_bytes(1), DEFAULT_MIN_HEADROOM_BYTES)
+        finally:
+            if original is not None:
+                os.environ["CRATEDIGGER_TEST_RAM_MIN_BYTES"] = original
+
+    def test_headroom_floor_bytes_honors_explicit_override_regardless_of_worker_count(
+        self,
+    ) -> None:
+        original = os.environ.pop("CRATEDIGGER_TEST_RAM_MIN_BYTES", None)
+        try:
+            os.environ["CRATEDIGGER_TEST_RAM_MIN_BYTES"] = "7000000"
+            self.assertEqual(headroom_floor_bytes(200), 7000000)
         finally:
             if original is None:
                 os.environ.pop("CRATEDIGGER_TEST_RAM_MIN_BYTES", None)

--- a/tests/test_world_model_coordinator.py
+++ b/tests/test_world_model_coordinator.py
@@ -653,9 +653,12 @@ class TestWorldModelReplayDatabase(unittest.TestCase):
         """
 
         def always_fail() -> None:
-            raise RamRootExhaustedError(
-                f"{TEST_RAM_ROOT_EXHAUSTED}: synthetic preflight trip"
-            )
+            # Independent review F9: the message deliberately does NOT
+            # embed TEST_RAM_ROOT_EXHAUSTED -- the identity in the assembled
+            # coordinator_error must come from main's own handler labeling
+            # (f"{TEST_RAM_ROOT_EXHAUSTED}: {error}"), never leak through
+            # from this fake's own text (agree-by-construction).
+            raise RamRootExhaustedError("synthetic preflight trip")
 
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -699,6 +702,47 @@ class TestWorldModelReplayDatabase(unittest.TestCase):
 
             self.assertEqual(status, 2)
 
+    def test_unavailable_runtime_dir_aborts_cleanly_not_as_a_raw_traceback(
+        self,
+    ) -> None:
+        """Independent review F3 (MEDIUM): private_runtime_dir() used to be
+        called ONE LINE ABOVE the try/except that exists to catch its own
+        RuntimeError, so it escaped as an unhandled traceback instead of
+        the intended exit 2. Drives the REAL production private_runtime_dir()
+        (check_headroom=None, the default -- no injected fake), pointed at
+        a real, non-tmpfs directory via XDG_RUNTIME_DIR: test-fidelity
+        Rule B, since test_preflight_non_ram_root_error_returns_two's fake
+        only proves the except clause's own handling, never the real raise
+        site. dir=repo_root deliberately: TMPDIR is itself tmpfs inside
+        this nix-shell, so a bare tempfile.TemporaryDirectory() would land
+        ON tmpfs and never trip the check this test exists to prove; the
+        repo checkout itself is real disk-backed storage.
+        """
+        repo_root = Path(__file__).resolve().parents[1]
+        with tempfile.TemporaryDirectory(dir=str(repo_root)) as fake_runtime_dir:
+            original = os.environ.get("XDG_RUNTIME_DIR")
+            os.environ["XDG_RUNTIME_DIR"] = fake_runtime_dir
+            try:
+                with tempfile.TemporaryDirectory() as temporary:
+                    root = Path(temporary)
+                    status = main(
+                        (
+                            "--database", str(root / "canonical"),
+                            "--output-dir", str(root / "output"),
+                            "--examples", "1",
+                            "--steps", "1",
+                            "--jobs", "1",
+                            "--seed", "13",
+                        ),
+                    )
+            finally:
+                if original is None:
+                    os.environ.pop("XDG_RUNTIME_DIR", None)
+                else:
+                    os.environ["XDG_RUNTIME_DIR"] = original
+
+        self.assertEqual(status, 2)
+
     def test_mid_run_headroom_exhaustion_aborts_and_labels_the_receipt(
         self,
     ) -> None:
@@ -711,9 +755,15 @@ class TestWorldModelReplayDatabase(unittest.TestCase):
         def flaky_check_headroom() -> None:
             calls["count"] += 1
             if calls["count"] >= 2:
-                raise RamRootExhaustedError(
-                    f"{TEST_RAM_ROOT_EXHAUSTED}: synthetic mid-run trip"
-                )
+                # Independent review F9: the message deliberately does NOT
+                # embed TEST_RAM_ROOT_EXHAUSTED -- assertIn(TEST_RAM_ROOT_
+                # EXHAUSTED, receipt.coordinator_error) below must be
+                # satisfied by main's own handler labeling
+                # (f"{TEST_RAM_ROOT_EXHAUSTED}: {error}"), not by this
+                # fake's own message text (agree-by-construction: with the
+                # identity embedded here, the assertion passed even when
+                # the handler's own f-string prefix was mutated away).
+                raise RamRootExhaustedError("synthetic mid-run trip")
 
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)

--- a/tests/test_world_model_coordinator.py
+++ b/tests/test_world_model_coordinator.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
+import io
 import os
 import sys
 import tempfile
@@ -585,14 +587,23 @@ class TestWorldModelReplayDatabase(unittest.TestCase):
             (canonical / "important").write_text("keep", encoding="utf-8")
             output = root / "output"
 
-            status = main((
-                "--database", str(canonical),
-                "--output-dir", str(output),
-                "--examples", "1",
-                "--steps", "1",
-                "--jobs", "1",
-                "--seed", "7",
-            ))
+            # Independent review B1 (BLOCKING): check_headroom=None (the
+            # production default) drives the REAL private_runtime_dir()/
+            # _check_suite_headroom(), coupling this test -- which is NOT
+            # about headroom -- to whatever the shared tmpfs root happens
+            # to have free at test time. Pin it to an always-satisfied
+            # no-op; the tests that ARE about headroom inject their own.
+            status = main(
+                (
+                    "--database", str(canonical),
+                    "--output-dir", str(output),
+                    "--examples", "1",
+                    "--steps", "1",
+                    "--jobs", "1",
+                    "--seed", "7",
+                ),
+                check_headroom=lambda: None,
+            )
 
             self.assertEqual(status, 1)
             run_directories = tuple(output.glob("run.*"))
@@ -620,6 +631,8 @@ class TestWorldModelReplayDatabase(unittest.TestCase):
             ) -> None:
                 raise OSError("injected corpus commit failure")
 
+            # Independent review B1 (BLOCKING): see the sibling test above
+            # -- this one is not about headroom either.
             status = main(
                 (
                     "--database", str(canonical),
@@ -630,6 +643,7 @@ class TestWorldModelReplayDatabase(unittest.TestCase):
                     "--seed", "8",
                 ),
                 replace_canonical=fail_commit,
+                check_headroom=lambda: None,
             )
 
             self.assertEqual(status, 1)
@@ -713,35 +727,60 @@ class TestWorldModelReplayDatabase(unittest.TestCase):
         a real, non-tmpfs directory via XDG_RUNTIME_DIR: test-fidelity
         Rule B, since test_preflight_non_ram_root_error_returns_two's fake
         only proves the except clause's own handling, never the real raise
-        site. dir=repo_root deliberately: TMPDIR is itself tmpfs inside
-        this nix-shell, so a bare tempfile.TemporaryDirectory() would land
-        ON tmpfs and never trip the check this test exists to prove; the
-        repo checkout itself is real disk-backed storage.
+        site. dir="/var/tmp" deliberately (independent review B9): TMPDIR
+        is itself tmpfs inside this nix-shell, so a bare
+        tempfile.TemporaryDirectory() would land ON tmpfs and never trip
+        the check this test exists to prove; /var/tmp is real disk-backed
+        storage that is also outside the git-tracked worktree, so a hard
+        kill mid-test cannot leave stray debris in the repo checkout.
         """
-        repo_root = Path(__file__).resolve().parents[1]
-        with tempfile.TemporaryDirectory(dir=str(repo_root)) as fake_runtime_dir:
+        # Independent review B8: this used to assert only the exit code,
+        # with no stdout/stderr capture at all -- so it could not tell "the
+        # intended infrastructure-precondition abort ran" apart from "some
+        # other unrelated path also happens to return 2" (e.g.
+        # test_preflight_non_ram_root_error_returns_two's own generic
+        # RuntimeError branch). Captured and asserted the same way the
+        # fuzz twin (tests/test_fuzz_burst.py::TestFuzzMainMidRunHeadroom::
+        # test_unavailable_runtime_dir_aborts_cleanly_not_as_a_raw_traceback)
+        # already does.
+        # dir="/var/tmp" deliberately (independent review B9, mirroring
+        # the fuzz twin's own fix): real disk-backed (non-tmpfs, so this
+        # actually trips the check under test) but NOT inside the
+        # git-tracked worktree, so a hard kill mid-test -- which skips
+        # TemporaryDirectory's own context-manager cleanup -- cannot leave
+        # stray debris in the repo checkout the way an earlier
+        # dir=repo_root version could.
+        with tempfile.TemporaryDirectory(dir="/var/tmp") as fake_runtime_dir:
             original = os.environ.get("XDG_RUNTIME_DIR")
             os.environ["XDG_RUNTIME_DIR"] = fake_runtime_dir
             try:
                 with tempfile.TemporaryDirectory() as temporary:
                     root = Path(temporary)
-                    status = main(
-                        (
-                            "--database", str(root / "canonical"),
-                            "--output-dir", str(root / "output"),
-                            "--examples", "1",
-                            "--steps", "1",
-                            "--jobs", "1",
-                            "--seed", "13",
-                        ),
-                    )
+                    stdout = io.StringIO()
+                    stderr = io.StringIO()
+                    with contextlib.redirect_stdout(
+                        stdout
+                    ), contextlib.redirect_stderr(stderr):
+                        status = main(
+                            (
+                                "--database", str(root / "canonical"),
+                                "--output-dir", str(root / "output"),
+                                "--examples", "1",
+                                "--steps", "1",
+                                "--jobs", "1",
+                                "--seed", "13",
+                            ),
+                        )
+                    output = stdout.getvalue() + stderr.getvalue()
             finally:
                 if original is None:
                     os.environ.pop("XDG_RUNTIME_DIR", None)
                 else:
                     os.environ["XDG_RUNTIME_DIR"] = original
 
-        self.assertEqual(status, 2)
+        self.assertEqual(status, 2, output)
+        self.assertIn("infrastructure precondition failed", output)
+        self.assertIn("not tmpfs", output)
 
     def test_mid_run_headroom_exhaustion_aborts_and_labels_the_receipt(
         self,
@@ -792,6 +831,55 @@ class TestWorldModelReplayDatabase(unittest.TestCase):
             self.assertIn(TEST_RAM_ROOT_EXHAUSTED, receipt.coordinator_error or "")
             self.assertEqual(receipt.targets, ())
             self.assertGreaterEqual(calls["count"], 2)
+
+    def test_drain_phase_never_calls_check_headroom_once_pending_is_empty(
+        self,
+    ) -> None:
+        """Independent review B6: the fuzz burst's twin regression pin
+        (tests/test_fuzz_burst.py::TestFuzzTargetsMidRunHeadroom::
+        test_drain_phase_never_calls_check_headroom_once_pending_is_empty)
+        has no world-model-side equivalent, even though
+        scripts/run_world_model_burst.py's own admission loop carries the
+        SAME `if pending and not admission_aborted: check_headroom()` gate
+        (line ~1138). `--jobs 10` exceeds this manifest's total target
+        count (5 generated + 1 pins = 6 for --engine in-process), so every
+        target is admitted in the FIRST admission-loop iteration -- call
+        #1 is the preflight check, call #2 is that single admission
+        check. Every later outer-loop iteration only drains `active`
+        (`pending` is empty), so a correctly gated loop never calls
+        check_headroom again. The poison pill traps starting at call #3:
+        correct code lets the whole burst complete successfully; a mutant
+        that drops the `pending` condition (checking on EVERY outer-loop
+        iteration regardless) would trip it as each of the six targets
+        completes and the loop re-polls."""
+        calls = {"count": 0}
+
+        def check_headroom() -> None:
+            calls["count"] += 1
+            if calls["count"] > 2:
+                raise RamRootExhaustedError(
+                    "must never fire once pending is empty"
+                )
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            canonical = root / "canonical"
+            output = root / "output"
+
+            status = main(
+                (
+                    "--database", str(canonical),
+                    "--output-dir", str(output),
+                    "--examples", "1",
+                    "--steps", "1",
+                    "--jobs", "10",
+                    "--seed", "14",
+                ),
+                check_headroom=check_headroom,
+            )
+
+        self.assertEqual(status, 0)
+        self.assertEqual(calls["count"], 2)
 
     def test_nonempty_unowned_database_path_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:

--- a/tests/test_world_model_coordinator.py
+++ b/tests/test_world_model_coordinator.py
@@ -17,6 +17,8 @@ from hypothesis.database import DirectoryBasedExampleDatabase
 from hypothesis.stateful import RuleBasedStateMachine, rule
 
 import tests._hypothesis_profiles  # noqa: F401 - required profile side effect
+from scripts.run_python_tests import TEST_RAM_ROOT_EXHAUSTED_EXIT_CODE
+from scripts.run_test_suite import TEST_RAM_ROOT_EXHAUSTED, RamRootExhaustedError
 from scripts.run_world_model_burst import (
     ChildReceipt,
     ReplayReceipt,
@@ -641,6 +643,105 @@ class TestWorldModelReplayDatabase(unittest.TestCase):
             self.assertEqual(len(receipt.targets), 6)
             self.assertEqual({target.outcome for target in receipt.targets}, {"passed"})
             self.assertEqual(receipt.not_started, ())
+
+    def test_preflight_headroom_exhaustion_returns_before_any_work(self) -> None:
+        """Issue #1156 item 3: the fail-fast, before-any-work precondition.
+
+        Distinct from the mid-run trip below: this fake always raises, so
+        it must trip on `main`'s very first `check_headroom()` call, before
+        `canonical_database`/`output_root` are even created.
+        """
+
+        def always_fail() -> None:
+            raise RamRootExhaustedError(
+                f"{TEST_RAM_ROOT_EXHAUSTED}: synthetic preflight trip"
+            )
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            canonical = root / "canonical"
+            output = root / "output"
+
+            status = main(
+                (
+                    "--database", str(canonical),
+                    "--output-dir", str(output),
+                    "--examples", "1",
+                    "--steps", "1",
+                    "--jobs", "1",
+                    "--seed", "10",
+                ),
+                check_headroom=always_fail,
+            )
+
+            self.assertEqual(status, TEST_RAM_ROOT_EXHAUSTED_EXIT_CODE)
+            self.assertFalse(output.exists())
+            self.assertFalse(canonical.exists())
+
+    def test_preflight_non_ram_root_error_returns_two(self) -> None:
+        def boom() -> None:
+            raise RuntimeError("synthetic infrastructure boom")
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+
+            status = main(
+                (
+                    "--database", str(root / "canonical"),
+                    "--output-dir", str(root / "output"),
+                    "--examples", "1",
+                    "--steps", "1",
+                    "--jobs", "1",
+                    "--seed", "11",
+                ),
+                check_headroom=boom,
+            )
+
+            self.assertEqual(status, 2)
+
+    def test_mid_run_headroom_exhaustion_aborts_and_labels_the_receipt(
+        self,
+    ) -> None:
+        """The admission loop's OWN check, not the preflight one: the fake
+        passes on call 1 (preflight) and trips on call 2 (the first
+        admission-loop iteration), proving the loop really consults it a
+        second time rather than only once at the top."""
+        calls = {"count": 0}
+
+        def flaky_check_headroom() -> None:
+            calls["count"] += 1
+            if calls["count"] >= 2:
+                raise RamRootExhaustedError(
+                    f"{TEST_RAM_ROOT_EXHAUSTED}: synthetic mid-run trip"
+                )
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            canonical = root / "canonical"
+            output = root / "output"
+
+            status = main(
+                (
+                    "--database", str(canonical),
+                    "--output-dir", str(output),
+                    "--examples", "1",
+                    "--steps", "1",
+                    "--jobs", "1",
+                    "--seed", "12",
+                ),
+                check_headroom=flaky_check_headroom,
+            )
+
+            self.assertEqual(status, TEST_RAM_ROOT_EXHAUSTED_EXIT_CODE)
+            run_directory, = output.glob("run.*")
+            receipt = msgspec.json.decode(
+                (run_directory / "replay.json").read_bytes(),
+                type=ReplayReceipt,
+            )
+            self.assertTrue(receipt.admission_aborted)
+            self.assertIn(TEST_RAM_ROOT_EXHAUSTED, receipt.coordinator_error or "")
+            self.assertEqual(receipt.targets, ())
+            self.assertGreaterEqual(calls["count"], 2)
 
     def test_nonempty_unowned_database_path_is_rejected(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:


### PR DESCRIPTION
Closes #1156 items 2, 3 and 6.

## What was wrong

The 2026-08-20 `cratedigger-daily-checks` ENOSPC failure (RCA: #1214) happened in the **generated fuzz burst** — the widest lane in the repo and the only one with no resource guard at all.

- **No headroom precondition on either burst.** Neither `run_fuzz_tests.py` nor `run_world_model_burst.py` called `run_suite`, `acquire_suite_admission`, or `_check_suite_headroom`. `daily_flake_update.sh:115` scopes `CRATEDIGGER_SUITE_OWNS_HEADROOM=1` to the deterministic stage only, so the fuzz stage's sole guard was `test_tmpfs.sh`'s one-shot check at shell entry — on a filesystem it then grew to 14 GB.
- **`recommended_fuzz_jobs = cpu_count * 2`** = 60 workers on doc1 with **no ceiling** — versus the suite's guarded 22.
- **Memory exhaustion was disguised.** An OOM-killed worker surfaces as `BrokenProcessPool`; the classifier measured free bytes *on the RAM root*, which says nothing about memory, so one kill produced **N `CheckFailureMarker`s each naming a different innocent test**, exit 1, phase `failed`. The N-disguises shape #1111 fixed for disk-full, unfixed for memory.
- **Item 6**: two timing-budget tests went spurious under CPU pressure. This is not theoretical — it cost a real gate run during this very series, failing `test_timeout_terminates_child_and_fails_closed` and then passing on the identical commit.

## What this does

1. **Caps the fuzz lane** (`MAX_FUZZ_JOBS`). Honestly documented: inert on this 30-core host (60 < 64, engaging only from 33 cores up), and it would **not** have prevented 2026-08-20 — it is fail-closed legislation for a larger host, not a fix for this incident.
2. **Gives both bursts a real headroom precondition** — preflight *and* re-checked once per admission cycle, using the shared `_check_suite_headroom` primitive. Also documented honestly: tripping it **stops admission only** — already-resident targets keep growing, so what it delivers is a correct label and exit code, not prevention.
3. **Classifies memory exhaustion honestly** — `BrokenProcessPool` plus a measured `/proc/meminfo` floor folds into one named `test host memory exhausted` marker with its own exit code, mirroring the existing `TEST_RAM_ROOT_EXHAUSTED` pattern. Residual stated in the docstring: the reading is taken after the victim dies, and on this host the RAM root *is* memory (tmpfs pages are cgroup-charged), so the disk-full branch often wins first.
4. **Item 6**: widens the three `timeout_seconds=0.1` sites in `test_node_jsonl_worker.py` that share the Node startup-handshake deadline.

## Kill matrix

| Site (assertion / clause / constant) | One-line mutant | Test that goes RED | Result |
| --- | --- | --- | --- |
| `run_fuzz_tests.py` mid-run check | drop `pending and` (fires during drain) | `test_drain_phase_never_calls_check_headroom_once_pending_is_empty` | RED |
| `run_world_model_burst.py` mid-run check | drop `pending and` | world-model drain-phase pin | RED |
| `run_fuzz_targets` | drop `headroom_exhausted = True` | `test_trip_aborts_admission_without_starting_the_rest` | RED |
| fuzz preflight | delete `check_headroom()` | `test_preflight_headroom_exhaustion_aborts_before_any_discovery` | RED |
| world-model preflight | delete `check_headroom()` / drop exit code | world-model preflight pins | RED |
| `private_runtime_dir()` placement | move back outside the `try` | `test_unavailable_runtime_dir_aborts_cleanly_not_as_a_raw_traceback` | RED |
| `TEST_HOST_MEMORY_EXHAUSTED_EXIT_CODE` | `5 → 1` (reinstates the disguise) | `test_memory_exhausted_exit_code_is_not_an_ordinary_python_failure_code` | RED |
| same | `5 → 4` (collides with the sibling constant) | same, via `assertNotEqual` | RED |
| `_MIN_VALID_MEMORY_HEADROOM_BYTES` | `256 MiB → 2` (feature dead) | `test_default_floor_uses_the_real_256mib_constant_not_env` | RED |
| `_measure_available_memory_bytes` | drop `* 1024` (kB read as bytes) | `test_measure_available_memory_converts_kib_to_bytes` | RED |
| same | `MemAvailable:` → `MemFree:` | `test_measure_available_memory_reads_memavailable_not_memfree` | RED |
| classifier | drop `isinstance(exc, BrokenProcessPool)` | `test_non_broken_process_pool_exception_is_never_memory_exhausted` | RED |
| classifier | drop `not disk_full` | `test_disk_full_takes_priority_over_memory_exhaustion` | RED |
| classifier | `<` → `<=` | `test_memory_exactly_at_the_floor_is_not_exhausted` | RED |
| classifier | `is not None` → truthiness | `test_zero_available_memory_is_still_exhausted` | RED |
| `main()` collapse wiring | feed raw `infrastructure_failures` | `test_worker_deaths_classified_pure_disk_full_never_reach_the_memory_bucket` | RED |
| `_collapse_memory_exhausted_failures` | keep folded rows in `remaining` | collapse + e2e pins | RED |
| promotion guard `and memory_marker is None` | delete the clause | two-marker composition test | RED |
| promotion guard `and ram_root_marker is None` | delete the clause | same | RED |
| negative-floor env guard | delete the `raise` (fail-open) | `test_negative_memory_floor_override_fails_closed` | RED |
| `headroom_floor_bytes` | `* worker_count` → `* 1` | `test_headroom_floor_bytes_scales_with_the_given_worker_count` | RED |
| `headroom_floor_bytes` | drop `worker_count < 1` raise | `test_headroom_floor_bytes_rejects_a_worker_count_below_one` | RED |
| `MAX_FUZZ_JOBS` | `64 → 128` / drop the `min()` | `test_worker_formula_is_capped_regardless_of_host_size` | RED |
| fuzz mid-run banner identity | → literal `"generic"` | fuzz main mid-run pin | RED |
| fuzz terminal-summary identity | → literal `"generic"` | same pin (assertion added this round) | RED |
| world-model receipt label | → `"generic: …"` | world-model mid-run pin | RED |

## Review

Three independent reviews. Round 1: 24 mutants, 8 survived, 2 HIGH. Round 2: 15 mutants, 5 survived, plus a **blocking** finding — the new preconditions coupled ~12 existing tests to ambient free space and made the canonical Python phase red. Round 3 verified that fix empirically: two full canonical runs (11 041 tests, exit 0 both), plus a starvation probe (`CRATEDIGGER_TEST_RAM_MIN_BYTES=10**18`) that flipped exactly one target — pre-existing on `main`, not free-space coupled.

Two decisions worth recording:

- **The bursts deliberately do NOT take `acquire_suite_admission`.** Both are long-running and variable-duration; folding them into the queue an ordinary `scripts/test.sh` run waits on (bounded at 1200 s) would starve that wait. Recorded in each `main`'s docstring rather than as normative rule prose.
- **A proposed Discogs fix was reverted.** A `handler_exit_delay` was added for item 6, then a mechanical trace of `_DiscogsMirror.do_GET` showed `leave()` closes the counted window *before* `send_response` and is idempotent, so the delay only postpones handler-thread teardown and cannot move `max_active`. An A/B probe (0/25 both ways) was inconclusive. Reverted with a comment explaining the investigation, rather than shipping an unsubstantiated fix.

No deploy: test-infrastructure, dev-shell and docs only — zero doc2 runtime delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
