### PR TITLE
test: local-import claim loop + literal pins for eleven unpinned constants (#1211)

### DIFF
--- a/tests/test_composite_audio_gap.py
+++ b/tests/test_composite_audio_gap.py
@@ -369,5 +369,22 @@ class TestDetectCompositeSilenceGap(unittest.TestCase):
         self.assertFalse(detect_composite_silence_gap(path))
 
 
+class TestGapThresholdConstantValues(unittest.TestCase):
+    """The boundary tests above (``TestGapDecisionFromSilenceFlags``, the
+    generated reference oracle) deliberately hardcode literal 5/10 rather
+    than importing these constants (review D2 — importing them would make
+    a mutated constant agree with itself by construction). This is
+    therefore the only place either constant's OWN value is pinned; a
+    changed threshold moves which physical gaps the detector flags as a
+    composite-audio splice and must be a deliberate edit.
+    """
+
+    def test_min_silence_seconds(self) -> None:
+        self.assertEqual(MIN_SILENCE_SECONDS, 5)
+
+    def test_min_trailing_audio_seconds(self) -> None:
+        self.assertEqual(MIN_TRAILING_AUDIO_SECONDS, 10)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_local_import_lane.py
+++ b/tests/test_local_import_lane.py
@@ -21,11 +21,14 @@ exposure, the strict distance threshold, its own attempt scenario).
 from __future__ import annotations
 
 import os
+import shutil
 import tempfile
 import unittest
 from types import SimpleNamespace
 from typing import Any, cast
+from unittest.mock import patch
 
+from lib.config import CratediggerConfig
 from lib.dispatch.manifest_guard import _guard_force_import_audio_manifest
 from lib.dispatch.types import DispatchOutcome, ImportAttemptResult
 from lib.import_execution import CancellationToken, OwnerSessionIdentity
