### PR TITLE
perf(#1156 item 1): shard test_nix_module's webAuthMatrix into two roughly-balanced evals

### DIFF
--- a/scripts/run_python_tests.py
+++ b/scripts/run_python_tests.py
@@ -82,26 +82,52 @@ WORLD_MODEL_MODULE = "tests.world_model.state_machine"
 # late enough to become the deterministic suite's tail.
 AUDITED_FRONTLOAD_MODULES = frozenset({"tests.test_nix_module"})
 #: tests.test_nix_module (issue #1131) is NOT method_batch here on purpose.
-#: Its nix-eval tests are cost-grouped into two ``functools``-free,
+#: Its nix-eval tests are cost-grouped into three ``functools``-free,
 #: exception-memoizing cached helpers in the test module
-#: (``_shared_module_worlds_web_auth_matrix`` / ``_shared_module_worlds_rest``)
-#: — a cache only pays off when every one of its consumers runs in the same
-#: worker PROCESS. method_batch splits methods across separate processes by
-#: TEST COUNT, blind to cost, and a naive full unshard (this issue's own
-#: round 1) serializes every merged world onto ONE target instead. Measured
-#: (round 2 review, quiet 30-core host): main's own method_batch worst case
-#: is 61.6s; a full unshard is 118.3s (+92%); this module's own
-#: HOTSPOT_ISOLATED_METHODS carve-out below restores a 2-target floor level
-#: with main (~61-65s), not better. The CPU merging saves is modest — on
-#: the order of a few seconds, bounded by the sub-1s shared preamble each
-#: eliminated `nix eval` call no longer pays, NOT the gap between each
-#: world's SOLO measured time and one combined run. The real payoff is
-#: capping this module at AT MOST TWO concurrent heavy nix-eval
-#: subprocesses instead of up to five under main's own scheme: a
-#: worker-count sweep on main shows this module's pole inflating hard with
-#: concurrency (88.0s at 8 workers, 122.7s at 12, 147.7s at 16, 152.3s at
-#: 20), so bounding its own concurrency is what makes raising the suite's
-#: worker count affordable — the next lever on this issue, not this PR.
+#: (``_shared_module_worlds_web_auth_matrix_part1`` /
+#: ``_shared_module_worlds_web_auth_matrix_part2`` /
+#: ``_shared_module_worlds_rest``) — a cache only pays off when every one of
+#: a given helper's consumers runs in the same worker PROCESS. method_batch
+#: splits methods across separate processes by TEST COUNT, blind to cost,
+#: and a naive full unshard (issue #1131's own round 1) serializes every
+#: merged world onto ONE target instead. Measured (round 2 review, quiet
+#: 30-core host): main's own method_batch worst case is 61.6s; a full
+#: unshard is 118.3s (+92%); the original HOTSPOT_ISOLATED_METHODS
+#: carve-out (one ``webAuthMatrix`` singleton + one ``_rest`` bundle)
+#: restored a 2-target floor level with main (~61-65s), not better. The CPU
+#: merging saves is modest — on the order of a few seconds, bounded by the
+#: sub-1s shared preamble each eliminated `nix eval` call no longer pays,
+#: NOT the gap between each world's SOLO measured time and one combined
+#: run.
+#:
+#: Issue #1156 item 1 split the single ``webAuthMatrix`` singleton itself
+#: into ``_part1``/``_part2`` (20/19 of its 39 independent worlds), raising
+#: this module's own concurrently-schedulable heavy-nix-eval target count
+#: from two to THREE — exactly the axis the original 2-target design
+#: capped, and exactly what the worker-count sweep below warns is
+#: sensitive to concurrency. Measured before shipping it (three interleaved
+#: baseline/candidate pairs of full ``run_tests.sh`` runs, ambient sibling
+#: contention acknowledged and visible in the spread): the worst single
+#: target this module contributes to a run dropped from a 100.1s/114.3s/
+#: 103.3s baseline (mean 105.9s) to a 95.0s/96.4s/85.7s candidate (mean
+#: 92.4s, -13%, every pair individually improved) with no runaway blowup —
+#: neither new half ever exceeded ~62s even competing against two heavy
+#: siblings instead of one. The suite-level python-phase wall time moved
+#: from a mean of 118.6s to 113.8s (-4%, noisier than the per-target
+#: number — baseline's own three runs alone spanned 107.5-137.0s from
+#: ambient contention before this change touches anything). A real, if
+#: modest, net win, not the dramatic headline number the solo floor alone
+#: (58.5s mean down to ~30s per half) would suggest. See
+#: ``_shared_module_worlds_web_auth_matrix_part1``'s own docstring in
+#: ``tests/test_nix_module.py`` for the full numbers.
+#:
+#: A worker-count sweep on PRE-#1156-item-1 main showed this module's pole
+#: inflating hard with concurrency (88.0s at 8 workers, 122.7s at 12,
+#: 147.7s at 16, 152.3s at 20) — bounding this module's own concurrent
+#: heavy-eval count is what makes raising the suite's worker count
+#: affordable in the first place; that headroom is why item 1's move from
+#: two to three concurrent heavy targets was safe to measure rather than
+#: assumed unsafe outright.
 HOTSPOT_SHARD_POLICIES = {
     "tests.test_beets_destructive_configs_generated": "method_batch",
     "tests.test_deploy_pin_generated": "method_batch",
@@ -110,13 +136,16 @@ HOTSPOT_SHARD_POLICIES = {
 }
 HOTSPOT_CLASS_BATCHES = 8
 HOTSPOT_METHOD_BATCHES = 12
-#: Issue #1131 review round 2: exact test IDs that must run as their OWN
-#: singleton target, isolated from the rest of their module. Unlike
-#: HOTSPOT_SHARD_POLICIES (a generic, cost-BLIND split balanced by test
-#: count), this is a manually audited, cost-AWARE carve-out — the named
-#: test is this module's single most expensive nix-eval consumer, and its
-#: own cached helper (see ``_shared_module_worlds_web_auth_matrix`` in
-#: ``tests/test_nix_module.py``) is scoped so this target pays for exactly
+#: Issue #1131 review round 2 (extended by #1156 item 1): exact test IDs
+#: that must run as their OWN singleton target, isolated from the rest of
+#: their module. Unlike HOTSPOT_SHARD_POLICIES (a generic, cost-BLIND split
+#: balanced by test count), this is a manually audited, cost-AWARE
+#: carve-out — the two named tests below are this module's most expensive
+#: nix-eval consumers (issue #1156 item 1 split the original single
+#: consumer in two), and each one's own cached helper (see
+#: ``_shared_module_worlds_web_auth_matrix_part1`` /
+#: ``_shared_module_worlds_web_auth_matrix_part2`` in
+#: ``tests/test_nix_module.py``) is scoped so its target pays for exactly
 #: the nix eval it needs, never a bundled neighbour's. A module named here
 #: with no ``HOTSPOT_SHARD_POLICIES`` entry bundles every OTHER discovered
 #: test into one remainder target (see ``hotspot_targets``).
@@ -124,7 +153,11 @@ HOTSPOT_ISOLATED_METHODS: Mapping[str, frozenset[str]] = {
     "tests.test_nix_module": frozenset({
         (
             "tests.test_nix_module.TestWebAuthenticationModuleContract."
-            "test_basic_and_insecure_mode_matrix_is_evaluated"
+            "test_basic_and_insecure_mode_matrix_is_evaluated_part1"
+        ),
+        (
+            "tests.test_nix_module.TestWebAuthenticationModuleContract."
+            "test_basic_and_insecure_mode_matrix_is_evaluated_part2"
         ),
     }),
 }

--- a/scripts/run_python_tests.py
+++ b/scripts/run_python_tests.py
@@ -101,8 +101,9 @@ AUDITED_FRONTLOAD_MODULES = frozenset({"tests.test_nix_module"})
 #: run.
 #:
 #: Issue #1156 item 1 split the single ``webAuthMatrix`` singleton itself
-#: into ``_part1``/``_part2`` (20/19 of its 39 independent worlds), raising
-#: this module's own concurrently-schedulable heavy-nix-eval target count
+#: into ``_part1``/``_part2`` (``missing``...``rootAccessGroup`` /
+#: ``wheelAccessGroup``...``nginxRestartDisabled``), raising this module's
+#: own concurrently-schedulable heavy-nix-eval target count
 #: from two to THREE — exactly the axis the original 2-target design
 #: capped, and exactly what the worker-count sweep below warns is
 #: sensitive to concurrency. Measured before shipping it (three interleaved

--- a/tests/test_nix_module.py
+++ b/tests/test_nix_module.py
@@ -282,42 +282,69 @@ def _cached_nix_eval_json(expression: str) -> dict[str, object]:
     return value
 
 
-def _shared_module_worlds_web_auth_matrix() -> dict[str, object]:
-    """The ``webAuthMatrix`` nix eval — this module's single heaviest world.
+def _shared_module_worlds_web_auth_matrix_part1() -> dict[str, object]:
+    """The first of two bounded ``webAuthMatrix`` nix evals (issue #1156 item 1).
 
-    Issue #1131 review round 2: measured per-world costs are wildly uneven
-    (``headlessComposition`` 0.80s, ``beetsReadiness`` 3.46s,
-    ``mergedGateway`` 18.67s, ``beetsCapability`` 38.28s, ``webAuthMatrix``
-    65.44s — the pole). Running the whole module unsharded (this issue's
-    own round 1) serializes every merged world onto ONE target and pushes
-    the module's critical-path contribution from main's own 61.6s (its
-    worst `method_batch` bin-packing) to 118.3s — a regression, not a fix.
+    Splits the 39 independent, equal-cost worlds this module's single
+    heaviest target used to force in one ``nix eval`` subprocess (measured
+    57.2-61.0s solo across three quiet-host runs, mean ~58.5s; the prior
+    #1131 docstring's 65.44s was this same target measured on an earlier
+    host state) into two roughly-balanced halves so the target's own solo
+    floor drops without changing what is evaluated or asserted. This half
+    carries the first 20 worlds in declaration order (``missing`` through
+    ``rootAccessGroup``); :func:`_shared_module_worlds_web_auth_matrix_part2`
+    carries the remaining 19.
 
-    The CPU saved by merging evaluations is modest, NOT the headline
-    reason for this split: the shared preamble (``getFlake`` + ``import
-    nixpkgs`` + ``import ./nix/beets.nix``) measured at well under 1s
-    forced standalone, so eliminating N-1 redundant preambles is bounded
-    above by roughly N-1 seconds, not by the sum of each eval's SOLO wall
-    time (which double-counts nixpkgs-import work every eval pays whether
-    merged or not). The real reason to split by cost rather than merge
-    everything or run one unsharded target: main's own `method_batch`
-    sharding can (and, this module's own shard simulation shows, does)
-    land more than one of these multi-GB nix-eval methods in the same
-    12-way batch, and a worker-count sweep on main shows this module's
-    pole inflating hard with concurrency (88.0s at 8 workers, 122.7s at
-    12, 147.7s at 16, 152.3s at 20). Isolating this one world caps this
-    module at AT MOST TWO concurrent
-    heavy nix-eval subprocesses (this function's, plus
-    ``_shared_module_worlds_rest``'s), down from up to five under main's
-    own scheme — which is what would make raising the suite's worker
-    count affordable, the next lever on this issue. Floor: level with
-    main's own 61.6s (~61-65s measured), not better.
+    Measured solo (quiet host): this half alone 31.9s, the other half alone
+    28.3s (59.0s summed vs the original single target's ~58.5s mean -- the
+    ~1s preamble each half now pays independently is exactly the modest,
+    bounded cost #1131's own docstring already priced in). Measured
+    concurrently (both halves launched together, no other suite load):
+    33.2s wall -- close to the per-half floor, confirming the two
+    subprocesses barely interfere with each other in isolation.
+
+    That isolation number was NOT what decided this split -- three
+    interleaved (baseline, candidate) pairs of full ``run_tests.sh``
+    invocations were, run back to back on an otherwise-shared 30-core host
+    (ambient contention from concurrent sibling work acknowledged and
+    visible in the spread below). The ORIGINAL unsplit target -- frontloaded
+    (``AUDITED_FRONTLOAD_MODULES``) and so starting alongside roughly twenty
+    other concurrent workers, several of them CPU-heavy generated-test
+    targets, not merely its own ``_rest`` sibling -- ran 100.1s / 114.3s /
+    103.3s across the three baseline runs (mean 105.9s, 1.7-2.0x its solo
+    floor). Splitting it into two raised this module's own
+    concurrently-schedulable heavy-nix-eval target count from two
+    (``webAuthMatrix`` + ``_rest``) to three (this half + the other half +
+    ``_rest``) -- exactly the axis #1131's own worker-count sweep (88.0s at
+    8 workers, 122.7s at 12, 147.7s at 16, 152.3s at 20) warned against
+    raising carelessly. Measured anyway: the worst single target this
+    module contributes to a run dropped to 95.0s / 96.4s / 85.7s (mean
+    92.4s, -13% average, and every one of the three pairs improved,
+    individually) with NO runaway blowup -- this half and the other half
+    each stayed in the 46-62s range even competing against two heavy
+    siblings instead of one. The suite-level python-phase wall time moved
+    from a mean of 118.6s to 113.8s (-4%, and noisier than the per-target
+    number: baseline's own three runs alone spanned 107.5-137.0s from
+    ambient contention, before this change touches anything) -- a real,
+    if modest, net win with no evidence of the feared regression, not the
+    dramatic headline number the solo floor alone would suggest.
+
+    Two of the original test method's assertion groups spanned this 20/21
+    world boundary (a 3-tuple checking "must be dedicated" across
+    ``serviceGroupOverlap``, ``nginxGroupOverlap``, ``secretGroupOverlap``,
+    and a 2-tuple checking "forbidden authority group" across
+    ``rootAccessGroup``, ``wheelAccessGroup``). Each was split into its own
+    half's assertions on the same message substrings against the same
+    worlds -- a partitioning change, not a coverage change: every world
+    this module ever evaluated is still evaluated, by exactly one half, and
+    asserted with the identical check it always got.
 
     See ``HOTSPOT_ISOLATED_METHODS`` in ``scripts/run_python_tests.py`` for
-    the scheduler half of this split: the whole point is defeated if this
-    function's sole consumer ever runs in a different worker process than
-    intended, so it is carved into its OWN singleton target rather than
-    left to generic count-balanced batching.
+    the scheduler half of this split: both this function's sole consumer
+    and its sibling's must each keep their own singleton target for the
+    same reason the original single-target carve-out did -- the whole
+    point is defeated if either ever shares a worker process with a
+    neighbour it was not measured against.
     """
     expression = r'''
       let
@@ -328,7 +355,7 @@ def _shared_module_worlds_web_auth_matrix() -> dict[str, object]:
         };
         beetsPackage = import ./nix/beets.nix { pkgs = modulePkgs; };
       in {
-        webAuthMatrix =
+        webAuthMatrixPart1 =
           let
             evaluate = extra:
               let
@@ -519,6 +546,67 @@ def _shared_module_worlds_web_auth_matrix() -> dict[str, object]:
                 };
               };
             };
+          };
+      }
+    '''
+    return _cached_nix_eval_json(expression)
+
+
+def _shared_module_worlds_web_auth_matrix_part2() -> dict[str, object]:
+    """The second of two bounded ``webAuthMatrix`` nix evals (issue #1156
+    item 1). See :func:`_shared_module_worlds_web_auth_matrix_part1` for the
+    full rationale, the measured solo/concurrent/under-load numbers, and why
+    this split is a measured boundary decision, not merely half the file.
+    This half carries the remaining 19 worlds in declaration order
+    (``wheelAccessGroup`` through ``nginxRestartDisabled``). Measured solo
+    (quiet host): 28.3s. Under full-suite load across the same three
+    interleaved pairs, this half itself measured 46.3s / 48.3s / 53.0s.
+    """
+    expression = r'''
+      let
+        f = builtins.getFlake (toString ./.);
+        lib = f.inputs.nixpkgs.lib;
+        modulePkgs = import f.inputs.nixpkgs {
+          system = builtins.currentSystem;
+        };
+        beetsPackage = import ./nix/beets.nix { pkgs = modulePkgs; };
+      in {
+        webAuthMatrixPart2 =
+          let
+            evaluate = extra:
+              let
+                system = lib.nixosSystem {
+                  system = builtins.currentSystem;
+                  modules = [
+                    f.nixosModules.default
+                    ({ ... }: {
+                      services.cratedigger = {
+                        enable = true;
+                        src = ./.;
+                        slskd.apiKeyFile = "/run/secrets/slskd-key";
+                        slskd.downloadDir = "/srv/slskd";
+                        pipelineDb.createLocally = true;
+                        web.enable = true;
+                        beets.runtime = {
+                          package = beetsPackage;
+                          configDir = "/etc/beets";
+                          expectedLibrary = "/srv/beets/beets-library.db";
+                          expectedDirectory = "/srv/music";
+                          expectedStateFile = "/var/lib/beets/state.pickle";
+                          expectedSecretInclude = "/run/secrets/beets.yaml";
+                        };
+                      };
+                    })
+                    extra
+                  ];
+                };
+              in map (assertion: assertion.message)
+                (builtins.filter
+                  (assertion:
+                    !assertion.assertion
+                    && lib.hasPrefix "services.cratedigger.web" assertion.message)
+                  system.config.assertions);
+          in {
             wheelAccessGroup = evaluate {
               services.cratedigger = {
                 user = "cratedigger";
@@ -716,11 +804,18 @@ def _shared_module_worlds_rest() -> dict[str, object]:
 
     Issue #1131 review round 2: ``headlessComposition`` (0.80s),
     ``mergedGateway`` (18.67s), ``beetsCapability`` (38.28s), and
-    ``beetsReadiness`` (3.46s) sum to ~61s solo — close enough to
-    ``webAuthMatrix``'s own 65.44s (see
-    ``_shared_module_worlds_web_auth_matrix``) that bundling them into one
-    target keeps the module's two-target floor level with main's own
-    worst-case bin-packed batch (~61.6s), not better. Merging these four
+    ``beetsReadiness`` (3.46s) sum to ~61s solo — close enough to the
+    original single ``webAuthMatrix`` target's 65.44s (see the historical
+    #1131 measurement recorded in
+    :func:`_shared_module_worlds_web_auth_matrix_part1`) that bundling them
+    into one target kept the module's original two-target floor level with
+    main's own worst-case bin-packed batch (~61.6s), not better. Issue
+    #1156 item 1 later split that single ``webAuthMatrix`` target into
+    ``_part1``/``_part2``, so this function is now one of THREE heavy
+    targets the module contributes rather than two — see
+    :func:`_shared_module_worlds_web_auth_matrix_part1` for the measured
+    effect of that split on this target's own under-load time and on the
+    module's total contribution. Merging these four
     also eliminates 3 of the 4 redundant ``getFlake`` + ``import nixpkgs``
     + ``import ./nix/beets.nix`` preambles they used to pay independently
     — each measured at well under 1s standalone, so the CPU this merge
@@ -734,9 +829,10 @@ def _shared_module_worlds_rest() -> dict[str, object]:
     with no ``web``/``beets.validation`` composition — the cheapest shape
     in this file). Measured this whole target's wall time before and
     after: ~34.9s solo before, ~41.8s solo after (+20%) — still well under
-    ``webAuthMatrix``'s own ~65s, so the two-target floor this function's
-    own docstring argues for is unchanged; no existing world here was
-    weakened to fit it in.
+    the original single ``webAuthMatrix`` target's ~65s, so the
+    (now-superseded, see above) two-target floor this function's own
+    docstring argued for was unchanged at the time; no existing world here
+    was weakened to fit it in.
 
     Every world here only ever reads ``.config.assertions`` or plain
     option/service values, never forces ``.system.build.toplevel``, so
@@ -1243,8 +1339,20 @@ class TestDefaultHeadlessComposition(unittest.TestCase):
 class TestWebAuthenticationModuleContract(unittest.TestCase):
     """The enabled web surface has one fail-closed module-owned perimeter."""
 
-    def test_basic_and_insecure_mode_matrix_is_evaluated(self) -> None:
-        worlds = _shared_module_worlds_web_auth_matrix()["webAuthMatrix"]
+    def test_basic_and_insecure_mode_matrix_is_evaluated_part1(self) -> None:
+        """Worlds 1-20 of the 39-world matrix (issue #1156 item 1).
+
+        See :func:`_shared_module_worlds_web_auth_matrix_part1` for why this
+        is now two methods/targets instead of one, and
+        ``test_basic_and_insecure_mode_matrix_is_evaluated_part2`` for the
+        rest. The ``serviceGroupOverlap``/``nginxGroupOverlap``/
+        ``secretGroupOverlap`` and ``rootAccessGroup``/``wheelAccessGroup``
+        checks straddled the 20/21 world boundary in the original single
+        method; each is now asserted once, in whichever half holds the
+        world it names, on the identical message substring it always
+        checked.
+        """
+        worlds = _shared_module_worlds_web_auth_matrix_part1()["webAuthMatrixPart1"]
         assert isinstance(worlds, dict)
         self.assertTrue(
             any("exactly one" in message for message in worlds["missing"])
@@ -1300,23 +1408,42 @@ class TestWebAuthenticationModuleContract(unittest.TestCase):
                 for message in worlds["disabledExternal"]
             )
         )
-        for world in (
-            "serviceGroupOverlap",
-            "nginxGroupOverlap",
-            "secretGroupOverlap",
-        ):
+        for world in ("serviceGroupOverlap", "nginxGroupOverlap"):
             self.assertTrue(
                 any("must be dedicated" in message for message in worlds[world]),
                 (world, worlds[world]),
             )
-        for world in ("rootAccessGroup", "wheelAccessGroup"):
-            self.assertTrue(
-                any(
-                    "forbidden authority group" in message
-                    for message in worlds[world]
-                ),
-                (world, worlds[world]),
-            )
+        self.assertTrue(
+            any(
+                "forbidden authority group" in message
+                for message in worlds["rootAccessGroup"]
+            ),
+            worlds["rootAccessGroup"],
+        )
+
+    def test_basic_and_insecure_mode_matrix_is_evaluated_part2(self) -> None:
+        """Worlds 21-39 of the 39-world matrix (issue #1156 item 1).
+
+        See ``test_basic_and_insecure_mode_matrix_is_evaluated_part1`` for
+        the split rationale and the two straddling checks this method
+        carries its half of.
+        """
+        worlds = _shared_module_worlds_web_auth_matrix_part2()["webAuthMatrixPart2"]
+        assert isinstance(worlds, dict)
+        self.assertTrue(
+            any(
+                "must be dedicated" in message
+                for message in worlds["secretGroupOverlap"]
+            ),
+            worlds["secretGroupOverlap"],
+        )
+        self.assertTrue(
+            any(
+                "forbidden authority group" in message
+                for message in worlds["wheelAccessGroup"]
+            ),
+            worlds["wheelAccessGroup"],
+        )
         self.assertEqual(worlds["explicitOperatorGroup"], [])
         self.assertTrue(
             any(

--- a/tests/test_nix_module.py
+++ b/tests/test_nix_module.py
@@ -285,23 +285,29 @@ def _cached_nix_eval_json(expression: str) -> dict[str, object]:
 def _shared_module_worlds_web_auth_matrix_part1() -> dict[str, object]:
     """The first of two bounded ``webAuthMatrix`` nix evals (issue #1156 item 1).
 
-    Splits the 39 independent, equal-cost worlds this module's single
+    Splits the independent, roughly-balanced worlds this module's single
     heaviest target used to force in one ``nix eval`` subprocess (measured
     57.2-61.0s solo across three quiet-host runs, mean ~58.5s; the prior
     #1131 docstring's 65.44s was this same target measured on an earlier
-    host state) into two roughly-balanced halves so the target's own solo
-    floor drops without changing what is evaluated or asserted. This half
-    carries the first 20 worlds in declaration order (``missing`` through
-    ``rootAccessGroup``); :func:`_shared_module_worlds_web_auth_matrix_part2`
-    carries the remaining 19.
+    host state) into two halves so the target's own solo floor drops
+    without changing what is evaluated or asserted. This half carries
+    ``missing`` through ``rootAccessGroup`` in declaration order;
+    :func:`_shared_module_worlds_web_auth_matrix_part2` carries
+    ``wheelAccessGroup`` through ``nginxRestartDisabled``.
 
     Measured solo (quiet host): this half alone 31.9s, the other half alone
-    28.3s (59.0s summed vs the original single target's ~58.5s mean -- the
-    ~1s preamble each half now pays independently is exactly the modest,
-    bounded cost #1131's own docstring already priced in). Measured
-    concurrently (both halves launched together, no other suite load):
-    33.2s wall -- close to the per-half floor, confirming the two
-    subprocesses barely interfere with each other in isolation.
+    28.3s -- 60.2s summed vs the original single target's ~58.5s mean,
+    +1.7s (an earlier draft of this sentence reported a wrong sum here;
+    corrected). Splitting pays exactly ONE additional shared preamble
+    (``getFlake`` + ``import nixpkgs`` + ``import ./nix/beets.nix``,
+    measured well under 1s standalone) -- one before the split, two after
+    -- not one per half, so the predicted overhead is ~1s; the measured
+    +1.7s is close to that (independent review's own measurement
+    corroborates the same shape: 59.75s base vs 33.85s + 28.13s = 61.98s
+    split, +2.23s/+3.7%). Measured concurrently (both halves launched
+    together, no other suite load): 33.2s wall -- close to the per-half
+    floor, confirming the two subprocesses barely interfere with each
+    other in isolation.
 
     That isolation number was NOT what decided this split -- three
     interleaved (baseline, candidate) pairs of full ``run_tests.sh``
@@ -328,16 +334,34 @@ def _shared_module_worlds_web_auth_matrix_part1() -> dict[str, object]:
     ambient contention, before this change touches anything) -- a real,
     if modest, net win with no evidence of the feared regression, not the
     dramatic headline number the solo floor alone would suggest.
+    Independent review's own controlled paired probes (real evals plus
+    synthetic CPU spinners held at fixed concurrency, isolating the
+    concurrency effect from ambient host noise) confirmed the same
+    direction more sharply: -22.6%/-29.5% at ~21-22 busy (this suite's real
+    worker count) and 72.3s -> 57.6s (-20.4%) at ~29-30 busy (at/over core
+    count), four paired runs all favouring the split; ``_rest`` was NOT
+    hurt by gaining a third competitor, and measured memory never dropped
+    below 21 of 32 GB.
 
-    Two of the original test method's assertion groups spanned this 20/21
-    world boundary (a 3-tuple checking "must be dedicated" across
-    ``serviceGroupOverlap``, ``nginxGroupOverlap``, ``secretGroupOverlap``,
-    and a 2-tuple checking "forbidden authority group" across
-    ``rootAccessGroup``, ``wheelAccessGroup``). Each was split into its own
-    half's assertions on the same message substrings against the same
-    worlds -- a partitioning change, not a coverage change: every world
-    this module ever evaluated is still evaluated, by exactly one half, and
-    asserted with the identical check it always got.
+    The ``serviceGroupOverlap``/``nginxGroupOverlap``/``secretGroupOverlap``
+    "must be dedicated" check and the ``rootAccessGroup``/
+    ``wheelAccessGroup`` "forbidden authority group" check both originally
+    lived in one ``for`` loop spanning the ``rootAccessGroup``/
+    ``wheelAccessGroup`` boundary this split introduces. Every one of the
+    original method's 39 ``worlds[...]`` references names exactly one
+    world -- there is no cross-world comparison anywhere in the base
+    method, so splitting a same-substring-check loop across that boundary
+    cannot weaken anything; each check now runs once, in whichever half
+    holds the world it names, on the identical message substring it
+    always checked. Independent review planted three mutants directly
+    against this claim; all three killed cleanly on both halves (record
+    in the shipping commit's kill matrix): dropping the ``accessGroup``
+    exclusion in ``nix/module.nix`` failed ``serviceGroupOverlap`` in this
+    half and ``secretGroupOverlap`` in the other; removing "root"/"wheel"
+    from the forbidden-group set failed ``rootAccessGroup`` here and
+    ``wheelAccessGroup`` there, independently; deleting a world's own
+    block from either half's expression failed that half with a
+    ``KeyError`` on the deleted world's name.
 
     See ``HOTSPOT_ISOLATED_METHODS`` in ``scripts/run_python_tests.py`` for
     the scheduler half of this split: both this function's sole consumer
@@ -345,6 +369,18 @@ def _shared_module_worlds_web_auth_matrix_part1() -> dict[str, object]:
     same reason the original single-target carve-out did -- the whole
     point is defeated if either ever shares a worker process with a
     neighbour it was not measured against.
+
+    The ~45-line Nix preamble (``getFlake``/``nixpkgs``/``beetsPackage``
+    header plus the shared ``evaluate`` base-world definition) is
+    byte-identical between this function and
+    :func:`_shared_module_worlds_web_auth_matrix_part2` today, with
+    nothing enforcing that beyond this claim -- the per-world assertions
+    above are same-world substring checks and so cannot detect one half's
+    base world silently drifting from the other's.
+    ``TestWebAuthMatrixPreamblesStayIdentical`` below pins the two
+    expressions' non-world regions equal so a future edit to one half's
+    base world cannot pass unnoticed while every existing assertion still
+    goes green.
     """
     expression = r'''
       let
@@ -557,7 +593,7 @@ def _shared_module_worlds_web_auth_matrix_part2() -> dict[str, object]:
     item 1). See :func:`_shared_module_worlds_web_auth_matrix_part1` for the
     full rationale, the measured solo/concurrent/under-load numbers, and why
     this split is a measured boundary decision, not merely half the file.
-    This half carries the remaining 19 worlds in declaration order
+    This half carries the remaining worlds in declaration order
     (``wheelAccessGroup`` through ``nginxRestartDisabled``). Measured solo
     (quiet host): 28.3s. Under full-suite load across the same three
     interleaved pairs, this half itself measured 46.3s / 48.3s / 53.0s.
@@ -799,6 +835,139 @@ def _shared_module_worlds_web_auth_matrix_part2() -> dict[str, object]:
     return _cached_nix_eval_json(expression)
 
 
+_WEB_AUTH_MATRIX_PART1_FIRST_WORLD_MARKER = "missing = evaluate {"
+_WEB_AUTH_MATRIX_PART2_FIRST_WORLD_MARKER = "wheelAccessGroup = evaluate {"
+
+
+def _web_auth_matrix_expression_source(function_name: str) -> str:
+    """The literal ``expression = r'''...'''`` string inside ``function_name``.
+
+    Static AST extraction of the source, not execution -- this module's own
+    established idiom for source-level Nix content checks (``_nix_source``,
+    :func:`strip_line_comments`). Reading the literal avoids paying for a
+    ``nix eval`` just to compare two Python string constants.
+    """
+    tree = ast.parse(Path(__file__).read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == function_name:
+            for stmt in node.body:
+                if (
+                    isinstance(stmt, ast.Assign)
+                    and len(stmt.targets) == 1
+                    and isinstance(stmt.targets[0], ast.Name)
+                    and stmt.targets[0].id == "expression"
+                    and isinstance(stmt.value, ast.Constant)
+                    and isinstance(stmt.value.value, str)
+                ):
+                    return stmt.value.value
+    raise AssertionError(
+        f"no literal `expression = r'''...'''` assignment found in {function_name}"
+    )
+
+
+def _assert_web_auth_matrix_preambles_equal(
+    part1_expression: str,
+    part2_expression: str,
+    *,
+    part1_marker: str = _WEB_AUTH_MATRIX_PART1_FIRST_WORLD_MARKER,
+    part2_marker: str = _WEB_AUTH_MATRIX_PART2_FIRST_WORLD_MARKER,
+) -> None:
+    """Issue #1156 item 1 review F3: the two split halves DUPLICATE (not
+    share) the ~45-line Nix preamble (``getFlake``/``nixpkgs``/
+    ``beetsPackage`` header plus the shared ``evaluate`` base-world
+    definition) -- nothing else keeps the two copies equal, and every
+    per-world assertion in both halves is a same-world substring check, so
+    none of them can detect one copy's base world silently drifting from
+    the other's. This is the guard that closes that gap.
+
+    Pure function so the pin test can drive it against the real file AND a
+    known-bad self-test can drive it against fabricated, controlled input
+    without touching disk or paying for a fresh ``nix eval``.
+    """
+    part1_header, part1_sep, _ = part1_expression.partition(part1_marker)
+    part2_header, part2_sep, _ = part2_expression.partition(part2_marker)
+    if not part1_sep:
+        raise AssertionError(f"part1 world-list marker not found: {part1_marker!r}")
+    if not part2_sep:
+        raise AssertionError(f"part2 world-list marker not found: {part2_marker!r}")
+    normalized_part1 = part1_header.replace(
+        "webAuthMatrixPart1 =", "webAuthMatrixPartN ="
+    )
+    normalized_part2 = part2_header.replace(
+        "webAuthMatrixPart2 =", "webAuthMatrixPartN ="
+    )
+    if normalized_part1 != normalized_part2:
+        raise AssertionError(
+            "the two webAuthMatrix halves' shared Nix preamble/evaluate "
+            "base world has drifted -- see "
+            "_shared_module_worlds_web_auth_matrix_part1's docstring for "
+            "why no per-world assertion can catch this"
+        )
+
+
+class TestWebAuthMatrixPreamblesStayIdentical(unittest.TestCase):
+    """Issue #1156 item 1 review F3. See
+    :func:`_assert_web_auth_matrix_preambles_equal`.
+    """
+
+    def test_real_halves_are_identical_today(self) -> None:
+        _assert_web_auth_matrix_preambles_equal(
+            _web_auth_matrix_expression_source(
+                "_shared_module_worlds_web_auth_matrix_part1"
+            ),
+            _web_auth_matrix_expression_source(
+                "_shared_module_worlds_web_auth_matrix_part2"
+            ),
+        )
+
+    def test_a_diverged_base_world_is_caught(self) -> None:
+        """Known-bad self-test: a base-world edit present in only one half
+        must fail this guard, even though it would pass every per-world
+        assertion in both halves (that is precisely the drift this guard
+        exists to catch)."""
+        part1 = (
+            "        webAuthMatrixPart1 =\n"
+            "          let\n"
+            "            evaluate = extra: /* base world */ null;\n"
+            "          in {\n"
+            "            missing = evaluate {};\n"
+        )
+        part2_diverged = (
+            "        webAuthMatrixPart2 =\n"
+            "          let\n"
+            "            evaluate = extra: /* DIFFERENT base world */ null;\n"
+            "          in {\n"
+            "            wheelAccessGroup = evaluate {};\n"
+        )
+        with self.assertRaisesRegex(AssertionError, "has drifted"):
+            _assert_web_auth_matrix_preambles_equal(part1, part2_diverged)
+
+    def test_identical_halves_pass(self) -> None:
+        """Must-still-work control for the self-test above."""
+        part1 = (
+            "        webAuthMatrixPart1 =\n"
+            "          let\n"
+            "            evaluate = extra: /* base world */ null;\n"
+            "          in {\n"
+            "            missing = evaluate {};\n"
+        )
+        part2_same = (
+            "        webAuthMatrixPart2 =\n"
+            "          let\n"
+            "            evaluate = extra: /* base world */ null;\n"
+            "          in {\n"
+            "            wheelAccessGroup = evaluate {};\n"
+        )
+        _assert_web_auth_matrix_preambles_equal(part1, part2_same)
+
+    def test_missing_marker_fails_closed(self) -> None:
+        """Known-bad self-test for the marker-not-found guard clauses."""
+        with self.assertRaisesRegex(AssertionError, "part1 world-list marker not found"):
+            _assert_web_auth_matrix_preambles_equal("no marker here", "wheelAccessGroup = evaluate {")
+        with self.assertRaisesRegex(AssertionError, "part2 world-list marker not found"):
+            _assert_web_auth_matrix_preambles_equal("missing = evaluate {", "no marker here")
+
+
 def _shared_module_worlds_rest() -> dict[str, object]:
     """The other five nix-eval worlds this module's tests still merge.
 
@@ -812,10 +981,21 @@ def _shared_module_worlds_rest() -> dict[str, object]:
     main's own worst-case bin-packed batch (~61.6s), not better. Issue
     #1156 item 1 later split that single ``webAuthMatrix`` target into
     ``_part1``/``_part2``, so this function is now one of THREE heavy
-    targets the module contributes rather than two — see
+    targets the module contributes rather than two, AND — because it did
+    not itself shrink while gaining a third competitor — this module's own
+    pole. Measured across the same three interleaved baseline/candidate
+    ``run_tests.sh`` pairs #1156 item 1's own shipping commit used: this
+    target ran 88.3s / 107.1s / 92.7s (mean 96.0s) before the split and
+    95.0s / 96.4s / 85.7s (mean 92.4s) after, competing against ONE extra
+    heavy sibling (-3.8%, not hurt by the extra competitor). On the
+    receipt bundle from the shipping commit's own ``check`` run, this
+    target (87.5s) was the single SLOWEST of all 463 targets in the whole
+    canonical suite, by 26s over the next entry — this module's own pole
+    is now the suite's own tail, which is the next lever if this module's
+    contribution is revisited. See
     :func:`_shared_module_worlds_web_auth_matrix_part1` for the measured
-    effect of that split on this target's own under-load time and on the
-    module's total contribution. Merging these four
+    effect of the split on the OTHER two targets this module contributes.
+    Merging these four
     also eliminates 3 of the 4 redundant ``getFlake`` + ``import nixpkgs``
     + ``import ./nix/beets.nix`` preambles they used to pay independently
     — each measured at well under 1s standalone, so the CPU this merge
@@ -1340,17 +1520,18 @@ class TestWebAuthenticationModuleContract(unittest.TestCase):
     """The enabled web surface has one fail-closed module-owned perimeter."""
 
     def test_basic_and_insecure_mode_matrix_is_evaluated_part1(self) -> None:
-        """Worlds 1-20 of the 39-world matrix (issue #1156 item 1).
+        """The ``missing``...``rootAccessGroup`` half of the webAuthMatrix
+        assertion matrix (issue #1156 item 1).
 
         See :func:`_shared_module_worlds_web_auth_matrix_part1` for why this
         is now two methods/targets instead of one, and
         ``test_basic_and_insecure_mode_matrix_is_evaluated_part2`` for the
         rest. The ``serviceGroupOverlap``/``nginxGroupOverlap``/
         ``secretGroupOverlap`` and ``rootAccessGroup``/``wheelAccessGroup``
-        checks straddled the 20/21 world boundary in the original single
-        method; each is now asserted once, in whichever half holds the
-        world it names, on the identical message substring it always
-        checked.
+        checks straddled the ``rootAccessGroup``/``wheelAccessGroup``
+        boundary in the original single method; each is now asserted once,
+        in whichever half holds the world it names, on the identical
+        message substring it always checked.
         """
         worlds = _shared_module_worlds_web_auth_matrix_part1()["webAuthMatrixPart1"]
         assert isinstance(worlds, dict)
@@ -1422,7 +1603,8 @@ class TestWebAuthenticationModuleContract(unittest.TestCase):
         )
 
     def test_basic_and_insecure_mode_matrix_is_evaluated_part2(self) -> None:
-        """Worlds 21-39 of the 39-world matrix (issue #1156 item 1).
+        """The ``wheelAccessGroup``...``nginxRestartDisabled`` half of the
+        webAuthMatrix assertion matrix (issue #1156 item 1).
 
         See ``test_basic_and_insecure_mode_matrix_is_evaluated_part1`` for
         the split rationale and the two straddling checks this method

--- a/tests/test_parallel_test_runner.py
+++ b/tests/test_parallel_test_runner.py
@@ -1021,7 +1021,7 @@ class TestModuleScheduling(unittest.TestCase):
         # shows this module's pole inflating hard with concurrency: 88.0s
         # at 8 workers, 122.7s at 12, 147.7s at 16, 152.3s at 20). Issue
         # #1156 item 1 split that single heaviest consumer's own world
-        # matrix into two cost-balanced halves (below), raising the count
+        # matrix into two roughly-balanced halves (below), raising the count
         # to THREE — measured (three interleaved baseline/candidate full-
         # suite pairs) as a real, if modest, net win: the module's worst
         # single target dropped from a mean of 105.9s to 92.4s (-13%,

--- a/tests/test_parallel_test_runner.py
+++ b/tests/test_parallel_test_runner.py
@@ -1004,7 +1004,7 @@ class TestModuleScheduling(unittest.TestCase):
         )
         # tests.test_nix_module is frontloaded but deliberately NOT
         # method_batch-sharded (issue #1131 review round 2): its nix-eval
-        # tests are cost-grouped into two exception-memoizing cached
+        # tests are cost-grouped into three exception-memoizing cached
         # helpers, which only pay off when every one of a group's
         # consumers runs in the same worker process. A blind method_batch
         # split could land more than one of the module's heavy nix-eval
@@ -1012,14 +1012,25 @@ class TestModuleScheduling(unittest.TestCase):
         # unshard (this issue's own round 1) serializes every merged world
         # onto one target instead (measured: main's own worst-case
         # bin-packed batch is 61.6s, a full unshard is 118.3s).
-        # HOTSPOT_ISOLATED_METHODS below is the narrower fix: carve the
-        # single heaviest consumer into its own target, bundle everything
-        # else into one remainder target — floor level with main (not
-        # better), at most TWO concurrent heavy nix-eval subprocesses
-        # instead of up to five, which is what makes raising the suite's
-        # worker count affordable (main's own worker-count sweep shows
-        # this module's pole inflating hard with concurrency: 88.0s at 8
-        # workers, 122.7s at 12, 147.7s at 16, 152.3s at 20).
+        # HOTSPOT_ISOLATED_METHODS below is the narrower fix: originally
+        # (issue #1131) carved the single heaviest consumer into its own
+        # target, bundling everything else into one remainder target — at
+        # most TWO concurrent heavy nix-eval subprocesses instead of up to
+        # five, which is what made raising the suite's worker count
+        # affordable in the first place (main's own worker-count sweep
+        # shows this module's pole inflating hard with concurrency: 88.0s
+        # at 8 workers, 122.7s at 12, 147.7s at 16, 152.3s at 20). Issue
+        # #1156 item 1 split that single heaviest consumer's own world
+        # matrix into two cost-balanced halves (below), raising the count
+        # to THREE — measured (three interleaved baseline/candidate full-
+        # suite pairs) as a real, if modest, net win: the module's worst
+        # single target dropped from a mean of 105.9s to 92.4s (-13%,
+        # every pair individually improved, no runaway blowup), and the
+        # suite's python-phase wall time moved from a mean of 118.6s to
+        # 113.8s (-4%, noisier — baseline alone spanned 107.5-137.0s from
+        # ambient host contention). See
+        # ``_shared_module_worlds_web_auth_matrix_part1``'s docstring in
+        # ``tests/test_nix_module.py`` for the full numbers.
         self.assertEqual(
             HOTSPOT_SHARD_POLICIES,
             {
@@ -1035,7 +1046,11 @@ class TestModuleScheduling(unittest.TestCase):
                 "tests.test_nix_module": frozenset({
                     (
                         "tests.test_nix_module.TestWebAuthenticationModuleContract."
-                        "test_basic_and_insecure_mode_matrix_is_evaluated"
+                        "test_basic_and_insecure_mode_matrix_is_evaluated_part1"
+                    ),
+                    (
+                        "tests.test_nix_module.TestWebAuthenticationModuleContract."
+                        "test_basic_and_insecure_mode_matrix_is_evaluated_part2"
                     ),
                 }),
             },


### PR DESCRIPTION
Addresses #1156 item 1 — the only lever the issue identified as moving the headline number.

## The target

`tests/test_nix_module.py::_shared_module_worlds_web_auth_matrix()` was a single `nix eval` holding **this module's heaviest world at 65.44s**. Measured per-world costs from that function's own docstring: `headlessComposition` 0.80s, `beetsReadiness` 3.46s, `mergedGateway` 18.67s, `beetsCapability` 38.28s, `webAuthMatrix` **65.44s**.

It is now split into two roughly-balanced evals, each carved into its own `HOTSPOT_ISOLATED_METHODS` singleton target so neither can share a worker with the module's other heavy evals.

## The risk this had to clear

#1151 deliberately capped this module at **at most two** concurrent heavy nix-eval subprocesses, because its pole inflates hard with concurrency — the base docstring's own sweep: **88.0s at 8 workers, 122.7s at 12, 147.7s at 16, 152.3s at 20**. Splitting raises that count to three, so the isolated floor could improve while the module's contribution *under real suite load* got worse. Running the module unsharded regresses it from 61.6s to 118.3s, so this is not a hypothetical failure mode.

**It did not materialise.** Independent review measured it directly with controlled paired probes (real evals plus synthetic spinners), at two concurrency levels:

| condition | pre-split (`base ∥ rest`) | post-split (`part1 ∥ part2 ∥ rest`) | Δ |
|---|---|---|---|
| 19 spinners (~21–22 busy, the suite's real worker count) | 97.1s / 95.2s | **75.2s / 67.1s** | −22.6% / −29.5% |
| 27 spinners (~29–30 busy, at/over core count) | 72.6s / 72.1s | **58.3s / 56.9s** | −20.4% mean |

Four paired runs, every one favouring the split. `_rest` — the target that *gained* a competitor — was **not hurt** (76.1→75.2, 72.9→67.1, 60.7→58.2, 55.4→56.8). Minimum `MemAvailable` never dropped below 21 GB of 32 GB.

The author's own full-suite interleaved pairs were more conservative: worst single target from this module 105.9s → 92.4s (**−13%**), python-phase wall 118.6s → 113.8s (−4%, explicitly labelled noisier than its own 107.5–137.0s baseline spread).

## Coverage equivalence — the actual merge gate

Proven three orthogonal ways by independent review:

1. **The Nix side is an exact partition.** Preambles byte-identical apart from the attribute name; 39 = 20 + 19 worlds, in order; the concatenated world bodies are byte-identical to the original, 341/341 lines. No world body changed by a character.
2. **The Python assertion set is preserved exactly.** AST-parsed and normalised (`for world in (...)` loops expanded): 39 base checks → 20 + 19, set-difference empty in both directions, identical multiplicities, no world asserted twice, no orphans.
3. **The "straddling assertions" hazard does not apply to this code.** Every one of the 39 assertions references **exactly one** world — there is no cross-world comparison anywhere. The "overlap" in `serviceGroupOverlap`/`nginxGroupOverlap`/`secretGroupOverlap` lives in each world's *nix configuration*, not in a Python assertion relating two worlds, so splitting the `for` loops that applied the same substring check to independent worlds cannot make anything vacuous.

## Kill matrix

| Site (assertion / clause / constant) | One-line mutant | Test that goes RED | Result |
| --- | --- | --- | --- |
| `HOTSPOT_ISOLATED_METHODS` dict | drop the `_part2` entry | `test_audited_hotspots_split_at_the_narrowest_safe_boundary` | RED |
| test method identity | rename `_part1` without updating the registry | `test_isolated_method_ids_are_real_discovered_tests` | RED, names the exact id |
| `hotspot_targets()` fail-closed guard | same rename, driven through the real `scripts/run_python_tests.py` entrypoint | live scheduler | RED (`ValueError`), exit 1, before any nix eval |
| `HOTSPOT_ISOLATED_METHODS` id string | typo `_part1` → `_Part1` | both scheduler pins | RED |
| `HOTSPOT_ISOLATED_METHODS` add-direction | add a spurious `_part3` | both scheduler pins | RED |
| `unknown = isolated - set(test_ids)` | replace with `frozenset()` | `test_hotspot_targets_rejects_an_unknown_isolated_id` | RED |
| **`nix/module.nix` `webAccessGroupIsSafe`** | drop `&& !lib.elem cfg.web.accessGroup webForbiddenAuthorityGroups` | **both halves** | RED (part1 `serviceGroupOverlap`, part2 `secretGroupOverlap`) |
| **`nix/module.nix` `webForbiddenAuthorityGroupKeys`** | remove `"root"` and `"wheel"` | **both halves** | RED — the split "forbidden authority group" checks each fire independently |
| **the two split evals' world sets** | delete `nginxGroupOverlap` from part1 and `secretGroupOverlap` from part2 | **both halves** | RED (`KeyError`) — a dropped world cannot pass silently |
| new preamble-drift guard | plant real drift in the live file | `TestWebAuthMatrixPreamblesStayIdentical` | RED with the right message |

The last four rows are the ones the original commit owed and did not have — its kill matrix targeted only the scheduler registry, not the assertion split, which is the part that could silently lose coverage. Review supplied them; they were then re-verified here with real `nix eval` runs rather than taken on faith.

## Also in this PR

A **preamble-drift pin**. The split duplicates ~45 lines of Nix (the `getFlake`/`nixpkgs`/`beetsPackage` header plus the whole `evaluate` base world) across the two functions, byte-identical today with nothing keeping them so. Concrete drift scenario: someone adds an option to part1's copy only — every assertion in both halves still passes, because they are per-world substring checks and no assertion relates two worlds, so the halves silently stop evaluating the same base world. `_assert_web_auth_matrix_preambles_equal` is a pure static-AST comparison (no `nix eval`) with a must-still-work control and two known-bad self-tests.

## Corrections made after review

- **Arithmetic error in a stated measurement**: 31.9 + 28.3 = **60.2s**, not the "59.0s summed" originally written — so the added overhead is **+1.7s**, not +0.5s (review measured +2.23s independently). The model was also wrong: only **one additional** preamble is paid overall, not one per half.
- "equal-cost"/"cost-balanced" → "roughly-balanced" (the halves differ by 12.7–18.4%).
- Removed five brittle-cardinality phrases the split had introduced, in favour of the world-name boundaries already documented.

## Where the next lever is

`tests.test_nix_module::remainder` is now the module's pole **and the slowest single target in the entire 464-target suite at 87.5s**, by 26s. Its docstring now says so, with its own baseline-vs-candidate number (96.0s → 92.4s, −3.8%, unharmed by the extra competitor).

No deploy: test infrastructure only — zero doc2 runtime delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
