### PR TITLE
perf(#1156 item 7): replace test-reset TRUNCATE with DELETE under one transaction

### DIFF
--- a/.claude/rules/pipeline-db.md
+++ b/.claude/rules/pipeline-db.md
@@ -56,7 +56,7 @@ paths:
 - Schema lives in `migrations/NNN_name.sql`. Files are applied in version order by `lib/migrator.py` and tracked in the `schema_migrations` table.
 - The deploy systemd unit `cratedigger-db-migrate.service` runs the migrator on every `nixos-rebuild switch` (`restartIfChanged = true`). `cratedigger-web.service` (and the other long-running workers) `requires` it, so they cannot start against an un-migrated DB. `cratedigger.service` and `cratedigger-unfindable.service` use `wants`+`after` instead — both are timer-driven, `restartIfChanged = false`, and a `requires` edge would let the migrate unit's every-deploy restart SIGTERM a mid-flight cycle — and gate on schema currency themselves at startup (`lib/migrator.py::assert_schema_current`).
 - `PipelineDB.__init__` does NOT run DDL. There is no `run_migrations` kwarg, no `init_schema()` method. Construct it against an already-migrated DB.
-- Tests get the schema applied once at session start in `tests/conftest.py` via `apply_migrations(TEST_DSN)`. Test setup helpers just `TRUNCATE` between tests.
+- Tests get the schema applied once at session start in `tests/conftest.py` via `apply_migrations(TEST_DSN)`. Test setup helpers `DELETE` between tests, inside one explicit transaction (`tests/helpers.py::delete_all_rows` — issue #1156 item 7 replaced the old per-test `TRUNCATE`; see that function's docstring for why a plain autocommitted DELETE loop is unsafe against migration 066's deferred constraint triggers).
 
 ## Adding a schema change
 

--- a/lib/ephemeral_postgres.py
+++ b/lib/ephemeral_postgres.py
@@ -82,9 +82,10 @@ class EphemeralPostgres:
             f"-k {self._socket_dir}",
             "-c listen_addresses=''",
             # PostgreSQL defers unlinking relation files replaced by TRUNCATE
-            # until a checkpoint (rare on this cluster now that most per-test
-            # resets DELETE instead — issue #1156 item 7 — but not the only
-            # source of dirty pages a checkpoint reclaims). Bound that
+            # until a checkpoint — no longer triggered by any test-reset
+            # call site (issue #1156 item 7 replaced every one with DELETE)
+            # but still a general protection against checkpoint-triggered
+            # dirty-page buildup from any workload. Bound that
             # disposable-test scratch lifetime instead of relying on the
             # five-minute production default.
             "-c checkpoint_timeout=30s",
@@ -157,13 +158,13 @@ class EphemeralPostgres:
             # over a database's working lifetime. Nothing here has one: the
             # whole cluster is destroyed in minutes, so a stats-driven
             # planner has nothing to learn from and nowhere to use it.
-            # Most per-test resets DELETE now, not TRUNCATE (issue #1156
+            # Every per-test reset DELETEs now, not TRUNCATEs (issue #1156
             # item 7), so this workload DOES leave dead tuples autovacuum
             # would otherwise reclaim — but measured over 2000 real reset
             # cycles that cost stayed at 9.6MB total db size, smaller than
-            # TRUNCATE's own catalog-relfilenode churn (20.1MB, unreclaimed
-            # by the same autovacuum=off) ever was. Turning autovacuum on to
-            # chase a reclaim this short-lived cluster never needs would
+            # TRUNCATE's own +10.5MB catalog-relfilenode growth (unreclaimed
+            # by the same autovacuum=off) ever cost. Turning autovacuum on
+            # to chase a reclaim this short-lived cluster never needs would
             # spend CPU (autovacuum workers, planner ANALYZE) this disposable
             # workload has better uses for.
             "-c autovacuum=off",

--- a/lib/ephemeral_postgres.py
+++ b/lib/ephemeral_postgres.py
@@ -82,8 +82,11 @@ class EphemeralPostgres:
             f"-k {self._socket_dir}",
             "-c listen_addresses=''",
             # PostgreSQL defers unlinking relation files replaced by TRUNCATE
-            # until a checkpoint. Bound that disposable-test scratch lifetime
-            # instead of relying on the five-minute production default.
+            # until a checkpoint (rare on this cluster now that most per-test
+            # resets DELETE instead — issue #1156 item 7 — but not the only
+            # source of dirty pages a checkpoint reclaims). Bound that
+            # disposable-test scratch lifetime instead of relying on the
+            # five-minute production default.
             "-c checkpoint_timeout=30s",
             "-c checkpoint_completion_target=0.1",
             # 128MB (the stock default) is sized for a real workload's
@@ -107,9 +110,12 @@ class EphemeralPostgres:
             # some replica-only record content for free. NOT a measured WAL
             # *volume* win: minimal's well-known same-transaction
             # create/truncate WAL-skip never triggers here — `PipelineDB`
-            # runs autocommit=True (lib/pipeline_db/_core.py) and the test
-            # helper's TRUNCATE is its own statement, so it commits before
-            # any test writes a row and every later INSERT is a different
+            # runs autocommit=True (lib/pipeline_db/_core.py), and the test
+            # helper's per-test reset (a short explicit transaction, several
+            # DELETE statements — issue #1156 item 7's
+            # `tests.helpers.delete_all_rows`, or historically a single
+            # autocommitted TRUNCATE statement) always commits before any
+            # test writes a row, and every later INSERT is a different
             # transaction. 100% of this PR's measured pg_wal reduction (see
             # the PR body) is the min/max_wal_size ceiling change below, not
             # this setting.
@@ -148,9 +154,18 @@ class EphemeralPostgres:
             # of this comment overstated, but a real and free reduction.
             "-c log_checkpoints=off",
             # Autovacuum exists to reclaim space and update planner stats
-            # over a database's working lifetime. Nothing here has one:
-            # tests TRUNCATE between runs (reclaiming space immediately,
-            # unlike DELETE) and the whole cluster is destroyed in minutes.
+            # over a database's working lifetime. Nothing here has one: the
+            # whole cluster is destroyed in minutes, so a stats-driven
+            # planner has nothing to learn from and nowhere to use it.
+            # Most per-test resets DELETE now, not TRUNCATE (issue #1156
+            # item 7), so this workload DOES leave dead tuples autovacuum
+            # would otherwise reclaim — but measured over 2000 real reset
+            # cycles that cost stayed at 9.6MB total db size, smaller than
+            # TRUNCATE's own catalog-relfilenode churn (20.1MB, unreclaimed
+            # by the same autovacuum=off) ever was. Turning autovacuum on to
+            # chase a reclaim this short-lived cluster never needs would
+            # spend CPU (autovacuum workers, planner ANALYZE) this disposable
+            # workload has better uses for.
             "-c autovacuum=off",
             # NOT one connection at a time: scripts/run_world_model_burst.py
             # runs ONE coordinator-owned EphemeralPostgres (this same class)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,8 @@ if TEST_DSN and os.environ.get("CRATEDIGGER_TEST_SCHEMA_READY") != "1":
     # Apply schema once at session start for either an externally supplied
     # TEST_DB_DSN or the ephemeral DB above. Parallel-suite module subprocesses
     # inherit an already-migrated worker-local DSN and explicitly skip this
-    # redundant step. Test helpers TRUNCATE between tests.
+    # redundant step. Test helpers DELETE between tests (issue #1156 item 7;
+    # see tests.helpers.delete_all_rows).
     from lib.migrator import apply_migrations
     try:
         apply_migrations(TEST_DSN)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -99,9 +99,12 @@ _DEPLOYED_BEETS_DB_PATHS = frozenset({
 # search_plan_items} plus CASCADE landed on this identical 13-table closure
 # regardless of which subset it spelled out, because ``album_requests`` was
 # always one of the seeds and already dominates it.
-# Order matters here (unlike the caller-visible contract for most of
-# ``delete_all_rows`` -- see its docstring): ``album_requests`` and
-# ``processing_cleanup_journal`` must both precede ``import_jobs``.
+#
+# Table order within this list is only independently load-bearing for
+# ``album_requests`` preceding ``import_jobs`` -- proven empirically, not
+# merely read off the DDL (see ``delete_all_rows``'s docstring for the full
+# mechanism). ``processing_cleanup_journal`` is kept before ``import_jobs``
+# anyway, for the simplest correct mental model.
 REQUEST_CASCADE_RESET_TABLES: tuple[str, ...] = (
     "album_requests",
     "processing_cleanup_journal",
@@ -120,18 +123,17 @@ REQUEST_CASCADE_RESET_TABLES: tuple[str, ...] = (
 
 
 class _ResettableConnection(Protocol):
-    autocommit: bool
     def commit(self) -> None: ...
-    def rollback(self) -> None: ...
 
 
 class _ResettableDB(Protocol):
     conn: _ResettableConnection
     def _execute(self, sql: str) -> object: ...
+    def _atomic(self) -> AbstractContextManager[object]: ...
 
 
 def delete_all_rows(db: _ResettableDB, tables: Sequence[str]) -> None:
-    """Empty ``tables`` IN ORDER, replacing a per-test ``TRUNCATE ... CASCADE``.
+    """Empty ``tables``, replacing a per-test ``TRUNCATE ... CASCADE`` reset.
 
     Ephemeral test clusters run ``autovacuum=off`` (``lib/ephemeral_postgres.py``)
     because a disposable cluster is destroyed within minutes -- but TRUNCATE
@@ -139,49 +141,91 @@ def delete_all_rows(db: _ResettableDB, tables: Sequence[str]) -> None:
     UPDATE, and with autovacuum off nothing ever reclaims those dead catalog
     tuples. Over thousands of per-test resets that bloats
     ``pg_class``/``pg_attribute`` for a benefit (immediate data-file space
-    reclaim) this disposable workload never needed, and is measured ~19x
-    slower per reset than a plain DELETE (issue #1156 item 7).
+    reclaim) this disposable workload never needed. The real win this buys,
+    measured against a live ephemeral cluster running the actual
+    ``make_db()`` reset call: ~2.2x faster than TRUNCATE (issue #1156 item
+    7). A cruder synthetic loop of bare ``TRUNCATE``/``DELETE`` statements
+    against no schema, no triggers, and no ``_atomic()`` overhead measured
+    ~19x in the issue that motivated this change -- that 19x is the
+    statement-level figure, not what this helper itself costs; quote 2.2x
+    for this function.
 
-    Runs one ``DELETE FROM`` per table inside a single explicit transaction,
-    for atomicity (a mid-reset failure rolls back instead of handing the next
-    test a half-cleared database) -- NOT to make table order irrelevant.
-    ``ON DELETE RESTRICT`` is the one action PostgreSQL documents as never
-    deferrable, regardless of a ``DEFERRABLE INITIALLY DEFERRED`` declaration
-    on the constraint (that flag governs the referencing row's existence
-    check, not the referenced row's delete-time RESTRICT action): it is
-    checked at the end of the statement that changed the REFERENCED table,
-    not at COMMIT. Proven empirically, not merely read off the DDL -- an
-    earlier draft of this helper assumed the declared deferral applied here
-    and it does not; a live-scenario probe raised
-    ``psycopg2.errors.RestrictViolation`` deleting ``import_jobs`` before
-    ``album_requests``. On the live schema this means: a caller passing
-    ``tables`` that include both ``import_jobs`` and one of
-    ``album_requests``/``processing_cleanup_journal`` MUST order the latter
-    first (see ``REQUEST_CASCADE_RESET_TABLES`` above). ``ON DELETE
-    CASCADE``/``SET NULL`` fire exactly as they always do for a DELETE,
-    independent of order. The two NOT DEFERRABLE self-referencing foreign
-    keys (``album_requests.replaces_request_id``,
-    ``download_log.source_download_log_id``) need no special ordering either,
-    because each table's entire content is cleared by a single DELETE
-    statement rather than row by row, and that same end-of-statement check
-    already sees every row in the same table deleted together.
+    Runs every ``DELETE FROM`` inside ``db._atomic()`` -- the SAME explicit-
+    transaction helper every other multi-row ``PipelineDB`` write already
+    uses (``lib/pipeline_db/_core.py``) -- for TWO INDEPENDENT reasons, not
+    merely atomicity for its own sake:
+
+    1. Constraint triggers, not just FK actions. Migration 066 installs
+       three constraint triggers
+       (``album_requests_complete_processing_owner``,
+       ``import_jobs_complete_processing_owner``,
+       ``processing_cleanup_journal_exact_owner`` -- all ``AFTER INSERT OR
+       DELETE OR UPDATE ... FOR EACH ROW DEFERRABLE INITIALLY DEFERRED``)
+       that validate cross-table album_requests/import_jobs/
+       processing_cleanup_journal consistency on every row change to any of
+       those three tables. TRUNCATE never fires row-level triggers at all
+       (a documented PostgreSQL behavior -- only TRUNCATE-specific triggers
+       fire, and none are declared here), so this reset boundary was
+       invisible to the old TRUNCATE-based implementation; DELETE fires
+       them. Proven empirically, not merely inferred: with the shipped
+       table order but autocommit left on (no transaction wrap), deleting a
+       world with a live processing owner raises
+       ``psycopg2.errors.CheckViolation`` ("cleanup journal must belong to
+       the exact active processing owner") the moment ``album_requests`` is
+       deleted -- the SET NULL cascade to ``import_jobs.request_id`` fires
+       the trigger immediately, and ``processing_cleanup_journal`` has not
+       been deleted yet. Only wrapping the whole reset in one transaction
+       defers the (DEFERRABLE INITIALLY DEFERRED) trigger checks past the
+       point the world is consistent again -- fully empty.
+
+       PRECONDITION this puts on every caller: a table list that includes
+       ``album_requests`` on a world with a live processing owner MUST also
+       include ``import_jobs`` and ``processing_cleanup_journal`` in the
+       SAME call. A caller-supplied list missing one of the three still
+       raises the same ``CheckViolation``, now at THIS call's own commit.
+
+    2. ``ON DELETE RESTRICT`` table order, independent of the transaction
+       wrap. RESTRICT is the one action PostgreSQL documents as never
+       deferrable, regardless of a ``DEFERRABLE INITIALLY DEFERRED``
+       declaration on the constraint (that flag governs the referencing
+       row's existence check, not the referenced row's delete-time
+       RESTRICT action): it is checked at the end of the statement that
+       changed the REFERENCED table, transaction or no. Proven
+       empirically: even wrapped in ``_atomic()``, deleting ``import_jobs``
+       before ``album_requests`` still raises
+       ``psycopg2.errors.RestrictViolation`` (the
+       ``album_requests_active_automation_owner_fk`` edge). A caller
+       passing ``tables`` that include both ``import_jobs`` and
+       ``album_requests`` MUST order the latter first (see
+       ``REQUEST_CASCADE_RESET_TABLES`` above). ``processing_cleanup_journal``'s
+       OWN position relative to ``import_jobs`` is NOT independently
+       load-bearing once ``album_requests`` precedes ``import_jobs`` --
+       proven empirically the other way too: reordering it after
+       ``import_jobs`` survives, because its FK's ON UPDATE side (implicit
+       "NO ACTION", genuinely deferrable) is satisfied by the same
+       transaction-wide commit reason 1 already requires. It is kept first
+       anyway, for the simplest correct mental model. ``ON DELETE
+       CASCADE``/``SET NULL`` fire exactly as they always do for a DELETE,
+       independent of order. The two NOT DEFERRABLE self-referencing
+       foreign keys (``album_requests.replaces_request_id``,
+       ``download_log.source_download_log_id``) need no special ordering
+       either, because each table's entire content is cleared by a single
+       DELETE statement rather than row by row, and that same
+       end-of-statement check already sees every row in the same table
+       deleted together.
 
     ``db`` is any ``_ResettableDB``-shaped object (``PipelineDB`` satisfies
-    it structurally): ``._execute(sql)`` plus a ``.conn`` exposing settable
-    ``autocommit``, ``commit()``, and ``rollback()`` (autocommit is flipped
-    off for the duration and always restored, even on failure).
+    it structurally): ``._execute(sql)``, ``._atomic()``, and a ``.conn``
+    exposing ``commit()``. Delegating to ``db._atomic()`` -- rather than a
+    hand-rolled autocommit flip/restore -- also means a connection closed
+    between tests reconnects correctly (``_ensure_conn()``, inside
+    ``_atomic()``) and a mid-reset failure rolls back and restores
+    autocommit without a second, untested copy of that logic living here.
     """
-    old_autocommit = db.conn.autocommit
-    db.conn.autocommit = False
-    try:
+    with db._atomic():
         for table in tables:
             db._execute(f"DELETE FROM {table}")
         db.conn.commit()
-    except Exception:
-        db.conn.rollback()
-        raise
-    finally:
-        db.conn.autocommit = old_autocommit
 
 
 def make_socket_file(path: str) -> None:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -86,6 +86,104 @@ _DEPLOYED_BEETS_DB_PATHS = frozenset({
 })
 
 
+# Every table ``TRUNCATE album_requests CASCADE`` reaches transitively on the
+# live schema (verified against the real FK graph via ``pg_constraint``, not
+# hand-traced): CASCADE follows every table with an FK pointing at
+# ``album_requests`` -- directly or, like ``processing_cleanup_journal`` via
+# ``import_jobs``, several hops away -- regardless of that FK's own ON DELETE
+# action (CASCADE/SET NULL/RESTRICT all get pulled in by TRUNCATE's CASCADE,
+# unlike a plain DELETE's cascade, which only follows ON DELETE CASCADE).
+# Every test-reset call site that used to TRUNCATE some subset of
+# {album_requests, import_jobs, processing_cleanup_journal, download_log,
+# album_tracks, source_denylist, search_log, search_plans,
+# search_plan_items} plus CASCADE landed on this identical 13-table closure
+# regardless of which subset it spelled out, because ``album_requests`` was
+# always one of the seeds and already dominates it.
+# Order matters here (unlike the caller-visible contract for most of
+# ``delete_all_rows`` -- see its docstring): ``album_requests`` and
+# ``processing_cleanup_journal`` must both precede ``import_jobs``.
+REQUEST_CASCADE_RESET_TABLES: tuple[str, ...] = (
+    "album_requests",
+    "processing_cleanup_journal",
+    "import_jobs",
+    "album_quality_evidence_files",
+    "album_quality_evidence",
+    "search_plan_items",
+    "search_plans",
+    "album_request_field_resolutions",
+    "album_tracks",
+    "download_log",
+    "search_log",
+    "source_denylist",
+    "bad_audio_hashes",
+)
+
+
+class _ResettableConnection(Protocol):
+    autocommit: bool
+    def commit(self) -> None: ...
+    def rollback(self) -> None: ...
+
+
+class _ResettableDB(Protocol):
+    conn: _ResettableConnection
+    def _execute(self, sql: str) -> object: ...
+
+
+def delete_all_rows(db: _ResettableDB, tables: Sequence[str]) -> None:
+    """Empty ``tables`` IN ORDER, replacing a per-test ``TRUNCATE ... CASCADE``.
+
+    Ephemeral test clusters run ``autovacuum=off`` (``lib/ephemeral_postgres.py``)
+    because a disposable cluster is destroyed within minutes -- but TRUNCATE
+    assigns each truncated table a new relfilenode, which is a catalog
+    UPDATE, and with autovacuum off nothing ever reclaims those dead catalog
+    tuples. Over thousands of per-test resets that bloats
+    ``pg_class``/``pg_attribute`` for a benefit (immediate data-file space
+    reclaim) this disposable workload never needed, and is measured ~19x
+    slower per reset than a plain DELETE (issue #1156 item 7).
+
+    Runs one ``DELETE FROM`` per table inside a single explicit transaction,
+    for atomicity (a mid-reset failure rolls back instead of handing the next
+    test a half-cleared database) -- NOT to make table order irrelevant.
+    ``ON DELETE RESTRICT`` is the one action PostgreSQL documents as never
+    deferrable, regardless of a ``DEFERRABLE INITIALLY DEFERRED`` declaration
+    on the constraint (that flag governs the referencing row's existence
+    check, not the referenced row's delete-time RESTRICT action): it is
+    checked at the end of the statement that changed the REFERENCED table,
+    not at COMMIT. Proven empirically, not merely read off the DDL -- an
+    earlier draft of this helper assumed the declared deferral applied here
+    and it does not; a live-scenario probe raised
+    ``psycopg2.errors.RestrictViolation`` deleting ``import_jobs`` before
+    ``album_requests``. On the live schema this means: a caller passing
+    ``tables`` that include both ``import_jobs`` and one of
+    ``album_requests``/``processing_cleanup_journal`` MUST order the latter
+    first (see ``REQUEST_CASCADE_RESET_TABLES`` above). ``ON DELETE
+    CASCADE``/``SET NULL`` fire exactly as they always do for a DELETE,
+    independent of order. The two NOT DEFERRABLE self-referencing foreign
+    keys (``album_requests.replaces_request_id``,
+    ``download_log.source_download_log_id``) need no special ordering either,
+    because each table's entire content is cleared by a single DELETE
+    statement rather than row by row, and that same end-of-statement check
+    already sees every row in the same table deleted together.
+
+    ``db`` is any ``_ResettableDB``-shaped object (``PipelineDB`` satisfies
+    it structurally): ``._execute(sql)`` plus a ``.conn`` exposing settable
+    ``autocommit``, ``commit()``, and ``rollback()`` (autocommit is flipped
+    off for the duration and always restored, even on failure).
+    """
+    old_autocommit = db.conn.autocommit
+    db.conn.autocommit = False
+    try:
+        for table in tables:
+            db._execute(f"DELETE FROM {table}")
+        db.conn.commit()
+    except Exception:
+        db.conn.rollback()
+        raise
+    finally:
+        db.conn.autocommit = old_autocommit
+
+
 def make_socket_file(path: str) -> None:
     """Plant one Unix-domain socket file at ``path``, at any depth.
 

--- a/tests/test_album_source.py
+++ b/tests/test_album_source.py
@@ -21,7 +21,11 @@ from album_source import AlbumRecord, DatabaseSource
 from lib.grab_list import GrabListEntry
 from lib.quality import DownloadInfo, ValidationResult
 from tests.fakes import FakePipelineDB
-from tests.helpers import make_request_row
+from tests.helpers import (
+    REQUEST_CASCADE_RESET_TABLES,
+    delete_all_rows,
+    make_request_row,
+)
 
 TEST_DSN = os.environ.get("TEST_DB_DSN")
 TEST_MB_WS2_BASE = "http://musicbrainz-mirror.test:5200/ws/2"
@@ -286,9 +290,7 @@ class TestDatabaseSource(unittest.TestCase):
         from lib.pipeline_db import PipelineDB
         assert TEST_DSN is not None, "conftest must set TEST_DB_DSN"
         db = PipelineDB(TEST_DSN)
-        for table in ["source_denylist", "download_log", "album_tracks", "album_requests"]:
-            db._execute(f"TRUNCATE {table} CASCADE")
-        db.conn.commit()
+        delete_all_rows(db, REQUEST_CASCADE_RESET_TABLES)
         source = DatabaseSource(
             TEST_DSN,
             musicbrainz_ws2_base=TEST_MB_WS2_BASE,

--- a/tests/test_automation_startup_recovery.py
+++ b/tests/test_automation_startup_recovery.py
@@ -64,8 +64,10 @@ from lib.terminal_outcomes import (
 )
 from tests.fakes import FakePipelineDB
 from tests.helpers import (
+    REQUEST_CASCADE_RESET_TABLES,
     claim_next_import_job,
     claim_next_import_preview_job,
+    delete_all_rows,
     handoff_automation_owner,
     make_album_quality_evidence,
     make_request_row,
@@ -1348,8 +1350,7 @@ class TestAutomationStartupRecoveryPostgres(
 ):
     def setUp(self) -> None:
         self.db = PipelineDB(TEST_DSN)
-        self.db._execute("TRUNCATE album_requests CASCADE")
-        self.db.conn.commit()
+        delete_all_rows(self.db, REQUEST_CASCADE_RESET_TABLES)
         self.mb_release_id = "cbb51c9f-5555-6666-7777-888888888888"
         self.request_id = self.db.add_request(
             "Startup Recovery",

--- a/tests/test_cleanup_journal.py
+++ b/tests/test_cleanup_journal.py
@@ -16,6 +16,7 @@ from lib.pipeline_db import (
     PipelineDB,
     ProcessingCleanupJournalRow,
 )
+from tests.helpers import REQUEST_CASCADE_RESET_TABLES, delete_all_rows
 
 TEST_DSN = os.environ["TEST_DB_DSN"]
 
@@ -44,10 +45,7 @@ class CleanupJournalPostgresCase(unittest.TestCase):
 
     def setUp(self) -> None:
         self.db = PipelineDB(TEST_DSN)
-        self.db._execute(
-            "TRUNCATE processing_cleanup_journal, import_jobs, "
-            "album_requests CASCADE"
-        )
+        delete_all_rows(self.db, REQUEST_CASCADE_RESET_TABLES)
 
     def tearDown(self) -> None:
         self.db.close()

--- a/tests/test_cleanup_journal_generated.py
+++ b/tests/test_cleanup_journal_generated.py
@@ -22,6 +22,7 @@ from lib.pipeline_db import (
     CleanupJournalIntent,
     PipelineDB,
 )
+from tests.helpers import REQUEST_CASCADE_RESET_TABLES, delete_all_rows
 
 TEST_DSN = os.environ["TEST_DB_DSN"]
 GuardMutation = Literal["none", "owner_blind", "revision_blind"]
@@ -73,10 +74,10 @@ class TestCleanupJournalGenerated(unittest.TestCase):
         self.db.close()
 
     def _reset(self) -> None:
-        self.db._execute(
-            "TRUNCATE processing_cleanup_journal, import_jobs, "
-            "album_requests CASCADE"
-        )
+        # Runs once per generated example (issue #1156 item 7) — the
+        # highest-frequency reset in the suite, and the reason DELETE
+        # replaced TRUNCATE here.
+        delete_all_rows(self.db, REQUEST_CASCADE_RESET_TABLES)
 
     def _owner(self, suffix: str) -> tuple[int, int]:
         with self.db._atomic():

--- a/tests/test_deploy_hold.py
+++ b/tests/test_deploy_hold.py
@@ -67,6 +67,7 @@ from scripts.cratedigger_deploy_hold import (
 from scripts.pipeline_cli.query import _render_query_table
 from tests._source_pins import pinned_source
 from tests.fakes.deploy_hold import FakeDeployHoldBackend
+from tests.helpers import REQUEST_CASCADE_RESET_TABLES
 
 INVOCATION = "a" * 32
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -159,16 +160,19 @@ class TestLifecyclePreflightPostgresContract(unittest.TestCase):
 
     def setUp(self) -> None:
         self.conn = psycopg2.connect(TEST_DSN)
-        with self.conn, self.conn.cursor() as cursor:
-            cursor.execute(
-                "TRUNCATE processing_cleanup_journal, import_jobs, "
-                "album_requests CASCADE"
-            )
+        self._reset_db()
         self.backend = _PostgresLifecyclePreflightBackend()
         self.request_sequence = 0
 
     def tearDown(self) -> None:
         self.conn.close()
+
+    def _reset_db(self) -> None:
+        # ``self.conn`` (plain psycopg2, not autocommit) already wraps this
+        # in a transaction via ``with self.conn:`` — issue #1156 item 7.
+        with self.conn, self.conn.cursor() as cursor:
+            for table in REQUEST_CASCADE_RESET_TABLES:
+                cursor.execute(f"DELETE FROM {table}")
 
     def _request(
         self,
@@ -251,11 +255,7 @@ class TestLifecyclePreflightPostgresContract(unittest.TestCase):
         )
         for marker, value in markers:
             with self.subTest(marker=marker):
-                with self.conn, self.conn.cursor() as cursor:
-                    cursor.execute(
-                        "TRUNCATE processing_cleanup_journal, import_jobs, "
-                        "album_requests CASCADE"
-                    )
+                self._reset_db()
                 self._request(
                     status="downloading",
                     active_download_state={
@@ -278,11 +278,7 @@ class TestLifecyclePreflightPostgresContract(unittest.TestCase):
         )
         for value in malformed:
             with self.subTest(value=value):
-                with self.conn, self.conn.cursor() as cursor:
-                    cursor.execute(
-                        "TRUNCATE processing_cleanup_journal, import_jobs, "
-                        "album_requests CASCADE"
-                    )
+                self._reset_db()
                 state: dict[str, object] = (
                     {} if value is None else {"enqueued_at": value}
                 )

--- a/tests/test_force_import.py
+++ b/tests/test_force_import.py
@@ -17,15 +17,15 @@ from unittest.mock import MagicMock, patch
 sys.path.append(os.path.dirname(__file__))
 import conftest  # noqa: F401
 
+from tests.helpers import REQUEST_CASCADE_RESET_TABLES, delete_all_rows
+
 TEST_DSN = os.environ.get("TEST_DB_DSN")
 
 
 def make_db():
     from lib.pipeline_db import PipelineDB
     db = PipelineDB(TEST_DSN)
-    for table in ["source_denylist", "download_log", "album_tracks", "album_requests"]:
-        db._execute(f"TRUNCATE {table} CASCADE")
-    db.conn.commit()
+    delete_all_rows(db, REQUEST_CASCADE_RESET_TABLES)
     return db
 
 

--- a/tests/test_import_job_recovery_detail.py
+++ b/tests/test_import_job_recovery_detail.py
@@ -43,7 +43,11 @@ from lib.import_queue import ImportJob
 from lib.pipeline_db.cleanup_journal import ProcessingCleanupJournalRow
 from lib.pipeline_db.rows import AlbumRequestRow
 from lib.release_identity import ReleaseIdentity
-from tests.helpers import make_request_row
+from tests.helpers import (
+    REQUEST_CASCADE_RESET_TABLES,
+    delete_all_rows,
+    make_request_row,
+)
 
 _RELEASE_ID = "75dbf62e-7dd2-4ddc-b57b-9bad1758b6b0"
 _OBSERVED = datetime(2026, 7, 29, 1, 2, 3, tzinfo=UTC)
@@ -549,8 +553,7 @@ class TestAutomationRecoveryDetailPostgres(unittest.TestCase):
         from lib.pipeline_db import PipelineDB
 
         self.db = PipelineDB(TEST_DSN)
-        self.db._execute("TRUNCATE album_requests CASCADE")
-        self.db.conn.commit()
+        delete_all_rows(self.db, REQUEST_CASCADE_RESET_TABLES)
 
     def tearDown(self) -> None:
         self.db.close()

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -59,9 +59,11 @@ from tests.fakes import (
     FakeSlskdAPI,
 )
 from tests.helpers import (
+    REQUEST_CASCADE_RESET_TABLES,
     RecordingQualityGate,
     claim_next_import_job,
     claim_next_import_preview_job,
+    delete_all_rows,
     finalize_claimed_dispatch,
     handoff_automation_owner,
     hermetic_beets_config_defaults,
@@ -7955,13 +7957,12 @@ class TestProcessingOwnerPostgresFilesystemSlice(unittest.TestCase):
     def setUp(self) -> None:
         self.db = PipelineDB(_u7_test_dsn())
         self.addCleanup(self.db.close)
-        self._truncate_fixture()
-        self.addCleanup(self._truncate_fixture)
+        self._reset_fixture()
+        self.addCleanup(self._reset_fixture)
 
-    def _truncate_fixture(self) -> None:
+    def _reset_fixture(self) -> None:
         """Keep the production queue entrypoint isolated from prior PG tests."""
-        self.db._execute("TRUNCATE album_requests CASCADE")
-        self.db.conn.commit()
+        delete_all_rows(self.db, REQUEST_CASCADE_RESET_TABLES)
 
     def _handoff_through_preview(
         self,

--- a/tests/test_long_tail_service.py
+++ b/tests/test_long_tail_service.py
@@ -51,7 +51,11 @@ from lib.release_identity import (
 # the injected band_fn (not a service constant).
 BAND_UNKNOWN = "unknown"
 from tests.fakes import FakePipelineDB
-from tests.helpers import make_request_row
+from tests.helpers import (
+    REQUEST_CASCADE_RESET_TABLES,
+    delete_all_rows,
+    make_request_row,
+)
 
 TEST_DSN = os.environ.get("TEST_DB_DSN")
 
@@ -478,9 +482,7 @@ class TestLongTailCohortRoundTrip(unittest.TestCase):
     def setUp(self) -> None:
         from lib import pipeline_db
         self.db = pipeline_db.PipelineDB(TEST_DSN)
-        for table in ("download_log", "album_requests"):
-            self.db._execute(f"TRUNCATE {table} CASCADE")
-        self.db.conn.commit()
+        delete_all_rows(self.db, REQUEST_CASCADE_RESET_TABLES)
 
     def tearDown(self) -> None:
         self.db.close()

--- a/tests/test_pipeline_cli.py
+++ b/tests/test_pipeline_cli.py
@@ -36,6 +36,8 @@ from scripts.pipeline_cli import api_mutations
 from scripts.pipeline_cli.api_mutations import TcpApiEndpoint
 from tests.fakes import FakeBeetsDB, FakePipelineDB
 from tests.helpers import (
+    REQUEST_CASCADE_RESET_TABLES,
+    delete_all_rows,
     handoff_automation_owner,
     make_album_quality_evidence,
     make_request_row,
@@ -85,9 +87,7 @@ SAMPLE_MB_RELEASE = {
 def make_db():
     from lib.pipeline_db import PipelineDB
     db = PipelineDB(TEST_DSN)
-    for table in ["import_jobs", "source_denylist", "download_log", "album_tracks", "album_requests"]:
-        db._execute(f"TRUNCATE {table} CASCADE")
-    db.conn.commit()
+    delete_all_rows(db, REQUEST_CASCADE_RESET_TABLES)
     return db
 
 

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -14,8 +14,9 @@ import tempfile
 import threading
 import time
 import unittest
-from collections.abc import Mapping, Sequence
+from collections.abc import Generator, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any, ClassVar, TypedDict, cast
@@ -92,10 +93,20 @@ def requires_postgres(cls):
 # ``TRUNCATE <21 explicitly-named tables> CASCADE`` used to reach, now spelled
 # out explicitly rather than left to three tables' worth of implicit cascade
 # (``album_quality_evidence_files``, ``search_plans``, ``search_plan_items``).
-# Order matters (see ``tests.helpers.delete_all_rows``'s docstring):
-# ``album_requests`` and ``processing_cleanup_journal`` must both precede
-# ``import_jobs`` — the only two ``ON DELETE RESTRICT`` foreign keys in the
-# schema, both checked immediately rather than deferred to commit.
+#
+# Order matters (see ``tests.helpers.delete_all_rows``'s docstring for the
+# full mechanism, including why an explicit transaction is required here at
+# all, independent of ordering): ``album_requests`` must precede
+# ``import_jobs`` — one of THREE ``ON DELETE RESTRICT`` foreign keys in the
+# schema (the other two: ``processing_cleanup_journal`` -> ``import_jobs``,
+# and the self-referencing ``album_requests.replaces_request_id`` ->
+# ``album_requests``, resolved for free since a single DELETE clears its
+# whole table in one statement) — checked immediately rather than deferred
+# to commit, regardless of any DEFERRABLE declaration on the constraint.
+# ``processing_cleanup_journal`` is kept before ``import_jobs`` too, for the
+# simplest correct mental model, though once ``album_requests`` precedes
+# ``import_jobs`` its own position relative to ``import_jobs`` is not
+# independently load-bearing (proven empirically both ways).
 _ALL_TABLES = [
     "album_requests",
     "processing_cleanup_journal",
@@ -140,7 +151,6 @@ def make_db():
 class _RecordingTestConnection:
     def __init__(self) -> None:
         self.commit_count = 0
-        self.autocommit = True
 
     def commit(self) -> None:
         self.commit_count += 1
@@ -150,9 +160,15 @@ class _RecordingTestDB:
     def __init__(self) -> None:
         self.statements: list[str] = []
         self.conn = _RecordingTestConnection()
+        self.atomic_entered = 0
 
     def _execute(self, sql: str) -> None:
         self.statements.append(sql)
+
+    @contextmanager
+    def _atomic(self) -> Generator[_RecordingTestConnection]:
+        self.atomic_entered += 1
+        yield self.conn
 
 
 class TestMakeDbIsolation(unittest.TestCase):
@@ -163,10 +179,12 @@ class TestMakeDbIsolation(unittest.TestCase):
 
         self.assertIs(result, db)
         self.assertEqual(db.statements, [f"DELETE FROM {t}" for t in _ALL_TABLES])
-        # delete_all_rows commits exactly once (all deletes in one
-        # transaction) and restores autocommit to its prior value.
+        # delete_all_rows runs every DELETE inside one db._atomic() call and
+        # commits exactly once inside it (issue #1156 item 7 P3-F4: this
+        # delegates to PipelineDB's own transaction/reconnect/rollback
+        # machinery instead of duplicating a second, untested copy of it).
+        self.assertEqual(db.atomic_entered, 1)
         self.assertEqual(db.conn.commit_count, 1)
-        self.assertTrue(db.conn.autocommit)
 
 
 def _seed_restrict_and_self_reference_scenario(db: PipelineDB) -> None:
@@ -302,6 +320,44 @@ class TestDeleteAllRowsRealPostgresRegression(unittest.TestCase):
             "expected the dropped table's row to survive — if it didn't, "
             "the 'leaves nothing behind' pins above are not falsifiable",
         )
+
+    def test_missing_predecessor_raises_and_leaves_the_world_untouched(
+        self,
+    ) -> None:
+        """Failure-path pin (issue #1156 item 7 P3-F5): the precondition
+        ``delete_all_rows``'s docstring documents — a table list that
+        includes ``album_requests`` on a world with a live processing
+        owner must also include ``import_jobs`` and
+        ``processing_cleanup_journal`` in the SAME call — is real, and the
+        failure it raises leaves nothing partially committed and the
+        connection usable for the next test. Exercises ``db._atomic()``'s
+        own rollback/autocommit-restore machinery, not a second
+        hand-rolled copy of it (P3-F4: the duplicate copy this pin
+        replaces silently dropped both dead-connection guards and never
+        called ``_ensure_conn()``).
+        """
+        _seed_restrict_and_self_reference_scenario(self.db)
+        before = self.db._execute(
+            "SELECT count(*) AS n FROM album_requests"
+        ).fetchone()["n"]
+        self.assertGreater(before, 0)
+
+        with self.assertRaises(psycopg2.errors.CheckViolation):
+            delete_all_rows(self.db, ["album_requests"])
+
+        # The deferred constraint trigger fires at COMMIT and PostgreSQL
+        # rolls back the whole transaction on failure — nothing was
+        # partially deleted.
+        after = self.db._execute(
+            "SELECT count(*) AS n FROM album_requests"
+        ).fetchone()["n"]
+        self.assertEqual(after, before)
+
+        # db._atomic() restores autocommit and the connection stays usable
+        # (Critical rule 7: PipelineDB must run autocommit=True).
+        self.assertTrue(self.db.conn.autocommit)
+        row = self.db._execute("SELECT 1 AS ok").fetchone()
+        self.assertEqual(row["ok"], 1)
 
 
 def _link_projection_evidence(

--- a/tests/test_pipeline_db.py
+++ b/tests/test_pipeline_db.py
@@ -69,8 +69,10 @@ from lib.quality import (
 )
 from tests.fakes import FakeBeetsDB, FakePipelineDB
 from tests.helpers import (
+    REQUEST_CASCADE_RESET_TABLES,
     claim_next_import_job,
     claim_next_import_preview_job,
+    delete_all_rows,
     handoff_automation_owner,
     make_album_quality_evidence,
     make_request_row,
@@ -85,45 +87,60 @@ def requires_postgres(cls):
     return cls
 
 
+# Every application table (every table but ``schema_migrations``), verified
+# against the live FK graph (issue #1156 item 7) — this is the closure
+# ``TRUNCATE <21 explicitly-named tables> CASCADE`` used to reach, now spelled
+# out explicitly rather than left to three tables' worth of implicit cascade
+# (``album_quality_evidence_files``, ``search_plans``, ``search_plan_items``).
+# Order matters (see ``tests.helpers.delete_all_rows``'s docstring):
+# ``album_requests`` and ``processing_cleanup_journal`` must both precede
+# ``import_jobs`` — the only two ``ON DELETE RESTRICT`` foreign keys in the
+# schema, both checked immediately rather than deferred to commit.
+_ALL_TABLES = [
+    "album_requests",
+    "processing_cleanup_journal",
+    "import_jobs",
+    "album_quality_evidence_files",
+    "album_quality_evidence",
+    "peer_observations",
+    "cycle_metrics",
+    "unfindable_run_metrics",
+    "bad_audio_hashes",
+    "user_cooldowns",
+    "source_denylist",
+    "search_plan_items",
+    "search_plans",
+    "search_log",
+    "download_log",
+    "album_request_field_resolutions",  # migration 030
+    "youtube_album_mappings",  # migration 034
+    "youtube_album_empty_resolutions",  # migration 035
+    "plex_added_at_pins",  # migration 040
+    "jellyfin_date_created_pins",  # migration 046
+    "slskd_event_cursor",  # migration 041
+    "slskd_search_ledger",  # migration 044
+    "slskd_transfer_ledger",  # migration 045
+    "album_tracks",
+]
+
+
 def make_db():
     """Create a PipelineDB connected to the test database, with clean tables.
 
     Schema is migrated once in conftest.py at session start. This helper
-    just truncates all tables for an isolated test slate.
+    just deletes every row from every table for an isolated test slate —
+    see ``tests.helpers.delete_all_rows`` for why DELETE replaced TRUNCATE.
     """
     from lib import pipeline_db
     db = pipeline_db.PipelineDB(TEST_DSN)
-    tables = [
-        "album_quality_evidence",
-        "peer_observations",
-        "cycle_metrics",
-        "unfindable_run_metrics",
-        "bad_audio_hashes",
-        "processing_cleanup_journal",
-        "import_jobs",
-        "user_cooldowns",
-        "source_denylist",
-        "search_log",
-        "download_log",
-        "album_request_field_resolutions",  # migration 030
-        "youtube_album_mappings",  # migration 034
-        "youtube_album_empty_resolutions",  # migration 035
-        "plex_added_at_pins",  # migration 040
-        "jellyfin_date_created_pins",  # migration 046
-        "slskd_event_cursor",  # migration 041
-        "slskd_search_ledger",  # migration 044
-        "slskd_transfer_ledger",  # migration 045
-        "album_tracks",
-        "album_requests",
-    ]
-    db._execute("TRUNCATE " + ", ".join(tables) + " CASCADE")
-    db.conn.commit()
+    delete_all_rows(db, _ALL_TABLES)
     return db
 
 
 class _RecordingTestConnection:
     def __init__(self) -> None:
         self.commit_count = 0
+        self.autocommit = True
 
     def commit(self) -> None:
         self.commit_count += 1
@@ -139,45 +156,152 @@ class _RecordingTestDB:
 
 
 class TestMakeDbIsolation(unittest.TestCase):
-    def test_truncates_the_exact_test_slate_once(self) -> None:
+    def test_deletes_the_exact_test_slate_once_in_one_transaction(self) -> None:
         db = _RecordingTestDB()
         with patch("lib.pipeline_db.PipelineDB", return_value=db):
             result = make_db()
 
         self.assertIs(result, db)
-        self.assertEqual(len(db.statements), 1)
-        sql = db.statements[0]
-        prefix = "TRUNCATE "
-        suffix = " CASCADE"
-        self.assertTrue(sql.startswith(prefix))
-        self.assertTrue(sql.endswith(suffix))
-        self.assertEqual(
-            sql.removeprefix(prefix).removesuffix(suffix).split(", "),
-            [
-                "album_quality_evidence",
-                "peer_observations",
-                "cycle_metrics",
-                "unfindable_run_metrics",
-                "bad_audio_hashes",
-                "processing_cleanup_journal",
-                "import_jobs",
-                "user_cooldowns",
-                "source_denylist",
-                "search_log",
-                "download_log",
-                "album_request_field_resolutions",
-                "youtube_album_mappings",
-                "youtube_album_empty_resolutions",
-                "plex_added_at_pins",
-                "jellyfin_date_created_pins",
-                "slskd_event_cursor",
-                "slskd_search_ledger",
-                "slskd_transfer_ledger",
-                "album_tracks",
-                "album_requests",
-            ],
-        )
+        self.assertEqual(db.statements, [f"DELETE FROM {t}" for t in _ALL_TABLES])
+        # delete_all_rows commits exactly once (all deletes in one
+        # transaction) and restores autocommit to its prior value.
         self.assertEqual(db.conn.commit_count, 1)
+        self.assertTrue(db.conn.autocommit)
+
+
+def _seed_restrict_and_self_reference_scenario(db: PipelineDB) -> None:
+    """Seed both ``ON DELETE RESTRICT`` edges and both NOT DEFERRABLE
+    self-referencing edges in the schema at once (issue #1156 item 7):
+
+    - ``album_requests.active_automation_import_job_id -> import_jobs``
+      AND ``processing_cleanup_journal -> import_jobs`` (both RESTRICT) —
+      a real "processing" owner plus its journal row, live together.
+    - ``album_requests.replaces_request_id -> album_requests`` (self, NOT
+      DEFERRABLE) — an old row replaced by a new one.
+    - ``download_log.source_download_log_id -> download_log`` (self, NOT
+      DEFERRABLE) — a force-import row lineage-linked to its source.
+    - one independent ``bad_audio_hashes`` row (SET NULL only, no RESTRICT
+      predecessor) as the known-bad self-test's drop target below.
+
+    This is exactly the world a wrong table order (or a table silently
+    dropped from the reset list) fails on — see
+    ``tests.helpers.delete_all_rows``'s docstring for why order matters,
+    and ``TestDeleteAllRowsRealPostgresRegression`` below for the pin.
+    """
+    with db._atomic():
+        old_req_id = db._execute(
+            "INSERT INTO album_requests (artist_name, album_title, source, "
+            "mb_release_id, status) VALUES (%s,%s,%s,%s,%s) RETURNING id",
+            ("Old Artist", "Old Album", "request", "mbid-1156-old", "replaced"),
+        ).fetchone()["id"]
+        new_req_id = db._execute(
+            "INSERT INTO album_requests (artist_name, album_title, source, "
+            "mb_release_id, status, replaces_request_id) "
+            "VALUES (%s,%s,%s,%s,%s,%s) RETURNING id",
+            ("New Artist", "New Album", "request", "mbid-1156-new", "wanted",
+             old_req_id),
+        ).fetchone()["id"]
+        proc_req_id = db._execute(
+            "INSERT INTO album_requests (artist_name, album_title, source, "
+            "mb_release_id, status) VALUES (%s,%s,%s,%s,%s) RETURNING id",
+            ("Proc Artist", "Proc Album", "request", "mbid-1156-proc",
+             "downloading"),
+        ).fetchone()["id"]
+        job_id = db._execute(
+            "INSERT INTO import_jobs (job_type, status, request_id) "
+            "VALUES (%s,%s,%s) RETURNING id",
+            ("automation_import", "running", proc_req_id),
+        ).fetchone()["id"]
+        db._execute(
+            "UPDATE album_requests SET status='processing', "
+            "active_automation_import_job_id=%s WHERE id=%s",
+            (job_id, proc_req_id),
+        )
+        db._execute(
+            "INSERT INTO processing_cleanup_journal (job_id, request_id, "
+            "action, source_path, source_manifest, source_manifest_hash) "
+            "VALUES (%s,%s,%s,%s,%s,%s)",
+            (job_id, proc_req_id, "move", "/processing/1156", "[]",
+             "deadbeef1156"),
+        )
+        original_dl_id = db._execute(
+            "INSERT INTO download_log (request_id, outcome) VALUES (%s,%s) "
+            "RETURNING id",
+            (new_req_id, "success"),
+        ).fetchone()["id"]
+        db._execute(
+            "INSERT INTO download_log (request_id, outcome, "
+            "source_download_log_id) VALUES (%s,%s,%s)",
+            (new_req_id, "force_import", original_dl_id),
+        )
+        db._execute(
+            "INSERT INTO bad_audio_hashes (hash_value, audio_format) "
+            "VALUES (%s,%s)",
+            (bytes.fromhex("ab" * 32), "flac"),
+        )
+        db.conn.commit()
+
+
+@requires_postgres
+class TestDeleteAllRowsRealPostgresRegression(unittest.TestCase):
+    """Real-PG pin (issue #1156 item 7): after ``delete_all_rows``, the
+    RESTRICT/self-referencing scenario TRUNCATE ... CASCADE used to clear
+    for free is genuinely gone, not merely unreferenced.
+    """
+
+    def setUp(self) -> None:
+        self.db = make_db()
+
+    def tearDown(self) -> None:
+        self.db.close()
+
+    _SEEDED_TABLES = (
+        "album_requests", "import_jobs", "processing_cleanup_journal",
+        "download_log", "bad_audio_hashes",
+    )
+
+    def _assert_seeded_tables_empty(self) -> None:
+        for table in self._SEEDED_TABLES:
+            with self.subTest(table=table):
+                row = self.db._execute(
+                    f"SELECT count(*) AS n FROM {table}"
+                ).fetchone()
+                self.assertEqual(row["n"], 0, f"{table} was not fully cleared")
+
+    def test_request_cascade_reset_tables_leaves_nothing_behind(self) -> None:
+        _seed_restrict_and_self_reference_scenario(self.db)
+        delete_all_rows(self.db, REQUEST_CASCADE_RESET_TABLES)
+        self._assert_seeded_tables_empty()
+
+    def test_all_tables_leaves_nothing_behind(self) -> None:
+        _seed_restrict_and_self_reference_scenario(self.db)
+        delete_all_rows(self.db, _ALL_TABLES)
+        self._assert_seeded_tables_empty()
+
+    def test_known_bad_a_table_dropped_from_the_list_is_not_cleared(
+        self,
+    ) -> None:
+        """Known-bad self-test: proves ``_assert_seeded_tables_empty`` is
+        not vacuous. Mutates a LOCAL copy of the reset list (never the
+        shipped ``REQUEST_CASCADE_RESET_TABLES`` constant) by dropping
+        ``bad_audio_hashes`` — a table with no RESTRICT predecessor, so the
+        drop produces a silent leftover row rather than an exception — and
+        asserts the row survives. If this assertion ever started passing,
+        the "leaves nothing behind" pins above would no longer be
+        falsifiable."""
+        mutated = tuple(
+            t for t in REQUEST_CASCADE_RESET_TABLES if t != "bad_audio_hashes"
+        )
+        _seed_restrict_and_self_reference_scenario(self.db)
+        delete_all_rows(self.db, mutated)
+        row = self.db._execute(
+            "SELECT count(*) AS n FROM bad_audio_hashes"
+        ).fetchone()
+        self.assertEqual(
+            row["n"], 1,
+            "expected the dropped table's row to survive — if it didn't, "
+            "the 'leaves nothing behind' pins above are not falsifiable",
+        )
 
 
 def _link_projection_evidence(

--- a/tests/test_request_creation_visibility.py
+++ b/tests/test_request_creation_visibility.py
@@ -19,6 +19,7 @@ from lib.pipeline_db import (
 )
 from lib.request_creation_service import RequestCreationInput, RequestCreationService
 from lib.search import SEARCH_PLAN_GENERATOR_ID
+from tests.helpers import REQUEST_CASCADE_RESET_TABLES, delete_all_rows
 
 TEST_DSN = os.environ.get("TEST_DB_DSN")
 
@@ -47,9 +48,7 @@ class TestRequestCreationVisibility(unittest.TestCase):
         assert TEST_DSN is not None
         self.writer = _PausePublicationDB(TEST_DSN)
         self.observer = PipelineDB(TEST_DSN)
-        for table in ("search_log", "search_plan_items", "search_plans", "album_tracks", "album_requests"):
-            self.writer._execute(f"TRUNCATE {table} CASCADE")
-        self.writer.conn.commit()
+        delete_all_rows(self.writer, REQUEST_CASCADE_RESET_TABLES)
 
     def tearDown(self) -> None:
         self.writer.close()


### PR DESCRIPTION
Addresses #1156 item 7.

## The finding

Ephemeral test clusters run `autovacuum=off` — correct for short-lived clusters. But `TRUNCATE` assigns a new relfilenode, which is a catalog UPDATE, so per-test `TRUNCATE` churn bloats `pg_class`/`pg_attribute` with dead tuples nothing reclaims.

## Measured

Independently reproduced by review on a quiet box, not just by the author:

| | isolated reset call | whole module `test_pipeline_db` |
|---|---|---|
| before (`TRUNCATE … CASCADE`) | 22.18 ms | 13.13 s |
| after (`DELETE FROM`) | **10.19 ms (2.18×)** | **9.74 s (26% faster, 6/6 paired trials)** |
| catalog growth over 400 resets | +4.70 MiB | — |
| after | **+0.00 MiB** | — |

At fuzz depth (`test_cleanup_journal_generated`, ~6,000 resets): wall **25.0 s → 13.1 s**, catalog growth **+15.14 MiB → +0.00**. `DELETE` does leave dead tuples where `TRUNCATE` reclaimed (**+1.90 MiB vs +0.15 MiB**), but it removes catalog bloat an order of magnitude larger, so **total db growth is 5.6× smaller**. No degradation over 2,500 consecutive resets — page-level opportunistic pruning keeps data growth sub-linear and plateauing.

The author's own first measurement suggested the module got *slower* and said so honestly rather than cherry-picking; review established that number was sibling-load contamination.

## Correctness — the actual merge gate

The FK closure was derived **mechanically from `pg_constraint`** on a real migrated cluster, by author and reviewer independently:

- All 11 `TRUNCATE album_requests[, …] CASCADE` sites reach an identical **13-table** closure, byte-for-byte `REQUEST_CASCADE_RESET_TABLES`. `album_requests` dominates the closure, which is why every site converged.
- `make_db()`'s old 21-table CASCADE closure = **24 tables** = `_ALL_TABLES`, set-identical; the only public table excluded is `schema_migrations`.
- **There is no production SQL `TRUNCATE` anywhere in the repo.** The four `lib/` grep hits are `_TRUNCATED_COMPONENT_HASH_CHARS`, `_TRUNCATED_MARKER`, `_ENQUEUE_FAILURE_REASON_TRUNCATE_LEN` and comments.

### Two real PostgreSQL subtleties this uncovered

**1. `TRUNCATE` never fires row-level DELETE triggers; `DELETE` does.** Migration 066 installs three constraint triggers (`album_requests_complete_processing_owner`, `import_jobs_complete_processing_owner`, `processing_cleanup_journal_exact_owner`), all `AFTER … FOR EACH ROW … DEFERRABLE INITIALLY DEFERRED`. So the wrapping transaction is **load-bearing for correctness**, not for atomicity: with autocommit on and the same table order, `DELETE FROM album_requests` fires `import_jobs.request_id → SET NULL` and the journal's validator fails at that statement's commit:

```
CheckViolation: cleanup journal must belong to the exact active processing owner
leftover: {'album_requests': 3, 'processing_cleanup_journal': 1, 'import_jobs': 1, ...}
```

Consequence documented in the helper: callers must pass `album_requests`, `import_jobs` and `processing_cleanup_journal` **together**, not merely in order.

**2. `ON DELETE RESTRICT` fires at end-of-statement even when the FK is `DEFERRABLE INITIALLY DEFERRED`** — only the existence check defers, not the delete-time action. Hence `album_requests` must precede `import_jobs`. Reproduced from scratch twice.

## Kill matrix

| Site (assertion / clause / constant) | One-line mutant | Test that goes RED | Result |
| --- | --- | --- | --- |
| `REQUEST_CASCADE_RESET_TABLES` order | `import_jobs` before `album_requests` | `test_request_cascade_reset_tables_leaves_nothing_behind` | RED (`RestrictViolation`) |
| `_ALL_TABLES` order | same | `test_all_tables_leaves_nothing_behind` | RED (`RestrictViolation`) |
| `_ALL_TABLES` order | restore pre-change order (`album_requests` last) | same | RED |
| `delete_all_rows` txn wrapper | drop the transaction | real-PG reset test | RED (`CheckViolation`) |
| `delete_all_rows` commit | never `commit()` | same | RED |
| `delete_all_rows` SQL | `DELETE FROM {t} WHERE false` | same | RED (`UniqueViolation`) |
| missing-precondition path | `delete_all_rows(db, ["album_requests"])` on a live owner | `test_missing_predecessor_raises_and_leaves_the_world_untouched` | RED → rolled back, connection reusable |
| closed-connection reconnect | drive on `db.conn.closed` | same | old code `InterfaceError`; new code reconnects |
| `_ALL_TABLES` membership | drop `slskd_transfer_ledger` / `peer_observations` / `album_quality_evidence` | module tests | RED (cross-test leakage) |
| "leaves nothing behind" pin itself | drop a table from a local list copy | `test_known_bad_a_table_dropped_from_the_list_is_not_cleared` | known-bad self-test proving the pin isn't vacuous |

## Review

One independent review, six findings, all fixed. The most important: `delete_all_rows` was a hand-rolled copy of `_CoreMixin._atomic_locked()` — whose own docstring says it is *"the one place that flip lives"* — and the copy dropped both dead-connection guards and skipped `_ensure_conn()`, so a closed connection raised `InterfaceError` where the old path reconnected. Now delegates to `db._atomic()`, which closes the duplicate path and the guard gap together. Also corrected: "the only two RESTRICT FKs" (there are three), a stale `.claude/rules/pipeline-db.md` line that would have misdirected every future agent session, and a docstring quoting the synthetic 19× figure where the real reset cost is 2.2×.

## Stated residuals

- A table can still silently drop out of `_ALL_TABLES` unnoticed (dropping `user_cooldowns` or `album_quality_evidence_files` leaves all 573 tests green — the latter genuinely redundant via `ON DELETE CASCADE`). **Unchanged from the `TRUNCATE` list**, not a regression.
- Crossover at large row counts: with 3,200 rows in one reset, DELETE 88.0 ms vs TRUNCATE 6.7 ms, because 066's per-row deferred validators dominate. Real resets clear ~15 rows, so we are far from the operating point — but a future test seeding thousands of rows per case would flip the sign.
- `tests/test_deploy_hold.py` re-implements the delete loop inline against a raw psycopg2 connection (justified — no `_execute`), so the ordering contract lives at two sites.

No deploy: tests, test helpers, and one rule file — zero production surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
