### PR TITLE
fix(quality): unify the eight force-action- spellings onto FORCE_ACTION_PREFIX (#1211)

### DIFF
--- a/lib/import_preview.py
+++ b/lib/import_preview.py
@@ -505,6 +505,20 @@ def remove_preview_snapshot(
     )
 
 
+#: The force-import lane's action-copy prefix (issue #1211) — the single
+#: named source for a string that used to be spelled independently as a
+#: literal at eight functional sites across this module,
+#: ``scripts/importer.py``, and ``scripts/import_preview_worker.py``. All
+#: eight were byte-identical, so nothing was broken, but editing any one
+#: alone would have silently drifted the importer's terminal cleanup
+#: comparison in ``cleanup_force_action_copy_for_job`` — which raises
+#: ``FilesystemAuthorityError`` BEFORE ever touching the filesystem on a
+#: mismatch, leaking the retained action copy permanently and re-raising on
+#: every subsequent importer startup recovery sweep. That exact defect
+#: already happened once for the local-import lane (see the comment at
+#: ``scripts/importer.py``'s ``_cleanup_terminal_force_action``).
+FORCE_ACTION_PREFIX = "force-action-"
+
 #: The local-import lane's action-copy prefix (issue #1176 PR3) — passed as
 #: ``prefix=`` to every action-copy helper below so a local-import job's
 #: retained private copy can never collide on name with a force job's, even
@@ -526,7 +540,7 @@ LOCAL_IMPORT_ACTION_PREFIX = "local-import-action-"
 #: on purpose — neither retains a private action copy under
 #: ``processing/albums/`` the way force/local-import do.
 ACTION_COPY_PREFIX_BY_JOB_TYPE: dict[str, str] = {
-    IMPORT_JOB_FORCE: "force-action-",
+    IMPORT_JOB_FORCE: FORCE_ACTION_PREFIX,
     IMPORT_JOB_LOCAL: LOCAL_IMPORT_ACTION_PREFIX,
 }
 
@@ -536,7 +550,7 @@ def retain_preview_snapshot_for_force_action(
     cfg: CratediggerConfig,
     *,
     import_job_id: int,
-    prefix: str = "force-action-",
+    prefix: str = FORCE_ACTION_PREFIX,
     cancellation_token: CancellationToken | None = None,
 ) -> str:
     """Promote one verified private snapshot to a job-scoped action copy.
@@ -547,11 +561,12 @@ def retain_preview_snapshot_for_force_action(
     preview so the importer consumes the exact normalized bytes evidence
     describes.
 
-    ``prefix`` (issue #1176 PR3) defaults to today's ``"force-action-"`` so
-    the force lane stays byte-identical; the local-import lane passes its
-    own ``"local-import-action-"`` prefix so a force copy and a local-import
-    copy can never collide on name even though ``import_job_id`` is drawn
-    from the same ``import_jobs`` sequence across every job type.
+    ``prefix`` (issue #1176 PR3) defaults to today's ``FORCE_ACTION_PREFIX``
+    (``"force-action-"``) so the force lane stays byte-identical; the
+    local-import lane passes its own ``LOCAL_IMPORT_ACTION_PREFIX``
+    (``"local-import-action-"``) so a force copy and a local-import copy can
+    never collide on name even though ``import_job_id`` is drawn from the
+    same ``import_jobs`` sequence across every job type.
     """
     name = os.path.basename(path)
     if name == path or not name.startswith("preview-"):
@@ -582,7 +597,7 @@ def remove_force_action_copy(
     path: str,
     cfg: CratediggerConfig,
     *,
-    prefix: str = "force-action-",
+    prefix: str = FORCE_ACTION_PREFIX,
     cancellation_token: CancellationToken | None = None,
 ) -> None:
     """Remove one unneeded retained job-scoped action copy after a terminal
@@ -616,7 +631,7 @@ def cleanup_force_action_copy_for_job(
     cfg: CratediggerConfig,
     *,
     import_job_id: int,
-    prefix: str = "force-action-",
+    prefix: str = FORCE_ACTION_PREFIX,
     cancellation_token: CancellationToken | None = None,
 ) -> None:
     """Remove only the deterministic action copy owned by this job.
@@ -638,7 +653,7 @@ def cleanup_force_action_copy_for_job(
 
 
 def force_action_copy_path(
-    cfg: CratediggerConfig, import_job_id: int, *, prefix: str = "force-action-",
+    cfg: CratediggerConfig, import_job_id: int, *, prefix: str = FORCE_ACTION_PREFIX,
 ) -> str:
     """The one reclaimable private action directory for a job.
     ``prefix`` — see :func:`retain_preview_snapshot_for_force_action`.

--- a/lib/import_preview.py
+++ b/lib/import_preview.py
@@ -550,7 +550,7 @@ def retain_preview_snapshot_for_force_action(
     cfg: CratediggerConfig,
     *,
     import_job_id: int,
-    prefix: str = FORCE_ACTION_PREFIX,
+    prefix: str,
     cancellation_token: CancellationToken | None = None,
 ) -> str:
     """Promote one verified private snapshot to a job-scoped action copy.
@@ -561,12 +561,17 @@ def retain_preview_snapshot_for_force_action(
     preview so the importer consumes the exact normalized bytes evidence
     describes.
 
-    ``prefix`` (issue #1176 PR3) defaults to today's ``FORCE_ACTION_PREFIX``
-    (``"force-action-"``) so the force lane stays byte-identical; the
-    local-import lane passes its own ``LOCAL_IMPORT_ACTION_PREFIX``
-    (``"local-import-action-"``) so a force copy and a local-import copy can
-    never collide on name even though ``import_job_id`` is drawn from the
-    same ``import_jobs`` sequence across every job type.
+    ``prefix`` (issue #1176 PR3) is REQUIRED, not defaulted (issue #1211
+    PR1 follow-up): the sole caller already always passes its lane's own
+    prefix explicitly — ``FORCE_ACTION_PREFIX`` (``"force-action-"``) for
+    force, ``LOCAL_IMPORT_ACTION_PREFIX`` (``"local-import-action-"``) for
+    local-import — so a force copy and a local-import copy can never
+    collide on name even though ``import_job_id`` is drawn from the same
+    ``import_jobs`` sequence across every job type. An unreachable default
+    that silently supplied force's prefix was exactly the implicit-
+    inheritance hazard this module exists to remove: a caller that forgot
+    ``prefix=`` would have silently retained every job type's action copy
+    under FORCE's deterministic name instead of failing loudly.
     """
     name = os.path.basename(path)
     if name == path or not name.startswith("preview-"):
@@ -597,7 +602,7 @@ def remove_force_action_copy(
     path: str,
     cfg: CratediggerConfig,
     *,
-    prefix: str = FORCE_ACTION_PREFIX,
+    prefix: str,
     cancellation_token: CancellationToken | None = None,
 ) -> None:
     """Remove one unneeded retained job-scoped action copy after a terminal
@@ -631,7 +636,7 @@ def cleanup_force_action_copy_for_job(
     cfg: CratediggerConfig,
     *,
     import_job_id: int,
-    prefix: str = FORCE_ACTION_PREFIX,
+    prefix: str,
     cancellation_token: CancellationToken | None = None,
 ) -> None:
     """Remove only the deterministic action copy owned by this job.

--- a/scripts/import_preview_worker.py
+++ b/scripts/import_preview_worker.py
@@ -49,6 +49,7 @@ from lib.import_execution import (
 )
 from lib.import_preview import (
     ACTION_COPY_PREFIX_BY_JOB_TYPE,
+    FORCE_ACTION_PREFIX,
     LOCAL_IMPORT_ACTION_PREFIX,
     PREVIEW_VERDICT_EVIDENCE_READY,
     PREVIEW_VERDICT_MEASUREMENT_FAILED,
@@ -664,7 +665,7 @@ class _JobActionAuthority:
 #: Default authority: today's force-import quarantine resolution, unchanged.
 _FORCE_ACTION_AUTHORITY = _JobActionAuthority(
     snapshot_fn=snapshot_configured_quarantine_directory,
-    action_prefix="force-action-",
+    action_prefix=FORCE_ACTION_PREFIX,
 )
 
 #: The local-import lane's authority (issue #1176 PR3): resolves through

--- a/scripts/importer.py
+++ b/scripts/importer.py
@@ -464,6 +464,7 @@ def _cleanup_terminal_force_action(job: ImportJob) -> dict[str, object] | None:
         from lib.config import read_runtime_config
         from lib.import_preview import (
             ACTION_COPY_PREFIX_BY_JOB_TYPE,
+            FORCE_ACTION_PREFIX,
             cleanup_force_action_copy_for_job,
         )
 
@@ -475,7 +476,16 @@ def _cleanup_terminal_force_action(job: ImportJob) -> dict[str, object] | None:
         # re-raised on every subsequent importer startup recovery sweep.
         # ``ACTION_COPY_PREFIX_BY_JOB_TYPE`` is the same table
         # scripts/import_preview_worker.py's sibling cleanup already uses.
-        prefix = ACTION_COPY_PREFIX_BY_JOB_TYPE.get(job.job_type, "force-action-")
+        # The fallback stays ``FORCE_ACTION_PREFIX`` (issue #1211 PR1): the
+        # table deliberately omits ``automation_import``/``youtube_import``,
+        # neither of which ever retains a private action copy, so
+        # ``_force_action_path`` above already returns ``None`` and short-
+        # circuits before this line for both — this default is provably dead
+        # for every current job type. Whether ``.get(...)`` should instead
+        # fail closed on an unrecognized job type is an open question left
+        # for a follow-up; this PR only collapses the eight literal spellings
+        # onto one constant and preserves every existing fallback behavior.
+        prefix = ACTION_COPY_PREFIX_BY_JOB_TYPE.get(job.job_type, FORCE_ACTION_PREFIX)
         cleanup_force_action_copy_for_job(
             action_path, cfg, import_job_id=job.id, prefix=prefix,
         )
@@ -835,11 +845,13 @@ def execute_import_job(
             [source_dir for source_dir in payload.source_dirs if source_dir]
             or None
         )
+        from lib.import_preview import FORCE_ACTION_PREFIX
+
         return _execute_action_copy_dispatch(
             db,
             job,
             request_id=job.request_id,
-            action_prefix="force-action-",
+            action_prefix=FORCE_ACTION_PREFIX,
             source_reference_path=payload.failed_path,
             source_username=payload.source_username,
             source_dirs=source_dirs,

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -2452,6 +2452,140 @@ class TestForceImportSlice(unittest.TestCase):
         row = db.request(833)
         self.assertNotIn("imported_path", row)
 
+    def test_force_action_copy_retain_cleanup_round_trip(self):
+        """Issue #1211: ``FORCE_ACTION_PREFIX`` is spelled independently at
+        eight functional sites across ``lib/import_preview.py``,
+        ``scripts/importer.py``, and ``scripts/import_preview_worker.py``.
+        All eight are byte-identical today, so nothing is currently broken —
+        this is a latent-defect regression guard, mirroring the local-import
+        mandatory slice
+        (``test_local_import_terminal_acceptance_drives_real_process_
+        claimed_job``) but for the force lane, and composing the REAL
+        producer with the REAL consumer instead of hand-building the
+        retained directory:
+
+        * **Real producer** — ``scripts.import_preview_worker.
+          _prepare_force_action_path`` (via its default
+          ``_FORCE_ACTION_AUTHORITY``) publishes the job-scoped action copy
+          under the real ``processing_dir/albums/`` exactly as the preview
+          worker does in production.
+        * **Real consumer** — ``scripts.importer._cleanup_terminal_force_
+          action`` (reached through ``process_claimed_job`` via
+          ``finalize_claimed_dispatch``) reaps it on a successful terminal
+          acceptance.
+
+        If any ONE of the eight sites drifts from the others,
+        ``cleanup_force_action_copy_for_job``'s deterministic-name
+        comparison raises ``FilesystemAuthorityError`` BEFORE ever touching
+        the filesystem: the retained copy leaks permanently and
+        ``force_action_cleanup.removed`` is always ``False`` — the exact
+        defect already recorded for the local-import lane at
+        ``scripts/importer.py``'s ``_cleanup_terminal_force_action``
+        (issue #1176 PR3 F5).
+        """
+        from lib.dispatch.types import DispatchOutcome
+        from lib.import_queue import (
+            IMPORT_JOB_FORCE,
+            force_import_dedupe_key,
+            force_import_payload,
+        )
+        from lib.terminal_outcomes import (
+            PendingImportTerminalOutcome,
+            TerminalDownloadAudit,
+        )
+        from lib.transitions import RequestTransition
+        from scripts import import_preview_worker
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(id=1211, status="wanted"))
+        with tempfile.TemporaryDirectory() as root:
+            staging_dir = os.path.join(root, "Incoming")
+            source = os.path.join(staging_dir, "failed_imports", "candidate")
+            os.makedirs(source)
+            with open(os.path.join(source, "01.mp3"), "wb") as handle:
+                handle.write(b"audio")
+            slskd_dir = os.path.join(root, "slskd")
+            os.mkdir(slskd_dir)
+            processing_dir = os.path.join(root, "processing")
+            os.makedirs(os.path.join(processing_dir, "albums"), mode=0o700)
+            os.makedirs(os.path.join(processing_dir, "preview"), mode=0o700)
+            os.chmod(processing_dir, 0o700)
+
+            download_log_id = db.log_download(
+                1211,
+                outcome="rejected",
+                validation_result={"failed_path": source},
+            )
+            job = db.enqueue_import_job(
+                IMPORT_JOB_FORCE,
+                request_id=1211,
+                dedupe_key=force_import_dedupe_key(download_log_id),
+                payload=force_import_payload(
+                    download_log_id=download_log_id,
+                    failed_path=source,
+                    source_username="alice",
+                ),
+            )
+            preview_claim = claim_next_import_preview_job(
+                db, worker_id="preview-1211",
+            )
+            assert preview_claim is not None and preview_claim.id == job.id
+
+            cfg = CratediggerConfig(
+                beets_staging_dir=staging_dir,
+                slskd_download_dir=slskd_dir,
+                processing_dir=processing_dir,
+            )
+
+            # Real producer: publishes the job-scoped action copy for real,
+            # under the deterministic name every one of the eight sites
+            # must agree on.
+            action_path = import_preview_worker._prepare_force_action_path(
+                db, preview_claim, cfg, raw_path=source,
+            )
+            self.assertTrue(os.path.isdir(action_path))
+            self.assertEqual(
+                os.path.basename(action_path), f"force-action-{job.id}",
+            )
+
+            db.mark_import_job_preview_importable(
+                job.id, preview_result={"action_path": action_path},
+            )
+            claimed = claim_next_import_job(db, worker_id="force-cleanup-1211")
+            assert claimed is not None and claimed.id == job.id
+
+            pending = PendingImportTerminalOutcome(
+                request_id=1211,
+                import_job_id=job.id,
+                initial_transition=RequestTransition.to_imported(
+                    from_status="wanted",
+                ),
+                audit=TerminalDownloadAudit(outcome="force_import"),
+            ).mark_successful_terminal_acceptance()
+            outcome = DispatchOutcome(
+                success=True, message="Imported", terminal_outcome=pending,
+            )
+
+            with patch("lib.config.read_runtime_config", return_value=cfg):
+                updated = finalize_claimed_dispatch(db, claimed, outcome)
+
+            # Real consumer: proven gone WHILE the tempdir is still alive,
+            # so this is the cleanup code's own doing, not teardown.
+            self.assertFalse(os.path.exists(action_path))
+
+        assert updated is not None
+        self.assertEqual(updated.status, "completed")
+        row = db.request(1211)
+        self.assertEqual(row["status"], "imported")
+        db.assert_log(self, 0, outcome="rejected")
+        assert updated.result is not None
+        cleanup = updated.result.get("force_action_cleanup")
+        assert isinstance(cleanup, dict)
+        self.assertTrue(
+            cleanup.get("removed"),
+            f"force action copy cleanup did not succeed: {cleanup!r}",
+        )
+
 
 class TestLocalImportSlice(unittest.TestCase):
     """Integration slice: dispatch_import_from_db through the local-import

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -2453,12 +2453,14 @@ class TestForceImportSlice(unittest.TestCase):
         self.assertNotIn("imported_path", row)
 
     def test_force_action_copy_retain_cleanup_round_trip(self):
-        """Issue #1211: ``FORCE_ACTION_PREFIX`` is spelled independently at
-        eight functional sites across ``lib/import_preview.py``,
-        ``scripts/importer.py``, and ``scripts/import_preview_worker.py``.
-        All eight are byte-identical today, so nothing is currently broken —
-        this is a latent-defect regression guard, mirroring the local-import
-        mandatory slice
+        """Issue #1211: ``FORCE_ACTION_PREFIX`` USED TO BE spelled
+        independently at eight functional sites across
+        ``lib/import_preview.py``, ``scripts/importer.py``, and
+        ``scripts/import_preview_worker.py``. All eight were byte-identical
+        at the time, so nothing was broken yet, but editing any one alone
+        would have silently drifted the importer's terminal cleanup
+        comparison — the latent-defect hazard this slice exists to guard
+        against, mirroring the local-import mandatory slice
         (``test_local_import_terminal_acceptance_drives_real_process_
         claimed_job``) but for the force lane, and composing the REAL
         producer with the REAL consumer instead of hand-building the
@@ -2474,14 +2476,37 @@ class TestForceImportSlice(unittest.TestCase):
           ``finalize_claimed_dispatch``) reaps it on a successful terminal
           acceptance.
 
-        If any ONE of the eight sites drifts from the others,
-        ``cleanup_force_action_copy_for_job``'s deterministic-name
-        comparison raises ``FilesystemAuthorityError`` BEFORE ever touching
-        the filesystem: the retained copy leaks permanently and
+        After the fix the string is spelled ONCE (``FORCE_ACTION_PREFIX`` in
+        ``lib/import_preview.py``). Five of the original eight sites
+        (``ACTION_COPY_PREFIX_BY_JOB_TYPE``, ``force_action_copy_path``'s
+        default, ``importer.py``'s ``.get(...)`` fallback, ``execute_import_
+        job``'s ``action_prefix=``, and ``_FORCE_ACTION_AUTHORITY.action_
+        prefix``) now reference it by name. The remaining three
+        (``retain_preview_snapshot_for_force_action``, ``remove_force_
+        action_copy``, ``cleanup_force_action_copy_for_job``) went further:
+        ``prefix`` is now a required keyword-only parameter with no default
+        at all, since every real caller already supplied it explicitly (an
+        unreachable default silently supplying force's prefix was itself
+        the implicit-inheritance hazard this module exists to remove) — a
+        caller that omits it now fails at Pyright type-check time
+        (``reportCallIssue: Argument missing for parameter "prefix"``)
+        before any test even runs.
+
+        So per-site drift can no longer come from editing one site in
+        isolation — every site moves together. What remains reachable is
+        (a) reintroducing an independent literal at one site, which still
+        raises ``cleanup_force_action_copy_for_job``'s
+        ``FilesystemAuthorityError`` BEFORE ever touching the filesystem
+        exactly as before (the retained copy leaks permanently and
         ``force_action_cleanup.removed`` is always ``False`` — the exact
         defect already recorded for the local-import lane at
-        ``scripts/importer.py``'s ``_cleanup_terminal_force_action``
-        (issue #1176 PR3 F5).
+        ``scripts/importer.py``'s ``_cleanup_terminal_force_action``, issue
+        #1176 PR3 F5), and (b) renaming the shared constant's VALUE, which
+        moves every site together and so would pass a mere
+        cross-site-agreement check. This slice pins the VALUE, not just
+        cross-site agreement: the assertion below hardcodes the literal
+        ``"force-action-"`` rather than deriving it from the constant, so a
+        consistent global rename (e.g. to ``"force-act-"``) still fails it.
         """
         from lib.dispatch.types import DispatchOutcome
         from lib.import_queue import (
@@ -2538,8 +2563,9 @@ class TestForceImportSlice(unittest.TestCase):
             )
 
             # Real producer: publishes the job-scoped action copy for real,
-            # under the deterministic name every one of the eight sites
-            # must agree on.
+            # under the deterministic name every one of the (now-unified)
+            # sites must agree on — the literal below pins the VALUE, not
+            # just cross-site agreement.
             action_path = import_preview_worker._prepare_force_action_path(
                 db, preview_claim, cfg, raw_path=source,
             )


### PR DESCRIPTION
## Summary

`"force-action-"` was spelled independently at **eight** functional sites across `lib/import_preview.py`, `scripts/importer.py` and `scripts/import_preview_worker.py` — the retain side, the cleanup table, the importer's fallback, the dispatch selection, and four kwarg defaults. All eight were byte-identical, so nothing was broken; the hazard was latent. If any one drifted, the importer's terminal cleanup compares the wrong deterministic name, `FilesystemAuthorityError` raises *before touching the filesystem*, the album action copy leaks permanently, and it re-raises on every importer startup sweep thereafter. That defect already happened once for the local lane, and PR3 of the #1176 series fixed it for local by introducing `ACTION_COPY_PREFIX_BY_JOB_TYPE` — leaving the identical shape open for force.

This folds all eight onto one `FORCE_ACTION_PREFIX`, beside the existing `LOCAL_IMPORT_ACTION_PREFIX`. The string value is unchanged, so no on-disk copy is orphaned — verified empirically by running identical probes against scratch copies of `main` and this branch and diffing the outputs byte-for-byte across every site, including the real producer, the real consumer, and `import_jobs.py`'s debris-confinement root.

Three of the four `prefix=` kwarg defaults turned out to be **unreachable** — all four call sites across the whole tree already passed `prefix=` explicitly — so they are now required keyword parameters. That converts three unfalsifiable defensive defaults into type-checked contracts: omitting the argument is caught by both Pyright contracts at every call site, including `importer.py:489`, the exact site of the original leak. `force_action_copy_path`'s default is retained and load-bearing (`lib/pipeline_db/import_jobs.py:218` calls it with no `prefix=`).

`ACTION_COPY_PREFIX_BY_JOB_TYPE` and `_FORCE_ACTION_AUTHORITY` previously had **zero test references anywhere in the tree**, so the PR adds a composed retain→cleanup round trip driving the real producer (`_prepare_force_action_path` via `_FORCE_ACTION_AUTHORITY`) and the real consumer (`_cleanup_terminal_force_action`) over one real 0700 tmp processing root.

Refs #1211 (non-closing).

## Kill matrix (per diff site, not per PR)

| Site (assertion / clause / constant) | One-line production mutant | Test that must go RED | Result |
| --- | --- | --- | --- |
| `ACTION_COPY_PREFIX_BY_JOB_TYPE[IMPORT_JOB_FORCE]` | append `"X"` | new composed slice + 8 others | Killed |
| `_FORCE_ACTION_AUTHORITY.action_prefix` (producer) | append `"X"` | **only** the new composed slice | Killed |
| `force_action_copy_path` retained default | append `"X"` | 27 tests across `test_import_queue` / `test_import_operation_fence` / `test_local_import_lane` | Killed |
| `FORCE_ACTION_PREFIX` **value** (consistent global rename) | `"force-action-"` → `"force-act-"` | new slice + 10 others | Killed |
| `execute_import_job` dispatch `action_prefix=` | append `"X"` | 18 tests | Killed |
| `action_name = f"{prefix}{import_job_id}"` | off-by-one on the id | **only** the new composed slice | Killed |
| `action_path = _force_action_path(job)` → `None` | consumer never runs | new slice + 8 others | Killed |
| `retain_preview_snapshot_for_force_action` / `remove_force_action_copy` / `cleanup_force_action_copy_for_job` prefix defaults | — | — | **Structurally eliminated** — now required kwargs; omission is a Pyright error at all four call sites |
| `importer.py:488` `.get(job.job_type, FORCE_ACTION_PREFIX)` fallback | `→ "MUTANT-DEAD-"` | none | **Survivor — dead code** (see Risk) |

All mutants applied at the production definition, confirmed RED for the named test, reverted; `PYTHONDONTWRITEBYTECODE=1` throughout.

## Reviewer

Independent review planted eight mutants of its own, aimed at sites outside the table above. The load-bearing result: across a 1001-test set spanning `test_integration_slices`, `test_import_queue`, `test_local_import_lane`, `test_import_operation_fence`, `test_automation_startup_recovery` and `test_pipeline_db`, **nothing except the new composed slice** catches producer-side prefix drift or the `action_name` off-by-one. It returned no blocking findings, and raised one prose finding: the slice's docstring described the pre-fix world in the present tense inside the very commit that removes that condition. Corrected — and while correcting it, the precise count turned out to be five sites referencing the constant by name, not the seven a straight tense-swap would have claimed, since the required-kwarg change removed three.

## Risk

Behaviour-preserving by construction: the prefix string is unchanged, verified byte-for-byte against `main` on every code path. No migration, no on-disk state affected.

The one acknowledged survivor is `importer.py:488`'s `.get(job.job_type, FORCE_ACTION_PREFIX)` fallback, byte-identical to `main` and left deliberately out of scope. Review confirmed it is unreachable two independent ways: live doc2 shows every row carrying an `action_path` key is `automation_import` (1539) or `youtube_import` (8) with a JSON `null` value, so `_force_action_path` short-circuits before it; and `ImportJob.from_row` runs `validate_job_type`, so a row with an unrecognised `job_type` cannot decode at all. Worth noting an asymmetry for a future follow-up: the sibling at `import_preview_worker.py:313` uses a bare `.get(job.job_type)` and fails closed, while the importer defaults to force.