@@ -34,6 +37,7 @@ from lib.import_queue import (
     IMPORT_JOB_FORCE,
     IMPORT_JOB_LOCAL,
     IMPORT_JOB_YOUTUBE,
+    ImportJob,
     force_import_dedupe_key,
     force_import_payload,
     local_import_dedupe_key,
@@ -405,6 +409,111 @@ class TestProcessClaimedJobForwardsPinnedSessionToLocal(unittest.TestCase):
 
         self.assertIs(captured.get("cancellation_token"), token)
         self.assertIs(captured.get("owner_session_identity"), identity)
+
+
+class TestRunOnceClaimsLocalImportCandidate(unittest.TestCase):
+    """Issue #1211 PR3 — no test anywhere drove ``importer.run_once`` all
+    the way through the ``IMPORT_JOB_LOCAL`` claim branch (the
+    ``elif candidate.job_type == IMPORT_JOB_LOCAL:`` arm at ~importer.py:2318,
+    which calls ``_process_force_claim(..., claim_fn=_claim_local_import)``
+    -> ``process_claimed_job``). #1210 covered ``process_claimed_job`` in
+    isolation once already claimed; this proves the claim-loop wiring one
+    level up actually reaches and claims a queued local-import candidate.
+    """
+
+    def setUp(self) -> None:
+        # Mirrors tests/test_import_queue.py::TestImporterWorker.setUp — the
+        # terminal cleanup this test exercises (_record_terminal_force_
+        # action_cleanup -> cleanup_force_action_copy_for_job) asserts the
+        # private processing root is mode 0700 (lib/fs_authority.py), so
+        # plain os.makedirs (as TestExecuteImportJobLocalBranchSeam uses,
+        # which never reaches terminal cleanup) is not enough here.
+        self._root = tempfile.mkdtemp(prefix="cratedigger-local-import-run-once-")
+        self.addCleanup(lambda: shutil.rmtree(self._root, ignore_errors=True))
+        downloads = os.path.join(self._root, "downloads")
+        processing = os.path.join(self._root, "processing")
+        os.mkdir(downloads, 0o700)
+        os.mkdir(processing, 0o700)
+        os.mkdir(os.path.join(processing, "albums"), 0o700)
+        os.mkdir(os.path.join(processing, "preview"), 0o700)
+        self._cfg = CratediggerConfig(
+            slskd_download_dir=downloads,
+            processing_dir=processing,
+            audio_check_mode="off",
+        )
+        patcher = patch(
+            "lib.config.read_runtime_config", return_value=self._cfg,
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_run_once_claims_and_completes_a_local_import_candidate(self) -> None:
+        db = FakePipelineDB()
+        job = _local_job(db, request_id=90, source_path="/operator/real/Album")
+        action_path = force_action_copy_path(
+            self._cfg, job.id, prefix=LOCAL_IMPORT_ACTION_PREFIX,
+        )
+        os.mkdir(action_path, 0o700)
+        marked = db.mark_import_job_preview_importable(
+            job.id, preview_result={"action_path": action_path}, message="ready",
+        )
+        assert marked is not None
+
+        dispatch_calls: list[dict[str, object]] = []
+
+        def _recording_dispatch(_db: object, **kwargs: object) -> DispatchOutcome:
+            dispatch_calls.append(kwargs)
+            return DispatchOutcome(success=True, message="imported")
+
+        def _execute_fn(
+            db_arg: object,
+            job_arg: ImportJob,
+            *,
+            ctx: object = None,
+            cancellation_token: CancellationToken | None = None,
+            owner_session_identity: OwnerSessionIdentity | None = None,
+        ) -> DispatchOutcome:
+            # The REAL execute_import_job, driven through ITS OWN
+            # force_dispatch_fn/force_runtime_config kwarg-DI seam
+            # (code-quality.md's preferred strategy over patching
+            # lib.dispatch.dispatch_import_from_db, which is not leaf-seam
+            # allowlisted) -- process_claimed_job's own execute_fn(...) call
+            # never forwards those two kwargs, so this wrapper (injected via
+            # run_once's own execute_fn= seam) supplies them instead.
+            return importer.execute_import_job(
+                db_arg,  # pyright: ignore[reportArgumentType]
+                job_arg,
+                ctx=ctx,
+                cancellation_token=cancellation_token,
+                owner_session_identity=owner_session_identity,
+                force_dispatch_fn=_recording_dispatch,
+                force_runtime_config=self._cfg,
+            )
+
+        result = importer.run_once(
+            db,  # pyright: ignore[reportArgumentType]
+            worker_id="worker",
+            stage_db_factory=lambda _dsn: db,
+            execute_fn=_execute_fn,
+        )
+
+        assert result is not None
+        self.assertEqual(result.id, job.id)
+        self.assertEqual(result.job_type, IMPORT_JOB_LOCAL)
+        # Domain-state assertion (Test Taxonomy #3): the job outcome
+        # persisted by the claim-loop, not merely "it ran without raising".
+        self.assertEqual(result.status, "completed")
+        stored = db.get_import_job(job.id)
+        assert stored is not None
+        self.assertEqual(stored.status, "completed")
+
+        self.assertEqual(len(dispatch_calls), 1)
+        dispatch_kwargs = dispatch_calls[0]
+        self.assertEqual(dispatch_kwargs["failed_path"], action_path)
+        # Decision 2 (#1176 PR3): local-import never audits the operator's
+        # real path.
+        self.assertIsNone(dispatch_kwargs["source_reference_path"])
+        self.assertEqual(dispatch_kwargs["scenario"], "local_import")
 
 
 if __name__ == "__main__":

--- a/tests/test_local_import_lane.py
+++ b/tests/test_local_import_lane.py
@@ -422,12 +422,21 @@ class TestRunOnceClaimsLocalImportCandidate(unittest.TestCase):
     """
 
     def setUp(self) -> None:
-        # Mirrors tests/test_import_queue.py::TestImporterWorker.setUp — the
+        # Mirrors tests/test_import_queue.py::TestImporterWorker.setUp. The
         # terminal cleanup this test exercises (_record_terminal_force_
-        # action_cleanup -> cleanup_force_action_copy_for_job) asserts the
-        # private processing root is mode 0700 (lib/fs_authority.py), so
-        # plain os.makedirs (as TestExecuteImportJobLocalBranchSeam uses,
-        # which never reaches terminal cleanup) is not enough here.
+        # action_cleanup -> cleanup_force_action_copy_for_job) requires the
+        # private processing root to be mode 0700 (lib/fs_authority.py) for
+        # the reap to SUCCEED -- _cleanup_terminal_force_action's blanket
+        # except Exception (scripts/importer.py) means a wrong mode does not
+        # fail this test; it silently folds into a logged
+        # {"removed": False, "error": "FilesystemAuthorityError: ..."}
+        # instead. The mode is asserted here (test_run_once_claims_and_
+        # completes_a_local_import_candidate below reads "removed": True and
+        # confirms the action copy no longer exists on disk) so that
+        # assertion is checking real cleanup, not a silently-failed one.
+        # Plain os.makedirs (as TestExecuteImportJobLocalBranchSeam uses,
+        # which never reaches terminal cleanup) would leave that assertion
+        # false.
         self._root = tempfile.mkdtemp(prefix="cratedigger-local-import-run-once-")
         self.addCleanup(lambda: shutil.rmtree(self._root, ignore_errors=True))
         downloads = os.path.join(self._root, "downloads")
@@ -506,6 +515,15 @@ class TestRunOnceClaimsLocalImportCandidate(unittest.TestCase):
         stored = db.get_import_job(job.id)
         assert stored is not None
         self.assertEqual(stored.status, "completed")
+        # ImportJob.result is already dict[str, Any] | None -- no cast
+        # needed to index it.
+        assert stored.result is not None
+        force_action_cleanup = stored.result["force_action_cleanup"]
+        assert isinstance(force_action_cleanup, dict)
+        # The action copy really was reaped, not silently left behind
+        # a logged {"removed": False} (see setUp's docstring).
+        self.assertTrue(force_action_cleanup["removed"])
+        self.assertFalse(os.path.exists(action_path))
 
         self.assertEqual(len(dispatch_calls), 1)
         dispatch_kwargs = dispatch_calls[0]

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1514,5 +1514,16 @@ class TestQueryTemplateForStrategy(unittest.TestCase):
                 )
 
 
+class TestMaxVaTrackArtistSlotsConstant(unittest.TestCase):
+    """``TestGenerateSearchPlanSlotMix`` exercises this cap only relative to
+    itself (``MAX_VA_TRACK_ARTIST_SLOTS + 2``), never pins its own value —
+    a changed cap moves how many VA per-track-artist slots a plan emits
+    and must be a deliberate edit.
+    """
+
+    def test_value(self) -> None:
+        self.assertEqual(MAX_VA_TRACK_ARTIST_SLOTS, 3)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_slskd_searches.py
+++ b/tests/test_slskd_searches.py
@@ -67,6 +67,20 @@ _PAST_GRACE = SEARCH_LEDGER_SWEEP_GRACE_S + 60.0
 _INSIDE_GRACE = SEARCH_LEDGER_SWEEP_GRACE_S / 2.0
 
 
+class TestSearchLedgerTunableConstants(unittest.TestCase):
+    """Every other test here exercises these constants only relative to
+    themselves (``+ 60.0``, ``/ 2.0``, ``+ 1`` days), never pins either
+    value — a changed constant moves the sweep's grace window or the
+    ledger's retention window and must be a deliberate edit.
+    """
+
+    def test_sweep_grace_seconds(self) -> None:
+        self.assertEqual(SEARCH_LEDGER_SWEEP_GRACE_S, 3600.0)
+
+    def test_prune_retention_days(self) -> None:
+        self.assertEqual(SEARCH_LEDGER_PRUNE_RETENTION_DAYS, 7)
+
+
 class TestConvergeSlskdSearchesI1Pin(unittest.TestCase):
     """I1 (kill-proof): a ledgered search whose creating process died
     right after the POST is still reaped once past GRACE."""

--- a/tests/test_unfindable_detection_service.py
+++ b/tests/test_unfindable_detection_service.py
@@ -91,6 +91,32 @@ def _inputs(
 
 
 # ---------------------------------------------------------------------------
+# 0. Tunable constant literal pins (issue #1211 PR3).
+# ---------------------------------------------------------------------------
+
+
+class TestTunableConstantValues(unittest.TestCase):
+    """These four constants (see their docstrings in
+    lib/unfindable_detection_service.py) govern detection sensitivity and
+    cadence; every other test here exercises them only at a +/-1 boundary,
+    never pins the value itself, so a changed constant is a deliberate edit
+    to be reviewed here, not a silent drift no test would catch.
+    """
+
+    def test_artist_match_threshold(self) -> None:
+        self.assertEqual(ARTIST_MATCH_THRESHOLD, 5)
+
+    def test_required_zero_find_cycles(self) -> None:
+        self.assertEqual(REQUIRED_ZERO_FIND_CYCLES, 3)
+
+    def test_wrong_pressing_min_hits(self) -> None:
+        self.assertEqual(WRONG_PRESSING_MIN_HITS, 3)
+
+    def test_probe_interval_days(self) -> None:
+        self.assertEqual(PROBE_INTERVAL_DAYS, 7)
+
+
+# ---------------------------------------------------------------------------
 # 1. Pure classifier — subTest table.
 # ---------------------------------------------------------------------------
 

--- a/tests/test_verdict_tiers.py
+++ b/tests/test_verdict_tiers.py
@@ -51,6 +51,17 @@ def _lattice(modal_count, scored_tracks=6):
         modal_count=modal_count, scored_tracks=scored_tracks, max_z=3.0))
 
 
+class TestUltrasonicProofDenyDeficitConstant(unittest.TestCase):
+    """Every other test here exercises this deny threshold only relative to
+    itself (``_ultrasonic(ULTRASONIC_PROOF_DENY_DEFICIT_DB)``,
+    ``... + 5.0``), never pins its own value — a changed threshold moves
+    which albums the proof gate denies and must be a deliberate edit.
+    """
+
+    def test_value(self) -> None:
+        self.assertEqual(ULTRASONIC_PROOF_DENY_DEFICIT_DB, 59.5)
+
+
 class TestAlbumProofVerdict(unittest.TestCase):
     """Every branch of the tier ladder, one row per branch."""
 

--- a/tests/test_web_triage_runner.py
+++ b/tests/test_web_triage_runner.py
@@ -44,6 +44,17 @@ class _FakeClock:
         self.value += delta
 
 
+class TestPendingCancelWindowConstant(unittest.TestCase):
+    """Every cancellation test below exercises this window only relative to
+    itself (``/ 2``, ``+ 1.0``), never pins its own value — a changed window
+    moves when a re-armed triage run lands pre-cancelled instead of
+    executing and must be a deliberate edit.
+    """
+
+    def test_value(self) -> None:
+        self.assertEqual(PENDING_CANCEL_WINDOW_SECONDS, 10.0)
+
+
 class TriageRunnerTest(unittest.TestCase):
     def setUp(self) -> None:
         self.runner = TriageRunner()


### PR DESCRIPTION
## Summary

Two test residuals from the #1211 verification pass. Tests-only — no production file changes (`git diff main..HEAD -- . ':!tests/'` is empty).

**Piece A — the local-import claim loop was never driven end to end.** PR #1210 added slices driving `process_claimed_job` directly, but nothing anywhere drove `importer.run_once` with an `IMPORT_JOB_LOCAL` candidate, so the wiring `run_once` → the `IMPORT_JOB_LOCAL` branch → `_process_force_claim(claim_fn=_claim_local_import)` → `claim_local_import_job_under_lock` → `process_claimed_job` was unexercised. `TestRunOnceClaimsLocalImportCandidate` in `tests/test_local_import_lane.py` now drives it, asserting persisted domain state (job status `completed`, the cleanup receipt, and the action copy's absence from disk) rather than "it ran".

Injection is through production kwarg-DI seams (`stage_db_factory=`, `execute_fn=`, and `execute_import_job`'s own `force_dispatch_fn`/`force_runtime_config`), not a module patch — a first draft patched `lib.dispatch.dispatch_import_from_db` and would have moved the mock-audit `MULTILINE_PATCH_BASELINE`.

**Piece B — eleven load-bearing constants had no value pin.** Each was used at a `±1` boundary in tests while nothing anywhere asserted its value, so changing any of them broke no test. Each now has a pin against a hand-typed literal — never an expression reading the symbol, which is the agree-by-construction trap that let `MIN_SILENCE_SECONDS 5→4` survive its own module in #1237.

`_property_gap_decision_needs_a_silent_run_and_a_trailing_run` is deliberately left reading the live constants: it is a threshold-*relative* structural invariant, and the literal value pin is the correct fix for it rather than a rewrite.

Refs #1211 (non-closing).

## Kill matrix (per diff site, not per PR)

| Site (assertion / clause / constant) | One-line production mutant | Test that must go RED | Result |
| --- | --- | --- | --- |
| `run_once` LOCAL claim arm (`importer.py:2330`) | `claim_fn=_claim_local_import` → `_claim_force_import` | `TestRunOnceClaimsLocalImportCandidate.test_run_once_claims_and_completes_a_local_import_candidate` | Killed |
| `run_once` LOCAL branch guard (`:2318`) | `== IMPORT_JOB_LOCAL` → `== IMPORT_JOB_YOUTUBE` | same | Killed |
| `run_once` claim callback (`:2329`) | delete `claim_callback=claim_state.mark` | same | Killed |
| `process_claimed_job` success arm (`:2097`) | `if outcome.success:` → `if not outcome.success:` | same | Killed |
| LOCAL `source_reference_path=None` (`:875`) | → operator path literal | same | Killed |
| LOCAL `scenario="local_import"` (`:880`) | → `"force_import"` | same | Killed |
| LOCAL `action_prefix=LOCAL_IMPORT_ACTION_PREFIX` (`:874`) | → `"force-action-"` | same | Killed |
| `_process_force_claim` return (`:1784`) | → `return job or process_claimed_job(...)` | same | Killed |
| cleanup receipt assertion | `ACTION_COPY_PREFIX_BY_JOB_TYPE.get(...)` (`:478`) → hardcoded `"force-action-"` (the historical leak bug) | same | Killed |
| action-copy absence assertion | `_cleanup_terminal_force_action` (`:453`) → `return None` | same | Killed (`KeyError`) |
| `ARTIST_MATCH_THRESHOLD` | `5` → `6` | `TestTunableConstantValues.test_artist_match_threshold` | Killed |
| `REQUIRED_ZERO_FIND_CYCLES` | `3` → `4` | `TestTunableConstantValues.test_required_zero_find_cycles` | Killed |
| `WRONG_PRESSING_MIN_HITS` | `3` → `4` | `TestTunableConstantValues.test_wrong_pressing_min_hits` | Killed |
| `PROBE_INTERVAL_DAYS` | `7` → `8` | `TestTunableConstantValues.test_probe_interval_days` | Killed |
| `ULTRASONIC_PROOF_DENY_DEFICIT_DB` | `59.5` → `60.5` | `TestUltrasonicProofDenyDeficitConstant.test_value` | Killed |
| `PENDING_CANCEL_WINDOW_SECONDS` | `10.0` → `11.0` | `TestPendingCancelWindowConstant.test_value` | Killed |
| `SEARCH_LEDGER_SWEEP_GRACE_S` | `3600.0` → `3700.0` | `TestSearchLedgerTunableConstants.test_sweep_grace_seconds` | Killed |
| `SEARCH_LEDGER_PRUNE_RETENTION_DAYS` | `7` → `8` | `TestSearchLedgerTunableConstants.test_prune_retention_days` | Killed |
| `MAX_VA_TRACK_ARTIST_SLOTS` | `3` → `4` | `TestMaxVaTrackArtistSlotsConstant.test_value` | Killed |
| `MIN_SILENCE_SECONDS` | `5` → `6` | `TestGapThresholdConstantValues.test_min_silence_seconds` | Killed |
| `MIN_TRAILING_AUDIO_SECONDS` | `10` → `11` | `TestGapThresholdConstantValues.test_min_trailing_audio_seconds` | Killed |

All mutants applied at the production definition, confirmed RED for the named test, then reverted; `PYTHONDONTWRITEBYTECODE=1` throughout.

## Reviewer

Independent review planted eight further mutants of its own across the real claim path — aimed at sites this table did not list — and all eight were killed; it separately re-derived all 11 constant pins as killed. It raised one finding: a `setUp` comment justified the 0700 processing-root mode with a consequence no assertion could produce (the `FilesystemAuthorityError` is swallowed by a blanket `except Exception` and folded into `{"removed": False}`, which nothing read). Fixed by asserting the cleanup receipt and the copy's absence — which also converted the two mutants that had survived at this level (`importer.py:478` and `:453`) into kills — and by rewriting the comment to state the real mechanism. Re-review confirmed CLOSED, verifying the corrected comment by mechanism rather than by claim.

## Risk

Tests-only; no production behaviour changes. Both typing-ratchet baselines and the mock-audit baseline are untouched — the one new escape hatch needed is a scoped `# pyright: ignore[reportArgumentType]` at the `run_once` call site, the sanctioned uncounted form, and pyright is clean on the file.
