### PR TITLE
perf(#1156 items 4-5): cache the deploy-fake shim's compiled bytecode across calls

### DIFF
--- a/tests/fakes/daily_flake_update.py
+++ b/tests/fakes/daily_flake_update.py
@@ -8,7 +8,11 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
-_FAKE_COMMAND = r'''#!/usr/bin/env python3
+_SHIM_MODULE = r'''# Shared body for the daily-flake-update fake git/nix/nix-shell commands.
+# Imported by a tiny stub (never executed directly as __main__) so CPython
+# compiles it once and caches the bytecode in __pycache__ across every fake
+# command invocation within one fixture directory, instead of recompiling
+# on every single subprocess spawn (issue #1156 items 4/5).
 import fcntl
 import json
 import os
@@ -16,150 +20,178 @@ import sys
 import time
 from pathlib import Path
 
-state_path = Path(os.environ["DAILY_UPDATE_FAKE_STATE"])
-with state_path.with_suffix(".lock").open("a+", encoding="utf-8") as lock:
-    fcntl.flock(lock, fcntl.LOCK_EX)
-    state = json.loads(state_path.read_text(encoding="utf-8"))
-    command = Path(sys.argv[0]).name
-    args = sys.argv[1:]
 
-    def save():
-        state_path.write_text(json.dumps(state, sort_keys=True), encoding="utf-8")
+def main():
+    state_path = Path(os.environ["DAILY_UPDATE_FAKE_STATE"])
+    with state_path.with_suffix(".lock").open("a+", encoding="utf-8") as lock:
+        fcntl.flock(lock, fcntl.LOCK_EX)
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+        command = Path(sys.argv[0]).name
+        args = sys.argv[1:]
 
-    def fail(message):
-        print(message, file=sys.stderr)
-        save()
-        raise SystemExit(1)
+        def save():
+            state_path.write_text(json.dumps(state, sort_keys=True), encoding="utf-8")
 
-    state["events"].append([command, *args])
-
-    if command == "git":
-        if args[:1] == ["clone"]:
-            clone_path = Path(args[-1])
-            clone_path.mkdir(parents=True)
-            clone_path.joinpath(".git").mkdir()
-            clone_path.joinpath("flake.lock").write_text(
-                json.dumps(state["seed_lock"], sort_keys=True), encoding="utf-8"
-            )
-            state["clone_path"] = str(clone_path)
-            state["lock_before"] = state["seed_lock"]
-        elif args == ["diff", "--quiet", "--", "flake.lock"]:
+        def fail(message):
+            print(message, file=sys.stderr)
             save()
-            raise SystemExit(1 if state["lock_changed"] else 0)
-        elif args[:2] == ["commit", "--only"]:
-            if state.get("fault") == "commit":
-                fail("fake commit failed")
-            state["commit_count"] += 1
-            state["commit_args"] = args
-            state["lock_at_commit"] = json.loads(
-                Path.cwd().joinpath("flake.lock").read_text(encoding="utf-8")
-            )
-        elif args[:2] == ["pull", "--rebase"]:
-            if state.get("fault") == "pull":
-                fail("fake rebase failed")
-            # A concurrent push to the branch is ordinary, not a canary
-            # failure: the runner rebases its lock-only commit onto it and
-            # the push that follows fast-forwards.
-            state["pull_count"] += 1
-            state["remote_moved"] = False
-        elif args[:2] == ["push", "origin"]:
-            if state.get("fault") == "push":
-                fail("fake push failed")
-            if state["remote_moved"]:
-                fail(
-                    "fake push rejected: remote contains work you do not have "
-                    "(the runner must rebase onto the branch before pushing)"
-                )
-            state["push_count"] += 1
-            state["push_ref"] = args[2]
-        else:
-            fail(f"unexpected git argv: {args!r}")
-        save()
-        raise SystemExit(0)
+            raise SystemExit(1)
 
-    if command == "nix":
-        if args[:2] == ["flake", "update"] and args[2:]:
-            targets = args[2:]
-            unknown = [t for t in targets if t not in state["seed_lock"]["nodes"]]
-            if unknown:
-                fail(f"unexpected flake update targets: {unknown!r}")
-            if state.get("fault") == "update":
-                fail("fake flake update failed")
-            if state["lock_changed"]:
-                lock_path = Path.cwd().joinpath("flake.lock")
-                lock = json.loads(lock_path.read_text(encoding="utf-8"))
-                for target in targets:
-                    lock["nodes"][target]["locked"]["rev"] = "new-" + target
-                lock_path.write_text(json.dumps(lock, sort_keys=True), encoding="utf-8")
-                state["lock_after_update"] = lock
+        state["events"].append([command, *args])
+
+        if command == "git":
+            if args[:1] == ["clone"]:
+                clone_path = Path(args[-1])
+                clone_path.mkdir(parents=True)
+                clone_path.joinpath(".git").mkdir()
+                clone_path.joinpath("flake.lock").write_text(
+                    json.dumps(state["seed_lock"], sort_keys=True), encoding="utf-8"
+                )
+                state["clone_path"] = str(clone_path)
+                state["lock_before"] = state["seed_lock"]
+            elif args == ["diff", "--quiet", "--", "flake.lock"]:
+                save()
+                raise SystemExit(1 if state["lock_changed"] else 0)
+            elif args[:2] == ["commit", "--only"]:
+                if state.get("fault") == "commit":
+                    fail("fake commit failed")
+                state["commit_count"] += 1
+                state["commit_args"] = args
+                state["lock_at_commit"] = json.loads(
+                    Path.cwd().joinpath("flake.lock").read_text(encoding="utf-8")
+                )
+            elif args[:2] == ["pull", "--rebase"]:
+                if state.get("fault") == "pull":
+                    fail("fake rebase failed")
+                # A concurrent push to the branch is ordinary, not a canary
+                # failure: the runner rebases its lock-only commit onto it and
+                # the push that follows fast-forwards.
+                state["pull_count"] += 1
+                state["remote_moved"] = False
+            elif args[:2] == ["push", "origin"]:
+                if state.get("fault") == "push":
+                    fail("fake push failed")
+                if state["remote_moved"]:
+                    fail(
+                        "fake push rejected: remote contains work you do not have "
+                        "(the runner must rebase onto the branch before pushing)"
+                    )
+                state["push_count"] += 1
+                state["push_ref"] = args[2]
+            else:
+                fail(f"unexpected git argv: {args!r}")
             save()
             raise SystemExit(0)
-        if args == [
-            "build",
-            ".#checks.x86_64-linux.beetsStableCandidate",
-            "--print-build-logs",
-        ]:
-            stage = "stable-candidate"
-        elif args == [
-            "develop",
-            ".#tip",
-            "--command",
-            "bash",
-            "scripts/run_tests.sh",
-        ]:
-            stage = "tip-suite"
-        else:
-            fail(f"unexpected nix argv: {args!r}")
-    elif command == "nix-shell":
-        if args[:1] != ["--run"] or len(args) != 2:
-            fail(f"unexpected nix-shell argv: {args!r}")
-        shell_command = args[1]
-        if shell_command == "bash scripts/run_tests.sh":
-            stage = "suite"
-        elif shell_command == "bash scripts/fuzz_burst.sh":
-            stage = "fuzz"
-        elif shell_command == "bash scripts/world_model_burst.sh":
-            stage = (
-                "mirror"
-                if os.environ.get("CRATEDIGGER_WORLD_ENGINE") == "mirror-harness"
-                else "world"
-            )
-        else:
-            fail(f"unexpected nix-shell command: {shell_command!r}")
-    else:
-        fail(f"unexpected fake command: {command}")
 
-    state["stage_started"].append(stage)
-    save()
-    if state.get("hold_stage") == stage:
-        time.sleep(float(state.get("hold_seconds", 0.25)))
-    state["stages"].append(stage)
-    state["stage_env"][stage] = {
-        "TEST_DB_DSN": os.environ.get("TEST_DB_DSN"),
-        "CRATEDIGGER_WORLD_DATABASE": os.environ.get(
-            "CRATEDIGGER_WORLD_DATABASE"
-        ),
-        "CRATEDIGGER_WORLD_ENGINE": os.environ.get("CRATEDIGGER_WORLD_ENGINE"),
-        "CRATEDIGGER_WORLD_MIRROR_URL": os.environ.get(
-            "CRATEDIGGER_WORLD_MIRROR_URL"
-        ),
-        "CRATEDIGGER_WORLD_EXAMPLES": os.environ.get(
-            "CRATEDIGGER_WORLD_EXAMPLES"
-        ),
-        "CRATEDIGGER_WORLD_STEPS": os.environ.get("CRATEDIGGER_WORLD_STEPS"),
-        "HYPOTHESIS_STORAGE_DIRECTORY": os.environ.get(
-            "HYPOTHESIS_STORAGE_DIRECTORY"
-        ),
-        "CRATEDIGGER_FUZZ_OUTPUT_DIR": os.environ.get(
-            "CRATEDIGGER_FUZZ_OUTPUT_DIR"
-        ),
-        "CRATEDIGGER_FUZZ_MAX_EXAMPLES": os.environ.get(
-            "CRATEDIGGER_FUZZ_MAX_EXAMPLES"
-        ),
-    }
-    if state.get("fault") == stage:
-        fail(f"fake {stage} failed")
-    save()
+        if command == "nix":
+            if args[:2] == ["flake", "update"] and args[2:]:
+                targets = args[2:]
+                unknown = [t for t in targets if t not in state["seed_lock"]["nodes"]]
+                if unknown:
+                    fail(f"unexpected flake update targets: {unknown!r}")
+                if state.get("fault") == "update":
+                    fail("fake flake update failed")
+                if state["lock_changed"]:
+                    lock_path = Path.cwd().joinpath("flake.lock")
+                    lock = json.loads(lock_path.read_text(encoding="utf-8"))
+                    for target in targets:
+                        lock["nodes"][target]["locked"]["rev"] = "new-" + target
+                    lock_path.write_text(json.dumps(lock, sort_keys=True), encoding="utf-8")
+                    state["lock_after_update"] = lock
+                save()
+                raise SystemExit(0)
+            if args == [
+                "build",
+                ".#checks.x86_64-linux.beetsStableCandidate",
+                "--print-build-logs",
+            ]:
+                stage = "stable-candidate"
+            elif args == [
+                "develop",
+                ".#tip",
+                "--command",
+                "bash",
+                "scripts/run_tests.sh",
+            ]:
+                stage = "tip-suite"
+            else:
+                fail(f"unexpected nix argv: {args!r}")
+        elif command == "nix-shell":
+            if args[:1] != ["--run"] or len(args) != 2:
+                fail(f"unexpected nix-shell argv: {args!r}")
+            shell_command = args[1]
+            if shell_command == "bash scripts/run_tests.sh":
+                stage = "suite"
+            elif shell_command == "bash scripts/fuzz_burst.sh":
+                stage = "fuzz"
+            elif shell_command == "bash scripts/world_model_burst.sh":
+                stage = (
+                    "mirror"
+                    if os.environ.get("CRATEDIGGER_WORLD_ENGINE") == "mirror-harness"
+                    else "world"
+                )
+            else:
+                fail(f"unexpected nix-shell command: {shell_command!r}")
+        else:
+            fail(f"unexpected fake command: {command}")
+
+        state["stage_started"].append(stage)
+        save()
+        if state.get("hold_stage") == stage:
+            time.sleep(float(state.get("hold_seconds", 0.25)))
+        state["stages"].append(stage)
+        state["stage_env"][stage] = {
+            "TEST_DB_DSN": os.environ.get("TEST_DB_DSN"),
+            "CRATEDIGGER_WORLD_DATABASE": os.environ.get(
+                "CRATEDIGGER_WORLD_DATABASE"
+            ),
+            "CRATEDIGGER_WORLD_ENGINE": os.environ.get("CRATEDIGGER_WORLD_ENGINE"),
+            "CRATEDIGGER_WORLD_MIRROR_URL": os.environ.get(
+                "CRATEDIGGER_WORLD_MIRROR_URL"
+            ),
+            "CRATEDIGGER_WORLD_EXAMPLES": os.environ.get(
+                "CRATEDIGGER_WORLD_EXAMPLES"
+            ),
+            "CRATEDIGGER_WORLD_STEPS": os.environ.get("CRATEDIGGER_WORLD_STEPS"),
+            "HYPOTHESIS_STORAGE_DIRECTORY": os.environ.get(
+                "HYPOTHESIS_STORAGE_DIRECTORY"
+            ),
+            "CRATEDIGGER_FUZZ_OUTPUT_DIR": os.environ.get(
+                "CRATEDIGGER_FUZZ_OUTPUT_DIR"
+            ),
+            "CRATEDIGGER_FUZZ_MAX_EXAMPLES": os.environ.get(
+                "CRATEDIGGER_FUZZ_MAX_EXAMPLES"
+            ),
+        }
+        if state.get("fault") == stage:
+            fail(f"fake {stage} failed")
+        save()
+'''
+
+# `command` stays a tiny stub, not the shim body itself -- the body lives in
+# one shared `_shim.py` module written once per fixture instance (see
+# FakeDailyFlakeUpdateCommands.__init__). CPython never caches bytecode for
+# a script run directly as __main__, so leaving the shim body inline here
+# would recompile it from source on every fake command invocation; importing
+# it instead lets CPython write `__pycache__/_shim.cpython-*.pyc` once and
+# reuse it for the rest (issue #1156 item 5, same fix as item 4's
+# tests/fakes/deploy_pin.py). `-S` skips `site` for faster startup (issue
+# #1156 item 5 also brings this sibling onto the #1152 startup fix). `-S`
+# does not remove the interpreter's own insertion of the running script's
+# directory as sys.path[0] -- that happens regardless of `site` -- but the
+# mechanism is made explicit here (via `__file__`) rather than relied on
+# implicitly. `git`/`nix`/`nix-shell` remain symlinks to this one file, same
+# as before; a symlink's own path (not its target) is what `__file__`
+# resolves to for a directly-run script, so this still finds `_shim.py`
+# alongside the symlink itself.
+_STUB_COMMAND = r'''#!/usr/bin/env -S python3 -S
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _shim
+
+_shim.main()
 '''
 
 
@@ -184,8 +216,12 @@ class FakeDailyFlakeUpdateCommands:
         # test-only relocation should paper over.
         self.tmpdir = root / "tmp"
         self.tmpdir.mkdir()
+        # The heavy shim body is written once as an importable module so
+        # CPython caches its compiled bytecode in __pycache__ across every
+        # fake command invocation (issue #1156 item 5).
+        (self.fake_bin / "_shim.py").write_text(_SHIM_MODULE, encoding="utf-8")
         command = self.fake_bin / "command"
-        command.write_text(_FAKE_COMMAND, encoding="utf-8")
+        command.write_text(_STUB_COMMAND, encoding="utf-8")
         command.chmod(0o755)
         for name in ("git", "nix", "nix-shell"):
             (self.fake_bin / name).symlink_to(command)

--- a/tests/fakes/daily_flake_update.py
+++ b/tests/fakes/daily_flake_update.py
@@ -176,19 +176,16 @@ def main():
 # it instead lets CPython write `__pycache__/_shim.cpython-*.pyc` once and
 # reuse it for the rest (issue #1156 item 5, same fix as item 4's
 # tests/fakes/deploy_pin.py). `-S` skips `site` for faster startup (issue
-# #1156 item 5 also brings this sibling onto the #1152 startup fix). `-S`
-# does not remove the interpreter's own insertion of the running script's
-# directory as sys.path[0] -- that happens regardless of `site` -- but the
-# mechanism is made explicit here (via `__file__`) rather than relied on
-# implicitly. `git`/`nix`/`nix-shell` remain symlinks to this one file, same
-# as before; a symlink's own path (not its target) is what `__file__`
-# resolves to for a directly-run script, so this still finds `_shim.py`
-# alongside the symlink itself.
+# #1156 item 5 also brings this sibling onto the #1152 startup fix). No
+# explicit sys.path manipulation: the interpreter inserts the running
+# script's own directory as sys.path[0] before user code executes, `-S`
+# does not change that, and `_shim.py` always sits beside this stub in the
+# same fixture directory -- so a bare `import _shim` already resolves.
+# `git`/`nix`/`nix-shell` remain symlinks to this one file, same as before;
+# a symlink's own path (not its target) is what the interpreter uses for
+# sys.path[0], and both the symlink and `_shim.py` live in the same
+# directory, so this still finds it.
 _STUB_COMMAND = r'''#!/usr/bin/env -S python3 -S
-import os
-import sys
-
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import _shim
 
 _shim.main()
@@ -283,12 +280,9 @@ class FakeDailyFlakeUpdateCommands:
         state.update(changes)
         self._write_state(state)
 
-    def run(
-        self,
-        script: Path,
-        *,
-        extra_env: dict[str, str] | None = None,
-    ) -> subprocess.CompletedProcess[str]:
+    def environment(
+        self, *, extra_env: dict[str, str] | None = None
+    ) -> dict[str, str]:
         env = os.environ.copy()
         env.update(
             {
@@ -306,10 +300,18 @@ class FakeDailyFlakeUpdateCommands:
         )
         if extra_env:
             env.update(extra_env)
+        return env
+
+    def run(
+        self,
+        script: Path,
+        *,
+        extra_env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
             ["bash", str(script)],
             cwd=self.root,
-            env=env,
+            env=self.environment(extra_env=extra_env),
             capture_output=True,
             text=True,
             check=False,

--- a/tests/fakes/deploy_cycle.py
+++ b/tests/fakes/deploy_cycle.py
@@ -122,17 +122,12 @@ def main():
 # instead lets CPython write `__pycache__/_shim.cpython-*.pyc` once and
 # reuse it for the rest (issue #1156 item 5, same fix as item 4's
 # tests/fakes/deploy_pin.py). `-S` skips `site` for faster startup (issue
-# #1156 item 5 also brings this sibling onto the #1152 startup fix). `-S`
-# does not remove the interpreter's own insertion of the running script's
-# directory as sys.path[0] -- that happens regardless of `site` -- but the
-# mechanism is made explicit here (via `__file__`) rather than relied on
-# implicitly, and it is independent of the process's current working
-# directory.
+# #1156 item 5 also brings this sibling onto the #1152 startup fix). No
+# explicit sys.path manipulation: the interpreter inserts the running
+# script's own directory as sys.path[0] before user code executes, `-S`
+# does not change that, and `_shim.py` always sits beside this stub in the
+# same fixture directory -- so a bare `import _shim` already resolves.
 _STUB_SSH = r'''#!/usr/bin/env -S python3 -S
-import os
-import sys
-
-sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import _shim
 
 _shim.main()
@@ -292,12 +287,7 @@ class FakeDeployCycleCommands:
             encoding="utf-8",
         )
 
-    def run(
-        self,
-        script: Path,
-        *args: str,
-        max_polls: int = 4,
-    ) -> subprocess.CompletedProcess[str]:
+    def environment(self, *, max_polls: int = 4) -> dict[str, str]:
         env = os.environ.copy()
         env.update(
             {
@@ -308,11 +298,19 @@ class FakeDeployCycleCommands:
                 "CRATEDIGGER_CYCLE_VERIFY_TIMEOUT_SECONDS": "60",
             }
         )
+        return env
+
+    def run(
+        self,
+        script: Path,
+        *args: str,
+        max_polls: int = 4,
+    ) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
             [str(script), *args],
             text=True,
             capture_output=True,
-            env=env,
+            env=self.environment(max_polls=max_polls),
             check=False,
         )
 

--- a/tests/fakes/deploy_cycle.py
+++ b/tests/fakes/deploy_cycle.py
@@ -8,110 +8,134 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
-_FAKE_SSH = r'''#!/usr/bin/env python3
+_SHIM_MODULE = r'''# Shared body for the deploy-cycle-verifier fake ssh command. Imported by a
+# tiny stub (never executed directly as __main__) so CPython compiles it
+# once and caches the bytecode in __pycache__ across every fake ssh
+# invocation, instead of recompiling on each one (issue #1156 item 5).
 import json
 import os
 import re
 import sys
 from pathlib import Path
 
-state_path = Path(os.environ["DEPLOY_CYCLE_FAKE_STATE"])
-state = json.loads(state_path.read_text(encoding="utf-8"))
-args = sys.argv[1:]
-remote = " ".join(args)
-state["events"].append(["ssh", *args])
 
+def main():
+    state_path = Path(os.environ["DEPLOY_CYCLE_FAKE_STATE"])
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    args = sys.argv[1:]
+    remote = " ".join(args)
+    state["events"].append(["ssh", *args])
 
-def save():
-    state_path.write_text(json.dumps(state, sort_keys=True), encoding="utf-8")
+    def save():
+        state_path.write_text(json.dumps(state, sort_keys=True), encoding="utf-8")
 
-
-agent_disabled = any(
-    args[index] == "-o"
-    and index + 1 < len(args)
-    and args[index + 1] == "IdentityAgent=none"
-    for index in range(len(args))
-) or "-oIdentityAgent=none" in args
-if state["forced_agent_present"] and not agent_disabled:
-    state["forced_command_hits"] += 1
-    save()
-    raise SystemExit(0)
-
-
-# A real read can fail outright: an unreachable host, a systemctl that exits
-# non-zero. The verifier's `die "could not read ..."` branches exist for that
-# world, so the fake has to be able to produce it -- otherwise those branches
-# are unreachable from every test and a regression there is invisible (#1172
-# item 6). Exit 255 is ssh's own transport-failure code.
-for fragment in state["ssh_failures"]:
-    if fragment in remote:
-        print(f"ssh: connect to host: {fragment}", file=sys.stderr)
+    agent_disabled = any(
+        args[index] == "-o"
+        and index + 1 < len(args)
+        and args[index + 1] == "IdentityAgent=none"
+        for index in range(len(args))
+    ) or "-oIdentityAgent=none" in args
+    if state["forced_agent_present"] and not agent_disabled:
+        state["forced_command_hits"] += 1
         save()
-        raise SystemExit(255)
+        raise SystemExit(0)
 
+    # A real read can fail outright: an unreachable host, a systemctl that exits
+    # non-zero. The verifier's `die "could not read ..."` branches exist for that
+    # world, so the fake has to be able to produce it -- otherwise those branches
+    # are unreachable from every test and a regression there is invisible (#1172
+    # item 6). Exit 255 is ssh's own transport-failure code.
+    for fragment in state["ssh_failures"]:
+        if fragment in remote:
+            print(f"ssh: connect to host: {fragment}", file=sys.stderr)
+            save()
+            raise SystemExit(255)
 
-def show_properties(current):
-    """Emit only the properties the command actually asked for, in the order
-    real `systemctl show` uses. Printing all four unconditionally would let a
-    dropped `--property=` survive every test while breaking every real deploy
-    (the caller's sed would yield an empty value)."""
-    for key in ("ActiveState", "SubState", "InvocationID", "Result"):
-        if f"--property={key}" in remote:
-            print(f"{key}={current.get(key, '')}")
+    def show_properties(current):
+        """Emit only the properties the command actually asked for, in the order
+        real `systemctl show` uses. Printing all four unconditionally would let a
+        dropped `--property=` survive every test while breaking every real deploy
+        (the caller's sed would yield an empty value)."""
+        for key in ("ActiveState", "SubState", "InvocationID", "Result"):
+            if f"--property={key}" in remote:
+                print(f"{key}={current.get(key, '')}")
 
-
-if "systemctl show cratedigger-db-migrate.service" in remote:
-    states = state["migrate_states"]
-    index = min(state["migrate_state_index"], len(states) - 1)
-    current = states[index]
-    state["migrate_state_index"] += 1
-    show_properties(current)
-    save()
-    raise SystemExit(0)
-
-if "systemctl show cratedigger.service" in remote:
-    states = state["system_states"]
-    index = min(state["system_state_index"], len(states) - 1)
-    current = states[index]
-    state["system_state_index"] += 1
-    show_properties(current)
-    save()
-    raise SystemExit(0)
-
-if "journalctl" in remote and "--show-cursor" in remote:
-    print("-- No entries --")
-    print(f"-- cursor: {state['cursor']}")
-    save()
-    raise SystemExit(0)
-
-if "journalctl" in remote and "--after-cursor=" in remote:
-    snapshots = state["start_journal_snapshots"]
-    index = min(state["start_journal_index"], len(snapshots) - 1)
-    state["start_journal_index"] += 1
-    for record in snapshots[index]:
-        print(json.dumps(record, sort_keys=True))
-    save()
-    raise SystemExit(0)
-
-if "journalctl" in remote and "--invocation=" in remote:
-    match = re.search(r"--invocation=([0-9a-f]{32})", remote)
-    if match is None:
-        print(f"invalid invocation command: {remote}", file=sys.stderr)
+    if "systemctl show cratedigger-db-migrate.service" in remote:
+        states = state["migrate_states"]
+        index = min(state["migrate_state_index"], len(states) - 1)
+        current = states[index]
+        state["migrate_state_index"] += 1
+        show_properties(current)
         save()
-        raise SystemExit(2)
-    invocation = match.group(1)
-    snapshots = state["journal_snapshots"].get(invocation, [[]])
-    journal_indexes = state["journal_indexes"]
-    index = min(journal_indexes.get(invocation, 0), len(snapshots) - 1)
-    journal_indexes[invocation] = index + 1
-    for record in snapshots[index]:
-        print(json.dumps(record, sort_keys=True))
-    save()
-    raise SystemExit(0)
+        raise SystemExit(0)
 
-print(f"unexpected fake ssh command: {args!r}", file=sys.stderr)
-save()
-raise SystemExit(2)
+    if "systemctl show cratedigger.service" in remote:
+        states = state["system_states"]
+        index = min(state["system_state_index"], len(states) - 1)
+        current = states[index]
+        state["system_state_index"] += 1
+        show_properties(current)
+        save()
+        raise SystemExit(0)
+
+    if "journalctl" in remote and "--show-cursor" in remote:
+        print("-- No entries --")
+        print(f"-- cursor: {state['cursor']}")
+        save()
+        raise SystemExit(0)
+
+    if "journalctl" in remote and "--after-cursor=" in remote:
+        snapshots = state["start_journal_snapshots"]
+        index = min(state["start_journal_index"], len(snapshots) - 1)
+        state["start_journal_index"] += 1
+        for record in snapshots[index]:
+            print(json.dumps(record, sort_keys=True))
+        save()
+        raise SystemExit(0)
+
+    if "journalctl" in remote and "--invocation=" in remote:
+        match = re.search(r"--invocation=([0-9a-f]{32})", remote)
+        if match is None:
+            print(f"invalid invocation command: {remote}", file=sys.stderr)
+            save()
+            raise SystemExit(2)
+        invocation = match.group(1)
+        snapshots = state["journal_snapshots"].get(invocation, [[]])
+        journal_indexes = state["journal_indexes"]
+        index = min(journal_indexes.get(invocation, 0), len(snapshots) - 1)
+        journal_indexes[invocation] = index + 1
+        for record in snapshots[index]:
+            print(json.dumps(record, sort_keys=True))
+        save()
+        raise SystemExit(0)
+
+    print(f"unexpected fake ssh command: {args!r}", file=sys.stderr)
+    save()
+    raise SystemExit(2)
+'''
+
+# `ssh` stays a tiny stub, not the shim body itself -- the body lives in one
+# shared `_shim.py` module written once per fixture instance (see
+# FakeDeployCycleCommands.__init__). CPython never caches bytecode for a
+# script run directly as __main__, so leaving the shim body inline here
+# would recompile it from source on every fake ssh invocation; importing it
+# instead lets CPython write `__pycache__/_shim.cpython-*.pyc` once and
+# reuse it for the rest (issue #1156 item 5, same fix as item 4's
+# tests/fakes/deploy_pin.py). `-S` skips `site` for faster startup (issue
+# #1156 item 5 also brings this sibling onto the #1152 startup fix). `-S`
+# does not remove the interpreter's own insertion of the running script's
+# directory as sys.path[0] -- that happens regardless of `site` -- but the
+# mechanism is made explicit here (via `__file__`) rather than relied on
+# implicitly, and it is independent of the process's current working
+# directory.
+_STUB_SSH = r'''#!/usr/bin/env -S python3 -S
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import _shim
+
+_shim.main()
 '''
 
 
@@ -137,8 +161,12 @@ class FakeDeployCycleCommands:
         self.fake_bin = root / "bin"
         self.state_path = root / "state.json"
         self.fake_bin.mkdir()
+        # The heavy shim body is written once as an importable module so
+        # CPython caches its compiled bytecode in __pycache__ across every
+        # fake ssh invocation (issue #1156 item 5).
+        (self.fake_bin / "_shim.py").write_text(_SHIM_MODULE, encoding="utf-8")
         ssh = self.fake_bin / "ssh"
-        ssh.write_text(_FAKE_SSH, encoding="utf-8")
+        ssh.write_text(_STUB_SSH, encoding="utf-8")
         ssh.chmod(0o755)
         self.write_state(
             system_states=[self.system_state(self.OLD)],

--- a/tests/fakes/deploy_pin.py
+++ b/tests/fakes/deploy_pin.py
@@ -8,8 +8,14 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
-_FAKE_COMMAND = r'''#!/usr/bin/env -S python3 -S
-# -S skips `site` import for faster startup: this shim must stay stdlib-only.
+_SHIM_MODULE = r'''# Shared body for the nixosconfig deploy-pin fake git/nix/hostname commands.
+# Imported by a tiny per-command stub (never executed directly as __main__)
+# so CPython compiles it once and caches the bytecode in __pycache__: the
+# ~28 subprocess spawns per script run (tests/fakes/deploy_pin.py profiling,
+# issue #1131 -- 26 git + 1 nix + 1 hostname) then load the cached .pyc
+# instead of recompiling this whole body from source on every single one
+# (issue #1156 item 4). Must stay stdlib-only -- the stub invoking main()
+# runs with `-S` (skips `site`).
 import fcntl
 import json
 import os
@@ -22,194 +28,212 @@ import time
 # time and this fake never needs anything from it beyond this one constant.
 SIGTERM = 15
 
-state_path = os.environ["DEPLOY_PIN_FAKE_STATE"]
-lock_path = os.path.splitext(state_path)[0] + ".lock"
-state_lock = open(lock_path, "a+", encoding="utf-8")
-fcntl.flock(state_lock, fcntl.LOCK_EX)
-with open(state_path, encoding="utf-8") as _f:
-    state = json.loads(_f.read())
-command = os.path.basename(sys.argv[0])
-raw_args = sys.argv[1:]
 
-
-def save():
-    with open(state_path, "w", encoding="utf-8") as _f:
-        _f.write(json.dumps(state, sort_keys=True))
-
-
-def fail(message):
-    print(message, file=sys.stderr)
-    save()
-    raise SystemExit(1)
-
-
-def rmtree(path):
-    """Best-effort recursive delete -- avoids importing `shutil` per call.
-    Matches shutil.rmtree(ignore_errors=True) for a real directory or a
-    missing path, the only two shapes this fake ever produces (it only
-    ever deletes a plain directory it itself created via os.makedirs()).
-    Diverges for a non-directory root: shutil's ignore_errors=True leaves
-    a file/symlink root untouched, this unlinks that one entry instead --
-    unreachable here, but not identical, so said plainly rather than
-    claimed away. It never follows a symlink out of the tree: a symlinked
-    child is unlinked, never descended into."""
-    if not os.path.isdir(path) or os.path.islink(path):
-        try:
-            os.remove(path)
-        except OSError:
-            pass
-        return
-    try:
-        entries = os.listdir(path)
-    except OSError:
-        return
-    for name in entries:
-        rmtree(os.path.join(path, name))
-    try:
-        os.rmdir(path)
-    except OSError:
-        pass
-
-
-def lock_payload(revision):
-    return json.dumps({
-        "nodes": {
-            "cratedigger-src": {
-                # Mirrors the real flake input's unpinned `original` node
-                # (github:abl030/cratedigger, no ref) -- production derives
-                # its `--override-input` ref from exactly this shape, never
-                # a hardcoded string, so the fake must carry it too.
-                "original": dict(state["cratedigger_input_original"]),
-                "locked": {"rev": revision},
-            },
-        },
-    }) + "\n"
-
-
-def live_remote_object():
-    return {
-        "parent": state["remote_parent"],
-        "target": state["remote_target"],
-        "signature_status": state["remote_signature_status"],
-        "lock_readable": state["remote_lock_readable"],
-    }
-
-
-def capture_live_remote():
-    revision = state["remote_rev"]
-    state["captured_objects"][revision] = live_remote_object()
-    state["fetched_rev"] = revision
-    return revision
-
-
-def move_live_remote():
-    state["remote_rev"] = state["moved_remote_rev"]
-    state["remote_parent"] = state["moved_remote_parent"]
-    state["remote_target"] = state["moved_remote_target"]
-    state["remote_signature_status"] = state["moved_remote_signature_status"]
-    state["remote_lock_readable"] = state["moved_remote_lock_readable"]
-
-
-def captured_object(revision):
-    return state["commits"].get(revision) or state["captured_objects"].get(revision)
-
-
-state["argv_calls"].append([command, *raw_args])
-
-if (
-    command == "git"
-    and os.environ.get("GIT_TRACE2")
-    and "GIT_CONFIG_VALUE_0" in os.environ.get("GIT_TRACE2_ENV_VARS", "")
-    and os.environ.get("GIT_CONFIG_VALUE_0")
-):
-    print(
-        "trace2: GIT_CONFIG_VALUE_0=" + os.environ["GIT_CONFIG_VALUE_0"],
-        file=sys.stderr,
-    )
-
-if command == "hostname":
-    print(state.get("hostname", "proxmox-vm"))
-    save()
-    raise SystemExit(0)
-
-if command == "nix":
-    state["events"].append(["nix", *raw_args])
-    save()
-    time.sleep(state.get("nix_delay_seconds", 0))
+def main():
+    state_path = os.environ["DEPLOY_PIN_FAKE_STATE"]
+    lock_path = os.path.splitext(state_path)[0] + ".lock"
+    state_lock = open(lock_path, "a+", encoding="utf-8")
+    fcntl.flock(state_lock, fcntl.LOCK_EX)
     with open(state_path, encoding="utf-8") as _f:
         state = json.loads(_f.read())
-    if state.get("fault") == "nix":
-        fail("fake nix update failed")
-    override_marker = ["--override-input", "cratedigger-src"]
-    if raw_args[:3] == ["flake", "update", "cratedigger-src"] and (
-        raw_args[3:5] == override_marker
+    command = os.path.basename(sys.argv[0])
+    raw_args = sys.argv[1:]
+
+    def save():
+        with open(state_path, "w", encoding="utf-8") as _f:
+            _f.write(json.dumps(state, sort_keys=True))
+
+    def fail(message):
+        print(message, file=sys.stderr)
+        save()
+        raise SystemExit(1)
+
+    def rmtree(path):
+        """Best-effort recursive delete -- avoids importing `shutil` per call.
+        Matches shutil.rmtree(ignore_errors=True) for a real directory or a
+        missing path, the only two shapes this fake ever produces (it only
+        ever deletes a plain directory it itself created via os.makedirs()).
+        Diverges for a non-directory root: shutil's ignore_errors=True leaves
+        a file/symlink root untouched, this unlinks that one entry instead --
+        unreachable here, but not identical, so said plainly rather than
+        claimed away. It never follows a symlink out of the tree: a symlinked
+        child is unlinked, never descended into."""
+        if not os.path.isdir(path) or os.path.islink(path):
+            try:
+                os.remove(path)
+            except OSError:
+                pass
+            return
+        try:
+            entries = os.listdir(path)
+        except OSError:
+            return
+        for name in entries:
+            rmtree(os.path.join(path, name))
+        try:
+            os.rmdir(path)
+        except OSError:
+            pass
+
+    def lock_payload(revision):
+        return json.dumps({
+            "nodes": {
+                "cratedigger-src": {
+                    # Mirrors the real flake input's unpinned `original` node
+                    # (github:abl030/cratedigger, no ref) -- production derives
+                    # its `--override-input` ref from exactly this shape, never
+                    # a hardcoded string, so the fake must carry it too.
+                    "original": dict(state["cratedigger_input_original"]),
+                    "locked": {"rev": revision},
+                },
+            },
+        }) + "\n"
+
+    def live_remote_object():
+        return {
+            "parent": state["remote_parent"],
+            "target": state["remote_target"],
+            "signature_status": state["remote_signature_status"],
+            "lock_readable": state["remote_lock_readable"],
+        }
+
+    def capture_live_remote():
+        revision = state["remote_rev"]
+        state["captured_objects"][revision] = live_remote_object()
+        state["fetched_rev"] = revision
+        return revision
+
+    def move_live_remote():
+        state["remote_rev"] = state["moved_remote_rev"]
+        state["remote_parent"] = state["moved_remote_parent"]
+        state["remote_target"] = state["moved_remote_target"]
+        state["remote_signature_status"] = state["moved_remote_signature_status"]
+        state["remote_lock_readable"] = state["moved_remote_lock_readable"]
+
+    def captured_object(revision):
+        return state["commits"].get(revision) or state["captured_objects"].get(revision)
+
+    state["argv_calls"].append([command, *raw_args])
+
+    if (
+        command == "git"
+        and os.environ.get("GIT_TRACE2")
+        and "GIT_CONFIG_VALUE_0" in os.environ.get("GIT_TRACE2_ENV_VARS", "")
+        and os.environ.get("GIT_CONFIG_VALUE_0")
     ):
-        # Production derives this ref from flake.lock's own cratedigger-src
-        # `original` node and never hardcodes it -- parse it back out here
-        # so a test can prove the SCRIPT actually derived it (rather than
-        # this fake just trusting DEPLOY_PIN_FAKE_TARGET), and so a mutant
-        # that reverts to a plain `nix flake update cratedigger-src` (no
-        # override) is caught: that shape falls through to the branch_tip
-        # case below instead of pinning the requested revision.
-        if len(raw_args) != 6:
-            fail(f"unexpected nix argv: {raw_args!r}")
-        ref = raw_args[5]
-        scheme, _, path = ref.partition(":")
-        segments = path.split("/")
-        if scheme != "github" or len(segments) != 3 or not segments[2]:
-            fail(f"unparseable override-input ref: {ref!r}")
-        revision = segments[2]
-        if state.get("fault") == "nix_missing_revision":
-            fail(f"fake nix: revision does not exist on remote: {revision}")
-        target_pin = revision
-    elif raw_args == ["flake", "update", "cratedigger-src"]:
-        # The plain (no-override) form now models what production used to
-        # do: follow whatever the branch currently resolves to, which is
-        # NOT necessarily the requested target. Reachable only by a mutant
-        # that drops the --override-input argv.
-        target_pin = state["branch_tip"]
-    else:
-        fail(f"unexpected nix argv: {raw_args!r}")
-    if state["remote_move_on_nix"]:
-        move_live_remote()
-    with open(os.path.join(os.getcwd(), "flake.lock"), "w", encoding="utf-8") as _f:
-        _f.write(lock_payload(target_pin))
-    save()
-    raise SystemExit(0)
+        print(
+            "trace2: GIT_CONFIG_VALUE_0=" + os.environ["GIT_CONFIG_VALUE_0"],
+            file=sys.stderr,
+        )
 
-if command != "git":
-    fail(f"unexpected fake command: {command}")
+    if command == "hostname":
+        print(state.get("hostname", "proxmox-vm"))
+        save()
+        raise SystemExit(0)
 
-args = list(raw_args)
-cwd = os.getcwd()
-if args[:1] == ["-C"]:
-    cwd = args[1]
-    args = args[2:]
-
-if args[:1] == ["fetch"]:
-    state["events"].append(["fetch", capture_live_remote()])
-elif args == ["remote", "get-url", "origin"]:
-    print(state["origin_url"])
-elif args == ["remote", "get-url", "--all", "origin"]:
-    print("\n".join(state["fetch_urls"]))
-elif args == ["remote", "get-url", "--push", "--all", "origin"]:
-    print("\n".join(state["push_urls"]))
-elif args == ["rev-parse", "--path-format=absolute", "--git-common-dir"]:
-    print(state["git_common_dir"])
-elif args == ["rev-parse", "refs/remotes/origin/master"]:
-    print(state["fetched_rev"])
-elif args[:3] == ["rev-parse", "--verify", "--quiet"]:
-    ref = args[3]
-    value = (
-        state.get("pending_rev")
-        if ref == "refs/cratedigger-deploy/cratedigger-src-pending"
-        else state.get("receipt_rev")
-    )
-    if value:
-        if (
-            state.get("fault") == "post_commit_rev_parse"
-            and state.get("pending_rev") in state["commits"]
+    if command == "nix":
+        state["events"].append(["nix", *raw_args])
+        save()
+        time.sleep(state.get("nix_delay_seconds", 0))
+        with open(state_path, encoding="utf-8") as _f:
+            state = json.loads(_f.read())
+        if state.get("fault") == "nix":
+            fail("fake nix update failed")
+        override_marker = ["--override-input", "cratedigger-src"]
+        if raw_args[:3] == ["flake", "update", "cratedigger-src"] and (
+            raw_args[3:5] == override_marker
         ):
+            # Production derives this ref from flake.lock's own cratedigger-src
+            # `original` node and never hardcodes it -- parse it back out here
+            # so a test can prove the SCRIPT actually derived it (rather than
+            # this fake just trusting DEPLOY_PIN_FAKE_TARGET), and so a mutant
+            # that reverts to a plain `nix flake update cratedigger-src` (no
+            # override) is caught: that shape falls through to the branch_tip
+            # case below instead of pinning the requested revision.
+            if len(raw_args) != 6:
+                fail(f"unexpected nix argv: {raw_args!r}")
+            ref = raw_args[5]
+            scheme, _, path = ref.partition(":")
+            segments = path.split("/")
+            if scheme != "github" or len(segments) != 3 or not segments[2]:
+                fail(f"unparseable override-input ref: {ref!r}")
+            revision = segments[2]
+            if state.get("fault") == "nix_missing_revision":
+                fail(f"fake nix: revision does not exist on remote: {revision}")
+            target_pin = revision
+        elif raw_args == ["flake", "update", "cratedigger-src"]:
+            # The plain (no-override) form now models what production used to
+            # do: follow whatever the branch currently resolves to, which is
+            # NOT necessarily the requested target. Reachable only by a mutant
+            # that drops the --override-input argv.
+            target_pin = state["branch_tip"]
+        else:
+            fail(f"unexpected nix argv: {raw_args!r}")
+        if state["remote_move_on_nix"]:
+            move_live_remote()
+        with open(os.path.join(os.getcwd(), "flake.lock"), "w", encoding="utf-8") as _f:
+            _f.write(lock_payload(target_pin))
+        save()
+        raise SystemExit(0)
+
+    if command != "git":
+        fail(f"unexpected fake command: {command}")
+
+    args = list(raw_args)
+    cwd = os.getcwd()
+    if args[:1] == ["-C"]:
+        cwd = args[1]
+        args = args[2:]
+
+    if args[:1] == ["fetch"]:
+        state["events"].append(["fetch", capture_live_remote()])
+    elif args == ["remote", "get-url", "origin"]:
+        print(state["origin_url"])
+    elif args == ["remote", "get-url", "--all", "origin"]:
+        print("\n".join(state["fetch_urls"]))
+    elif args == ["remote", "get-url", "--push", "--all", "origin"]:
+        print("\n".join(state["push_urls"]))
+    elif args == ["rev-parse", "--path-format=absolute", "--git-common-dir"]:
+        print(state["git_common_dir"])
+    elif args == ["rev-parse", "refs/remotes/origin/master"]:
+        print(state["fetched_rev"])
+    elif args[:3] == ["rev-parse", "--verify", "--quiet"]:
+        ref = args[3]
+        value = (
+            state.get("pending_rev")
+            if ref == "refs/cratedigger-deploy/cratedigger-src-pending"
+            else state.get("receipt_rev")
+        )
+        if value:
+            if (
+                state.get("fault") == "post_commit_rev_parse"
+                and state.get("pending_rev") in state["commits"]
+            ):
+                fail("fake post-commit rev-parse failed")
+            if (
+                state.get("fault") in {
+                    "signal_after_commit",
+                    "invalid_signature_signal_after_commit",
+                } and value in state["commits"]
+            ) or (
+                state.get("fault") == "signal_after_pending_commit"
+                and value == state.get("pending_rev")
+                and value in state["commits"]
+            ):
+                save()
+                os.kill(os.getppid(), SIGTERM)
+                time.sleep(0.1)
+                raise SystemExit(143)
+            print(value)
+        else:
+            save()
+            raise SystemExit(1)
+    elif args[:2] == ["rev-parse", "--verify"]:
+        ref = args[2]
+        value = state.get("pending_rev") if ref.endswith("-pending") else None
+        if not value:
+            fail(f"unknown fake ref: {ref}")
+        if state.get("fault") == "post_commit_rev_parse" and value in state["commits"]:
             fail("fake post-commit rev-parse failed")
         if (
             state.get("fault") in {
@@ -226,232 +250,229 @@ elif args[:3] == ["rev-parse", "--verify", "--quiet"]:
             time.sleep(0.1)
             raise SystemExit(143)
         print(value)
-    else:
-        save()
-        raise SystemExit(1)
-elif args[:2] == ["rev-parse", "--verify"]:
-    ref = args[2]
-    value = state.get("pending_rev") if ref.endswith("-pending") else None
-    if not value:
-        fail(f"unknown fake ref: {ref}")
-    if state.get("fault") == "post_commit_rev_parse" and value in state["commits"]:
-        fail("fake post-commit rev-parse failed")
-    if (
-        state.get("fault") in {
+    elif args[:3] == ["worktree", "add", "--detach"]:
+        worktree = args[3]
+        revision = args[4]
+        commit = captured_object(revision)
+        if commit is None:
+            fail(f"worktree revision was not captured: {revision}")
+        if state["remote_move_on_worktree_add"]:
+            move_live_remote()
+        os.makedirs(worktree)
+        with open(os.path.join(worktree, "flake.lock"), "w", encoding="utf-8") as _f:
+            _f.write(lock_payload(commit["target"]))
+        state["worktree"] = worktree
+        state["worktree_base"] = revision
+        state["events"].append(["worktree-add", worktree, revision])
+    elif args == ["status", "--porcelain"]:
+        print(" M flake.lock")
+    elif args == ["add", "flake.lock"]:
+        state["events"].append(["add", "flake.lock"])
+    elif args[:2] == ["symbolic-ref", "HEAD"]:
+        state["worktree_attached_ref"] = args[2]
+        state["events"].append(["symbolic-ref", args[2]])
+    elif args[:2] == ["commit", "-m"]:
+        state["commit_count"] += 1
+        revision = f'{0xC000 + state["commit_count"]:040x}'
+        with open(os.path.join(cwd, "flake.lock"), encoding="utf-8") as _f:
+            target = json.loads(_f.read())["nodes"]["cratedigger-src"]["locked"]["rev"]
+        state["commits"][revision] = {
+            "parent": state["worktree_base"],
+            "target": target,
+            "message": args[2],
+            "signature_material": (
+                "bad"
+                if state.get("fault") in {
+                    "signature",
+                    "invalid_signature_signal_after_commit",
+                }
+                else "good"
+            ),
+            # A correctly signed pin commit that also carries a module change --
+            # the world verify_pin_commit's changed-paths guard exists to reject
+            # as definitively invalid (#1172 item 2).
+            "changed_paths": (
+                ["flake.lock", "modules/nixos/services/cratedigger.nix"]
+                if state.get("fault") == "extra_changed_paths"
+                else ["flake.lock"]
+            ),
+        }
+        state["worktree_head"] = revision
+        if state.get("worktree_attached_ref") == (
+            "refs/cratedigger-deploy/cratedigger-src-pending"
+        ):
+            state["pending_rev"] = revision
+        state["events"].append(["commit", revision])
+    elif args == ["rev-parse", "HEAD"]:
+        if state.get("fault") == "post_commit_rev_parse":
+            fail("fake post-commit rev-parse failed")
+        if state.get("fault") in {
             "signal_after_commit",
             "invalid_signature_signal_after_commit",
-        } and value in state["commits"]
-    ) or (
-        state.get("fault") == "signal_after_pending_commit"
-        and value == state.get("pending_rev")
-        and value in state["commits"]
-    ):
-        save()
-        os.kill(os.getppid(), SIGTERM)
-        time.sleep(0.1)
-        raise SystemExit(143)
-    print(value)
-elif args[:3] == ["worktree", "add", "--detach"]:
-    worktree = args[3]
-    revision = args[4]
-    commit = captured_object(revision)
-    if commit is None:
-        fail(f"worktree revision was not captured: {revision}")
-    if state["remote_move_on_worktree_add"]:
-        move_live_remote()
-    os.makedirs(worktree)
-    with open(os.path.join(worktree, "flake.lock"), "w", encoding="utf-8") as _f:
-        _f.write(lock_payload(commit["target"]))
-    state["worktree"] = worktree
-    state["worktree_base"] = revision
-    state["events"].append(["worktree-add", worktree, revision])
-elif args == ["status", "--porcelain"]:
-    print(" M flake.lock")
-elif args == ["add", "flake.lock"]:
-    state["events"].append(["add", "flake.lock"])
-elif args[:2] == ["symbolic-ref", "HEAD"]:
-    state["worktree_attached_ref"] = args[2]
-    state["events"].append(["symbolic-ref", args[2]])
-elif args[:2] == ["commit", "-m"]:
-    state["commit_count"] += 1
-    revision = f'{0xC000 + state["commit_count"]:040x}'
-    with open(os.path.join(cwd, "flake.lock"), encoding="utf-8") as _f:
-        target = json.loads(_f.read())["nodes"]["cratedigger-src"]["locked"]["rev"]
-    state["commits"][revision] = {
-        "parent": state["worktree_base"],
-        "target": target,
-        "message": args[2],
-        "signature_material": (
-            "bad"
-            if state.get("fault") in {
-                "signature",
-                "invalid_signature_signal_after_commit",
-            }
-            else "good"
-        ),
-        # A correctly signed pin commit that also carries a module change --
-        # the world verify_pin_commit's changed-paths guard exists to reject
-        # as definitively invalid (#1172 item 2).
-        "changed_paths": (
-            ["flake.lock", "modules/nixos/services/cratedigger.nix"]
-            if state.get("fault") == "extra_changed_paths"
-            else ["flake.lock"]
-        ),
-    }
-    state["worktree_head"] = revision
-    if state.get("worktree_attached_ref") == (
-        "refs/cratedigger-deploy/cratedigger-src-pending"
-    ):
-        state["pending_rev"] = revision
-    state["events"].append(["commit", revision])
-elif args == ["rev-parse", "HEAD"]:
-    if state.get("fault") == "post_commit_rev_parse":
-        fail("fake post-commit rev-parse failed")
-    if state.get("fault") in {
-        "signal_after_commit",
-        "invalid_signature_signal_after_commit",
-    }:
-        save()
-        os.kill(os.getppid(), SIGTERM)
-        time.sleep(0.1)
-        raise SystemExit(143)
-    print(state["worktree_head"])
-elif args[:3] == ["log", "-1", "--format=%G?"]:
-    revision = args[3]
-    if state.get("fault") == "post_commit_verify":
-        fail("fake post-commit verification failed")
-    commit = captured_object(revision)
-    if commit is None:
-        fail(f"uncaptured fake commit: {revision}")
-    if revision in state["commits"] and state.get("fault") == "signature_unknown":
-        signature_status = "U"
-    elif revision in state["captured_objects"]:
-        signature_status = commit.get("signature_status", "G")
-    elif commit is not None and commit["signature_material"] == "bad":
-        signature_status = "B"
-    else:
-        signature_status = "G"
-    state["events"].append(["signature-status", revision, signature_status])
-    print(signature_status)
-elif args[:2] == ["cat-file", "commit"]:
-    commit = captured_object(args[2])
-    if commit is None:
-        fail(f"uncaptured fake commit: {args[2]}")
-    print("tree deadbeef")
-    print("parent " + commit["parent"])
-    print("gpgsig -----BEGIN SSH SIGNATURE-----")
-    print(" fake")
-    print(" -----END SSH SIGNATURE-----")
-elif args[:3] == ["rev-list", "--parents", "-n1"]:
-    revision = args[3]
-    commit = captured_object(revision)
-    if commit is None:
-        fail(f"unknown fake commit: {revision}")
-    print(revision, commit["parent"])
-elif args[:2] == ["merge-base", "--is-ancestor"]:
-    ancestor = args[2]
-    descendant = args[3]
-    if descendant != state["remote_rev"] or ancestor not in state["remote_ancestors"]:
-        save()
-        raise SystemExit(1)
-elif args[:3] == ["show-ref", "--verify", "--hash"]:
-    value = state.get("pending_rev") if args[3].endswith("-pending") else None
-    if value:
-        print(value)
-    else:
-        save()
-        raise SystemExit(1)
-elif args[:4] == ["diff-tree", "--no-commit-id", "--name-only", "-r"]:
-    # Answer for the revision actually asked about. Printing "flake.lock"
-    # unconditionally made verify_pin_revision's "changes paths other than
-    # flake.lock" rejection unreachable from every test -- a pin commit that
-    # smuggled in a module change alongside the lock bump could not be
-    # modelled at all (#1172 item 2).
-    revision = args[4]
-    commit = captured_object(revision)
-    if commit is None:
-        fail(f"uncaptured fake revision: {revision}")
-    print("\n".join(commit.get("changed_paths") or ["flake.lock"]))
-elif args[:1] == ["show"] and args[1].endswith(":flake.lock"):
-    revision = args[1].split(":", 1)[0]
-    commit = captured_object(revision)
-    if commit is None:
-        fail(f"uncaptured fake revision: {revision}")
-    if not commit.get("lock_readable", True):
-        fail("fake remote flake.lock is unreadable")
-    print(lock_payload(commit["target"]), end="")
-elif args[:1] == ["update-ref"]:
-    if args[1] == "-d":
-        ref = args[2]
+        }:
+            save()
+            os.kill(os.getppid(), SIGTERM)
+            time.sleep(0.1)
+            raise SystemExit(143)
+        print(state["worktree_head"])
+    elif args[:3] == ["log", "-1", "--format=%G?"]:
+        revision = args[3]
+        if state.get("fault") == "post_commit_verify":
+            fail("fake post-commit verification failed")
+        commit = captured_object(revision)
+        if commit is None:
+            fail(f"uncaptured fake commit: {revision}")
+        if revision in state["commits"] and state.get("fault") == "signature_unknown":
+            signature_status = "U"
+        elif revision in state["captured_objects"]:
+            signature_status = commit.get("signature_status", "G")
+        elif commit is not None and commit["signature_material"] == "bad":
+            signature_status = "B"
+        else:
+            signature_status = "G"
+        state["events"].append(["signature-status", revision, signature_status])
+        print(signature_status)
+    elif args[:2] == ["cat-file", "commit"]:
+        commit = captured_object(args[2])
+        if commit is None:
+            fail(f"uncaptured fake commit: {args[2]}")
+        print("tree deadbeef")
+        print("parent " + commit["parent"])
+        print("gpgsig -----BEGIN SSH SIGNATURE-----")
+        print(" fake")
+        print(" -----END SSH SIGNATURE-----")
+    elif args[:3] == ["rev-list", "--parents", "-n1"]:
+        revision = args[3]
+        commit = captured_object(revision)
+        if commit is None:
+            fail(f"unknown fake commit: {revision}")
+        print(revision, commit["parent"])
+    elif args[:2] == ["merge-base", "--is-ancestor"]:
+        ancestor = args[2]
+        descendant = args[3]
+        if descendant != state["remote_rev"] or ancestor not in state["remote_ancestors"]:
+            save()
+            raise SystemExit(1)
+    elif args[:3] == ["show-ref", "--verify", "--hash"]:
+        value = state.get("pending_rev") if args[3].endswith("-pending") else None
+        if value:
+            print(value)
+        else:
+            save()
+            raise SystemExit(1)
+    elif args[:4] == ["diff-tree", "--no-commit-id", "--name-only", "-r"]:
+        # Answer for the revision actually asked about. Printing "flake.lock"
+        # unconditionally made verify_pin_revision's "changes paths other than
+        # flake.lock" rejection unreachable from every test -- a pin commit that
+        # smuggled in a module change alongside the lock bump could not be
+        # modelled at all (#1172 item 2).
+        revision = args[4]
+        commit = captured_object(revision)
+        if commit is None:
+            fail(f"uncaptured fake revision: {revision}")
+        print("\n".join(commit.get("changed_paths") or ["flake.lock"]))
+    elif args[:1] == ["show"] and args[1].endswith(":flake.lock"):
+        revision = args[1].split(":", 1)[0]
+        commit = captured_object(revision)
+        if commit is None:
+            fail(f"uncaptured fake revision: {revision}")
+        if not commit.get("lock_readable", True):
+            fail("fake remote flake.lock is unreadable")
+        print(lock_payload(commit["target"]), end="")
+    elif args[:1] == ["update-ref"]:
+        if args[1] == "-d":
+            ref = args[2]
+            expected_old = args[3] if len(args) == 4 else None
+            current = (
+                state.get("pending_rev")
+                if ref == "refs/cratedigger-deploy/cratedigger-src-pending"
+                else state.get("receipt_rev")
+            )
+            if expected_old is None or (current or "") != expected_old:
+                fail("fake delete-ref compare-and-swap failed")
+            if ref == "refs/cratedigger-deploy/cratedigger-src-pending":
+                state["pending_rev"] = None
+            state["events"].append(["delete-ref", ref, expected_old])
+            save()
+            raise SystemExit(0)
+        ref = args[1]
         expected_old = args[3] if len(args) == 4 else None
         current = (
             state.get("pending_rev")
             if ref == "refs/cratedigger-deploy/cratedigger-src-pending"
             else state.get("receipt_rev")
         )
-        if expected_old is None or (current or "") != expected_old:
-            fail("fake delete-ref compare-and-swap failed")
+        if expected_old is not None and (current or "") != expected_old:
+            fail("fake update-ref compare-and-swap failed")
+        if (
+            ref == "refs/cratedigger-deploy/cratedigger-src"
+            and state.get("fault") == "post_commit_update_ref"
+            and args[2] in state["commits"]
+        ):
+            fail("fake receipt update-ref failed")
         if ref == "refs/cratedigger-deploy/cratedigger-src-pending":
-            state["pending_rev"] = None
-        state["events"].append(["delete-ref", ref, expected_old])
-        save()
-        raise SystemExit(0)
-    ref = args[1]
-    expected_old = args[3] if len(args) == 4 else None
-    current = (
-        state.get("pending_rev")
-        if ref == "refs/cratedigger-deploy/cratedigger-src-pending"
-        else state.get("receipt_rev")
-    )
-    if expected_old is not None and (current or "") != expected_old:
-        fail("fake update-ref compare-and-swap failed")
-    if (
-        ref == "refs/cratedigger-deploy/cratedigger-src"
-        and state.get("fault") == "post_commit_update_ref"
-        and args[2] in state["commits"]
-    ):
-        fail("fake receipt update-ref failed")
-    if ref == "refs/cratedigger-deploy/cratedigger-src-pending":
-        state["pending_rev"] = args[2]
+            state["pending_rev"] = args[2]
+        else:
+            state["receipt_rev"] = args[2]
+        state["events"].append(["update-ref", ref, args[2], expected_old])
+    elif args[:1] == ["push"]:
+        revision = args[2].split(":", 1)[0]
+        state["events"].append([
+            "push", revision,
+            "header-present" if os.environ.get("GIT_CONFIG_VALUE_0") else "no-header",
+        ])
+        if state.get("fault") == "push":
+            fail("fake push rejected")
+        if state["remote_move_on_push"]:
+            move_live_remote()
+        commit = state["commits"][revision]
+        if state["remote_rev"] != commit["parent"]:
+            fail("fake non-fast-forward push rejected")
+        state["remote_rev"] = revision
+        state["remote_parent"] = commit["parent"]
+        state["remote_target"] = commit["target"]
+        state["remote_signature_status"] = "G"
+        state["remote_lock_readable"] = True
+        state["remote_ancestors"] = [*state["remote_ancestors"], commit["parent"]]
+    elif args[:1] == ["ls-remote"] and args[-1] == "refs/heads/master":
+        state["events"].append(["ls-remote"])
+        state["ls_remote_count"] += 1
+        if state["ls_remote_count"] == state["remote_change_on_ls_remote_call"]:
+            move_live_remote()
+        print(f'{state["remote_rev"]}\trefs/heads/master')
+    elif args[:2] == ["worktree", "remove"]:
+        worktree = args[-1]
+        state["events"].append(["worktree-remove", worktree])
+        if state.get("fault") == "cleanup":
+            fail("fake worktree cleanup failed")
+        rmtree(worktree)
+        state["worktree"] = None
     else:
-        state["receipt_rev"] = args[2]
-    state["events"].append(["update-ref", ref, args[2], expected_old])
-elif args[:1] == ["push"]:
-    revision = args[2].split(":", 1)[0]
-    state["events"].append([
-        "push", revision,
-        "header-present" if os.environ.get("GIT_CONFIG_VALUE_0") else "no-header",
-    ])
-    if state.get("fault") == "push":
-        fail("fake push rejected")
-    if state["remote_move_on_push"]:
-        move_live_remote()
-    commit = state["commits"][revision]
-    if state["remote_rev"] != commit["parent"]:
-        fail("fake non-fast-forward push rejected")
-    state["remote_rev"] = revision
-    state["remote_parent"] = commit["parent"]
-    state["remote_target"] = commit["target"]
-    state["remote_signature_status"] = "G"
-    state["remote_lock_readable"] = True
-    state["remote_ancestors"] = [*state["remote_ancestors"], commit["parent"]]
-elif args[:1] == ["ls-remote"] and args[-1] == "refs/heads/master":
-    state["events"].append(["ls-remote"])
-    state["ls_remote_count"] += 1
-    if state["ls_remote_count"] == state["remote_change_on_ls_remote_call"]:
-        move_live_remote()
-    print(f'{state["remote_rev"]}\trefs/heads/master')
-elif args[:2] == ["worktree", "remove"]:
-    worktree = args[-1]
-    state["events"].append(["worktree-remove", worktree])
-    if state.get("fault") == "cleanup":
-        fail("fake worktree cleanup failed")
-    rmtree(worktree)
-    state["worktree"] = None
-else:
-    fail(f"unexpected git argv in {cwd}: {args!r}")
+        fail(f"unexpected git argv in {cwd}: {args!r}")
 
-save()
+    save()
+'''
+
+# Each fake command is this tiny stub, not the shim body itself: the body
+# lives in one shared `_shim.py` module written once per fixture instance
+# (see FakeDeployPinCommands.__init__). CPython never caches bytecode for a
+# script run directly as __main__, so leaving the shim body inline here
+# would recompile it from source on every one of the ~28 subprocess spawns
+# per script run. Importing it instead lets CPython write
+# `__pycache__/_shim.cpython-*.pyc` on the first call and reuse it on every
+# later one within the same fixture directory (issue #1156 item 4).
+#
+# No explicit sys.path manipulation: the interpreter inserts the running
+# script's own directory as sys.path[0] before user code executes, `-S`
+# (skip `site`) does not change that, and `_shim.py` always sits beside this
+# stub in the same fixture directory -- so a bare `import _shim` already
+# resolves. Nothing here changes the process's current working directory;
+# the shim's own `git -C ...` handling tracks `cwd` as a plain local to
+# build paths with, it never calls `os.chdir`.
+_STUB_COMMAND = r'''#!/usr/bin/env -S python3 -S
+import _shim
+
+_shim.main()
 '''
 
 
@@ -479,9 +500,14 @@ class FakeDeployPinCommands:
         self.fake_bin.mkdir()
         self.tmp.mkdir()
         self.token_file.write_bytes(self.TOKEN_BYTES)
+        # The heavy shim body is written once as an importable module so
+        # CPython caches its compiled bytecode in __pycache__ across the
+        # ~28 subprocess spawns per script run; each fake command below is
+        # a tiny stub that imports it (issue #1156 item 4).
+        (self.fake_bin / "_shim.py").write_text(_SHIM_MODULE, encoding="utf-8")
         for name in ("git", "nix", "hostname"):
             path = self.fake_bin / name
-            path.write_text(_FAKE_COMMAND, encoding="utf-8")
+            path.write_text(_STUB_COMMAND, encoding="utf-8")
             path.chmod(0o755)
         self.write_state({
             "argv_calls": [],

--- a/tests/test_daily_flake_update.py
+++ b/tests/test_daily_flake_update.py
@@ -479,16 +479,6 @@ class TestDailyFlakeUpdateFakeShimCaching(unittest.TestCase):
         self.addCleanup(self.tempdir.cleanup)
         self.fake = FakeDailyFlakeUpdateCommands(Path(self.tempdir.name))
 
-    def fake_environment(self) -> dict[str, str]:
-        env = os.environ.copy()
-        env.update(
-            {
-                "PATH": f"{self.fake.fake_bin}:{env['PATH']}",
-                "DAILY_UPDATE_FAKE_STATE": str(self.fake.state_path),
-            }
-        )
-        return env
-
     def test_command_stub_is_tiny_and_shares_one_cached_shim_module(self) -> None:
         shim_path = self.fake.fake_bin / "_shim.py"
         self.assertTrue(shim_path.exists())
@@ -507,21 +497,33 @@ class TestDailyFlakeUpdateFakeShimCaching(unittest.TestCase):
         pycache = self.fake.fake_bin / "__pycache__"
         self.assertFalse(pycache.exists())
 
-        self.fake.update_state(lock_changed=False)
+        # Default seed state is lock_changed=True (`_write_state` above), so
+        # this world exits 1 -- an exit-0 world here would be indistinguishable
+        # from a stub that never calls main() at all (P2-F1 review finding on
+        # #1156 items 4/5). The `events` assertion below is the direct kill:
+        # `main()` appends to `state["events"]` before any branch dispatch, so
+        # a stub that imports `_shim` but never calls `main()` leaves it empty
+        # regardless of exit code.
         proc = subprocess.run(
             [str(self.fake.fake_bin / "git"), "diff", "--quiet", "--", "flake.lock"],
-            env=self.fake_environment(),
+            env=self.fake.environment(),
             capture_output=True,
             text=True,
             check=False,
         )
-        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(proc.returncode, 1, proc.stderr)
+        self.assertIn(
+            ["git", "diff", "--quiet", "--", "flake.lock"],
+            self.fake.state["events"],
+        )
 
         cached = list(pycache.glob("_shim.*.pyc"))
         self.assertEqual(
             len(cached), 1,
             "expected the shim's bytecode to be cached in __pycache__ "
-            f"after one call, found {cached}",
+            f"after one call, found {cached} -- check for an ambient "
+            "PYTHONDONTWRITEBYTECODE or PYTHONPYCACHEPREFIX in your "
+            "environment, either of which silently defeats this caching",
         )
 
     def test_command_stub_fails_loudly_without_the_shared_shim_module(self) -> None:
@@ -529,7 +531,7 @@ class TestDailyFlakeUpdateFakeShimCaching(unittest.TestCase):
 
         proc = subprocess.run(
             [str(self.fake.fake_bin / "git"), "diff", "--quiet", "--", "flake.lock"],
-            env=self.fake_environment(),
+            env=self.fake.environment(),
             capture_output=True,
             text=True,
             check=False,

--- a/tests/test_daily_flake_update.py
+++ b/tests/test_daily_flake_update.py
@@ -468,5 +468,76 @@ class TestDailyFlakeUpdateScript(unittest.TestCase):
         self.assertLess(daily_push, update_tip)
 
 
+class TestDailyFlakeUpdateFakeShimCaching(unittest.TestCase):
+    """Pins for the shared-module fake-command shape (issue #1156 item 5):
+    git/nix/nix-shell remain symlinks to one tiny stub that imports a shared
+    ``_shim.py``, so CPython caches its compiled bytecode across every fake
+    command invocation instead of recompiling on each one."""
+
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.fake = FakeDailyFlakeUpdateCommands(Path(self.tempdir.name))
+
+    def fake_environment(self) -> dict[str, str]:
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{self.fake.fake_bin}:{env['PATH']}",
+                "DAILY_UPDATE_FAKE_STATE": str(self.fake.state_path),
+            }
+        )
+        return env
+
+    def test_command_stub_is_tiny_and_shares_one_cached_shim_module(self) -> None:
+        shim_path = self.fake.fake_bin / "_shim.py"
+        self.assertTrue(shim_path.exists())
+        shim_size = shim_path.stat().st_size
+        stub_path = self.fake.fake_bin / "command"
+        stub_size = stub_path.stat().st_size
+        # A regression back to writing the full body into the shared
+        # "command" file (the pre-#1156-item-5 shape) would make the stub
+        # as large as the shim itself.
+        self.assertLess(stub_size, 300, "command stub is not tiny")
+        self.assertLess(stub_size * 5, shim_size,
+                         "command stub looks like a full shim copy")
+        for name in ("git", "nix", "nix-shell"):
+            self.assertTrue((self.fake.fake_bin / name).is_symlink())
+
+        pycache = self.fake.fake_bin / "__pycache__"
+        self.assertFalse(pycache.exists())
+
+        self.fake.update_state(lock_changed=False)
+        proc = subprocess.run(
+            [str(self.fake.fake_bin / "git"), "diff", "--quiet", "--", "flake.lock"],
+            env=self.fake_environment(),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+
+        cached = list(pycache.glob("_shim.*.pyc"))
+        self.assertEqual(
+            len(cached), 1,
+            "expected the shim's bytecode to be cached in __pycache__ "
+            f"after one call, found {cached}",
+        )
+
+    def test_command_stub_fails_loudly_without_the_shared_shim_module(self) -> None:
+        (self.fake.fake_bin / "_shim.py").unlink()
+
+        proc = subprocess.run(
+            [str(self.fake.fake_bin / "git"), "diff", "--quiet", "--", "flake.lock"],
+            env=self.fake_environment(),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("ModuleNotFoundError", proc.stderr)
+        self.assertIn("_shim", proc.stderr)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_deploy_cycle_verifier.py
+++ b/tests/test_deploy_cycle_verifier.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import os
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
@@ -593,6 +595,80 @@ class TestMigrateRanForThisSwitch(unittest.TestCase):
         self.assertTrue(ssh_events)
         for event in ssh_events:
             self.assertIn("IdentityAgent=none", event)
+
+
+class TestDeployCycleFakeShimCaching(unittest.TestCase):
+    """Pins for the shared-module fake-command shape (issue #1156 item 5):
+    the fake ``ssh`` is a tiny stub importing a shared ``_shim.py``, so
+    CPython caches its compiled bytecode across every fake ssh invocation
+    instead of recompiling on each one."""
+
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.fake = FakeDeployCycleCommands(Path(self.tempdir.name))
+
+    def fake_environment(self) -> dict[str, str]:
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{self.fake.fake_bin}:{env['PATH']}",
+                "DEPLOY_CYCLE_FAKE_STATE": str(self.fake.state_path),
+            }
+        )
+        return env
+
+    def test_ssh_stub_is_tiny_and_shares_one_cached_shim_module(self) -> None:
+        shim_path = self.fake.fake_bin / "_shim.py"
+        self.assertTrue(shim_path.exists())
+        shim_size = shim_path.stat().st_size
+        stub_size = (self.fake.fake_bin / "ssh").stat().st_size
+        # A regression back to writing the full body into the fake ssh
+        # command (the pre-#1156-item-5 shape) would make the stub as
+        # large as the shim itself.
+        self.assertLess(stub_size, 300, "ssh stub is not tiny")
+        self.assertLess(stub_size * 5, shim_size,
+                         "ssh stub looks like a full shim copy")
+
+        pycache = self.fake.fake_bin / "__pycache__"
+        self.assertFalse(pycache.exists())
+
+        proc = subprocess.run(
+            [
+                str(self.fake.fake_bin / "ssh"), "doc2", "systemctl", "show",
+                "cratedigger-db-migrate.service", "--property=ActiveState",
+            ],
+            env=self.fake_environment(),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(proc.stdout.strip(), "ActiveState=active")
+
+        cached = list(pycache.glob("_shim.*.pyc"))
+        self.assertEqual(
+            len(cached), 1,
+            "expected the shim's bytecode to be cached in __pycache__ "
+            f"after one call, found {cached}",
+        )
+
+    def test_ssh_stub_fails_loudly_without_the_shared_shim_module(self) -> None:
+        (self.fake.fake_bin / "_shim.py").unlink()
+
+        proc = subprocess.run(
+            [
+                str(self.fake.fake_bin / "ssh"), "doc2", "systemctl", "show",
+                "cratedigger-db-migrate.service", "--property=ActiveState",
+            ],
+            env=self.fake_environment(),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIn("ModuleNotFoundError", proc.stderr)
+        self.assertIn("_shim", proc.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/test_deploy_cycle_verifier.py
+++ b/tests/test_deploy_cycle_verifier.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import subprocess
 import tempfile
 import unittest
@@ -608,16 +607,6 @@ class TestDeployCycleFakeShimCaching(unittest.TestCase):
         self.addCleanup(self.tempdir.cleanup)
         self.fake = FakeDeployCycleCommands(Path(self.tempdir.name))
 
-    def fake_environment(self) -> dict[str, str]:
-        env = os.environ.copy()
-        env.update(
-            {
-                "PATH": f"{self.fake.fake_bin}:{env['PATH']}",
-                "DEPLOY_CYCLE_FAKE_STATE": str(self.fake.state_path),
-            }
-        )
-        return env
-
     def test_ssh_stub_is_tiny_and_shares_one_cached_shim_module(self) -> None:
         shim_path = self.fake.fake_bin / "_shim.py"
         self.assertTrue(shim_path.exists())
@@ -638,7 +627,7 @@ class TestDeployCycleFakeShimCaching(unittest.TestCase):
                 str(self.fake.fake_bin / "ssh"), "doc2", "systemctl", "show",
                 "cratedigger-db-migrate.service", "--property=ActiveState",
             ],
-            env=self.fake_environment(),
+            env=self.fake.environment(),
             capture_output=True,
             text=True,
             check=False,
@@ -650,7 +639,9 @@ class TestDeployCycleFakeShimCaching(unittest.TestCase):
         self.assertEqual(
             len(cached), 1,
             "expected the shim's bytecode to be cached in __pycache__ "
-            f"after one call, found {cached}",
+            f"after one call, found {cached} -- check for an ambient "
+            "PYTHONDONTWRITEBYTECODE or PYTHONPYCACHEPREFIX in your "
+            "environment, either of which silently defeats this caching",
         )
 
     def test_ssh_stub_fails_loudly_without_the_shared_shim_module(self) -> None:
@@ -661,7 +652,7 @@ class TestDeployCycleFakeShimCaching(unittest.TestCase):
                 str(self.fake.fake_bin / "ssh"), "doc2", "systemctl", "show",
                 "cratedigger-db-migrate.service", "--property=ActiveState",
             ],
-            env=self.fake_environment(),
+            env=self.fake.environment(),
             capture_output=True,
             text=True,
             check=False,

--- a/tests/test_deploy_pin_script.py
+++ b/tests/test_deploy_pin_script.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess
 import tempfile
 import time
 import unittest
@@ -837,6 +838,65 @@ class TestDeployPinScript(unittest.TestCase):
                 self.assertNotIn("token", proc.stderr.lower())
                 self.assertFalse(any(event[0] in {"fetch", "push"}
                                      for event in state["events"]))
+
+
+class TestDeployPinFakeShimCaching(unittest.TestCase):
+    """Pins for the shared-module fake-command shape (issue #1156 item 4):
+    each fake command (git/nix/hostname) is a tiny stub importing one shared
+    ``_shim.py``, so CPython caches its compiled bytecode across the ~28
+    subprocess spawns per script run instead of recompiling the whole body
+    on every one."""
+
+    def test_stubs_are_tiny_and_share_one_cached_shim_module(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            fake = FakeDeployPinCommands(Path(td))
+            shim_path = fake.fake_bin / "_shim.py"
+            self.assertTrue(shim_path.exists())
+            shim_size = shim_path.stat().st_size
+            for name in ("git", "nix", "hostname"):
+                stub_size = (fake.fake_bin / name).stat().st_size
+                # A regression back to writing the full body into every fake
+                # command (the pre-#1156-item-4 shape) would make each stub
+                # as large as the shim itself.
+                self.assertLess(stub_size, 300, f"{name} stub is not tiny")
+                self.assertLess(stub_size * 5, shim_size,
+                                 f"{name} stub looks like a full shim copy")
+
+            pycache = fake.fake_bin / "__pycache__"
+            self.assertFalse(pycache.exists())
+
+            proc = subprocess.run(
+                [str(fake.fake_bin / "hostname")],
+                env=fake.environment(fake.TARGET_REV),
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(proc.returncode, 0, proc.stderr)
+            self.assertEqual(proc.stdout.strip(), "proxmox-vm")
+
+            cached = list(pycache.glob("_shim.*.pyc"))
+            self.assertEqual(
+                len(cached), 1,
+                "expected the shim's bytecode to be cached in __pycache__ "
+                f"after one call, found {cached}",
+            )
+
+    def test_stub_fails_loudly_without_the_shared_shim_module(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            fake = FakeDeployPinCommands(Path(td))
+            (fake.fake_bin / "_shim.py").unlink()
+
+            proc = subprocess.run(
+                [str(fake.fake_bin / "hostname")],
+                env=fake.environment(fake.TARGET_REV),
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertNotEqual(proc.returncode, 0)
+            self.assertIn("ModuleNotFoundError", proc.stderr)
+            self.assertIn("_shim", proc.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/test_deploy_pin_script.py
+++ b/tests/test_deploy_pin_script.py
@@ -879,7 +879,9 @@ class TestDeployPinFakeShimCaching(unittest.TestCase):
             self.assertEqual(
                 len(cached), 1,
                 "expected the shim's bytecode to be cached in __pycache__ "
-                f"after one call, found {cached}",
+                f"after one call, found {cached} -- check for an ambient "
+                "PYTHONDONTWRITEBYTECODE or PYTHONPYCACHEPREFIX in your "
+                "environment, either of which silently defeats this caching",
             )
 
     def test_stub_fails_loudly_without_the_shared_shim_module(self) -> None:


### PR DESCRIPTION
Addresses #1156 items 4 and 5.

## Item 4 — the measured lever

`tests/fakes/deploy_pin.py` embedded a 411-line shim body **identically into each fake command** (`git`, `nix`, `hostname`), so every fake invocation re-compiled the whole thing. `tests.test_deploy_pin_generated` is the suite's largest single target (~60s after #1152 cut it from 94.1s), and it spawns **28 fake commands per script run** (26 git + 1 nix + 1 hostname, measured), with many script runs per Hypothesis-generated test method.

Now the body is written once as a shared `_shim.py` per fixture directory, and each fake command is a tiny stub — literally `import _shim` / `_shim.main()` — so CPython caches the compiled bytecode in `__pycache__` and later invocations skip compilation.

## Measured

Reported from **independent review's** balanced ABBA×2 design (B,A,A,B,B,A,A,B) on a quiet box, not the author's original run:

| | mean | range |
|---|---|---|
| before | **53.70 s** | 52.87–54.91 |
| after | **49.12 s** | 47.73–50.70 |

**−4.58 s, −8.5 %**, with non-overlapping distributions (worst "after" 50.70 < best "before" 52.87), load 1.38–2.65 across all eight runs.

The author's original 5-run design (B,A,A,B,A) was unbalanced and biased toward the second variant under the falling load trend it had itself observed; it reported −13 %. That claim was corrected down rather than defended.

**Verified not a cache artefact, in either direction:** every Hypothesis example builds a fresh `tempfile.TemporaryDirectory()` fixture, so bytecode is cold at the start of every example in every run (no cross-run carryover); `PYTHONPYCACHEPREFIX` is unset; within a fixture the first call writes `_shim.cpython-314.pyc` and **30 further calls leave its inode and `st_mtime_ns` unchanged** (cold 24.8 ms → warm median 16.3 ms). A `RUSAGE_CHILDREN` child-CPU cross-check favoured "after" in every interleaved pair.

## Item 5 — the two siblings

`tests/fakes/daily_flake_update.py` and `tests/fakes/deploy_cycle.py` were still on the pre-#1152 pattern. Brought onto the same shape. **Measured as no meaningful difference** (14.74 s → 14.53 s over 3 runs each on a combined 59-test set) — confirming the issue's own "not a hotspot" call rather than inventing a win.

The `json`-import lever remains **declined**, as #1152 decided under `code-quality.md`'s stopping condition.

## Kill matrix

| Site (assertion / clause / constant) | One-line mutant | Test that goes RED | Result |
| --- | --- | --- | --- |
| `deploy_pin.py` stub shape | write the full `_SHIM_MODULE` into each fake command (pre-fix shape) | `test_stubs_are_tiny_and_share_one_cached_shim_module` | RED (`16921 not less than 300`) |
| `deploy_pin.py::environment()` | inject `PYTHONDONTWRITEBYTECODE=1` | same | RED (`found []`) |
| `deploy_pin.py` stub | `import _shim` but never call `main()` | same | RED (`'' != 'proxmox-vm'`) |
| `deploy_pin.py` stub | swallow `ModuleNotFoundError` → `SystemExit(0)` | `test_stub_fails_loudly_without_the_shared_shim_module` | RED |
| all three stubs | `except ModuleNotFoundError: pass` | all three fail-loud pins | RED |
| `daily_flake_update.py` / `deploy_cycle.py` stub shape | write the full body into `command` / `ssh` | both item-5 "tiny" pins | RED |
| `daily_flake_update.py` stub | `import _shim` but never call `main()` | daily caching pin | RED (returncode 0 ≠ 1) |
| `daily_flake_update.py::environment()` | inject `PYTHONDONTWRITEBYTECODE=1` | daily caching pin | RED (0 cached files) |
| `deploy_cycle.py::environment()` | inject `PYTHONDONTWRITEBYTECODE=1` | cycle caching pin | RED |
| moved shim body (behavioural control) | `command = sys.argv[0]` instead of `basename(...)` | pre-existing `test_deploy_pin_script` | RED |

## Review

Independent review verified behavioural equivalence directly: the nested closures still see the rebound `state` (cell-equivalent to the old module-global rebind), exit codes propagate identically via `SystemExit`, `sys.argv[0]` basename dispatch is unchanged, and the `flock` move from module-global to a `main()` local preserves the read-modify-write critical section (proven by the existing concurrent same-target test). Parallel `.pyc` writes are safe (CPython's `_write_atomic`), no stale-`.pyc` path exists (every fixture gets a fresh tempdir), and nothing leaks. 113 tests across the six consumer modules pass.

It found and this PR fixed: a caching pin that **could not fail** (asserted exit 0, indistinguishable from a stub running nothing); two item-5 pins that built their own subprocess env rather than the fake's own builder, so a `PYTHONDONTWRITEBYTECODE=1` silent-defeat mutant survived all 53 tests; a false claim that "the shim itself changes `cwd`" (it never calls `os.chdir`); a false "two-line stub" (8 lines); and the overstated headline number above.

`sys.path.insert(...)` was **dropped** from the stubs: the interpreter already inserts the script's own directory as `sys.path[0]` regardless of `-S`, it only bought anything under `PYTHONSAFEPATH` (unset, and absent from the repo), and it was strictly *less* correct for symlinks (`__file__` resolves to the link, `sys.path[0]` resolves the target). `scope.md`: no machinery kept in case.

## Known coupling

Setting `PYTHONDONTWRITEBYTECODE` or `PYTHONPYCACHEPREFIX` ambiently defeats the caching — the fakes build their subprocess env from `{**os.environ, …}`. The three caching pins now go red rather than quietly slow, and their failure messages name both variables as the likely cause.

No deploy: test fixtures only — zero doc2 runtime delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
