### PR TITLE
perf(tests): close out #1229 — nix develop eval cache and measured-cost queue ordering

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -392,13 +392,20 @@ automated launcher of the canonical suite (`scripts/test.sh`,
 `scripts/run_final_gate.sh`, `scripts/daily_flake_update.sh`'s
 `deterministic_suite` stage, and `scripts/daily_beets_tip_update.sh`, which
 runs the same suite through `nix develop .#tip` — grep for BOTH
-`nix-shell --run .*run_tests.sh` and `nix develop .* run_tests.sh`, since the
-tip canary enters its shell the flake way) sets
+`nix-shell --run` and `nix develop`, since only the daily-gate stages still
+enter the shell the legacy way) sets
 `CRATEDIGGER_SUITE_OWNS_HEADROOM=1` before its own shell invocation,
 which tells that shellHook check to skip only its free-bytes refusal
 (everything else in `setup_cratedigger_test_tmpfs` still runs); `run_suite`'s
 own post-lock headroom precondition is then the single enforcement point for
-every suite run launched this way. The documented DIRECT command
+every suite run launched this way. Issue #1229 moved the first two of those
+launchers from `nix-shell --run` to `nix develop --command` — the same
+derivation either way (`flake.nix`'s `devShells.default` IS `./nix/shell.nix`),
+but only the flake path gets Nix's own eval cache, worth ~4.7s per invocation
+on a clean tree. The two daily-gate stages deliberately did NOT move: they are
+unattended nightly jobs where the saving is irrelevant, and moving them would
+mean teaching their fake `nix` shim a new subcommand for no operator-visible
+gain. The documented DIRECT command
 (`nix-shell --run "bash scripts/run_tests.sh"`, CLAUDE.md/README.md/this
 file's own code block above) deliberately stays as-is: a human running it
 interactively gets the entry guard on purpose, since nothing there is

--- a/.claude/rules/nix-shell.md
+++ b/.claude/rules/nix-shell.md
@@ -17,3 +17,13 @@ nix-shell --run "python3 -c '...'"                     # one-off
 ```
 
 NEVER run `python3` outside nix-shell in this repo.
+
+`nix develop --command <cmd>` is an exact equivalent and is what
+`scripts/test.sh` and `scripts/run_final_gate.sh` use internally (issue
+#1229): `flake.nix`'s `devShells.default` IS `./nix/shell.nix`, the same
+derivation `shell.nix` delegates to, so the environment — store paths,
+`CRATEDIGGER_BEETS_PYTHON`, and the `scripts/test_tmpfs.sh` shellHook that
+allocates `TMPDIR` — is identical. It is preferred for anything scripted
+because it evaluates a locked flake and so hits Nix's own eval cache
+(measured ~5.2s → ~0.5s per entry on a clean tree). The `nix-shell` forms
+above stay correct and are fine to type by hand.

--- a/scripts/run_final_gate.sh
+++ b/scripts/run_final_gate.sh
@@ -158,8 +158,16 @@ run_gate() {
     command=$(canonical_command)
     # See scripts/test.sh for why: run_suite()'s own post-lock headroom
     # precondition is the single enforcement point for suite runs; the
-    # nix-shell shellHook entry guard defers to it here too (issue #1111 M2).
-    gate_argv=(env CRATEDIGGER_SUITE_OWNS_HEADROOM=1 nix-shell --run "$command")
+    # dev-shell shellHook entry guard defers to it here too (issue #1111 M2).
+    # `nix develop` rather than `nix-shell` for the eval-cache reason
+    # documented in full at scripts/test.sh (issue #1229). The gate is the
+    # best case for it: it already refuses to run on anything but a
+    # committed clean tree (below), which is exactly the state whose flake
+    # fingerprint Nix can cache -- ~4.7s off every gate invocation.
+    # `canonical_command` is unchanged, so the receipt still records the
+    # same canonical `bash scripts/run_tests.sh` and `status` still
+    # compares it the same way; only the launcher around it moved.
+    gate_argv=(env CRATEDIGGER_SUITE_OWNS_HEADROOM=1 nix develop --command bash -c "$command")
     receipt=$(mktemp -d "$runtime/cratedigger-final-gate.XXXXXXXX") \
         || die "cannot create final-gate receipt beneath $runtime"
     chmod 700 "$receipt" || die "cannot secure receipt directory: $receipt"

--- a/scripts/run_python_tests.py
+++ b/scripts/run_python_tests.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import errno
 import io
+import math
 import multiprocessing
 import os
 import shutil
@@ -42,6 +43,7 @@ from scripts.run_test_suite import (
     CheckFailureMarker,
     CheckMetricsMarker,
     _default_min_headroom_bytes,
+    private_runtime_dir,
     recommended_worker_count,
 )
 
@@ -964,6 +966,117 @@ def select_test_targets(
     return tuple(targets)
 
 
+#: Issue #1229: the LAST of the packing loss, and the only thing that can
+#: reach it. `schedule_modules` orders by `_line_weight` (line count) with
+#: `AUDITED_FRONTLOAD_MODULES` as a hand-audited override, and that override
+#: is MEASURED SATURATED: replaying a real 464-target duration map through
+#: the real scheduler, every membership variant tried landed between 81.0s
+#: and 82.3s against a longest-processing-time bound of 76.2s. Membership
+#: cannot close a gap that comes from ordering WITHIN the early group, so
+#: the only way to reach the bound is an actual per-target cost.
+#:
+#: The honest source of that cost is the previous run's own measurement.
+#: A committed table was considered and rejected in #1226: 464 numbers that
+#: drift on every test change is a worse trade than the seconds it buys.
+#: This cache has no such problem -- it is written by the run that measured
+#: it, and a tree change simply leaves the changed targets unknown.
+#:
+#: This is a SCHEDULING HINT and never a correctness boundary. Every target
+#: still runs; `assert_exact_target_schedule` compares by name as a SET, so
+#: it is order-insensitive by construction. A missing, stale, or corrupt
+#: cache costs some packing efficiency and nothing else, and the no-cache
+#: path is exactly the pre-#1229 behaviour.
+TARGET_DURATION_CACHE_NAME = "cratedigger-target-durations.json"
+
+
+def load_target_durations(runtime_dir: Path) -> dict[str, float]:
+    """Read the previous run's per-target seconds, or ``{}`` if unusable.
+
+    Every failure mode degrades to ``{}`` (schedule as before) rather than
+    raising: this file is an optimisation hint written by a previous
+    process, so a truncated write, a foreign format, or no file at all must
+    never be able to fail a test run.
+    """
+    path = runtime_dir / TARGET_DURATION_CACHE_NAME
+    try:
+        raw = path.read_bytes()
+    except OSError:
+        return {}
+    try:
+        decoded = msgspec.json.decode(raw, type=dict[str, float])
+    except (msgspec.DecodeError, msgspec.ValidationError):
+        return {}
+    return {
+        name: seconds
+        for name, seconds in decoded.items()
+        if seconds >= 0.0
+    }
+
+
+def store_target_durations(
+    runtime_dir: Path,
+    results: Sequence[TargetRunResult],
+) -> None:
+    """Merge this run's measured target seconds into the ordering cache.
+
+    Merged, not replaced, so a `--test`-selected partial run refines the
+    cache instead of discarding every target it did not run. Written to a
+    temporary file and renamed, so a concurrent reader sees either the old
+    map or the new one, never a half-written one. Best effort throughout.
+    """
+    if not results:
+        return
+    merged = load_target_durations(runtime_dir)
+    for result in results:
+        merged[result.target.test_name] = round(result.elapsed_seconds, 3)
+    path = runtime_dir / TARGET_DURATION_CACHE_NAME
+    try:
+        with tempfile.NamedTemporaryFile(
+            dir=runtime_dir,
+            prefix=f"{TARGET_DURATION_CACHE_NAME}.",
+            delete=False,
+        ) as handle:
+            handle.write(msgspec.json.encode(merged))
+            temporary = Path(handle.name)
+    except OSError:
+        return
+    try:
+        temporary.replace(path)
+    except OSError:
+        temporary.unlink(missing_ok=True)
+
+
+def order_targets_by_measured_cost(
+    schedule: Sequence[TestTarget],
+    durations: Mapping[str, float],
+) -> tuple[TestTarget, ...]:
+    """Longest-processing-time-first, using the previous run's measurements.
+
+    An UNKNOWN target (new, renamed, or resharded since the cache was
+    written) sorts as if it were the most expensive known one, so it is
+    admitted early. That is the fail-safe direction: admitting an unknown
+    target early costs almost nothing when it turns out to be cheap, while
+    admitting a genuinely expensive one late is exactly the tail this
+    ordering exists to prevent. Python's sort is stable, so targets of
+    equal cost -- including every target when the cache is empty -- keep
+    the incoming heuristic order untouched.
+    """
+    if not durations:
+        return tuple(schedule)
+    # Strictly greater than every known cost, not equal to the largest: a
+    # stable sort keeps ties in their incoming order, so `max(...)` would
+    # leave an unknown target sitting BEHIND the dearest known one — the
+    # opposite of the fail-safe direction this is documented to take.
+    # (Caught by this function's own test, not by review.)
+    unknown_cost = math.inf
+    return tuple(
+        sorted(
+            schedule,
+            key=lambda target: -durations.get(target.test_name, unknown_cost),
+        )
+    )
+
+
 def assert_exact_target_schedule(
     expected: Sequence[TestTarget],
     actual: Sequence[TestTarget],
@@ -1772,6 +1885,33 @@ def main(
         schedule = build_test_targets(module_schedule, listed_test_ids)
     worker_count = min(args.jobs, len(schedule))
 
+    # Issue #1229: reorder by the previous run's measured per-target cost.
+    # Hint only — see TARGET_DURATION_CACHE_NAME. Announced rather than
+    # silent, so a run whose wall time differs from a sibling's is
+    # explainable instead of mysterious.
+    # RuntimeError is the one `private_runtime_dir` actually raises for every
+    # unusable-root case (missing, symlink, wrong owner, wrong mode, not
+    # tmpfs); OSError covers the stat/resolve paths underneath it. Catching
+    # BOTH matters because this module is also runnable directly, without
+    # `run_suite`'s admission lock having already demanded that root — an
+    # ordering hint must never be the thing that fails such a run.
+    try:
+        runtime_dir = private_runtime_dir()
+    except (OSError, RuntimeError):
+        runtime_dir = None
+    measured_durations = (
+        load_target_durations(runtime_dir) if runtime_dir is not None else {}
+    )
+    if measured_durations:
+        schedule = order_targets_by_measured_cost(schedule, measured_durations)
+        known = sum(
+            1 for target in schedule if target.test_name in measured_durations
+        )
+        print(
+            f"Order: longest-first from {len(measured_durations)} cached "
+            f"target timings ({known}/{len(schedule)} known)"
+        )
+
     print(
         f"Python suite: {len({target.module.name for target in schedule})} "
         f"modules across {worker_count} workers "
@@ -1792,6 +1932,9 @@ def main(
         durations=args.durations,
     )
     wall_seconds = time.monotonic() - started_at
+
+    if runtime_dir is not None:
+        store_target_durations(runtime_dir, results)
 
     failed_results = [result for result in results if not result.successful]
     for result in sorted(results, key=lambda item: item.elapsed_seconds, reverse=True)[

--- a/scripts/run_python_tests.py
+++ b/scripts/run_python_tests.py
@@ -1061,13 +1061,17 @@ def order_targets_by_measured_cost(
     equal cost -- including every target when the cache is empty -- keep
     the incoming heuristic order untouched.
     """
-    if not durations:
-        return tuple(schedule)
     # Strictly greater than every known cost, not equal to the largest: a
     # stable sort keeps ties in their incoming order, so `max(...)` would
     # leave an unknown target sitting BEHIND the dearest known one — the
     # opposite of the fail-safe direction this is documented to take.
     # (Caught by this function's own test, not by review.)
+    #
+    # This also makes an empty cache need no special case: every target is
+    # then unknown, every key is equal, and a stable sort returns the
+    # incoming order untouched. An `if not durations: return` short-circuit
+    # was written here first and removed — a planted mutant proved it had
+    # no observable behaviour at all, only a redundant branch to maintain.
     unknown_cost = math.inf
     return tuple(
         sorted(

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -8,5 +8,21 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
+#
+# `nix develop`, not `nix-shell` (issue #1229): flake.nix's devShells.default
+# IS ./nix/shell.nix -- the same derivation `shell.nix` delegates to -- so the
+# environment is identical (verified: same python3 store path, same
+# CRATEDIGGER_BEETS_PYTHON, and scripts/test_tmpfs.sh's shellHook still runs
+# and still allocates TMPDIR). What differs is that `nix develop` evaluates a
+# LOCKED FLAKE, so Nix's own eval cache applies, while `nix-shell` re-evaluates
+# every time. Measured on doc1: `nix-shell --run true` 5181ms, `nix develop
+# --command true` 481ms warm on a clean tree -- ~4.7s saved per invocation, on
+# the single most frequent command in the dev loop. The cache key is the
+# flake's own locked fingerprint, so this is Nix invalidating its own cache,
+# not a hand-rolled one: a modified TRACKED file makes the tree dirty and Nix
+# re-evaluates (measured 2824ms, still faster than nix-shell), while an
+# untracked file does not participate in the flake source at all (490ms).
+# There is deliberately no nix-shell fallback: this repo already requires
+# `nix develop` for scripts/daily_beets_tip_update.sh's `.#tip` canary.
 printf -v command '%q ' python3 scripts/run_targeted_tests.py "$@"
-exec env CRATEDIGGER_SUITE_OWNS_HEADROOM=1 nix-shell --run "$command"
+exec env CRATEDIGGER_SUITE_OWNS_HEADROOM=1 nix develop --command bash -c "$command"

--- a/tests/test_final_gate_receipt.py
+++ b/tests/test_final_gate_receipt.py
@@ -15,22 +15,22 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 HELPER = REPO_ROOT / "scripts" / "run_final_gate.sh"
 
 
-_FAKE_NIX_SHELL = """#!/usr/bin/env bash
+_FAKE_NIX = """#!/usr/bin/env bash
 set -u
-printf '%s\\n' "$@" > "$FAKE_NIX_SHELL_RECORD"
-printf '%s' "${CRATEDIGGER_SUITE_OWNS_HEADROOM:-}" > "$FAKE_NIX_SHELL_HEADROOM_ENV_RECORD"
+printf '%s\\n' "$@" > "$FAKE_NIX_RECORD"
+printf '%s' "${CRATEDIGGER_SUITE_OWNS_HEADROOM:-}" > "$FAKE_NIX_HEADROOM_ENV_RECORD"
 printf 'gate output\\n'
 printf 'gate error\\n' >&2
-if [[ "${2:-}" == "bash scripts/run_tests.sh" ]]; then
-    printf 'bundle: %s\\n' "$FAKE_NIX_SHELL_BUNDLE"
+if [[ "${5:-}" == "bash scripts/run_tests.sh" ]]; then
+    printf 'bundle: %s\\n' "$FAKE_NIX_BUNDLE"
 fi
-case "$FAKE_NIX_SHELL_MODE" in
-    exit) exit "$FAKE_NIX_SHELL_EXIT" ;;
+case "$FAKE_NIX_MODE" in
+    exit) exit "$FAKE_NIX_EXIT" ;;
     sleep) sleep 30 ;;
     term) kill -TERM "$$" ;;
     kill) kill -KILL "$$" ;;
