### PR TITLE
feat(tests): bound suite runs to their own cgroup (#1238)

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -617,6 +617,30 @@ rather than promoting to infrastructure-failure — a known, accepted
 residual (independent review F10), not a claim that the two never
 co-occur.
 
+Every guard above CLASSIFIES an exhaustion that already happened; none
+BOUNDS it. Until #1238 nothing limited a suite run to its own share of the
+host, so the 2026-08-19 leak produced a `CONSTRAINT_NONE ... global_oom` —
+the kernel choosing victims across the whole machine by `oom_score`, killing
+six unrelated processes rather than the offender. `scripts/memory_scope.sh`
+closes that: `scripts/test.sh` and `scripts/run_final_gate.sh` launch the
+suite inside a transient `systemd-run --user --scope` carrying
+`MemoryMax` (70% of the host's own MemTotal — derived, never a constant, so
+other installations scale) plus `MemorySwapMax=0`. The swap cap is
+load-bearing, not belt-and-braces: `MemoryMax` alone bounds only RESIDENT
+memory, so on a host with swap a runaway spills over and thrashes instead
+of dying (measured: 200 MiB under a 64 MiB cap exits 0 without it, 137
+with it). `MemoryHigh` is deliberately absent — it stalls a runaway in the
+reclaim loop for minutes rather than killing it, turning an unattended gate
+into a hang. `CRATEDIGGER_TEST_MEMORY_MAX_BYTES` overrides the limit; `0`
+disables containment. Missing infrastructure (no `systemd-run`, no delegated
+memory controller) warns and runs UNCONTAINED — containment is a safety net,
+not a correctness gate — but an invalid explicit override fails closed, the
+same asymmetry `headroom_floor_bytes` already uses. The two nightly runners
+deliberately opt out and are bounded by a declarative `MemoryMax=` on their
+nixosconfig system units instead: `systemd-run --user` needs a user D-Bus
+session those units do not reliably have, so wiring the helper there would
+fail open on precisely the unattended path that failed in the first place.
+
 **Generated (property-based) production tests**
 (`tests/test_*_generated.py`, Hypothesis)
 run deterministically in the suite. After changing quality policy, run the

--- a/scripts/daily_beets_tip_update.sh
+++ b/scripts/daily_beets_tip_update.sh
@@ -39,6 +39,14 @@ nix flake update beets-tip mutagen-tip mediafile-tip
 # entry-time free-bytes refusal defers to it (issue #1111). Every automated
 # launcher of the canonical suite sets this.
 export CRATEDIGGER_SUITE_OWNS_HEADROOM=1
+# No scripts/memory_scope.sh containment here, deliberately: this runner is
+# launched by the nixosconfig `cratedigger-beets-tip-canary` SYSTEM unit
+# (Type=oneshot, User=abl030), which has no reliable user D-Bus session, so
+# `systemd-run --user` would fail-open to no containment on exactly the
+# unattended path that most needs it. The nightly units carry a declarative
+# `MemoryMax=` on the unit itself instead -- enforced by the system manager,
+# no bus required. The helper is for the interactive/agent launchers
+# (scripts/test.sh, scripts/run_final_gate.sh) that do have a user session.
 nix develop .#tip --command bash scripts/run_tests.sh
 
 # Deliberately no lock commit or push. The canary's product is the signal,

--- a/scripts/daily_flake_update.sh
+++ b/scripts/daily_flake_update.sh
@@ -129,6 +129,15 @@ run_stage() {
     daily_resource_monitor_set_phase runner_overhead
 }
 
+# No scripts/memory_scope.sh containment in this runner, deliberately. It is
+# launched by the nixosconfig `cratedigger-daily-checks` SYSTEM unit
+# (Type=oneshot, User=abl030), which has no reliable user D-Bus session, so
+# `systemd-run --user` would fail open to no containment on exactly the
+# unattended path that suffered the 2026-08-19 global OOM. These stages are
+# bounded by a declarative `MemoryMax=` on the unit itself, enforced by the
+# system manager with no bus involved. `stable_nix` would be unbounded either
+# way: `nix build` delegates the work to the nix-daemon, which runs in the
+# system slice under its own cgroup, outside anything this script controls.
 daily_resource_monitor_set_phase runner_overhead
 run_stage deterministic_suite "deterministic full suite" \
     env CRATEDIGGER_SUITE_OWNS_HEADROOM=1 \

--- a/scripts/memory_scope.sh
+++ b/scripts/memory_scope.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# Transient-cgroup memory containment for canonical suite launches.
+#
+# WHY THIS EXISTS
+#
+# On 2026-08-19 a leaking test phase (#1214, one tmpfs world per Hypothesis
+# example) drove doc1 into a GLOBAL out-of-memory event. The kernel log is
+# explicit about the blast radius:
+#
+#     oom-kill:constraint=CONSTRAINT_NONE,...,global_oom
+#
+# CONSTRAINT_NONE means no cgroup limit bounded the allocation, so the kernel
+# chose victims across the WHOLE machine by oom_score rather than killing the
+# offender. Six processes died, every one a Python `MainThread` worker holding
+# 0.7-3.0 GB, and four gate units ended `Failed with result 'oom-kill'`.
+#
+# The leak itself is fixed. What is NOT fixed is the shape: nothing bounds a
+# suite run to its own share of the host, so the next runaway again takes out
+# whatever else the operator happened to be running -- including the Claude
+# daemon that owns their background agent sessions, which shares this user
+# slice and would be picked off as collateral.
+#
+# A transient scope with a memory limit converts that global event into a
+# local one: reclaim pressure applies to the suite's own cgroup first, and
+# past the hard limit only the suite's processes are killed. The host, and
+# everything else on it, survives.
+#
+# SIZING IS DERIVED, NEVER A CONSTANT
+#
+# A limit tuned to this homelab's 32 GiB box is precisely the
+# host-specific rule this repository rejects (#1079), and `scope.md` requires
+# that defaults not assume this installation. Both limits are therefore
+# fractions of the host's own MemTotal.
+#
+# The fraction is chosen against measured evidence, not taste.
+# `scripts/daily_resource_monitor.sh` telemetry from 2026-08-20 (i.e. after
+# the #1214 fix, so a healthy run) recorded the `deterministic_suite` phase
+# peaking at 22.41 GB of user-slice memory across 15,746 samples, against a
+# 14.56 GB baseline in the same run -- the suite's OWN share is therefore
+# roughly 8 GB. On a 32 GiB host this fraction gives ~22.4 GiB before a kill:
+# about 2.8x measured headroom.
+#
+# MemoryHigh IS DELIBERATELY NOT SET. It looks like the obvious gentler first
+# tier -- throttle and reclaim before killing anything -- and it is a trap
+# here. Measured on doc1 while writing this file: with `-p MemoryHigh` set
+# below MemoryMax and swap capped, a runaway allocation did not die at
+# MemoryMax at all. It stalled in the kernel's reclaim-throttle loop for over
+# 120 seconds with nothing to reclaim, and had to be killed by hand. For an
+# unattended nightly gate that converts "fail fast with exit 137" into "hang
+# forever and never report", which is worse than the uncontained behaviour
+# this file exists to fix. A single hard limit fails promptly and legibly.
+#
+# MemorySwapMax=0 IS LOAD-BEARING, not belt-and-braces. MemoryMax alone does
+# NOT bound a cgroup on a host with swap: it bounds RESIDENT memory, and the
+# excess is reclaimed to swap rather than refused. Measured on doc1 while
+# writing this file -- a 200 MiB allocation under `-p MemoryMax=64M` ran to
+# completion and exited 0, because 136 MiB simply spilled into the 16 GiB
+# swapfile. The same allocation with `-p MemorySwapMax=0` added was killed
+# (exit 137). Without the swap limit a leaking suite balloons into swap and
+# thrashes the host instead of dying quickly -- nearly as damaging as the
+# global OOM this exists to prevent, and much harder to diagnose.
+#
+# The cost is that tmpfs pages become unevictable, so they count permanently
+# against MemoryMax. That is the right trade here twice over: the measured
+# suite share (~8 GB, below) already includes its tmpfs, leaving wide margin
+# under the limit; and uncontrolled tmpfs growth was the #1214 failure mode
+# itself, so charging it against the cap is the containment, not a side
+# effect.
+_CRATEDIGGER_MEMORY_MAX_PERCENT=70
+
+# Emitted once per launch when containment cannot be established, so an
+# uncontained run is always visible in gate output rather than silently
+# behaving like the pre-#1214 world.
+_cratedigger_memory_scope_warn() {
+    printf 'memory containment unavailable (%s); running uncontained\n' "$1" >&2
+}
+
+# _CRATEDIGGER_MEMINFO_PATH and _CRATEDIGGER_CGROUP_ROOT default to the real
+# kernel interfaces, so every production caller is unaffected. They exist so a
+# test can pin the MemTotal -> MemoryMax percentage arithmetic against a KNOWN
+# fixture, and drive the not-delegated branch, neither of which can otherwise
+# be forced to a controlled value. This mirrors the `meminfo_path` seam
+# `_measure_available_memory_bytes` already uses for the same reason
+# (issue #1156 review F4).
+_cratedigger_mem_total_bytes() {
+    local key value
+    while read -r key value _; do
+        if [[ "$key" == "MemTotal:" ]]; then
+            printf '%s\n' "$((value * 1024))"
+            return 0
+        fi
+    done <"${_CRATEDIGGER_MEMINFO_PATH:-/proc/meminfo}"
+    return 1
+}
+
+# Populate CRATEDIGGER_MEMORY_SCOPE_ARGV with a systemd-run prefix, or leave
+# it empty when containment is unavailable.
+#
+# Fail-open is deliberate and asymmetric:
+#
+#   * MISSING INFRASTRUCTURE (no systemd-run, no delegated memory controller,
+#     unreadable MemTotal) leaves the array empty and warns. Containment is a
+#     safety net, not a correctness gate; refusing to run the suite because a
+#     cgroup could not be created would trade a rare host OOM for a common
+#     hard stop, and the suite's own result is unaffected by running
+#     uncontained.
+#
+#   * AN INVALID EXPLICIT OVERRIDE fails closed with a non-zero return. The
+#     operator asked for a specific limit and typo'd it; silently ignoring
+#     that would run with a limit they did not choose. This mirrors
+#     `headroom_floor_bytes`, which raises on a malformed
+#     CRATEDIGGER_TEST_RAM_MIN_BYTES rather than falling back.
+cratedigger_memory_scope_prefix() {
+    CRATEDIGGER_MEMORY_SCOPE_ARGV=()
+
+    # An inner launcher inside an already-scoped run would nest a second
+    # cgroup under the first. Harmless (the outer limit still binds) but
+    # pointless, and it would double the warning noise when containment is
+    # unavailable.
+    if [[ -n "${CRATEDIGGER_MEMORY_SCOPE_ACTIVE:-}" ]]; then
+        return 0
+    fi
+
+    local mem_total max raw
+    raw="${CRATEDIGGER_TEST_MEMORY_MAX_BYTES:-}"
+    if [[ -n "$raw" ]]; then
+        if [[ ! "$raw" =~ ^[0-9]+$ ]]; then
+            printf 'CRATEDIGGER_TEST_MEMORY_MAX_BYTES must be a non-negative integer: %s\n' \
+                "$raw" >&2
+            return 1
+        fi
+        # An explicit 0 disables containment outright -- the documented
+        # escape hatch for a host where the scope itself is the problem.
+        if [[ "$raw" == 0 ]]; then
+            return 0
+        fi
+        max="$raw"
+    else
+        if ! mem_total=$(_cratedigger_mem_total_bytes); then
+            _cratedigger_memory_scope_warn "cannot read MemTotal from /proc/meminfo"
+            return 0
+        fi
+        max=$((mem_total * _CRATEDIGGER_MEMORY_MAX_PERCENT / 100))
+    fi
+
+    if ! command -v systemd-run >/dev/null 2>&1; then
+        _cratedigger_memory_scope_warn "systemd-run is not available"
+        return 0
+    fi
+
+    # The user manager must have the memory controller delegated, otherwise
+    # systemd-run accepts the -p flags and silently enforces nothing. Checking
+    # the delegated controller list is cheaper and more precise than probing
+    # with a throwaway scope, and it is the exact condition that fails on a
+    # host without cgroup v2 memory delegation.
+    local cgroup_root="${_CRATEDIGGER_CGROUP_ROOT:-/sys/fs/cgroup}"
+    local controllers="$cgroup_root/user.slice/user-$(id -u).slice/user@$(id -u).service/cgroup.controllers"
+    if [[ ! -r "$controllers" ]]; then
+        _cratedigger_memory_scope_warn "user manager cgroup is unreadable: $controllers"
+        return 0
+    fi
+    if [[ " $(<"$controllers") " != *" memory "* ]]; then
+        _cratedigger_memory_scope_warn "memory controller is not delegated to the user manager"
+        return 0
+    fi
+
+    CRATEDIGGER_MEMORY_SCOPE_ARGV=(
+        systemd-run --user --scope --quiet --collect
+        --setenv=CRATEDIGGER_MEMORY_SCOPE_ACTIVE=1
+        -p "MemoryMax=$max"
+        -p "MemorySwapMax=0"
+    )
+    return 0
+}

--- a/scripts/run_final_gate.sh
+++ b/scripts/run_final_gate.sh
@@ -2,6 +2,9 @@
 # Run the canonical full suite with a runtime-tmpfs receipt, or inspect one.
 set -uo pipefail
 
+# shellcheck source=scripts/memory_scope.sh
+source "$(dirname "${BASH_SOURCE[0]}")/memory_scope.sh"
+
 die() {
     printf '%s\n' "$*" >&2
     exit 2
@@ -167,7 +170,22 @@ run_gate() {
     # `canonical_command` is unchanged, so the receipt still records the
     # same canonical `bash scripts/run_tests.sh` and `status` still
     # compares it the same way; only the launcher around it moved.
-    gate_argv=(env CRATEDIGGER_SUITE_OWNS_HEADROOM=1 nix develop --command bash -c "$command")
+    # Bound the suite to its own cgroup so a runaway kills only itself
+    # instead of triggering the host-wide OOM that took out six unrelated
+    # processes on 2026-08-19 (see scripts/memory_scope.sh). An invalid
+    # explicit override fails the gate closed rather than silently running
+    # with a limit the operator did not choose.
+    cratedigger_memory_scope_prefix \
+        || die "invalid CRATEDIGGER_TEST_MEMORY_MAX_BYTES"
+    # `$!` below becomes the systemd-run process rather than the suite's own.
+    # That is the correct thing to record: `--scope` runs the command
+    # synchronously under one long-lived process which propagates the exit
+    # status verbatim (measured: `exit 7` -> 7, an OOM kill -> 137), so it
+    # remains an exact liveness proxy for `status`'s exact-active check.
+    gate_argv=(
+        "${CRATEDIGGER_MEMORY_SCOPE_ARGV[@]}"
+        env CRATEDIGGER_SUITE_OWNS_HEADROOM=1 nix develop --command bash -c "$command"
+    )
     receipt=$(mktemp -d "$runtime/cratedigger-final-gate.XXXXXXXX") \
         || die "cannot create final-gate receipt beneath $runtime"
     chmod 700 "$receipt" || die "cannot secure receipt directory: $receipt"

--- a/scripts/targeted_test_selection.py
+++ b/scripts/targeted_test_selection.py
@@ -94,6 +94,15 @@ EXACT_PATH_NEIGHBOURS: dict[str, tuple[str, ...]] = {
     "pyrightconfig.production.json": (
         "tests.test_pyright_checks",
     ),
+    "scripts/memory_scope.sh": (
+        "tests.test_memory_scope",
+    ),
+    "scripts/run_final_gate.sh": (
+        # The gate's own receipt contract, plus the containment prefix it
+        # now applies: a solo edit to either seam must select both.
+        "tests.test_final_gate_receipt",
+        "tests.test_memory_scope",
+    ),
     "scripts/run_pyright_checks.py": (
         "tests.test_pyright_checks",
     ),
@@ -111,6 +120,7 @@ EXACT_PATH_NEIGHBOURS: dict[str, tuple[str, ...]] = {
     ),
     "scripts/test.sh": (
         "tests.test_targeted_test_selection",
+        "tests.test_memory_scope",
     ),
     "scripts/test_tmpfs.sh": (
         # Issue #1208 review D1: this file had NO entry at all — a solo

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -24,5 +24,15 @@ cd "$(dirname "$0")/.."
 # untracked file does not participate in the flake source at all (490ms).
 # There is deliberately no nix-shell fallback: this repo already requires
 # `nix develop` for scripts/daily_beets_tip_update.sh's `.#tip` canary.
+#
+# The targeted runner calls the same run_suite() as the canonical suite, so it
+# carries the same runaway risk and gets the same cgroup containment
+# (scripts/memory_scope.sh). The prefix is empty when containment is
+# unavailable, so this stays a plain exec on such a host.
+# shellcheck source=scripts/memory_scope.sh
+source "$(dirname "${BASH_SOURCE[0]}")/memory_scope.sh"
+cratedigger_memory_scope_prefix || exit 2
+
 printf -v command '%q ' python3 scripts/run_targeted_tests.py "$@"
-exec env CRATEDIGGER_SUITE_OWNS_HEADROOM=1 nix develop --command bash -c "$command"
+exec "${CRATEDIGGER_MEMORY_SCOPE_ARGV[@]}" \
+    env CRATEDIGGER_SUITE_OWNS_HEADROOM=1 nix develop --command bash -c "$command"

--- a/tests/test_memory_scope.py
+++ b/tests/test_memory_scope.py
@@ -1,0 +1,279 @@
+"""Contract tests for the shared suite-launch memory containment helper.
+
+Deterministic only. `scripts/memory_scope.sh` is test infrastructure, and
+`.claude/rules/code-quality.md` reserves Hypothesis for production behaviour.
+
+What these tests pin is the ARGV the helper emits, not the kernel's
+enforcement of it. Whether `MemoryMax` actually kills a process is a property
+of cgroup v2, not of this repository; driving a real systemd scope from the
+suite would make the whole suite depend on a live user D-Bus session. The
+enforcement evidence is measured and recorded in the PR body and in the
+helper's own header comment (a 200 MiB allocation under a 64 MiB cap: exit 0
+without `MemorySwapMax=0`, exit 137 with it).
+
+That split is why `test_prefix_caps_swap` exists and matters: `MemorySwapMax=0`
+is the single non-obvious load-bearing flag -- without it `MemoryMax` bounds
+only resident memory and a runaway spills into swap instead of dying -- so it
+gets its own pin rather than riding along inside a whole-argv assertion.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+HELPER = REPO_ROOT / "scripts" / "memory_scope.sh"
+
+#: Resolved once, absolutely, so a test that narrows PATH to prove the
+#: missing-systemd-run branch cannot also make the interpreter unresolvable.
+BASH = shutil.which("bash") or "/bin/bash"
+
+#: 8 GiB expressed the way /proc/meminfo does (kB), so the expected
+#: MemoryMax below is arithmetic a reader can check by hand rather than a
+#: number copied out of a previous run.
+_FIXTURE_MEM_TOTAL_KB = 8 * 1024 * 1024
+_FIXTURE_MEM_TOTAL_BYTES = _FIXTURE_MEM_TOTAL_KB * 1024
+_EXPECTED_MAX_BYTES = _FIXTURE_MEM_TOTAL_BYTES * 70 // 100
+
+
+class _HelperCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tempdir.cleanup)
+        self.root = Path(self.tempdir.name)
+
+        self.meminfo = self.root / "meminfo"
+        self.meminfo.write_text(
+            f"MemTotal:       {_FIXTURE_MEM_TOTAL_KB} kB\n"
+            "MemFree:         1000000 kB\n"
+            "MemAvailable:    2000000 kB\n",
+            encoding="utf-8",
+        )
+
+        # A delegated-memory-controller cgroup tree, at the exact path shape
+        # the helper derives from the current uid.
+        self.cgroup_root = self.root / "cgroup"
+        uid = os.getuid()
+        self.user_service = (
+            self.cgroup_root
+            / "user.slice"
+            / f"user-{uid}.slice"
+            / f"user@{uid}.service"
+        )
+        self.user_service.mkdir(parents=True)
+        self.controllers = self.user_service / "cgroup.controllers"
+        self.controllers.write_text("cpu io memory pids\n", encoding="utf-8")
+
+        # A stub `systemd-run` so the helper's availability probe passes
+        # without this test depending on a real one being installed.
+        self.fake_bin = self.root / "bin"
+        self.fake_bin.mkdir()
+        stub = self.fake_bin / "systemd-run"
+        stub.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+        stub.chmod(0o755)
+
+        # The helper shells out to `id` and nothing else. Giving it its own
+        # minimal directory lets the missing-systemd-run test drop `fake_bin`
+        # from PATH without also removing the tools the helper legitimately
+        # needs -- and, critically, without hiding the REAL systemd-run that
+        # the host PATH would otherwise still supply, which would make that
+        # test silently assert nothing.
+        self.sysbin = self.root / "sysbin"
+        self.sysbin.mkdir()
+        real_id = shutil.which("id")
+        assert real_id is not None, "coreutils `id` must be available"
+        (self.sysbin / "id").symlink_to(real_id)
+
+    def run_helper(self, **env_overrides: str) -> subprocess.CompletedProcess[str]:
+        """Source the helper, call it, print one argv element per line.
+
+        The `rc=` line is printed before the argv so a failing return is
+        visible even when the array is empty.
+        """
+        script = textwrap.dedent(
+            f"""
+            source {HELPER}
+            cratedigger_memory_scope_prefix
+            printf 'rc=%s\\n' "$?"
+            printf '%s\\n' "${{CRATEDIGGER_MEMORY_SCOPE_ARGV[@]}}"
+            """
+        )
+        env = dict(os.environ)
+        # Drop any inherited real values so a test never reads the host's.
+        for leaked in (
+            "CRATEDIGGER_TEST_MEMORY_MAX_BYTES",
+            "CRATEDIGGER_MEMORY_SCOPE_ACTIVE",
+        ):
+            env.pop(leaked, None)
+        env.update(
+            {
+                "PATH": f"{self.fake_bin}:{self.sysbin}",
+                "_CRATEDIGGER_MEMINFO_PATH": str(self.meminfo),
+                "_CRATEDIGGER_CGROUP_ROOT": str(self.cgroup_root),
+            }
+        )
+        env.update(env_overrides)
+        return subprocess.run(
+            [BASH, "-c", script],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+
+    def argv_of(self, result: subprocess.CompletedProcess[str]) -> list[str]:
+        lines = [line for line in result.stdout.splitlines() if line]
+        self.assertTrue(lines, f"helper printed nothing; stderr={result.stderr}")
+        self.assertEqual(lines[0], "rc=0", f"helper failed: {result.stderr}")
+        return lines[1:]
+
+
+class TestPrefixConstruction(_HelperCase):
+    def test_default_limit_is_seventy_percent_of_mem_total(self) -> None:
+        argv = self.argv_of(self.run_helper())
+        self.assertIn(f"MemoryMax={_EXPECTED_MAX_BYTES}", argv)
+
+    def test_prefix_caps_swap(self) -> None:
+        """`MemorySwapMax=0` is what makes `MemoryMax` a real bound.
+
+        Without it the kernel reclaims the overage to swap instead of
+        refusing it, and a runaway thrashes indefinitely rather than dying
+        (measured; see this module's docstring). A mutant dropping this flag
+        leaves every other assertion here green.
+        """
+        argv = self.argv_of(self.run_helper())
+        self.assertIn("MemorySwapMax=0", argv)
+
+    def test_prefix_is_a_transient_collected_user_scope(self) -> None:
+        argv = self.argv_of(self.run_helper())
+        self.assertEqual(argv[0], "systemd-run")
+        for flag in ("--user", "--scope", "--collect"):
+            self.assertIn(flag, argv)
+
+    def test_prefix_marks_the_scope_active_to_prevent_nesting(self) -> None:
+        argv = self.argv_of(self.run_helper())
+        self.assertIn("--setenv=CRATEDIGGER_MEMORY_SCOPE_ACTIVE=1", argv)
+
+    def test_does_not_set_memory_high(self) -> None:
+        """MemoryHigh stalls a runaway in reclaim instead of killing it.
+
+        Measured at over 120s with nothing to reclaim, which turns an
+        unattended gate into a hang. Re-adding it must fail here.
+        """
+        argv = self.argv_of(self.run_helper())
+        self.assertFalse(
+            [item for item in argv if item.startswith("MemoryHigh=")],
+            f"MemoryHigh must not be set: {argv}",
+        )
+
+
+class TestExplicitOverride(_HelperCase):
+    def test_override_is_used_verbatim(self) -> None:
+        argv = self.argv_of(
+            self.run_helper(CRATEDIGGER_TEST_MEMORY_MAX_BYTES="123456789")
+        )
+        self.assertIn("MemoryMax=123456789", argv)
+
+    def test_zero_disables_containment(self) -> None:
+        result = self.run_helper(CRATEDIGGER_TEST_MEMORY_MAX_BYTES="0")
+        self.assertEqual(self.argv_of(result), [])
+
+    def test_invalid_override_fails_closed(self) -> None:
+        """An operator who typo'd a limit must not silently get a different
+        one. Contrast with the fail-OPEN infrastructure branches below."""
+        result = self.run_helper(CRATEDIGGER_TEST_MEMORY_MAX_BYTES="16GiB")
+        self.assertIn("rc=1", result.stdout)
+        self.assertIn("must be a non-negative integer", result.stderr)
+
+    def test_negative_override_fails_closed(self) -> None:
+        result = self.run_helper(CRATEDIGGER_TEST_MEMORY_MAX_BYTES="-1")
+        self.assertIn("rc=1", result.stdout)
+        self.assertIn("must be a non-negative integer", result.stderr)
+
+
+class TestFailOpenBranches(_HelperCase):
+    """Missing infrastructure degrades to an uncontained run, loudly.
+
+    Each branch is driven to its own condition with the EARLIER branches
+    passing, so a short-circuit cannot let one assertion stand in for
+    another, and each asserts its own distinct message.
+    """
+
+    def test_already_scoped_run_does_not_nest(self) -> None:
+        result = self.run_helper(CRATEDIGGER_MEMORY_SCOPE_ACTIVE="1")
+        self.assertEqual(self.argv_of(result), [])
+        self.assertEqual(result.stderr, "")
+
+    def test_missing_systemd_run_warns_and_continues(self) -> None:
+        result = self.run_helper(PATH=str(self.sysbin))
+        self.assertEqual(self.argv_of(result), [])
+        self.assertIn("systemd-run is not available", result.stderr)
+        self.assertIn("running uncontained", result.stderr)
+
+    def test_undelegated_memory_controller_warns_and_continues(self) -> None:
+        self.controllers.write_text("cpu io pids\n", encoding="utf-8")
+        result = self.run_helper()
+        self.assertEqual(self.argv_of(result), [])
+        self.assertIn("memory controller is not delegated", result.stderr)
+
+    def test_unreadable_cgroup_warns_and_continues(self) -> None:
+        self.controllers.unlink()
+        result = self.run_helper()
+        self.assertEqual(self.argv_of(result), [])
+        self.assertIn("cgroup is unreadable", result.stderr)
+
+    def test_unreadable_meminfo_warns_and_continues(self) -> None:
+        self.meminfo.unlink()
+        result = self.run_helper()
+        self.assertEqual(self.argv_of(result), [])
+        self.assertIn("cannot read MemTotal", result.stderr)
+
+    def test_substring_controller_name_is_not_a_match(self) -> None:
+        """`memory` must match a whole controller, not a prefix of one.
+
+        A naive `[[ $controllers == *memory* ]]` would accept a future
+        controller merely containing the word and enable a limit the kernel
+        then ignores.
+        """
+        self.controllers.write_text("cpu io memoryfoo pids\n", encoding="utf-8")
+        result = self.run_helper()
+        self.assertEqual(self.argv_of(result), [])
+        self.assertIn("memory controller is not delegated", result.stderr)
+
+
+class TestLaunchersUseTheHelper(unittest.TestCase):
+    """The helper is worthless if a launcher stops calling it.
+
+    Pinned by reading each launcher's source rather than by executing it:
+    running them for real means running the whole suite.
+    """
+
+    LAUNCHERS = ("run_final_gate.sh", "test.sh")
+
+    def test_every_suite_launcher_sources_and_applies_the_prefix(self) -> None:
+        for name in self.LAUNCHERS:
+            with self.subTest(launcher=name):
+                source = (REPO_ROOT / "scripts" / name).read_text(encoding="utf-8")
+                self.assertIn("memory_scope.sh", source)
+                self.assertIn("cratedigger_memory_scope_prefix", source)
+                self.assertIn('"${CRATEDIGGER_MEMORY_SCOPE_ARGV[@]}"', source)
+
+    def test_nightly_runners_document_why_they_opt_out(self) -> None:
+        """The two nightly runners deliberately do NOT use the helper: they
+        run under nixosconfig SYSTEM units with no reliable user bus, and
+        carry a declarative unit-level MemoryMax instead. An undocumented
+        absence is indistinguishable from an oversight."""
+        for name in ("daily_flake_update.sh", "daily_beets_tip_update.sh"):
+            with self.subTest(runner=name):
+                source = (REPO_ROOT / "scripts" / name).read_text(encoding="utf-8")
+                self.assertIn("memory_scope.sh", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1238.

## What

A suite run had no memory limit of its own. The 2026-08-19 #1214 leak therefore produced a **global** OOM — `oom-kill:constraint=CONSTRAINT_NONE,...,global_oom` — so the kernel chose victims across the whole host by `oom_score` and killed six unrelated processes rather than the offender. The leak is fixed; the shape is not. The next runaway's collateral includes the Claude daemon in the same user slice, which owns the operator's background agent sessions.

Every existing guard (`TEST_RAM_ROOT_EXHAUSTED`, `TEST_HOST_MEMORY_EXHAUSTED`, `_check_suite_headroom`) classifies an exhaustion after the fact, or refuses admission before one. None bounds a run in progress.

`scripts/memory_scope.sh` emits a transient `systemd-run --user --scope` prefix. `scripts/test.sh` and `scripts/run_final_gate.sh` launch through it.

## Sizing is measured, not chosen

`MemoryMax` = 70% of the host's own MemTotal — derived, never a constant, so other installations scale (#1079). Margin comes from `daily_resource_monitor.sh` telemetry, 2026-08-20 (post-#1214-fix, healthy):

| phase | peak user-slice memory | samples |
| --- | --- | --- |
| `deterministic_suite` | 22.41 GB | 15,746 |
| baseline, same run | 14.56 GB | — |

Suite's own share ≈ 8 GB; the cap on this 32 GiB host is ~22.4 GiB, about 2.8× headroom.

## Two findings that came from measuring, not reasoning

Both were wrong in my first draft, and the file records both.

**`MemorySwapMax=0` is load-bearing.** `MemoryMax` alone bounds only *resident* memory; on a host with swap the overage spills instead of being refused, so a runaway thrashes rather than dying. Measured:

| config | 200 MiB alloc under 64 MiB cap |
| --- | --- |
| `MemoryMax` only | **exit 0** — not contained |
| `+ MemorySwapMax=0` | **exit 137** — killed |

**`MemoryHigh` must not be set.** It looks like the obvious gentler first tier and is a trap: with swap capped it stalled a runaway in the kernel's reclaim loop for **over 120 seconds** with nothing to reclaim, and had to be killed by hand. For an unattended nightly gate that converts "fail fast with 137" into "hang forever and never report" — worse than the uncontained behaviour this fixes.

## Fail-open vs fail-closed

Asymmetric, deliberately:

- **Missing infrastructure** (no `systemd-run`, no delegated memory controller, unreadable MemTotal) → warn, run uncontained. Containment is a safety net, not a correctness gate; refusing to run the suite would trade a rare host OOM for a common hard stop.
- **Invalid explicit override** → fail closed. An operator who typo'd a limit must not silently get a different one. Mirrors `headroom_floor_bytes`.

`CRATEDIGGER_TEST_MEMORY_MAX_BYTES` overrides the limit; `0` disables containment.

*The operator did not pick between these when asked; this is my recommendation, and it is one line in `cratedigger_memory_scope_prefix` to flip.*

## Nightly runners deliberately opt out

`daily_flake_update.sh` / `daily_beets_tip_update.sh` run under nixosconfig **system** units (`Type=oneshot`, `User=abl030`) with no reliable user D-Bus, so `systemd-run --user` would fail open to no containment on exactly the unattended path that failed. They get a declarative unit-level `MemoryMax=` in nixosconfig instead — **not in this PR**. Both files document the opt-out, and a test asserts that documentation exists, so an undocumented absence can't pass for an oversight.

## Testing

`tests/test_memory_scope.py`, 17 deterministic tests. Test infrastructure, so deterministic-only per `code-quality.md`.

These pin the **argv the helper emits**, not the kernel's enforcement of it — whether `MemoryMax` kills a process is a property of cgroup v2, and driving a real scope from the suite would make the whole suite depend on a live user D-Bus session. Enforcement evidence is the measured table above.

Each fail-open branch is driven to its own condition with earlier branches passing, and asserts its own distinct message, so a short-circuit can't let one assertion stand in for another.

### Kill matrix

| Site | Mutant | Test that goes RED | Result |
| --- | --- | --- | --- |
| `-p MemorySwapMax=0` | delete the flag | `test_prefix_caps_swap` | KILLED |
| `_CRATEDIGGER_MEMORY_MAX_PERCENT=70` | → `60` | `test_default_limit_is_seventy_percent_of_mem_total` | KILLED |
| absence of `MemoryHigh` | re-add `-p MemoryHigh=$((max/2))` | `test_does_not_set_memory_high` | KILLED |
| invalid-override `return 1` | → `return 0` | `test_invalid_override_fails_closed` | KILLED |
| `!= *" memory "*` | → `!= *memory*` | `test_substring_controller_name_is_not_a_match` | KILLED |
| nesting guard | condition → `false` | `test_already_scoped_run_does_not_nest` | KILLED |
| `test.sh` prefix application | drop the argv expansion | `test_every_suite_launcher_sources_and_applies_the_prefix` | KILLED |

Control (unmutated tree) green; 7/7 killed; tree verified reverted after the run.

### Gates

`bash scripts/test.sh tests.test_memory_scope` → **6/6 phases pass** (js-syntax, js-unit, pyright, ruff, vulture, python). That run also exercised the new wiring for real — `test.sh` now launches through the scope — and emitted zero `uncontained` warnings, so containment was established live.

## Docs

`.claude/rules/code-quality.md` gains the knob and the two constraints, in the section that already owns `CRATEDIGGER_TEST_RAM_MIN_BYTES` / `CRATEDIGGER_TEST_MEMORY_MIN_BYTES`. Registry entries added for `scripts/memory_scope.sh` and `scripts/run_final_gate.sh` (which had none), and `tests.test_memory_scope` added to `scripts/test.sh`'s.
