### PR TITLE
perf(tests): share one nixpkgs instance per nix eval, and frontload by measured cost (#1226)

### DIFF
--- a/scripts/run_python_tests.py
+++ b/scripts/run_python_tests.py
@@ -80,7 +80,43 @@ TEST_HOST_MEMORY_EXHAUSTED_EXIT_CODE = 5
 WORLD_MODEL_MODULE = "tests.world_model.state_machine"
 # Method profiling showed the dominant Nix evaluation was otherwise admitted
 # late enough to become the deterministic suite's tail.
-AUDITED_FRONTLOAD_MODULES = frozenset({"tests.test_nix_module"})
+#
+# Issue #1226: ``schedule_modules`` below orders everything that is NOT
+# frontloaded by ``_line_weight`` — a module's LINE COUNT — which is only a
+# proxy for cost, and an actively misleading one for a small file that runs
+# real subprocesses. Once #1226's shared-``nixpkgs`` fix removed
+# ``test_nix_module`` as the phase's pole, the phase stopped being
+# pole-bound and became throughput-bound, at which point queue ORDER is
+# what costs wall time: a long target admitted late cannot be packed
+# against anything. Measured on doc1 (30 cores, quiet, 22 workers) from a
+# full per-target duration map of one real phase run, replayed through this
+# same scheduler: perfect packing 76.0s, this queue order 88.1s, and
+# longest-processing-time-first 76.2s — i.e. ~12s of the phase was pure
+# ordering loss. The four modules added below are the ones the map showed
+# were both expensive AND admitted late (measured target seconds, and their
+# position in a 464-target queue): test_world_model_coordinator 38.9s at
+# 256, test_fuzz_burst 33.6s at 211, test_targeted_test_selection 32.0s at
+# 311, test_aac_lattice 30.9s at 273. None of them ends in ``_generated``,
+# so nothing else pulls them forward. Replaying the map with exactly these
+# four frontloaded predicts 81.5s (-6.3s); adding further modules past
+# these four plateaus at ~81.4s and buys nothing, so the list stops here
+# rather than growing to track every heavy module. Measured rather than
+# only predicted: the real phase went 89.6s -> 82.6s on the same host,
+# within 1.1s of the replay's prediction.
+#
+# This list is a hand-audited scheduling HINT, never a correctness
+# boundary: a stale entry (a module that got cheap, or a new heavy one that
+# is missing) costs a little wall time and nothing else. Do NOT grow it
+# into a maintained per-target cost table — the remaining ~5s between the
+# prediction above and the LPT bound is not worth 464 committed numbers
+# that drift on every test change.
+AUDITED_FRONTLOAD_MODULES = frozenset({
+    "tests.test_nix_module",
+    "tests.test_world_model_coordinator",
+    "tests.test_fuzz_burst",
+    "tests.test_targeted_test_selection",
+    "tests.test_aac_lattice",
+})
 #: tests.test_nix_module (issue #1131) is NOT method_batch here on purpose.
 #: Its nix-eval tests are cost-grouped into three ``functools``-free,
 #: exception-memoizing cached helpers in the test module
@@ -129,6 +165,25 @@ AUDITED_FRONTLOAD_MODULES = frozenset({"tests.test_nix_module"})
 #: affordable in the first place; that headroom is why item 1's move from
 #: two to three concurrent heavy targets was safe to measure rather than
 #: assumed unsafe outright.
+#:
+#: Issue #1226 ended this module's reign as the pole, and NOT by splitting
+#: it again: it made each eval ~2.5x cheaper by sharing one nixpkgs
+#: instance across the worlds inside it (details and the byte-identical
+#: proof are in ``_shared_module_worlds_web_auth_matrix_part1``'s
+#: docstring). Measured on a quiet 30-core doc1 at the default 22 workers,
+#: this module's three targets went from 95.0s/65.6s/57.0s to
+#: 38.9s/31.1s/24.8s, and the python phase from 98.6s to 89.6s. Two things
+#: follow for anyone tuning this file next. First, the sweep above is now
+#: historical: it measured a pole that no longer exists at that size, so do
+#: not cite it as evidence about today's concurrency headroom without
+#: re-measuring. Second, the phase is no longer POLE-bound at all — its
+#: largest target (47.9s) is well under the perfect-packing floor
+#: (1673 measured core-seconds / 22 workers = 76.0s), so splitting any
+#: target further cannot move the phase. Raising the worker count cannot
+#: either, and was measured: 26 workers inflated total core-seconds by 11%
+#: (1673 -> 1860) for a 2% wall gain, because the host is already CPU-
+#: saturated. What is left is total CPU work, and queue ORDER — see
+#: ``AUDITED_FRONTLOAD_MODULES`` above.
 HOTSPOT_SHARD_POLICIES = {
     "tests.test_beets_destructive_configs_generated": "method_batch",
     "tests.test_deploy_pin_generated": "method_batch",

--- a/tests/test_nix_module.py
+++ b/tests/test_nix_module.py
@@ -285,6 +285,29 @@ def _cached_nix_eval_json(expression: str) -> dict[str, object]:
 def _shared_module_worlds_web_auth_matrix_part1() -> dict[str, object]:
     """The first of two bounded ``webAuthMatrix`` nix evals (issue #1156 item 1).
 
+    Issue #1226 (read this first — it supersedes the SIZES quoted below,
+    not the reasoning): every ``lib.nixosSystem`` in this module's
+    expressions now takes ``{ nixpkgs.pkgs = modulePkgs; }`` as its first
+    module, so all of a given eval's worlds share the ONE nixpkgs instance
+    the preamble already built for ``beetsPackage`` instead of each
+    instantiating its own. ``flake.nix``'s own eval-level guards
+    (``runtimeSrcPin``, ``packageSetPin``, ``moduleAssertions``) already
+    used exactly this idiom; these expressions were the odd ones out. It
+    changes nothing about what is evaluated or asserted -- the ``nix eval
+    --json`` stdout is BYTE-IDENTICAL before and after for all three
+    expressions, which is how the change was qualified -- and it is
+    fail-closed rather than silent if that ever stops being true, because
+    nixpkgs' own module errors out when ``nixpkgs.pkgs`` is set alongside a
+    ``nixpkgs.config``/``overlays``/``hostPlatform`` definition. Measured
+    solo on a quiet 30-core host, base vs candidate: this half 31.4s ->
+    13.9s (-55.7%), the other half 26.6s -> 12.2s (-54.3%),
+    :func:`_shared_module_worlds_rest` 44.0s -> 16.3s (-63.0%). The cost
+    removed was never the shared preamble (measured at 0.19s standalone --
+    see the paragraph below, which over-credited it); it was ~20 redundant
+    nixpkgs instantiations, one per world. A bare ``lib.nixosSystem``
+    reading only ``.config.assertions`` costs 0.21s marginal, so what each
+    world pays now is close to that floor.
+
     Splits the independent, roughly-balanced worlds this module's single
     heaviest target used to force in one ``nix eval`` subprocess (measured
     57.2-61.0s solo across three quiet-host runs, mean ~58.5s; the prior
@@ -398,6 +421,7 @@ def _shared_module_worlds_web_auth_matrix_part1() -> dict[str, object]:
                 system = lib.nixosSystem {
                   system = builtins.currentSystem;
                   modules = [
+                    { nixpkgs.pkgs = modulePkgs; }
                     f.nixosModules.default
                     ({ ... }: {
                       services.cratedigger = {
@@ -597,6 +621,10 @@ def _shared_module_worlds_web_auth_matrix_part2() -> dict[str, object]:
     (``wheelAccessGroup`` through ``nginxRestartDisabled``). Measured solo
     (quiet host): 28.3s. Under full-suite load across the same three
     interleaved pairs, this half itself measured 46.3s / 48.3s / 53.0s.
+
+    Issue #1226 superseded those sizes: with the shared nixpkgs instance
+    (see part1's own #1226 paragraph) this half is 12.2s solo and 24.8s
+    under full-suite load, byte-identical output either way.
     """
     expression = r'''
       let
@@ -614,6 +642,7 @@ def _shared_module_worlds_web_auth_matrix_part2() -> dict[str, object]:
                 system = lib.nixosSystem {
                   system = builtins.currentSystem;
                   modules = [
+                    { nixpkgs.pkgs = modulePkgs; }
                     f.nixosModules.default
                     ({ ... }: {
                       services.cratedigger = {
@@ -991,8 +1020,17 @@ def _shared_module_worlds_rest() -> dict[str, object]:
     receipt bundle from the shipping commit's own ``check`` run, this
     target (87.5s) was the single SLOWEST of all 463 targets in the whole
     canonical suite, by 26s over the next entry — this module's own pole
-    is now the suite's own tail, which is the next lever if this module's
-    contribution is revisited. See
+    was then the suite's own tail. Issue #1226 closed that without
+    splitting anything: sharing ONE nixpkgs instance across this
+    expression's eight ``lib.nixosSystem`` calls (see
+    :func:`_shared_module_worlds_web_auth_matrix_part1`'s own #1226
+    paragraph for the mechanism and the byte-identical-output proof) took
+    this eval from 44.0s to 16.3s solo, and this target from 95.0s to 38.9s
+    in a real phase run. It is no longer the suite's tail and this module
+    is no longer the phase's pole. Splitting this target further is now
+    the wrong lever regardless: with the pole gone the phase is
+    throughput-bound, so what costs wall time is total CPU and queue
+    order, not any one target's length. See
     :func:`_shared_module_worlds_web_auth_matrix_part1` for the measured
     effect of the split on the OTHER two targets this module contributes.
     Merging these four
@@ -1042,6 +1080,7 @@ def _shared_module_worlds_rest() -> dict[str, object]:
             system = lib.nixosSystem {
               system = builtins.currentSystem;
               modules = [
+                { nixpkgs.pkgs = modulePkgs; }
                 f.nixosModules.default
                 ({ ... }: {
                   services.cratedigger = {
@@ -1083,6 +1122,7 @@ def _shared_module_worlds_rest() -> dict[str, object]:
                 system = lib.nixosSystem {
                   system = builtins.currentSystem;
                   modules = [
+                    { nixpkgs.pkgs = modulePkgs; }
                     f.nixosModules.default
                     ({ ... }: {
                       networking.enableIPv6 = enableIPv6;
@@ -1215,6 +1255,7 @@ def _shared_module_worlds_rest() -> dict[str, object]:
               let system = lib.nixosSystem {
                 system = builtins.currentSystem;
                 modules = [
+                  { nixpkgs.pkgs = modulePkgs; }
                   f.nixosModules.default
                   ({ ... }: {
                     services.cratedigger = {
@@ -1242,12 +1283,13 @@ def _shared_module_worlds_rest() -> dict[str, object]:
                   system.config.assertions);
             disabled = lib.nixosSystem {
               system = builtins.currentSystem;
-              modules = [ f.nixosModules.default ];
+              modules = [ { nixpkgs.pkgs = modulePkgs; } f.nixosModules.default ];
             };
             identityFailures = user: group:
               let system = lib.nixosSystem {
                 system = builtins.currentSystem;
                 modules = [
+                  { nixpkgs.pkgs = modulePkgs; }
                   f.nixosModules.default
                   ({ ... }: {
                     services.cratedigger = {
@@ -1276,6 +1318,7 @@ def _shared_module_worlds_rest() -> dict[str, object]:
             defaultIdentity = let system = lib.nixosSystem {
               system = builtins.currentSystem;
               modules = [
+                { nixpkgs.pkgs = modulePkgs; }
                 f.nixosModules.default
                 ({ ... }: {
                   services.cratedigger = {
@@ -1364,6 +1407,7 @@ def _shared_module_worlds_rest() -> dict[str, object]:
             system = lib.nixosSystem {
               system = builtins.currentSystem;
               modules = [
+                { nixpkgs.pkgs = modulePkgs; }
                 f.nixosModules.default
                 ({ ... }: {
                   services.cratedigger = {
@@ -1426,6 +1470,7 @@ def _shared_module_worlds_rest() -> dict[str, object]:
                 system = lib.nixosSystem {
                   system = builtins.currentSystem;
                   modules = [
+                    { nixpkgs.pkgs = modulePkgs; }
                     f.nixosModules.default
                     ({ ... }: {
                       services.cratedigger = {
@@ -1734,6 +1779,7 @@ class TestWebAuthenticationModuleContract(unittest.TestCase):
             system = f.inputs.nixpkgs.lib.nixosSystem {
               system = builtins.currentSystem;
               modules = [
+                { nixpkgs.pkgs = modulePkgs; }
                 f.nixosModules.default
                 ({ ... }: {
                   services.cratedigger = {

--- a/tests/test_parallel_test_runner.py
+++ b/tests/test_parallel_test_runner.py
@@ -998,10 +998,28 @@ class TestModuleScheduling(unittest.TestCase):
         self.assertEqual(env["PATH"], "/bin")
 
     def test_audited_hotspots_split_at_the_narrowest_safe_boundary(self) -> None:
+        # Issue #1226 added the four measured-heavy, late-admitted modules
+        # below. They are frontloaded for SCHEDULING ONLY — unlike
+        # tests.test_nix_module they carry no sharding policy at all, so
+        # nothing about how they are split changes; only when they enter
+        # the queue does. See AUDITED_FRONTLOAD_MODULES' own comment in
+        # scripts/run_python_tests.py for the measured ordering loss.
         self.assertEqual(
             AUDITED_FRONTLOAD_MODULES,
-            frozenset({"tests.test_nix_module"}),
+            frozenset({
+                "tests.test_nix_module",
+                "tests.test_world_model_coordinator",
+                "tests.test_fuzz_burst",
+                "tests.test_targeted_test_selection",
+                "tests.test_aac_lattice",
+            }),
         )
+        # The scheduling-only additions must stay scheduling-only: a
+        # sharding policy or isolated-method carve-out for one of them
+        # would be a different, unaudited change wearing this one's name.
+        for module_name in AUDITED_FRONTLOAD_MODULES - {"tests.test_nix_module"}:
+            self.assertNotIn(module_name, HOTSPOT_SHARD_POLICIES)
+            self.assertNotIn(module_name, HOTSPOT_ISOLATED_METHODS)
         # tests.test_nix_module is frontloaded but deliberately NOT
         # method_batch-sharded (issue #1131 review round 2): its nix-eval
         # tests are cost-grouped into three exception-memoizing cached

--- a/tests/test_web_auth_mode_generated.py
+++ b/tests/test_web_auth_mode_generated.py
@@ -104,7 +104,17 @@ def _nix_web_attrs(world: ModeWorld) -> str:
 
 @functools.cache
 def _evaluate_mode_worlds() -> dict[str, dict[str, object]]:
-    """Evaluate all sixteen worlds against the real module in one nix eval."""
+    """Evaluate all sixteen worlds against the real module in one nix eval.
+
+    Issue #1226: the sixteen worlds share ONE nixpkgs instance
+    (``{ nixpkgs.pkgs = modulePkgs; }`` as each system's first module,
+    ``flake.nix``'s own established idiom) rather than each
+    ``lib.nixosSystem`` instantiating its own. Nothing about what is
+    evaluated or asserted changes; it took this module from 54.0s to 21.9s
+    in a real phase run. See
+    ``tests/test_nix_module.py::_shared_module_worlds_web_auth_matrix_part1``
+    for the mechanism and the byte-identical-output evidence.
+    """
     worlds = "\n            ".join(
         f"{world.key} = evaluate {{ {_nix_web_attrs(world)} }};"
         for world in MODE_WORLDS
@@ -122,6 +132,7 @@ def _evaluate_mode_worlds() -> dict[str, dict[str, object]]:
             system = lib.nixosSystem {{
               system = builtins.currentSystem;
               modules = [
+                {{ nixpkgs.pkgs = modulePkgs; }}
                 f.nixosModules.default
                 ({{ ... }}: {{
                   services.cratedigger = {{


### PR DESCRIPTION
## Summary

Issue #1226 framed the last lever on suite wall time as splitting
`tests.test_nix_module::remainder` a third time. Measuring first said otherwise.

The preamble those earlier splits were sized around (`getFlake` +
`import nixpkgs` + `import ./nix/beets.nix`) costs **0.19s** standalone, and a
bare `lib.nixosSystem` reading only `.config.assertions` costs **0.21s**
marginal — against **~1.4s** for each of this module's real worlds. The gap was
~20 redundant nixpkgs instantiations, one per world: every `lib.nixosSystem` in
these expressions let the NixOS `nixpkgs` module build its own `pkgs` instead of
reusing the one the preamble had already built for `beetsPackage`.

`flake.nix`'s own eval-level guards (`runtimeSrcPin`, `packageSetPin`,
`moduleAssertions`) already pass `nixpkgs.pkgs`; these expressions were the odd
ones out. Adding `{ nixpkgs.pkgs = modulePkgs; }` as each system's first module
(12 sites across two test modules):

| eval | before | after | Δ |
| --- | --- | --- | --- |
| `webAuthMatrix` part1 | 31.4s | 13.9s | −55.7% |
| `webAuthMatrix` part2 | 26.6s | 12.2s | −54.3% |
| `_shared_module_worlds_rest` | 44.0s | 16.3s | −63.0% |

Removing the pole made the phase **throughput-bound rather than pole-bound**,
which moved the next lever from target *size* to queue *order*. Replaying a full
464-target duration map through the real scheduler: perfect packing 76.0s,
actual queue order 88.1s, longest-processing-time-first 76.2s — ~12s of pure
ordering loss, because everything not frontloaded is ordered by `_line_weight`
(a module's **line count**). Four measured-heavy modules were being admitted past
queue position 200 of 464. Frontloading exactly those recovers most of it;
adding more plateaus at ~81.4s, so the list stops there.

Two levers were measured and **rejected** rather than assumed:

- **Raising the worker count.** 26 workers inflated total core-seconds 11%
  (1673 → 1860) for a 2% wall gain. The host is already CPU-saturated at 22.
- **Sharding the new heavy targets.** At method granularity `test_aac_lattice`
  costs 120.2s versus 30.9s as one target — those modules rebuild per-process
  fixtures, so splitting buys packing and pays far more for it.

### Measured end to end

doc1 (30 cores, quiet), balanced ABBA, full `run_tests.sh`. Every candidate run
beat every baseline run:

| | base | base2 | cand | cand2 | mean Δ |
| --- | --- | --- | --- | --- | --- |
| suite wall | 112s | 119s | **104s** | **103s** | 115.5s → 103.5s (**−10.4%**) |
| python phase | 106.1s | 113.6s | **99.1s** | **97.3s** | 109.9s → 98.2s (**−10.6%**) |

Python phase measured standalone: **98.6s → 82.6s (−16.2%)**.

### Correctness qualification

The optimisation's gate is not a test — it is a differential. Each expression was
rendered from this tree and from the base ref and the raw `nix eval --json`
stdout compared: **byte-identical, all three**. It also cannot drift silently —
nixpkgs' own module errors out if `nixpkgs.pkgs` is set alongside a
`config`/`overlays`/`hostPlatform` definition — and it cannot mask a regression
the old shape would have caught, because the ambient `pkgs` each world used to
build was already `import f.inputs.nixpkgs {...}`, which is exactly what
`modulePkgs` is. No new stderr output (0 bytes).

Stale claims corrected in the same commit rather than left to rot:
`_shared_module_worlds_rest` no longer says it is the suite's slowest target,
part1/part2 carry the new sizes, and the worker-count sweep in
`run_python_tests.py` is explicitly labelled historical — it measured a pole that
no longer exists at that size.

Final gate: **pass** (`/run/user/1000/cratedigger-final-gate.noqIWxdH`).

## Kill matrix (per diff site, not per PR)

| Site (assertion / clause / constant) | One-line production mutant | Test that must go RED | Result |
| --- | --- | --- | --- |
| `AUDITED_FRONTLOAD_MODULES` membership (frozenset equality pin) | drop `"tests.test_aac_lattice"` from the frozenset | `test_audited_hotspots_split_at_the_narrowest_safe_boundary` | KILLED |
| NEW clause `assertNotIn(module_name, HOTSPOT_SHARD_POLICIES)` | add `"tests.test_fuzz_burst": "method_batch"` to `HOTSPOT_SHARD_POLICIES` | same test, and it must fail **at that clause** (line 1021), not at the frozenset equality | KILLED at line 1021 |
| `{ nixpkgs.pkgs = modulePkgs; }` in `webAuthMatrix` part1 (still-has-teeth) | `nix/module.nix`: `assertion = !cfg.web.enable \|\| webModeCount == 1;` → `assertion = true;` | `...test_basic_and_insecure_mode_matrix_is_evaluated_part1` | KILLED |
| `{ nixpkgs.pkgs = modulePkgs; }` in `webAuthMatrix` part2 (still-has-teeth) | `nix/module.nix`: `assertion = !cfg.web.enable \|\| config.services.nginx.enableReload;` → `assertion = true;` | `...test_basic_and_insecure_mode_matrix_is_evaluated_part2` | KILLED |
| `{ nixpkgs.pkgs = modulePkgs; }` in `_shared_module_worlds_rest` (still-has-teeth) | `nix/module.nix`: `assertion = cfg.beets.runtime.configDir != null;` → `assertion = true;` | `TestExternalBeetsRuntimeCapability` | KILLED, naming the exact removed assertion |

The three `nixpkgs.pkgs` rows deliberately answer "does this eval still constrain
`nix/module.nix` after the change?" — issue #1226's own stated merge gate — rather
than claiming the insertion is an assertion. Its *equivalence* is proven by the
byte-identical differential above, which is stronger than a mutant.

All mutants were run with `PYTHONDONTWRITEBYTECODE=1` and the file restored via
`git checkout --` after each, per the same-second mutate/test `__pycache__` trap.

Not covered by a mutant, stated plainly: the 12th `nixpkgs.pkgs` insertion is in
`test_web_auth_mode_generated`, qualified by that module's own 9 tests passing
plus the byte-identical differential, not by a separate planted mutant.

## Reviewer

Plant at least two mutants yourself. Aim at the named subject of each new or
changed test, not only at the sites above. Worth attacking specifically:

- Does the `assertNotIn` loop actually iterate a non-empty set? (Mutant: reduce
  `AUDITED_FRONTLOAD_MODULES` to just `tests.test_nix_module` and confirm the
  loop body becomes vacuous — the frozenset pin should catch it first.)
- Do the `nixpkgs.pkgs` insertions really share ONE instance? (Mutant: replace
  one site's `modulePkgs` with a fresh `import f.inputs.nixpkgs {...}` — output
  must stay identical, but the eval should get measurably slower again.)

## Risk

Test-infrastructure only. No production code path changes: `nix/module.nix`,
`lib/`, `web/`, `scripts/pipeline_cli/` and every runtime surface are untouched,
so there is nothing here to deploy or verify live.

Blast radius is two test modules' Nix expressions and one scheduling constant.
`AUDITED_FRONTLOAD_MODULES` is a hand-audited scheduling **hint**, never a
correctness boundary — a stale entry (a module that got cheap, or a new heavy one
that is missing) costs a little wall time and nothing else. The comment says so,
and explicitly warns the next reader not to grow it into a maintained per-target
cost table: the remaining ~5s between the prediction and the LPT bound is not
worth 464 committed numbers that drift on every test change.

Known residual: the frontload burst measurably slows the concurrently-overlapped
Pyright phase (28.4s/32.3s baseline → 34.7s/34.4s candidate) because both compete
for the same saturated cores. Net suite wall still improves in every paired run,
so this is a real trade recorded honestly, not an unnoticed regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