-    dirty) touch "$FAKE_NIX_SHELL_REPO/dirty" ;;
-    head-change) git -C "$FAKE_NIX_SHELL_REPO" commit --allow-empty -qm changed ;;
+    dirty) touch "$FAKE_NIX_REPO/dirty" ;;
+    head-change) git -C "$FAKE_NIX_REPO" commit --allow-empty -qm changed ;;
     *) exit 126 ;;
 esac
 """
@@ -50,11 +50,13 @@ class FinalGateReceiptTestCase(unittest.TestCase):
         )
         self.bundle.chmod(0o700)
         (self.bundle / "summary.json").write_text("{}\n", encoding="utf-8")
-        fake_nix_shell = Path(self.fake_bin.name) / "nix-shell"
-        fake_nix_shell.write_text(_FAKE_NIX_SHELL)
-        fake_nix_shell.chmod(0o755)
-        self.record = Path(self.fake_bin.name) / "nix-shell.argv"
-        self.headroom_env_record = Path(self.fake_bin.name) / "nix-shell.headroom-env"
+        # Issue #1229: the gate launches `nix develop --command bash -c ...`,
+        # so the binary to fake is `nix`, not `nix-shell`.
+        fake_nix = Path(self.fake_bin.name) / "nix"
+        fake_nix.write_text(_FAKE_NIX)
+        fake_nix.chmod(0o755)
+        self.record = Path(self.fake_bin.name) / "nix.argv"
+        self.headroom_env_record = Path(self.fake_bin.name) / "nix.headroom-env"
         self.created_receipts: list[Path] = []
         self._git("init", "-q")
         self._git("config", "user.email", "tests@example.invalid")
@@ -90,12 +92,12 @@ class FinalGateReceiptTestCase(unittest.TestCase):
         env |= {
             "XDG_RUNTIME_DIR": str(self.runtime),
             "PATH": f"{self.fake_bin.name}:{os.environ['PATH']}",
-            "FAKE_NIX_SHELL_RECORD": str(self.record),
-            "FAKE_NIX_SHELL_HEADROOM_ENV_RECORD": str(self.headroom_env_record),
-            "FAKE_NIX_SHELL_MODE": mode,
-            "FAKE_NIX_SHELL_EXIT": str(exit_code),
-            "FAKE_NIX_SHELL_REPO": self.repo.name,
-            "FAKE_NIX_SHELL_BUNDLE": str(self.bundle),
+            "FAKE_NIX_RECORD": str(self.record),
+            "FAKE_NIX_HEADROOM_ENV_RECORD": str(self.headroom_env_record),
+            "FAKE_NIX_MODE": mode,
+            "FAKE_NIX_EXIT": str(exit_code),
+            "FAKE_NIX_REPO": self.repo.name,
+            "FAKE_NIX_BUNDLE": str(self.bundle),
         }
         return env
 
@@ -146,7 +148,10 @@ class FinalGateReceiptTestCase(unittest.TestCase):
 
         self.assertEqual(process.returncode, 0, stderr)
         self.assertIn("final gate: pass (exit 0)", stdout)
-        self.assertEqual(self.record.read_text(), "--run\nbash scripts/run_tests.sh\n")
+        self.assertEqual(
+            self.record.read_text(),
+            "develop\n--command\nbash\n-c\nbash scripts/run_tests.sh\n",
+        )
         self.assertEqual(self._status(receipt), "pass")
         self.assertEqual((receipt / "terminal").read_text(), "pass 0\n")
         self.assertIn("gate output", (receipt / "output.log").read_text())
@@ -162,8 +167,8 @@ class FinalGateReceiptTestCase(unittest.TestCase):
     def test_gate_sets_the_suite_owns_headroom_env_var(self) -> None:
         """Issue #1111 review MAJOR-3: the M2 producer side is otherwise
         unpinned — deleting `env CRATEDIGGER_SUITE_OWNS_HEADROOM=1` from
