### PR TITLE
fix(quality): record the measured beets distance on local-import accepts (#1211)

### DIFF
--- a/lib/dispatch/entry_points.py
+++ b/lib/dispatch/entry_points.py
@@ -561,9 +561,26 @@ def _dispatch_import_from_db_locked(
         beets_harness_path=resolved_cfg.beets_harness_path,
         db=db,
         dl_info=dl_info,
-        # Force-import explicitly bypasses the beets distance
-        # check — no measurement exists to report (#550 defect #4).
-        distance=None,
+        # Since #1080 a measurement DOES exist for both lanes — the
+        # exact-release validation above always runs first. Force
+        # deliberately overrides that verdict rather than lacking one (it
+        # imports despite the result, per Authority: "D19 — Force-import
+        # overrides the beets distance and nothing else." —
+        # https://github.com/abl030/cratedigger/issues/711#issuecomment-4999204451),
+        # so recording it here would misrepresent an overridden decision
+        # as a passing measurement: force keeps auditing NULL (#550
+        # defect #4). Local-import, by contrast, only reaches this call
+        # after PASSING strict validation at the ordinary threshold (the
+        # strict-validation guard above rejects it otherwise, per
+        # CLAUDE.md's decision 3 for #1176) — its distance is a genuine
+        # accepted measurement, so it is recorded for audit (issue
+        # #1211). ``scenario`` is the lane discriminator already in scope
+        # here: every production caller sets it to exactly
+        # "force_import" or "local_import"
+        # (scripts/importer.py::execute_import_job).
+        distance=(
+            validation.result.distance if scenario == "local_import" else None
+        ),
         scenario=scenario,
         files=files,
         cfg=resolved_cfg,

--- a/lib/dispatch/entry_points.py
+++ b/lib/dispatch/entry_points.py
@@ -569,17 +569,22 @@ def _dispatch_import_from_db_locked(
         # https://github.com/abl030/cratedigger/issues/711#issuecomment-4999204451),
         # so recording it here would misrepresent an overridden decision
         # as a passing measurement: force keeps auditing NULL (#550
-        # defect #4). Local-import, by contrast, only reaches this call
-        # after PASSING strict validation at the ordinary threshold (the
-        # strict-validation guard above rejects it otherwise, per
-        # CLAUDE.md's decision 3 for #1176) — its distance is a genuine
-        # accepted measurement, so it is recorded for audit (issue
-        # #1211). ``scenario`` is the lane discriminator already in scope
-        # here: every production caller sets it to exactly
-        # "force_import" or "local_import"
-        # (scripts/importer.py::execute_import_job).
+        # defect #4). Keyed on ``distance_threshold is not None`` — the
+        # SAME condition the strict-validation guard above (this
+        # function, ~line 429) tests before this call is ever reached —
+        # rather than on the ``scenario`` label a caller happens to pass:
+        # only that guard's caller (local-import) sets an explicit
+        # threshold, and only after PASSING validation AT it (the guard
+        # rejects and returns early otherwise, per CLAUDE.md's decision 3
+        # for #1176), so by construction, reaching this line with
+        # ``distance_threshold is not None`` means the recorded distance
+        # is a genuine accepted measurement (issue #1211). Tying the
+        # audit write to the guard that earns it, rather than to a
+        # same-caller label that merely happens to agree with it today,
+        # keeps the two from drifting apart under a future caller.
         distance=(
-            validation.result.distance if scenario == "local_import" else None
+            validation.result.distance
+            if distance_threshold is not None else None
         ),
         scenario=scenario,
         files=files,

--- a/tests/fakes/pipeline_db.py
+++ b/tests/fakes/pipeline_db.py
@@ -9574,7 +9574,7 @@ class FakePipelineDB:
         for field_name, value in expected.items():
             actual = getattr(entry, field_name, entry.extra.get(field_name))
             test.assertEqual(actual, value,
-                             f"download_log[{index}].{field}: "
+                             f"download_log[{index}].{field_name}: "
                              f"expected {value!r}, got {actual!r}")
 
 

--- a/tests/test_dispatch_outcomes_generated.py
+++ b/tests/test_dispatch_outcomes_generated.py
@@ -68,7 +68,7 @@ from unittest.mock import MagicMock, mock_open, patch
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from hypothesis import given, settings
+from hypothesis import example, given, settings
 from hypothesis import strategies as st
 
 import tests._hypothesis_profiles  # noqa: F401  (loads the active profile)
@@ -593,6 +593,18 @@ class TestGeneratedLaneDistanceAudit(unittest.TestCase):
         self.beets = BeetsWorld(_REPO_ROOT)
         self.addCleanup(self.beets.close)
 
+    # code-quality.md: "an entropy budget miss [gets] pin[ned as] the
+    # decisive world as an `@example`". `measured=None` lands exactly
+    # once per lane in 150 derandomized examples, and local/None is the
+    # one cell no deterministic pin covers (see the harness comment
+    # above) — nothing else in this property proves that cell is
+    # exercised. All four lane x measured-presence cells are pinned
+    # explicitly so a future Hypothesis version or strategy tweak cannot
+    # silently drop the edge probe and still report green.
+    @example(lane="force_import", measured=None)
+    @example(lane="force_import", measured=0.42)
+    @example(lane="local_import", measured=None)
+    @example(lane="local_import", measured=0.42)
     @given(
         lane=st.sampled_from(("force_import", "local_import")),
         measured=st.one_of(

--- a/tests/test_dispatch_outcomes_generated.py
+++ b/tests/test_dispatch_outcomes_generated.py
@@ -468,6 +468,152 @@ def _run_dispatch(
 
 
 # ===========================================================================
+# World + harness — the entry-point lane/distance seam (issue #1211 F2).
+# ===========================================================================
+#
+# ``_run_dispatch`` above deliberately calls ``dispatch_import_core``
+# directly, bypassing ``lib.dispatch.entry_points.dispatch_import_from_db``
+# entirely — so it never exercises the lane ternary this property patrols.
+# The real space is lane x validation-distance-presence (four cells); the
+# deterministic pins in ``tests/test_integration_slices.py`` occupy three
+# of them — ``TestForceImportSlice.test_force_import_success``
+# (force/None, incidentally: its fake harness path never starts, so the
+# validation seam measures nothing), ``test_force_import_ignores_
+# measured_distance`` (force/present, explicit 0.42), and
+# ``TestLocalImportSlice.test_local_import_success`` (local/present,
+# explicit 0.01). Only local/None has no deterministic pin. This property
+# drives the REAL ``dispatch_import_from_db`` over the full two-lane x
+# float-or-None distance grid, covering all four cells including that gap.
+
+def _run_dispatch_from_db(
+    lane: str,
+    measured_distance: float | None,
+    *,
+    beets: BeetsWorld,
+) -> dict:
+    """Drive the REAL ``dispatch_import_from_db`` entry point.
+
+    ``lane`` is one of the exact two ``scenario`` literals the sole
+    production caller (``scripts/importer.py::execute_import_job``) ever
+    passes. ``lib.beets.beets_validate`` is patched to return a PASSING
+    (``valid=True``) verdict carrying ``measured_distance`` for both
+    lanes, so both reach the accept-path ternary in
+    ``lib.dispatch.entry_points._dispatch_import_from_db_locked`` rather
+    than local-import's separate strict-validation reject branch — that
+    branch is a pre-existing, unaffected-by-#1211 path already covered by
+    ``TestLocalImportSlice.test_local_import_strict_reject_lands_as_
+    ordinary_wrong_match`` in ``tests/test_integration_slices.py``.
+    """
+    from lib.dispatch import dispatch_import_from_db
+    from lib.import_queue import IMPORT_JOB_FORCE, IMPORT_JOB_LOCAL
+    from lib.pipeline_db.download_log import DownloadLogOutcome
+    from lib.quality import ValidationResult
+
+    scenario: DownloadLogOutcome = (
+        "force_import" if lane == "force_import" else "local_import"
+    )
+
+    root = tempfile.mkdtemp()
+    processing_dir = os.path.join(root, "processing")
+    processing_albums = os.path.join(processing_dir, "albums")
+    os.makedirs(processing_albums)
+    tmpdir = tempfile.mkdtemp(dir=processing_albums)
+    cfg = CratediggerConfig(
+        beets_harness_path=_HARNESS,
+        pipeline_db_enabled=True,
+        processing_dir=processing_dir,
+        beets_distance_threshold=0.15,
+    )
+    try:
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=42, status="wanted", mb_release_id="mbid-lane-distance",
+        ))
+        db.set_tracks(42, [{"track_number": 1, "title": "Track"}])
+        with open(os.path.join(tmpdir, "01 - Track.mp3"), "wb") as handle:
+            handle.write(b"generated fixture audio")
+
+        job_type = IMPORT_JOB_FORCE if lane == "force_import" else IMPORT_JOB_LOCAL
+        payload = (
+            {"download_log_id": 1, "failed_path": tmpdir}
+            if lane == "force_import"
+            else {"source_path": tmpdir, "request_id": 42}
+        )
+        job = db.enqueue_import_job(job_type, request_id=42, payload=payload)
+        evidence = make_album_quality_evidence(
+            mb_release_id="mbid-lane-distance",
+            source_path=tmpdir,
+            files=snapshot_audio_files(tmpdir),
+        )
+        db.upsert_album_quality_evidence(evidence)
+        persisted = db.find_album_quality_evidence(
+            mb_release_id=evidence.mb_release_id,
+            snapshot_fingerprint=evidence.snapshot_fingerprint,
+        )
+        assert persisted is not None and persisted.id is not None
+        assert db.set_import_job_candidate_evidence(job.id, persisted.id)
+        assert db.mark_import_job_preview_importable(
+            job.id, preview_result={"ready": True},
+        )
+        claimed = claim_next_import_job(db, worker_id="generated-dispatch-from-db")
+        assert claimed is not None
+
+        ir = make_import_result(decision="import", new_min_bitrate=320)
+        distance_threshold = (
+            cfg.beets_distance_threshold if lane == "local_import" else None
+        )
+        with patch_dispatch_externals(), \
+             patch("lib.dispatch.subprocess_runner.parse_import_result",
+                   return_value=ir), \
+             patch("lib.beets.beets_validate", return_value=ValidationResult(
+                 valid=True, scenario="strong_match",
+                 distance=measured_distance, target_mbid="mbid-lane-distance",
+             )), \
+             patch("lib.config.read_runtime_config", return_value=cfg):
+            result = dispatch_import_from_db(
+                db, request_id=42, failed_path=tmpdir,  # pyright: ignore[reportArgumentType]
+                import_job_id=claimed.id,
+                distance_threshold=distance_threshold,
+                scenario=scenario,
+                quality_gate_fn=noop_quality_gate,
+                beets_library_db_path=str(beets.library_db),
+                beets_library_root=str(beets.library_root),
+            )
+        finalize_claimed_dispatch(db, claimed, result)
+    finally:
+        shutil.rmtree(root, ignore_errors=True)
+    return {"db": db, "result": result}
+
+
+class TestGeneratedLaneDistanceAudit(unittest.TestCase):
+    """Issue #1211 F2 — the lane x distance-presence grid, through the
+    real entry point."""
+
+    def setUp(self) -> None:
+        self.beets = BeetsWorld(_REPO_ROOT)
+        self.addCleanup(self.beets.close)
+
+    @given(
+        lane=st.sampled_from(("force_import", "local_import")),
+        measured=st.one_of(
+            st.none(),
+            st.floats(min_value=0.0, max_value=1.0, allow_nan=False),
+        ),
+    )
+    def test_persisted_distance_matches_lane(self, lane, measured):
+        """The accept-path terminal audit records the measured distance
+        for local-import and NULL for force-import, regardless of what
+        the validation seam actually measured — force's own suppression
+        is deliberate, not an absence of a measurement (issue #1211)."""
+        outcome = _run_dispatch_from_db(lane, measured, beets=self.beets)
+        self.assertTrue(outcome["result"].success)
+        expected = measured if lane == "local_import" else None
+        row = outcome["db"].request(42)
+        self.assertEqual(row["beets_distance"], expected)
+        outcome["db"].assert_log(self, 0, beets_distance=expected)
+
+
+# ===========================================================================
 # World + harness — evidence-decision reject path (owns the U11 override).
 # ===========================================================================
 

--- a/tests/test_fakes.py
+++ b/tests/test_fakes.py
@@ -1752,6 +1752,19 @@ class TestFakePipelineDB(unittest.TestCase):
         # Extra field goes into .extra dict
         self.assertEqual(db.download_logs[0].extra["spectral_grade"], "genuine")
 
+    def test_assert_log_failure_message_names_the_real_field(self):
+        """Issue #1211 review F4 regression pin: assert_log's f-string used
+        to interpolate ``{field}`` (``dataclasses.field``, imported at
+        module scope in ``tests/fakes/pipeline_db.py``) instead of
+        ``{field_name}``, so every failure printed the function's repr
+        instead of the actual column name. Assert the real field name
+        appears in the message, not just that it raises."""
+        db = FakePipelineDB()
+        db.log_download(42, outcome="success", beets_distance=None)
+
+        with self.assertRaisesRegex(AssertionError, r"beets_distance"):
+            db.assert_log(self, 0, beets_distance=0.01)
+
     def test_advisory_lock_default_yields_true(self):
         db = FakePipelineDB()
         with db.advisory_lock(0x1234, 42) as acquired:

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -2561,7 +2561,15 @@ class TestLocalImportSlice(unittest.TestCase):
         # status here rather than flipping it, since neither side of this
         # slice's job is to exercise that separate upgrade-delta path.
         self.assertEqual(row["status"], "wanted")
-        db.assert_log(self, 0, outcome="local_import")
+        # Issue #1211: unlike force (which audits NULL — the distance
+        # check is deliberately overridden, never absent), a local import
+        # only reaches this dispatch call after PASSING strict validation,
+        # so its real measured distance (0.01, patched into
+        # beets_validate above) is a genuine accepted measurement and is
+        # recorded on both sinks, not silently dropped as an em-dash in
+        # Recents.
+        self.assertEqual(row["beets_distance"], 0.01)
+        db.assert_log(self, 0, outcome="local_import", beets_distance=0.01)
         # Hazard B, end to end: the terminal audit never names the
         # operator's real folder.
         raw = db.download_logs[0].validation_result

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -2360,13 +2360,125 @@ class TestForceImportSlice(unittest.TestCase):
         # Decision 19 keeps the quality/search policy identical; terminal
         # persistence preserves the current operator-owned search stop.
         self.assertEqual(row["status"], "unsearchable")
-        # #550 defect #4: force import bypasses the beets distance check —
-        # no measurement exists, so the write is NULL (was a fabricated
-        # 0.0), overwriting the stale 0.31 seeded above.
+        # #550 defect #4: force import overrides the beets distance check
+        # (issue #1211: a measurement DOES exist since #1080 — this fixture's
+        # fake harness path just happens to leave it None too — force
+        # deliberately discards it either way), so the write is NULL (was a
+        # fabricated 0.0), overwriting the stale 0.31 seeded above. The
+        # override-even-when-real case is isolated in
+        # test_force_import_ignores_measured_distance below.
         self.assertIsNone(
             row["beets_distance"],
-            "a successful force import has no measured beets distance and "
+            "a successful force import overrides its beets distance and "
             "must record NULL on the request row, not a fabricated number")
+        db.assert_log(self, 0, outcome="force_import", beets_distance=None)
+
+    def test_force_import_ignores_measured_distance(self):
+        """Issue #1211 review F1 — isolate the guard from the fixture.
+
+        ``test_force_import_success`` above never patches
+        ``lib.beets.beets_validate``, so its fake harness path
+        (``_HARNESS``) fails to start and ``validation.result.distance``
+        is naturally ``None`` regardless of whether the lane guard in
+        ``lib.dispatch.entry_points._dispatch_import_from_db_locked``
+        holds. That makes its ``beets_distance=None`` assertion unable to
+        distinguish "the guard held" from "the guard is gone" — a
+        `distance=validation.result.distance` mutant with the ``scenario
+        == "local_import"`` check removed survives it. This test patches
+        ``beets_validate`` to return a real, PASSING measurement
+        (``distance=0.42``) and proves force still audits NULL: the
+        override is deliberate (Authority D19), not an absence of
+        measurement.
+        """
+        from lib.dispatch import dispatch_import_from_db
+        from lib.import_queue import IMPORT_JOB_FORCE
+        from lib.quality import AudioQualityMeasurement, ValidationResult
+        from lib.quality_evidence import snapshot_audio_files
+
+        db = FakePipelineDB()
+        db.seed_request(make_request_row(
+            id=91, status="wanted", mb_release_id="mbid-distance-force",
+        ))
+        db.set_tracks(91, [{"track_number": 1, "title": "Track"}])
+
+        ir = make_import_result(decision="import", new_min_bitrate=320)
+        stdout = _make_stdout(ir)
+        beets_info = AlbumInfo(
+            album_id=1, track_count=10, min_bitrate_kbps=320,
+            avg_bitrate_kbps=320, format="MP3",
+            is_cbr=False, album_path="/Beets/Test")
+
+        cfg = CratediggerConfig(
+            beets_harness_path=_HARNESS,
+            pipeline_db_enabled=True,
+        )
+
+        tmpdir = tempfile.mkdtemp()
+        try:
+            with open(os.path.join(tmpdir, "01.mp3"), "wb") as handle:
+                handle.write(b"audio")
+            job = db.enqueue_import_job(
+                IMPORT_JOB_FORCE,
+                request_id=91,
+                payload={"download_log_id": 1, "failed_path": tmpdir},
+            )
+            _seed_candidate_for_import_job(
+                db, job.id,
+                mb_release_id="mbid-distance-force",
+                source_path=tmpdir,
+                files=snapshot_audio_files(tmpdir),
+                measurement=AudioQualityMeasurement(
+                    min_bitrate_kbps=320, avg_bitrate_kbps=320,
+                    median_bitrate_kbps=320, format="MP3",
+                    spectral_grade="genuine",
+                ),
+                codec="mp3", container="mp3", storage_format="MP3",
+            )
+            db.mark_import_job_preview_importable(
+                job.id, preview_result={"ready": True},
+            )
+            claimed = claim_next_import_job(db, worker_id="force-distance-slice")
+            assert claimed is not None and claimed.id == job.id
+            _seed_current_for_request(
+                db, 91,
+                mb_release_id="mbid-distance-force",
+                measurement=AudioQualityMeasurement(
+                    min_bitrate_kbps=180, avg_bitrate_kbps=180,
+                    median_bitrate_kbps=180, format="MP3",
+                    spectral_bitrate_kbps=128,
+                    spectral_grade="likely_transcode",
+                ),
+                codec="mp3", container="mp3", storage_format="mp3",
+            )
+            with patch_dispatch_externals() as ext, \
+                 _patch_linked_current_beets(db, 91, beets_info), \
+                 patch("lib.config.read_runtime_config", return_value=cfg), \
+                 patch(
+                     "lib.beets.beets_validate",
+                     return_value=ValidationResult(
+                         valid=True, scenario="strong_match", distance=0.42,
+                         target_mbid="mbid-distance-force",
+                     ),
+                 ):
+                ext.run.return_value = MagicMock(
+                    returncode=0, stdout=stdout, stderr="")
+                result = dispatch_import_from_db(
+                    db, request_id=91, failed_path=tmpdir,  # pyright: ignore[reportArgumentType]
+                    source_username="user1",
+                    import_job_id=claimed.id,
+                )
+                finalize_claimed_dispatch(db, claimed, result)
+        finally:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+        self.assertTrue(result.success)
+        row = db.request(91)
+        self.assertIsNone(
+            row["beets_distance"],
+            "force must audit NULL even when the strict-validation seam "
+            "returns a real, PASSING measurement (distance=0.42) — the "
+            "distance check is deliberately overridden, not merely absent "
+            "(issue #1211)")
         db.assert_log(self, 0, outcome="force_import", beets_distance=None)
 
     def test_force_import_does_not_copy_postflight_path_to_request(self):

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -2383,12 +2383,11 @@ class TestForceImportSlice(unittest.TestCase):
         ``lib.dispatch.entry_points._dispatch_import_from_db_locked``
         holds. That makes its ``beets_distance=None`` assertion unable to
         distinguish "the guard held" from "the guard is gone" — a
-        `distance=validation.result.distance` mutant with the ``scenario
-        == "local_import"`` check removed survives it. This test patches
-        ``beets_validate`` to return a real, PASSING measurement
-        (``distance=0.42``) and proves force still audits NULL: the
-        override is deliberate (Authority D19), not an absence of
-        measurement.
+        `distance=validation.result.distance` mutant with the lane guard
+        removed survives it. This test patches ``beets_validate`` to
+        return a real, PASSING measurement (``distance=0.42``) and proves
+        force still audits NULL: the override is deliberate (Authority
+        D19), not an absence of measurement.
         """
         from lib.dispatch import dispatch_import_from_db
         from lib.import_queue import IMPORT_JOB_FORCE
@@ -2398,6 +2397,13 @@ class TestForceImportSlice(unittest.TestCase):
         db = FakePipelineDB()
         db.seed_request(make_request_row(
             id=91, status="wanted", mb_release_id="mbid-distance-force",
+            # Stale non-None value, exactly like test_force_import_success
+            # above: without this seed, the request row's default
+            # beets_distance is already None (make_request_row's default),
+            # so assertIsNone below couldn't distinguish "force wrote
+            # NULL" from "nothing wrote this column at all" — the same
+            # unfalsifiability class this test exists to fix.
+            beets_distance=0.31,
         ))
         db.set_tracks(91, [{"track_number": 1, "title": "Track"}])
 


### PR DESCRIPTION
## Summary

`_dispatch_import_from_db_locked` passed `distance=None` into `dispatch_import_core` for **both** the force and local lanes. For force that is right — force deliberately overrides the beets distance and the UI renders `overridden`. For local it was lossy: the local-import lane passes *strict* validation with a real measured distance, and that value was already in scope, used ~73 lines above on the reject path. So local **rejects** recorded a real distance while local **accepts** wrote NULL and Recents rendered "Distance: —".

The accept path now records the measured distance for the strict-validation lane. `distance` is audit-only at this boundary — verified independently twice: every use in `dispatch_import_core` is a log label or an audit sink, and no consumer branches on `beets_distance` (the only conditionals anywhere are null-checks for rendering). **No decision changes.**

**The discriminator changed during review, and the new one is strictly better.** The first implementation keyed on `scenario == "local_import"`. It now keys on `distance_threshold is not None` — the same subexpression the strict-validation guard itself tests — which makes "the recorded distance passed validation at the threshold it was validated against" true by construction. Review found the old key had a live failure mode the new one closes: a caller passing `scenario="local_import"` with `distance_threshold=None` would fall through to `FORCE_IMPORT_DISTANCE_THRESHOLD` (999.0) and record a distance that never passed strict validation. There is no counterexample in the other direction. Note the branch history carries two contradictory rationales — the first commit argued against inferring the lane from `distance_threshold`; that objection was to *truthiness*, and `is not None` is what shipped, so the reversal is sound.

Refs #1211 (non-closing).

## Kill matrix (per diff site, not per PR)

| Site (assertion / clause / constant) | One-line production mutant | Test that must go RED | Result |
| --- | --- | --- | --- |
| accept-path lane ternary | revert to unconditional `distance=None` | `TestLocalImportSlice.test_local_import_success` + the property | Killed |
| accept-path lane ternary | remove the guard — force also emits a measured distance | `TestForceImportSlice.test_force_import_ignores_measured_distance` + the property | Killed |
| accept-path lane ternary | invert to `if distance_threshold is None` | both force and local pins + the property | Killed |
| accept-path lane ternary | local lane emits a constant instead of the measurement | the property (property-only kill) | Killed |
| `outcome_actions.py` `"beets_distance": distance` writer | drop the key from `update_fields` | both force pins + `test_local_import_success` | Killed |
| `assert_log` failure message (`tests/fakes/pipeline_db.py`) | restore the `{field}` typo | `test_assert_log_failure_message_names_the_real_field` | Killed |

All mutants applied at the production definition, confirmed RED for the named test, reverted; `PYTHONDONTWRITEBYTECODE=1` throughout. `@example` pins cover all four lane × measured-presence cells, because `local/None` — the cell no deterministic pin covers — otherwise rests on 1 generated example in 150.

## Reviewer

Two independent review rounds. The first found the change's central weakness: the `else None` (force) arm was **unfalsifiable** — removing the lane guard entirely survived 652 tests across 11 modules, because the force fixture's validator hits a fake harness path and yields `distance=None` naturally, so its `beets_distance=None` assertion could not distinguish "guard held" from "guard gone". Fixed by a pin that patches the validator to return a real passing measurement, plus a generated property driving the real `dispatch_import_from_db` (the pre-existing generated harness calls `dispatch_import_core` directly and bypasses lane selection entirely).

The second round found that the *new* pin reproduced a milder form of the same defect — it seeded no `beets_distance`, so `assertIsNone` could not distinguish "wrote NULL" from "never written", proven by a writer-drop mutant that left it green while the older sibling went red. Fixed by seeding the row. It also caught a claim that had gone stale inside the very commit that created it: the new docstring named the `scenario ==` check that the same commit deleted.

## Risk

**Rule D is vacuous here, by construction.** `beets_distance` is a primitive the browser turns into visible text, so Rule D applies — but this changes the *writer*, not the renderer, so no existing row's appearance changes and a render differential is zero by definition. The live corpus confirms the population is empty: `source='local'` has exactly **one** row in the entire live `download_log`, a `rejected` that already carries a real distance. There are **zero accepted local imports in production**, so this is forward-looking. Forward-only residual: any local_import rows written before this lands keep `NULL` and are not backfilled, so that lane's distance history will be non-uniform.

Force rows are provably unaffected — 30 in the last 14 days, all NULL, and the force pins hold. Both typing-ratchet baselines are byte-identical to the merge-base: the two new suppressions use the scoped `# pyright: ignore[reportArgumentType]` form, which the ratchet scanner's regex deliberately excludes, and `reportUnnecessaryTypeIgnoreComment` is set to error so a redundant one could not ship green.