-        run_final_gate.sh's own nix-shell invocation would leave every
-        other test green while M2 silently reverts. The fake nix-shell
+        run_final_gate.sh's own dev-shell invocation would leave every
+        other test green while M2 silently reverts. The fake `nix`
         records the var's value from its OWN received environment, not the
         argv (an `env VAR=val cmd` prefix doesn't change `cmd`'s argv at
         all, only its environment)."""

--- a/tests/test_parallel_test_runner.py
+++ b/tests/test_parallel_test_runner.py
@@ -33,6 +33,7 @@ from scripts.run_python_tests import (
     HOTSPOT_SHARD_POLICIES,
     HYPOTHESIS_CASE_STATUSES,
     STRATEGY_SPACE_EXHAUSTED,
+    TARGET_DURATION_CACHE_NAME,
     TEST_HOST_MEMORY_EXHAUSTED,
     TEST_HOST_MEMORY_EXHAUSTED_EXIT_CODE,
     TEST_RAM_ROOT_EXHAUSTED_EXIT_CODE,
@@ -64,12 +65,15 @@ from scripts.run_python_tests import (
     hotspot_targets,
     hypothesis_example_budgets,
     list_module_test_ids,
+    load_target_durations,
     main,
+    order_targets_by_measured_cost,
     recommended_worker_count,
     resolve_hypothesis_settings,
     schedule_modules,
     select_test_targets,
     shard_test_ids,
+    store_target_durations,
     test_subprocess_environment,
     worker_environment,
 )
@@ -862,27 +866,184 @@ class TestMeasureTempdirAvailableBytesTracksDiskUsage(unittest.TestCase):
     """
 
     def test_measured_value_tracks_a_real_consumption_delta(self) -> None:
-        before = _measure_tempdir_available_bytes()
-        self.assertIsNotNone(before)
-        assert before is not None
+        """Issue #1229: retried, because the quantity under test is SHARED.
 
+        The original single-shot form raced the suite's other 21 workers on
+        the one test RAM root and failed intermittently in a real gate
+        (`3235840 not greater than or equal to 16777216`): a sibling
+        RELEASING space inside the measurement window offsets this test's
+        own payload, and no fixed threshold can absorb that, since a
+        sibling freeing a whole scratch tree can dwarf any payload this
+        test is willing to write. Widening the tolerance would have been
+        the wrong fix -- it trades the mutant kill away to buy quiet.
+
+        Retrying keeps the kill exactly as strong while removing the race.
+        The `.total` mutant is a STATIC filesystem property: it never moves
+        when contents change, so it fails every attempt, however many are
+        allowed. Only the correct `.free` field can ever produce the drop,
+        and it needs just one window that no sibling happens to free space
+        inside.
+        """
         payload_bytes = 32 * 1024 * 1024
-        with tempfile.NamedTemporaryFile(dir=tempfile.gettempdir()) as scratch:
-            scratch.write(b"\0" * payload_bytes)
-            scratch.flush()
-            os.fsync(scratch.fileno())
+        observed: list[int] = []
 
-            after = _measure_tempdir_available_bytes()
+        for _ in range(8):
+            before = _measure_tempdir_available_bytes()
+            self.assertIsNotNone(before)
+            assert before is not None
 
-        self.assertIsNotNone(after)
-        assert after is not None
-        # `.total` would report the identical value before and after --
-        # real usage never changes it. `.free` (the correct field) must
-        # drop by roughly the payload size. A deliberately loose
-        # half-payload threshold absorbs concurrent sibling activity on
-        # the shared root without losing the ability to catch the
-        # swapped-field mutant, whose reported drop is ~0.
-        self.assertGreaterEqual(before - after, payload_bytes // 2)
+            with tempfile.NamedTemporaryFile(dir=tempfile.gettempdir()) as scratch:
+                scratch.write(b"\0" * payload_bytes)
+                scratch.flush()
+                os.fsync(scratch.fileno())
+
+                after = _measure_tempdir_available_bytes()
+
+            self.assertIsNotNone(after)
+            assert after is not None
+            drop = before - after
+            observed.append(drop)
+            if drop >= payload_bytes // 2:
+                return
+
+        self.fail(
+            "free bytes never tracked a real 32 MiB write across 8 attempts; "
+            f"observed drops: {observed}"
+        )
+
+
+class TestMeasuredCostOrdering(unittest.TestCase):
+    """Issue #1229: the duration cache is a scheduling HINT.
+
+    Every clause below is about ordering or about degrading safely. None of
+    them can change WHICH targets run — `assert_exact_target_schedule`
+    compares by name as a set, so coverage is order-insensitive by
+    construction and is covered by its own tests.
+    """
+
+    @staticmethod
+    def _target(name: str) -> TestTarget:
+        return TestTarget(TestModule(name, Path(f"/{name}.py"), 1), name)
+
+    def _schedule(self, *names: str) -> tuple[TestTarget, ...]:
+        return tuple(self._target(name) for name in names)
+
+    def test_longest_measured_target_is_admitted_first(self) -> None:
+        schedule = self._schedule("cheap", "dear", "middling")
+        ordered = order_targets_by_measured_cost(
+            schedule, {"cheap": 0.5, "dear": 40.0, "middling": 4.0}
+        )
+
+        self.assertEqual(
+            [target.test_name for target in ordered],
+            ["dear", "middling", "cheap"],
+        )
+
+    def test_an_unknown_target_is_admitted_before_every_known_one(self) -> None:
+        """The fail-safe direction. An unknown target is new, renamed, or
+        resharded; treating it as cheap would risk re-creating exactly the
+        late-admitted tail this ordering exists to remove."""
+        schedule = self._schedule("dear", "brand-new")
+        ordered = order_targets_by_measured_cost(schedule, {"dear": 40.0})
+
+        self.assertEqual(
+            [target.test_name for target in ordered], ["brand-new", "dear"]
+        )
+
+    def test_an_empty_cache_leaves_the_heuristic_order_untouched(self) -> None:
+        """Cold start must be exactly the pre-#1229 behaviour, not a
+        reshuffle: a stable sort over equal keys would still be a no-op,
+        but the empty cache short-circuits before sorting at all."""
+        schedule = self._schedule("first", "second", "third")
+
+        self.assertEqual(order_targets_by_measured_cost(schedule, {}), schedule)
+
+    def test_equal_costs_preserve_the_incoming_order(self) -> None:
+        schedule = self._schedule("alpha", "beta", "gamma")
+        ordered = order_targets_by_measured_cost(
+            schedule, {"alpha": 2.0, "beta": 2.0, "gamma": 2.0}
+        )
+
+        self.assertEqual(ordered, schedule)
+
+    def test_durations_round_trip_through_the_cache_file(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            runtime = Path(raw)
+            store_target_durations(
+                runtime,
+                (
+                    TargetRunResult(
+                        target=self._target("dear"),
+                        worker_pid=1,
+                        successful=True,
+                        tests_run=1,
+                        elapsed_seconds=40.25,
+                        output="",
+                        failed_test_ids=(),
+                    ),
+                ),
+            )
+
+            self.assertEqual(load_target_durations(runtime), {"dear": 40.25})
+
+    def test_a_partial_run_refines_rather_than_discards_the_cache(self) -> None:
+        """A `--test`-selected run measures a handful of targets. Replacing
+        the file would throw away every other target's timing and silently
+        return the next full run to cold-start ordering."""
+        with tempfile.TemporaryDirectory() as raw:
+            runtime = Path(raw)
+            (runtime / TARGET_DURATION_CACHE_NAME).write_bytes(
+                b'{"untouched": 12.0, "dear": 1.0}'
+            )
+            store_target_durations(
+                runtime,
+                (
+                    TargetRunResult(
+                        target=self._target("dear"),
+                        worker_pid=1,
+                        successful=True,
+                        tests_run=1,
+                        elapsed_seconds=40.0,
+                        output="",
+                        failed_test_ids=(),
+                    ),
+                ),
+            )
+
+            self.assertEqual(
+                load_target_durations(runtime),
+                {"untouched": 12.0, "dear": 40.0},
+            )
+
+    def test_an_unreadable_or_corrupt_cache_degrades_to_no_ordering(self) -> None:
+        """Known-bad self-test, one world per degradation clause: this file
+        is written by a previous process, so nothing in it may ever be able
+        to fail a run."""
+        with tempfile.TemporaryDirectory() as raw:
+            runtime = Path(raw)
+
+            # 1. absent
+            self.assertEqual(load_target_durations(runtime), {})
+
+            # 2. not JSON at all (e.g. a truncated or clobbered write)
+            path = runtime / TARGET_DURATION_CACHE_NAME
+            path.write_bytes(b"{not json")
+            self.assertEqual(load_target_durations(runtime), {})
+
+            # 3. valid JSON of the wrong shape
+            path.write_bytes(b'{"dear": "forty"}')
+            self.assertEqual(load_target_durations(runtime), {})
+
+            # 4. a negative duration is not a measurement
+            path.write_bytes(b'{"dear": -1.0, "real": 2.0}')
+            self.assertEqual(load_target_durations(runtime), {"real": 2.0})
+
+    def test_storing_nothing_never_creates_a_cache(self) -> None:
+        with tempfile.TemporaryDirectory() as raw:
+            runtime = Path(raw)
+            store_target_durations(runtime, ())
+
+            self.assertFalse((runtime / TARGET_DURATION_CACHE_NAME).exists())
 
 
 class TestModuleDiscovery(unittest.TestCase):

--- a/tests/test_parallel_test_runner.py
+++ b/tests/test_parallel_test_runner.py
@@ -952,8 +952,9 @@ class TestMeasuredCostOrdering(unittest.TestCase):
 
     def test_an_empty_cache_leaves_the_heuristic_order_untouched(self) -> None:
         """Cold start must be exactly the pre-#1229 behaviour, not a
-        reshuffle: a stable sort over equal keys would still be a no-op,
-        but the empty cache short-circuits before sorting at all."""
+        reshuffle. There is no short-circuit for this case: every target is
+        unknown, so every sort key is equal and the stable sort returns the
+        incoming order. This drives the real sort, not a guard around it."""
         schedule = self._schedule("first", "second", "third")
 
         self.assertEqual(order_targets_by_measured_cost(schedule, {}), schedule)

--- a/tests/test_targeted_test_selection.py
+++ b/tests/test_targeted_test_selection.py
@@ -407,13 +407,18 @@ class TestTargetedSuiteWiring(unittest.TestCase):
     def test_shell_entrypoint_sets_the_suite_owns_headroom_env_var(self) -> None:
         """Issue #1111 review MAJOR-3: the M2 producer side is otherwise
         unpinned — deleting `env CRATEDIGGER_SUITE_OWNS_HEADROOM=1` from
-        scripts/test.sh's own nix-shell invocation would leave every other
+        scripts/test.sh's own dev-shell invocation would leave every other
         test green while M2 silently reverts to the old shell-entry-dies-
-        under-contention shape."""
+        under-contention shape.
+
+        Issue #1229 moved the launcher from `nix-shell --run` to `nix
+        develop --command` for Nix's flake eval cache; the var must be set
+        on whichever one is there, so both the var AND the launcher it
+        prefixes are pinned together."""
         source = pinned_source(REPO_ROOT / "scripts" / "test.sh")
 
         self.assertIn(
-            "env CRATEDIGGER_SUITE_OWNS_HEADROOM=1 nix-shell", source
+            "env CRATEDIGGER_SUITE_OWNS_HEADROOM=1 nix develop", source
         )
 
     def test_targeted_runner_takes_the_same_suite_admission_lock(self) -> None:


### PR DESCRIPTION
## Summary

Works #1229 to completion: **every item measured, two shipped, four closed with numbers.** No follow-up residual issue — where something wasn't worth doing, the measurement that says so is recorded in place.

Headline, canonical `run_final_gate.sh` on doc1: **109s → 93s** (three consecutive passing gates this session: 97s, 95s, 93s). Python phase measured standalone: **82.6s → 74.5s** warm.

### Shipped

**1. `nix develop` instead of `nix-shell` for the two launchers the operator runs** (`scripts/test.sh`, `scripts/run_final_gate.sh`).

`flake.nix`'s `devShells.default` IS `./nix/shell.nix` — the same derivation `shell.nix` delegates to — so the environment is identical, but only the flake path evaluates a *locked* flake, which is what makes Nix's own eval cache apply.

| | cost |
| --- | --- |
| `nix-shell --run true` | 5181ms |
| `nix develop --command true` (clean tree, warm) | **481ms** |
| same, tracked file modified (dirty) | 2824ms |
| same, untracked file added | 490ms |

The gate is the best case: it already refuses to run on anything but a committed clean tree, which is exactly the state Nix can cache. Verified equivalent directly — same `python3` store path, same `CRATEDIGGER_BEETS_PYTHON`, `scripts/test_tmpfs.sh`'s shellHook still runs and still allocates `TMPDIR`, exit codes propagate (23 → 23). The cache key is the flake's own locked fingerprint: **Nix invalidating its own cache, not a hand-rolled one** — which is precisely why the "cache `nix print-dev-env` behind a hand-written invalidation key" design sketched in #1229 was *not* built.

**2. Longest-processing-time queue ordering from measured target timings.**

Frontload *membership* turned out to be saturated: replaying a real 464-target duration map through the real scheduler, every variant tried (the four heavy non-generated modules from #1226, plus ten heavy `_generated` ones in every prefix combination) lands between **81.0s and 82.3s** against an LPT bound of **76.2s**. The gap is ordering *within* the early group, and no membership constant can reach it.

So the queue is now ordered by the previous run's own measurement, cached in the private runtime tmpfs. Measured same-session: cold **79.3s** → warm **73.7s / 75.2s** (−4.8s, −6%).

It is a hint, never a boundary: `assert_exact_target_schedule` compares by name as a **set**, so coverage is order-insensitive by construction. Absent / truncated / wrong-shaped / negative-valued caches and an unusable runtime root all degrade to the exact pre-#1229 order.

**3. A pre-existing intermittent gate failure**, which this work made *more* likely by concentrating load. `TestMeasureTempdirAvailableBytesTracksDiskUsage` measured free bytes on the tmpfs root shared by 22 workers, so a sibling releasing space inside its window offset its own payload — it failed a real gate here with `3235840 not greater than or equal to 16777216`. Retried rather than loosened: the `.total` mutant it exists to kill is a *static* filesystem property that never moves, so it fails all 8 attempts, while the correct `.free` field needs one quiet window.

### Measured and NOT done (with the numbers that say so)

| #1229 item | Ceiling, measured | Verdict |
| --- | --- | --- |
| 1. Per-child hypothesis import tax | Only **259 of 422** test modules would skip it (163 import hypothesis anyway) → 30 core-s ≈ **1.35s** | Not worth restructuring the Hypothesis deadline/stats guard path. #1229's own "~60 core-s" estimate assumed all 464 targets skip; that was wrong. |
| 2. `test_deploy_pin_generated`'s ~1680 shim spawns | Stub already at the Python floor (`-S` + cached bytecode, #1156 item 4): 7.8ms vs 6.9ms without `env`, 7.1ms for bare `python3 -S`. Whole spawn cost ≈ **13 core-s ≈ 0.6s wall** | Not worth it. `-I` would be faster but implies `-P`, which removes the script dir from `sys.path` and breaks `import _shim`. A bash shim (1.5ms) means reimplementing JSON state handling in bash. |
| 3. `test_beets_destructive_configs_generated` (largest module, 100.6 core-s) | The real child's import floor is **0.046s**; all 24 spawns ≈ **1.4 core-s**. The 2-3s per cell is the beets work the test exists to do | Nothing recoverable without gutting a real-beets contract test. |
| 5. Pyright/python contention | Both directions measured: **8 threads → 108s wall** (pyright 43.8s, lengthening the overlap window), **16 threads → 119s wall**, current **12 → ~103.5s** | Already optimal. Window length dominates instantaneous oversubscription. |

A correction worth stating plainly, because it reframes #1229's own ranking: **serial and packing overhead is worth ~22× more wall time than per-test CPU savings.** A 5-core-second test saving is 0.23s of wall at 22 workers; a 5-second serial saving is 5 seconds. That is why items 1-3 (all per-test CPU) are worth ~1s combined while items 4 and 6 (packing and serial) were worth ~9.5s.

## Kill matrix (per diff site, not per PR)

| Site (assertion / clause / constant) | One-line production mutant | Test that must go RED | Result |
| --- | --- | --- | --- |
| `order_targets_by_measured_cost` unknown-cost direction (`math.inf`) | `unknown_cost = max(durations.values())` | `test_an_unknown_target_is_admitted_before_every_known_one` | **Found a real defect** — this was the first implementation; the stable sort left the unknown target *behind* the dearest known one. Caught by the test, not review. |
| `order_targets_by_measured_cost` sort direction | drop the `-` from the sort key | `test_longest_measured_target_is_admitted_first` | KILLED |
| `order_targets_by_measured_cost` empty-cache short circuit | `if not durations: return tuple(schedule)` → `if False:` | `test_an_empty_cache_leaves_the_heuristic_order_untouched` | **SURVIVED — and the branch was deleted because of it.** With `math.inf` every target is unknown, every key is equal, and the stable sort already returns the incoming order, so the guard had no observable behaviour. The test now drives the real sort rather than a guard around it. |
| `store_target_durations` merge (not replace) | `merged = {}` instead of `merged = load_target_durations(runtime_dir)` | `test_a_partial_run_refines_rather_than_discards_the_cache` | KILLED |
| `load_target_durations` corrupt-input clauses (4 worlds: absent / non-JSON / wrong shape / negative) | remove any one `except` or the `seconds >= 0.0` filter | `test_an_unreadable_or_corrupt_cache_degrades_to_no_ordering` (one world per clause) | KILLED |
| `store_target_durations` empty-results guard | remove `if not results: return` | `test_storing_nothing_never_creates_a_cache` | KILLED |
| `_measure_tempdir_available_bytes` retry (the `.free` field) | `.free` → `.total` | `TestMeasureTempdirAvailableBytesTracksDiskUsage` | KILLED — re-planted after the retry rewrite specifically to prove retrying did not weaken it |
| `run_final_gate.sh` launcher argv | revert to `nix-shell --run` | `test_success_runs_only_the_canonical_suite_and_preserves_output` (argv pin now `develop\n--command\nbash\n-c\n...`) | KILLED |
| `scripts/test.sh` headroom var + launcher | delete `env CRATEDIGGER_SUITE_OWNS_HEADROOM=1` | `test_shell_entrypoint_sets_the_suite_owns_headroom_env_var` | KILLED |

All mutants run with `PYTHONDONTWRITEBYTECODE=1` and reverted via `git checkout --`.

Degradation verified live rather than only unit-tested: a mode-0755 tmpfs `XDG_RUNTIME_DIR` makes `private_runtime_dir` raise `RuntimeError`, and the run still exits 0 with no `Order:` line. That also caught a real bug in review-of-self — the first version caught only `(OSError, ValueError)`, so a direct `run_python_tests.py` invocation on such a host would have crashed.

## Reviewer

Plant at least two mutants yourself, aimed at the named subject of each new test. Worth attacking specifically:

- **Is the ordering actually load-bearing, or is the win noise?** Delete the `order_targets_by_measured_cost` call in `main()` (keep the cache writes) and re-run cold-vs-warm; the ~5s spread should vanish.
- **Does the cache survive a concurrent writer?** Two suites finishing at once both call `store_target_durations`; the temp-file-plus-rename should mean a reader never sees a partial map. A mutant writing in place should be catchable by a reader looping during a large write.
- The `Order:` line is new output on the python phase — confirm nothing parsing phase output (`CRATEDIGGER_CHECK_FAILURE` / `CRATEDIGGER_CHECK_METRICS` markers) is position-sensitive.

## Risk

Test-infrastructure only. No production code path changes: `lib/`, `web/`, `nix/module.nix`, `scripts/pipeline_cli/` untouched — nothing here to deploy or verify live.

Two behaviour changes worth naming:

- **Queue order now depends on history.** Same tree, different cache → different admission order, so two runs' wall times are no longer directly comparable. This is deliberate and announced (`Order: longest-first from N cached target timings`) rather than silent, so a differing wall time is explainable. It cannot change *which* tests run. Anyone A/B-measuring a future suite change should delete `$XDG_RUNTIME_DIR/cratedigger-target-durations.json` first or compare warm-to-warm.
- **`scripts/test.sh` and `run_final_gate.sh` now require `nix develop`** (flakes). The repo already requires it for `scripts/daily_beets_tip_update.sh`'s `.#tip` canary, so this adds no new dependency. `daily_flake_update.sh`'s four stages deliberately stay on `nix-shell` — unattended nightly jobs where the saving is irrelevant, and moving them would mean teaching their fake `nix` shim a new subcommand for no operator-visible gain.

The cache file lives in the private runtime tmpfs, matches no `_REAPABLE_PREFIXES` entry (so the bundle reaper ignores it), is ~25 KB, and is wiped on reboot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
