### PR TITLE
fix: close the post-#1211 residuals — selection gaps, a fail-open cleanup fallback, and two rules (#1246)

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -1052,6 +1052,23 @@ rationale; never allowlist a pure decision.
   new false claim can hide. Earned four times in one batch (#1101,
   #1102, #1107, #1110); in each, the false claim was caught only by the
   next independent read, never by the round that wrote it.
+- **Briefs are an unreviewed claim surface.** Every other artifact in this
+  pipeline gets an independent read — a commit, a PR, a test. The brief an
+  orchestrator hands an implementer does not; the implementer treats it as
+  settled fact and builds on it. Two things fix it: a brief separates what
+  its author MEASURED (ran it, read the actual output) from what they
+  INFERRED (a plausible causal claim resting on a measurement); and the
+  implementer verifies a brief's load-bearing claims before building on
+  them, rather than taking them as given. Three false claims shipped this
+  way in the #1211 series, all caught only by an independent reviewer
+  (issue #1246, `.claude/memory/feedback_orchestrator_briefs_become_defects.md`):
+  a real count (71 `db=… # type: ignore[arg-type]` sites) with a false
+  causal claim attached (that two `tests/helpers.py` bridges "exist to
+  replace" them — zero of the 71 sit at either bridge's target); a
+  citation naming an identifier (`BASELINE`) that exists nowhere, at a
+  line that was not the mechanism being described; and an instruction to
+  write "the other seven sites reference it by name" when the true count
+  was five.
 - Independent review plants at least two mutants PER new or changed test,
   aimed at that test's named subject, not only at sites the author's Fault
   injection sentence already covers (issue #1143 / #1155).

--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -1059,16 +1059,19 @@ rationale; never allowlist a pure decision.
   its author MEASURED (ran it, read the actual output) from what they
   INFERRED (a plausible causal claim resting on a measurement); and the
   implementer verifies a brief's load-bearing claims before building on
-  them, rather than taking them as given. Three false claims shipped this
-  way in the #1211 series, all caught only by an independent reviewer
-  (issue #1246, `.claude/memory/feedback_orchestrator_briefs_become_defects.md`):
-  a real count (71 `db=… # type: ignore[arg-type]` sites) with a false
-  causal claim attached (that two `tests/helpers.py` bridges "exist to
-  replace" them — zero of the 71 sit at either bridge's target); a
-  citation naming an identifier (`BASELINE`) that exists nowhere, at a
-  line that was not the mechanism being described; and an instruction to
-  write "the other seven sites reference it by name" when the true count
-  was five.
+  them, rather than taking them as given. Three false claims originated in
+  briefs during the #1211 series (issue #1246,
+  `.claude/memory/feedback_orchestrator_briefs_become_defects.md`). Two
+  shipped and were caught only by an independent reviewer: a real count
+  (71 `db=… # type: ignore[arg-type]` sites) with a false causal claim
+  attached (that two `tests/helpers.py` bridges "exist to replace" them —
+  zero of the 71 sit at either bridge's target); and a citation naming an
+  identifier (`BASELINE`) that exists nowhere, at a line that was not the
+  mechanism being described. The third — an instruction to write "the
+  other seven sites reference it by name" when the true count was five —
+  never shipped: the implementer verified the count before writing it and
+  caught the error. That third instance is the rule working as intended,
+  not another failure of it.
 - Independent review plants at least two mutants PER new or changed test,
   aimed at that test's named subject, not only at sites the author's Fault
   injection sentence already covers (issue #1143 / #1155).

--- a/.claude/rules/test-fidelity.md
+++ b/.claude/rules/test-fidelity.md
@@ -264,6 +264,34 @@ screenshots of changed cases and must-still-work controls. Use the existing
 recipe in `docs/solutions/ui-dev-server-screenshot-loop.md`; it is the visual
 evidence leg of Rule D, not a second differential runbook.
 
+**The vacuous case: an empty affected population.** When the live rows a
+change could possibly affect number zero, the differential is zero by
+construction — there is nothing to render twice and compare. That is not
+missing evidence; the honest evidence IS the population query itself (the
+`WHERE` clause that scopes the change, and its live row count), put in the
+PR body in place of a differential. Running the differential machinery
+anyway would only reproduce the same zero the population query already
+proved, for no additional confidence.
+
+**Writer changes and renderer changes answer different questions.** Rule D
+is written for a RENDERER change — the same stored rows, displayed
+differently — where the differential is the only instrument that settles
+"what does this change on the rows that exist?" A change to what gets
+WRITTEN going forward is a different claim: it moves no existing row's
+appearance at all, so a differential over already-written rows would
+correctly report zero regardless of whether the writer change is even
+correct. The right evidence for a writer change is that the new rows it
+produces carry the intended values (an ordinary behavior test), not a
+render differential.
+
+PR #1245 is the worked example, and had to argue this from first
+principles: `source='local'` has exactly one row in the entire live
+`download_log`, and it is a rejection that already carries a real
+distance (measured 2026-08-22: id 40287, outcome `rejected`, scenario
+`high_distance`, `beets_distance=0.5401`) — zero accepted local imports
+exist in production. The change there was to what gets written on a
+future accepted local import, not to how any existing row renders.
+
 ## Executable coverage and its boundary
 
 Rule A coverage is enforced by `tests/test_pipeline_db_write_audit.py` plus

--- a/.claude/rules/test-fidelity.md
+++ b/.claude/rules/test-fidelity.md
@@ -289,13 +289,17 @@ before/after shape.
 
 What actually licensed skipping live-corpus evidence for PR #1245 is the
 vacuous-case argument above, not the writer/renderer distinction on its
-own: `source='local'` has exactly one row in the entire live
-`download_log`, and it is a rejection that already carries a real distance
+own, and it is keyed on the EXISTING-row population exactly as the
+vacuous-case paragraph is — never on an unmeasurable future one:
+`source='local'` has exactly one row in the entire live `download_log`
 (measured 2026-08-22: id 40287, outcome `rejected`, scenario
-`high_distance`, `beets_distance=0.5401`) — the forward population of
-future accepted local imports the writer change affects was itself zero
-at ship time. A future writer change whose forward population is
-NOT empty does not get to cite this distinction to skip a live-corpus
+`high_distance`, `beets_distance=0.5401`), and it is a rejection, not an
+acceptance — so the accept-path write this PR changed had never fired in
+production as of that measurement. There is no existing row whose
+accept-path write behavior the change could be judged against, which is
+the vacuous case applied to a writer instead of a renderer. A future
+writer change where existing rows already show nonzero accept-path
+volume does not get to cite this distinction to skip a live-corpus
 tally.
 
 ## Executable coverage and its boundary

--- a/.claude/rules/test-fidelity.md
+++ b/.claude/rules/test-fidelity.md
@@ -273,24 +273,30 @@ PR body in place of a differential. Running the differential machinery
 anyway would only reproduce the same zero the population query already
 proved, for no additional confidence.
 
-**Writer changes and renderer changes answer different questions.** Rule D
-is written for a RENDERER change — the same stored rows, displayed
-differently — where the differential is the only instrument that settles
-"what does this change on the rows that exist?" A change to what gets
-WRITTEN going forward is a different claim: it moves no existing row's
-appearance at all, so a differential over already-written rows would
-correctly report zero regardless of whether the writer change is even
-correct. The right evidence for a writer change is that the new rows it
-produces carry the intended values (an ordinary behavior test), not a
-render differential.
+**A writer change's differential reports zero for a mechanical reason, not
+a licensing one.** `beets_distance` IS rendered on the Recents card, so
+Rule D's own scope ("presentation **or output**") applies to changing what
+gets written into it, exactly as it applies to a renderer change. The
+render-differential mechanism compares old-renderer-output to
+new-renderer-output over the SAME already-written rows; a change to what
+gets WRITTEN going forward touches none of those rows, so the differential
+correctly reports zero regardless of whether the writer change is even
+correct. That mechanical zero is not, by itself, evidence — a writer
+change with a nonempty forward population still owes Rule D's live-corpus
+tally, just answered by a different instrument (the new rows it produces
+carry the intended values) rather than the render-differential's specific
+before/after shape.
 
-PR #1245 is the worked example, and had to argue this from first
-principles: `source='local'` has exactly one row in the entire live
-`download_log`, and it is a rejection that already carries a real
-distance (measured 2026-08-22: id 40287, outcome `rejected`, scenario
-`high_distance`, `beets_distance=0.5401`) — zero accepted local imports
-exist in production. The change there was to what gets written on a
-future accepted local import, not to how any existing row renders.
+What actually licensed skipping live-corpus evidence for PR #1245 is the
+vacuous-case argument above, not the writer/renderer distinction on its
+own: `source='local'` has exactly one row in the entire live
+`download_log`, and it is a rejection that already carries a real distance
+(measured 2026-08-22: id 40287, outcome `rejected`, scenario
+`high_distance`, `beets_distance=0.5401`) — the forward population of
+future accepted local imports the writer change affects was itself zero
+at ship time. A future writer change whose forward population is
+NOT empty does not get to cite this distinction to skip a live-corpus
+tally.
 
 ## Executable coverage and its boundary
 

--- a/scripts/importer.py
+++ b/scripts/importer.py
@@ -464,7 +464,6 @@ def _cleanup_terminal_force_action(job: ImportJob) -> dict[str, object] | None:
         from lib.config import read_runtime_config
         from lib.import_preview import (
             ACTION_COPY_PREFIX_BY_JOB_TYPE,
-            FORCE_ACTION_PREFIX,
             cleanup_force_action_copy_for_job,
         )
 
@@ -476,16 +475,25 @@ def _cleanup_terminal_force_action(job: ImportJob) -> dict[str, object] | None:
         # re-raised on every subsequent importer startup recovery sweep.
         # ``ACTION_COPY_PREFIX_BY_JOB_TYPE`` is the same table
         # scripts/import_preview_worker.py's sibling cleanup already uses.
-        # The fallback stays ``FORCE_ACTION_PREFIX`` (issue #1211 PR1): the
-        # table deliberately omits ``automation_import``/``youtube_import``,
-        # neither of which ever retains a private action copy, so
-        # ``_force_action_path`` above already returns ``None`` and short-
-        # circuits before this line for both — this default is provably dead
-        # for every current job type. Whether ``.get(...)`` should instead
-        # fail closed on an unrecognized job type is an open question left
-        # for a follow-up; this PR only collapses the eight literal spellings
-        # onto one constant and preserves every existing fallback behavior.
-        prefix = ACTION_COPY_PREFIX_BY_JOB_TYPE.get(job.job_type, FORCE_ACTION_PREFIX)
+        # issue #1246 item 2: an unrecognized ``job.job_type`` now fails
+        # CLOSED (skips cleanup, returns ``None``) instead of silently
+        # defaulting to ``FORCE_ACTION_PREFIX`` — matching the sibling
+        # ``scripts/import_preview_worker.py::_cleanup_terminal_preview_
+        # force_action``'s own ``prefix is None`` early return. The
+        # fail-open default was left in place by issue #1211 PR1 as an
+        # explicit open question; this closes it now that the prefix table
+        # is single-sourced. Both the old default and the new early return
+        # are dead today two independent ways: ``ImportJob.from_row`` runs
+        # ``validate_job_type``, so ``job.job_type`` can only ever be one of
+        # the four ``IMPORT_JOB_TYPES``; and of the two types this table
+        # omits (``automation_import``, ``youtube_import``), every live
+        # doc2 row carries a JSON ``null`` ``action_path`` (measured
+        # 2026-08-22: 1542 automation_import + 8 youtube_import rows, zero
+        # non-null), so ``_force_action_path`` above already returns
+        # ``None`` and this function never reaches here for either.
+        prefix = ACTION_COPY_PREFIX_BY_JOB_TYPE.get(job.job_type)
+        if prefix is None:
+            return None
         cleanup_force_action_copy_for_job(
             action_path, cfg, import_job_id=job.id, prefix=prefix,
         )

--- a/scripts/importer.py
+++ b/scripts/importer.py
@@ -486,11 +486,17 @@ def _cleanup_terminal_force_action(job: ImportJob) -> dict[str, object] | None:
         # are dead today two independent ways: ``ImportJob.from_row`` runs
         # ``validate_job_type``, so ``job.job_type`` can only ever be one of
         # the four ``IMPORT_JOB_TYPES``; and of the two types this table
-        # omits (``automation_import``, ``youtube_import``), every live
-        # doc2 row carries a JSON ``null`` ``action_path`` (measured
-        # 2026-08-22: 1542 automation_import + 8 youtube_import rows, zero
-        # non-null), so ``_force_action_path`` above already returns
-        # ``None`` and this function never reaches here for either.
+        # omits (``automation_import``, ``youtube_import``), the small
+        # minority of live doc2 rows of either type that carry an
+        # ``action_path`` key AT ALL carry it as JSON ``null`` (not a
+        # string) -- most rows of both types have no such key, and none
+        # observed to date has a non-null one -- so ``_force_action_path``
+        # above already returns ``None`` and this function never reaches
+        # here for either. See issue #1246 F5 for the live query and its
+        # exact counts as of the review round that found this; that count
+        # is not reproduced here since a frozen number inside a permanent
+        # comment only drifts (it moved between two measurements taken
+        # hours apart in that same review round).
         prefix = ACTION_COPY_PREFIX_BY_JOB_TYPE.get(job.job_type)
         if prefix is None:
             return None

--- a/scripts/importer.py
+++ b/scripts/importer.py
@@ -492,11 +492,12 @@ def _cleanup_terminal_force_action(job: ImportJob) -> dict[str, object] | None:
         # string) -- most rows of both types have no such key, and none
         # observed to date has a non-null one -- so ``_force_action_path``
         # above already returns ``None`` and this function never reaches
-        # here for either. See issue #1246 F5 for the live query and its
-        # exact counts as of the review round that found this; that count
-        # is not reproduced here since a frozen number inside a permanent
-        # comment only drifts (it moved between two measurements taken
-        # hours apart in that same review round).
+        # here for either. A live doc2 count is deliberately not
+        # reproduced here: the table grows continuously (rows accrued
+        # between successive measurements already differed), so a
+        # frozen number inside a permanent comment would only go stale.
+        # Re-query ``import_jobs`` for the current counts if this needs
+        # re-verifying.
         prefix = ACTION_COPY_PREFIX_BY_JOB_TYPE.get(job.job_type)
         if prefix is None:
             return None

--- a/scripts/targeted_test_selection.py
+++ b/scripts/targeted_test_selection.py
@@ -374,6 +374,33 @@ EXACT_PATH_NEIGHBOURS: dict[str, tuple[str, ...]] = {
     # and tests.world_model.state_machine (indirectly, via
     # tests/world_model/support.py's LifecycleWorld.force_import_request,
     # real-PostgreSQL + real Beets, ~33s).
+    #
+    # Two more additions, issue #1246 item 1: PR #1245 added
+    # tests.test_dispatch_outcomes_generated's
+    # ``TestGeneratedLaneDistanceAudit`` specifically to patrol the
+    # ``distance_threshold is not None`` lane discriminator this file's
+    # ``_dispatch_import_from_db_locked`` uses to decide whether the
+    # accept-path terminal audit records a measured distance or NULL
+    # (issue #1211) — and tests.test_local_import_lane, which pins the
+    # caller-side (``scripts/importer.py``) contract that discriminator
+    # depends on as an invariant (which lane passes which threshold).
+    # Measured on 2026-08-22 (this issue's own repro): before this entry,
+    # editing only this file selected neither. Qualified by fault
+    # injection, flipping the discriminator's ``is not None`` to
+    # ``is None``: tests.test_dispatch_outcomes_generated's
+    # ``TestGeneratedLaneDistanceAudit`` DOES kill it (real dynamic
+    # execution through the real ``dispatch_import_from_db`` — confirmed
+    # RED, ``0.42 != None`` on the force/present cell). tests.test_local_
+    # import_lane does NOT kill it (confirmed: exit 0, all 9 tests pass
+    # with the mutant live) — every one of its ``execute_import_job``
+    # calls injects ``force_dispatch_fn=<recorder>``, so it never runs
+    # this file's real code at all. Kept anyway, for the same reason as
+    # tests.test_issue_573_boundaries above: it is real, valuable coverage
+    # of a different regression class — the caller-side pairing this
+    # discriminator's own correctness assumes as a precondition (only
+    # local-import's caller ever passes a non-None threshold, and only
+    # after its own strict-validation guard already passed) — not a
+    # substitute for the dynamic-execution coverage above.
     "lib/dispatch/entry_points.py": (
         "tests.test_dispatch_from_db",
         "tests.test_force_import_merge_redirect",
@@ -381,6 +408,8 @@ EXACT_PATH_NEIGHBOURS: dict[str, tuple[str, ...]] = {
         "tests.test_import_manifest",
         "tests.test_import_queue",
         "tests.test_issue_573_boundaries",
+        "tests.test_dispatch_outcomes_generated",
+        "tests.test_local_import_lane",
     ),
 }
 

--- a/scripts/targeted_test_selection.py
+++ b/scripts/targeted_test_selection.py
@@ -411,6 +411,60 @@ EXACT_PATH_NEIGHBOURS: dict[str, tuple[str, ...]] = {
         "tests.test_dispatch_outcomes_generated",
         "tests.test_local_import_lane",
     ),
+    # scripts/importer.py and scripts/import_preview_worker.py live under
+    # scripts/, so _direct_test_candidates probes tests.test_importer and
+    # tests.test_import_preview_worker respectively -- neither exists, so
+    # both resolved ZERO real neighbours (issue #1246 F3, found reviewing
+    # item 1/2 of this same issue). Unlike the lib/ case above, scripts/
+    # is not covered by _changed_path_neighbours's fail-closed check
+    # either (it only fires for path.parts[:1] == ("lib",)), so this was
+    # SILENT under-selection, not an admitted gap -- and it meant this
+    # issue's OWN item-2 pin (TestCleanupTerminalForceActionFailsClosed
+    # in tests.test_import_queue) did not run when its subject,
+    # scripts/importer.py, changed.
+    #
+    # Both entries qualified by fault injection, the same way as
+    # entry_points.py above: a ``raise RuntimeError`` planted as the
+    # first executable statement of each file's own central,
+    # every-job-type entry point (``process_claimed_job`` for importer.py
+    # -- "the single queue-outcome mapper all four job types route
+    # through", per its own docstring; ``process_claimed_preview_job``
+    # for import_preview_worker.py, its direct analogue), run against
+    # every plausible candidate found by grepping for real imports of the
+    # module under test.
+    #
+    # importer.py -- killed: tests.test_import_dispatch,
+    # tests.test_import_operation_fence,
+    # tests.test_import_queue (this issue's own new pin lives here),
+    # tests.test_integration_slices, tests.test_local_import_lane,
+    # tests.test_terminal_outcomes. Confirmed NOT killed (real imports
+    # exist but exercise other surfaces of the module, or bypass this
+    # entry point via their own DI seams): tests.test_importer_graceful_
+    # shutdown, tests.test_merge_rekey, tests.test_importer_runtime_
+    # context, tests.test_automation_startup_recovery, tests.test_beets_
+    # config_startup.
+    #
+    # import_preview_worker.py -- killed: tests.test_import_queue,
+    # tests.test_integration_slices (both already listed above for
+    # importer.py -- real, independent coverage of the preview worker's
+    # own module, not double-counted), tests.test_issue_1030_postgres_
+    # slice, tests.test_terminal_outcome_callers. Confirmed NOT killed:
+    # tests.test_import_preview, tests.test_import_result,
+    # tests.test_beets_config_startup_entrypoints.
+    "scripts/importer.py": (
+        "tests.test_import_dispatch",
+        "tests.test_import_operation_fence",
+        "tests.test_import_queue",
+        "tests.test_integration_slices",
+        "tests.test_local_import_lane",
+        "tests.test_terminal_outcomes",
+    ),
+    "scripts/import_preview_worker.py": (
+        "tests.test_import_queue",
+        "tests.test_integration_slices",
+        "tests.test_issue_1030_postgres_slice",
+        "tests.test_terminal_outcome_callers",
+    ),
 }
 
 #: Shared tests/ modules with NO real consuming test today — an admitted,

--- a/scripts/targeted_test_selection.py
+++ b/scripts/targeted_test_selection.py
@@ -414,43 +414,70 @@ EXACT_PATH_NEIGHBOURS: dict[str, tuple[str, ...]] = {
     # scripts/importer.py and scripts/import_preview_worker.py live under
     # scripts/, so _direct_test_candidates probes tests.test_importer and
     # tests.test_import_preview_worker respectively -- neither exists, so
-    # both resolved ZERO real neighbours (issue #1246 F3, found reviewing
-    # item 1/2 of this same issue). Unlike the lib/ case above, scripts/
-    # is not covered by _changed_path_neighbours's fail-closed check
-    # either (it only fires for path.parts[:1] == ("lib",)), so this was
-    # SILENT under-selection, not an admitted gap -- and it meant this
-    # issue's OWN item-2 pin (TestCleanupTerminalForceActionFailsClosed
-    # in tests.test_import_queue) did not run when its subject,
-    # scripts/importer.py, changed.
+    # both resolved ZERO real neighbours. Unlike the lib/ case above,
+    # scripts/ is not covered by _changed_path_neighbours's fail-closed
+    # check either (it only fires for path.parts[:1] == ("lib",)), so
+    # this was SILENT under-selection, not an admitted gap -- and it
+    # meant tests.test_import_queue's TestCleanupTerminalForceAction
+    # FailsClosed did not run when its subject, scripts/importer.py,
+    # changed.
     #
-    # Both entries qualified by fault injection, the same way as
-    # entry_points.py above: a ``raise RuntimeError`` planted as the
-    # first executable statement of each file's own central,
-    # every-job-type entry point (``process_claimed_job`` for importer.py
-    # -- "the single queue-outcome mapper all four job types route
-    # through", per its own docstring; ``process_claimed_preview_job``
-    # for import_preview_worker.py, its direct analogue), run against
-    # every plausible candidate found by grepping for real imports of the
-    # module under test.
+    # Method: a ``raise RuntimeError`` planted as the first executable
+    # statement of each file's own central, every-job-type entry point
+    # (``process_claimed_job`` for importer.py -- "the single
+    # queue-outcome mapper all four job types route through", per its
+    # own docstring; ``process_claimed_preview_job`` for import_preview_
+    # worker.py, its direct analogue), run against every module found by
+    # grepping for real imports of the module under test, PLUS every
+    # module that reaches the entry point indirectly through tests/
+    # helpers.py's finalize_claimed_dispatch bridge (a search grep alone
+    # cannot find, since those modules never spell the module's own
+    # name). This list is a QUALIFIED SUBSET chosen for coverage value,
+    # NOT a complete kill set -- an import-name grep is structurally
+    # incomplete for the bridge-reached case, and other real consumers
+    # likely exist beyond what either search turned up. Preference order
+    # among confirmed killers: a generated property whose own subject is
+    # behavior these two files own outranks a deterministic slice that
+    # merely passes through them on the way to exercising something else.
     #
-    # importer.py -- killed: tests.test_import_dispatch,
-    # tests.test_import_operation_fence,
-    # tests.test_import_queue (this issue's own new pin lives here),
-    # tests.test_integration_slices, tests.test_local_import_lane,
-    # tests.test_terminal_outcomes. Confirmed NOT killed (real imports
-    # exist but exercise other surfaces of the module, or bypass this
-    # entry point via their own DI seams): tests.test_importer_graceful_
-    # shutdown, tests.test_merge_rekey, tests.test_importer_runtime_
-    # context, tests.test_automation_startup_recovery, tests.test_beets_
-    # config_startup.
+    # importer.py -- confirmed killed and included: tests.test_import_
+    # dispatch, tests.test_import_operation_fence, tests.test_import_
+    # queue (this file's own pin lives here), tests.test_integration_
+    # slices, tests.test_local_import_lane, tests.test_terminal_outcomes,
+    # tests.test_dispatch_outcomes_generated (patrols this file's own
+    # lane discriminator -- see the entry_points.py entry above),
+    # tests.test_force_import_service_generated, tests.test_import_job_
+    # lifecycle_generated, tests.test_processing_lifecycle_generated,
+    # tests.test_spectral_attempt_audit_generated, tests.test_wrong_
+    # match_post_commit_generated. Confirmed killed but deliberately
+    # excluded for selection cost or relevance, mirroring the entry_
+    # points.py entry's own precedent: tests.test_pipeline_db
+    # (real-PostgreSQL, 574 tests, ~23s -- the two failures it produces
+    # under the mutant are indirect, a real child process failing to
+    # reach an expected barrier, not a direct assertion on the mutant,
+    # confirmed genuine by reverting the mutant and observing both pass
+    # cleanly at baseline); tests.test_dispatch_core (a deterministic
+    # slice whose own subject is lib/dispatch/core.py's orchestration,
+    # reached via the finalize_claimed_dispatch bridge -- it touches this
+    # file rather than patrolling behavior this file owns). Confirmed NOT
+    # killed (real imports exist but exercise other surfaces of the
+    # module, or bypass this entry point via their own DI seams):
+    # tests.test_importer_graceful_shutdown, tests.test_merge_rekey,
+    # tests.test_importer_runtime_context, tests.test_automation_
+    # startup_recovery, tests.test_beets_config_startup.
     #
-    # import_preview_worker.py -- killed: tests.test_import_queue,
-    # tests.test_integration_slices (both already listed above for
-    # importer.py -- real, independent coverage of the preview worker's
-    # own module, not double-counted), tests.test_issue_1030_postgres_
-    # slice, tests.test_terminal_outcome_callers. Confirmed NOT killed:
-    # tests.test_import_preview, tests.test_import_result,
-    # tests.test_beets_config_startup_entrypoints.
+    # import_preview_worker.py -- confirmed killed and included:
+    # tests.test_import_queue, tests.test_integration_slices (both
+    # already listed above for importer.py -- real, independent coverage
+    # of the preview worker's own module, not double-counted),
+    # tests.test_issue_1030_postgres_slice, tests.test_terminal_outcome_
+    # callers, tests.test_evidence_generated, tests.test_path_authority_
+    # generated, tests.test_preview_failure_evidence_generated,
+    # tests.test_spectral_attempt_audit_generated (kills both this
+    # file's mutant and importer.py's -- real, independent coverage of
+    # each). Confirmed NOT killed: tests.test_import_preview,
+    # tests.test_import_result, tests.test_beets_config_startup_
+    # entrypoints.
     "scripts/importer.py": (
         "tests.test_import_dispatch",
         "tests.test_import_operation_fence",
@@ -458,12 +485,22 @@ EXACT_PATH_NEIGHBOURS: dict[str, tuple[str, ...]] = {
         "tests.test_integration_slices",
         "tests.test_local_import_lane",
         "tests.test_terminal_outcomes",
+        "tests.test_dispatch_outcomes_generated",
+        "tests.test_force_import_service_generated",
+        "tests.test_import_job_lifecycle_generated",
+        "tests.test_processing_lifecycle_generated",
+        "tests.test_spectral_attempt_audit_generated",
+        "tests.test_wrong_match_post_commit_generated",
     ),
     "scripts/import_preview_worker.py": (
         "tests.test_import_queue",
         "tests.test_integration_slices",
         "tests.test_issue_1030_postgres_slice",
         "tests.test_terminal_outcome_callers",
+        "tests.test_evidence_generated",
+        "tests.test_path_authority_generated",
+        "tests.test_preview_failure_evidence_generated",
+        "tests.test_spectral_attempt_audit_generated",
     ),
 }
 

--- a/tests/test_import_queue.py
+++ b/tests/test_import_queue.py
@@ -62,6 +62,7 @@ from lib.import_queue import (
     AutomationImportPayload,
     ForceImportPayload,
     ImportJob,
+    ImportJobPayload,
     YoutubeImportPayload,
     force_import_dedupe_key,
     force_import_payload,
@@ -3700,6 +3701,109 @@ class TestImporterWorker(unittest.TestCase):
         self.assertEqual(
             observed_offsets,
             [0, importer.IMPORT_CANDIDATE_SCAN_LIMIT],
+        )
+
+
+class TestCleanupTerminalForceActionFailsClosed(unittest.TestCase):
+    """Issue #1246 item 2: ``scripts.importer._cleanup_terminal_force_
+    action``'s prefix lookup must fail CLOSED on a job type
+    ``ACTION_COPY_PREFIX_BY_JOB_TYPE`` does not map, matching the sibling
+    ``scripts.import_preview_worker._cleanup_terminal_preview_force_
+    action``'s own ``prefix is None`` early return — rather than silently
+    defaulting to ``FORCE_ACTION_PREFIX`` and comparing an unrelated job's
+    action path against force-import's deterministic name.
+
+    Both the old fail-open default and the new fail-closed guard are
+    unreachable in production today: ``ImportJob.from_row`` runs
+    ``validate_job_type``, so a real job's ``job_type`` can only ever be one
+    of the four ``IMPORT_JOB_TYPES``, and of the two the table omits
+    (``automation_import``, ``youtube_import``), every live doc2 row carries
+    a JSON ``null`` ``action_path`` (measured 2026-08-22), so ``_force_
+    action_path`` already returns ``None`` first. This test bypasses both
+    guards by constructing the ``ImportJob`` directly (not through ``from_
+    row``) with a real, unmapped job type and a synthetic non-null
+    ``action_path``, to pin the guard itself independent of today's live
+    reachability.
+    """
+
+    def _job(
+        self, *, job_type: str, payload: ImportJobPayload, action_path: str,
+    ) -> ImportJob:
+        now = datetime(2026, 8, 22, tzinfo=UTC)
+        return ImportJob(
+            id=9001,
+            job_type=job_type,
+            status="running",
+            request_id=9001,
+            dedupe_key=None,
+            payload=payload,
+            result=None,
+            message=None,
+            error=None,
+            attempts=0,
+            worker_id="w",
+            created_at=now,
+            updated_at=now,
+            started_at=now,
+            heartbeat_at=now,
+            completed_at=None,
+            preview_result={"action_path": action_path},
+        )
+
+    # Exhaustive over the two job types ACTION_COPY_PREFIX_BY_JOB_TYPE
+    # omits -- the entire "unmapped" half of the four IMPORT_JOB_TYPES.
+    UNMAPPED_CASES: ClassVar[list[tuple[str, str, ImportJobPayload]]] = [
+        ("automation_import", IMPORT_JOB_AUTOMATION, AutomationImportPayload()),
+        ("youtube_import", IMPORT_JOB_YOUTUBE, YoutubeImportPayload(
+            staged_path="/tmp/staged", request_id=9001,
+            browse_id="MPREb_x", download_log_id=1,
+        )),
+    ]
+
+    def test_unmapped_job_types_skip_cleanup_instead_of_using_force_prefix(
+        self,
+    ) -> None:
+        from scripts import importer
+
+        for desc, job_type, payload in self.UNMAPPED_CASES:
+            with self.subTest(desc=desc):
+                job = self._job(
+                    job_type=job_type, payload=payload,
+                    action_path="/tmp/not-a-real-action-copy",
+                )
+
+                result = importer._cleanup_terminal_force_action(job)
+
+                # Fail-closed: no cleanup metadata at all, not a
+                # {"removed": False, "error": ...} dict from a raised
+                # FilesystemAuthorityError -- that dict is exactly what the
+                # old fail-open default
+                # (`.get(job.job_type, FORCE_ACTION_PREFIX)`) produced here,
+                # since the synthetic path never matches
+                # force_action_copy_path(cfg, job.id, prefix=FORCE_ACTION_
+                # PREFIX).
+                self.assertIsNone(result)
+
+    def test_mapped_job_types_still_resolve_a_real_prefix(self) -> None:
+        """Must-still-work: the two job types the table DOES map --
+        together with the two proven unmapped above, the full, exhaustive
+        four-member IMPORT_JOB_TYPES domain -- keep resolving their own
+        real prefix, unaffected by the fail-closed guard for the two it
+        omits. Full end-to-end cleanup success for these two (a real
+        on-disk action copy actually removed) is already proven by
+        tests/test_integration_slices.py's F5 slice and its
+        force_import sibling; this only pins the lookup the guard itself
+        depends on."""
+        from lib.import_preview import ACTION_COPY_PREFIX_BY_JOB_TYPE
+        from lib.import_queue import IMPORT_JOB_FORCE, IMPORT_JOB_LOCAL
+
+        self.assertEqual(
+            ACTION_COPY_PREFIX_BY_JOB_TYPE.get(IMPORT_JOB_FORCE),
+            "force-action-",
+        )
+        self.assertEqual(
+            ACTION_COPY_PREFIX_BY_JOB_TYPE.get(IMPORT_JOB_LOCAL),
+            "local-import-action-",
         )
 
 

--- a/tests/test_import_queue.py
+++ b/tests/test_import_queue.py
@@ -3717,13 +3717,14 @@ class TestCleanupTerminalForceActionFailsClosed(unittest.TestCase):
     unreachable in production today: ``ImportJob.from_row`` runs
     ``validate_job_type``, so a real job's ``job_type`` can only ever be one
     of the four ``IMPORT_JOB_TYPES``, and of the two the table omits
-    (``automation_import``, ``youtube_import``), every live doc2 row carries
-    a JSON ``null`` ``action_path`` (measured 2026-08-22), so ``_force_
-    action_path`` already returns ``None`` first. This test bypasses both
-    guards by constructing the ``ImportJob`` directly (not through ``from_
-    row``) with a real, unmapped job type and a synthetic non-null
-    ``action_path``, to pin the guard itself independent of today's live
-    reachability.
+    (``automation_import``, ``youtube_import``), the small minority of live
+    doc2 rows of either type that carry an ``action_path`` key at all carry
+    it as JSON ``null`` -- most rows have no such key, and none observed to
+    date has a non-null one (issue #1246 F5) -- so ``_force_action_path``
+    already returns ``None`` first. This test bypasses both guards by
+    constructing the ``ImportJob`` directly (not through ``from_row``) with
+    a real, unmapped job type and a synthetic non-null ``action_path``, to
+    pin the guard itself independent of today's live reachability.
     """
 
     def _job(
@@ -3763,7 +3764,19 @@ class TestCleanupTerminalForceActionFailsClosed(unittest.TestCase):
     def test_unmapped_job_types_skip_cleanup_instead_of_using_force_prefix(
         self,
     ) -> None:
+        from lib.import_preview import ACTION_COPY_PREFIX_BY_JOB_TYPE
+        from lib.import_queue import IMPORT_JOB_TYPES
         from scripts import importer
+
+        # Derive exhaustiveness rather than asserting it in prose: a
+        # future fifth IMPORT_JOB_TYPES member would silently escape both
+        # this loop and the mapped test below unless this equality is
+        # checked against the real enum and the real table (issue #1246
+        # F4).
+        self.assertEqual(
+            {job_type for _, job_type, _ in self.UNMAPPED_CASES},
+            IMPORT_JOB_TYPES - set(ACTION_COPY_PREFIX_BY_JOB_TYPE),
+        )
 
         for desc, job_type, payload in self.UNMAPPED_CASES:
             with self.subTest(desc=desc):
@@ -3796,6 +3809,15 @@ class TestCleanupTerminalForceActionFailsClosed(unittest.TestCase):
         depends on."""
         from lib.import_preview import ACTION_COPY_PREFIX_BY_JOB_TYPE
         from lib.import_queue import IMPORT_JOB_FORCE, IMPORT_JOB_LOCAL
+
+        # Derive, not assert in prose: the mapped half is EXACTLY these
+        # two -- no more, no fewer (issue #1246 F4). Paired with the
+        # unmapped test's own derived equality above, this proves the two
+        # halves partition the full IMPORT_JOB_TYPES domain rather than
+        # merely covering four hand-picked members of it.
+        self.assertEqual(
+            set(ACTION_COPY_PREFIX_BY_JOB_TYPE), {IMPORT_JOB_FORCE, IMPORT_JOB_LOCAL},
+        )
 
         self.assertEqual(
             ACTION_COPY_PREFIX_BY_JOB_TYPE.get(IMPORT_JOB_FORCE),

--- a/tests/test_import_queue.py
+++ b/tests/test_import_queue.py
@@ -3720,8 +3720,8 @@ class TestCleanupTerminalForceActionFailsClosed(unittest.TestCase):
     (``automation_import``, ``youtube_import``), the small minority of live
     doc2 rows of either type that carry an ``action_path`` key at all carry
     it as JSON ``null`` -- most rows have no such key, and none observed to
-    date has a non-null one (issue #1246 F5) -- so ``_force_action_path``
-    already returns ``None`` first. This test bypasses both guards by
+    date has a non-null one -- so ``_force_action_path`` already returns
+    ``None`` first. This test bypasses both guards by
     constructing the ``ImportJob`` directly (not through ``from_row``) with
     a real, unmapped job type and a synthetic non-null ``action_path``, to
     pin the guard itself independent of today's live reachability.
@@ -3771,8 +3771,7 @@ class TestCleanupTerminalForceActionFailsClosed(unittest.TestCase):
         # Derive exhaustiveness rather than asserting it in prose: a
         # future fifth IMPORT_JOB_TYPES member would silently escape both
         # this loop and the mapped test below unless this equality is
-        # checked against the real enum and the real table (issue #1246
-        # F4).
+        # checked against the real enum and the real table.
         self.assertEqual(
             {job_type for _, job_type, _ in self.UNMAPPED_CASES},
             IMPORT_JOB_TYPES - set(ACTION_COPY_PREFIX_BY_JOB_TYPE),
@@ -3811,10 +3810,10 @@ class TestCleanupTerminalForceActionFailsClosed(unittest.TestCase):
         from lib.import_queue import IMPORT_JOB_FORCE, IMPORT_JOB_LOCAL
 
         # Derive, not assert in prose: the mapped half is EXACTLY these
-        # two -- no more, no fewer (issue #1246 F4). Paired with the
-        # unmapped test's own derived equality above, this proves the two
-        # halves partition the full IMPORT_JOB_TYPES domain rather than
-        # merely covering four hand-picked members of it.
+        # two -- no more, no fewer. Paired with the unmapped test's own
+        # derived equality above, this proves the two halves partition
+        # the full IMPORT_JOB_TYPES domain rather than merely covering
+        # four hand-picked members of it.
         self.assertEqual(
             set(ACTION_COPY_PREFIX_BY_JOB_TYPE), {IMPORT_JOB_FORCE, IMPORT_JOB_LOCAL},
         )

--- a/tests/test_integration_slices.py
+++ b/tests/test_integration_slices.py
@@ -2595,11 +2595,15 @@ class TestForceImportSlice(unittest.TestCase):
           acceptance.
 
         After the fix the string is spelled ONCE (``FORCE_ACTION_PREFIX`` in
-        ``lib/import_preview.py``). Five of the original eight sites
+        ``lib/import_preview.py``). Four of the original eight sites
         (``ACTION_COPY_PREFIX_BY_JOB_TYPE``, ``force_action_copy_path``'s
-        default, ``importer.py``'s ``.get(...)`` fallback, ``execute_import_
-        job``'s ``action_prefix=``, and ``_FORCE_ACTION_AUTHORITY.action_
-        prefix``) now reference it by name. The remaining three
+        default, ``execute_import_job``'s ``action_prefix=``, and
+        ``_FORCE_ACTION_AUTHORITY.action_prefix``) now reference it by name.
+        Issue #1246 item 2 dropped a fifth (``importer.py``'s ``.get(...)``
+        fallback): ``_cleanup_terminal_force_action`` no longer defaults an
+        unrecognized job type to ``FORCE_ACTION_PREFIX`` at all — it fails
+        closed instead, matching its preview-worker sibling, so that site
+        no longer references the constant. The remaining three
         (``retain_preview_snapshot_for_force_action``, ``remove_force_
         action_copy``, ``cleanup_force_action_copy_for_job``) went further:
         ``prefix`` is now a required keyword-only parameter with no default

--- a/tests/test_targeted_test_selection.py
+++ b/tests/test_targeted_test_selection.py
@@ -132,13 +132,24 @@ class TestTargetedTestSelection(unittest.TestCase):
         under-selection either. A diff touching only this file previously
         selected zero of its real behavior coverage.
 
-        The six-module set is qualified by fault injection (a ``raise
-        RuntimeError`` planted as the first statement of
+        The original six-module set is qualified by fault injection (a
+        ``raise RuntimeError`` planted as the first statement of
         ``dispatch_import_from_db``, run against each module — see the
         registry's own comment). ``tests.test_force_import_gates`` is
         deliberately absent: an #1196 review round found it kills nothing
         (its only references to this module are docstring lines saying
         coverage MOVED OUT after the U4 importer-never-measures refactor).
+
+        Issue #1246 item 1 added two more: PR #1245's own
+        ``tests.test_dispatch_outcomes_generated::TestGeneratedLaneDistanceAudit``
+        was written specifically to patrol this file's lane discriminator
+        but was never selected by a solo edit to it, and
+        ``tests.test_local_import_lane`` pins the caller-side contract that
+        discriminator depends on. Qualified the same way: flipping the
+        discriminator's ``is not None`` to ``is None`` kills
+        ``TestGeneratedLaneDistanceAudit`` (real dynamic execution); it does
+        NOT kill ``test_local_import_lane``, which is kept anyway as a
+        different, real regression class (see the registry's own comment).
         """
         selected = expand_test_selection(
             (),
@@ -154,6 +165,8 @@ class TestTargetedTestSelection(unittest.TestCase):
                 "tests.test_import_manifest",
                 "tests.test_import_queue",
                 "tests.test_issue_573_boundaries",
+                "tests.test_dispatch_outcomes_generated",
+                "tests.test_local_import_lane",
             }.issubset(selected)
         )
         self.assertNotIn("tests.test_force_import_gates", selected)

--- a/tests/test_targeted_test_selection.py
+++ b/tests/test_targeted_test_selection.py
@@ -171,6 +171,57 @@ class TestTargetedTestSelection(unittest.TestCase):
         )
         self.assertNotIn("tests.test_force_import_gates", selected)
 
+    def test_importer_and_preview_worker_changes_add_their_real_consumers(
+        self,
+    ) -> None:
+        """Issue #1246 F3: ``scripts/importer.py`` and
+        ``scripts/import_preview_worker.py`` had no ``EXACT_PATH_NEIGHBOURS``
+        entry. Both live under ``scripts/``, not ``lib/``, so
+        ``_changed_path_neighbours``'s lib-only fail-closed check never
+        caught the resulting under-selection either -- silent, not admitted.
+        A diff touching only ``scripts/importer.py`` previously selected
+        zero of its real behavior coverage, including this issue's own item-2
+        pin (``TestCleanupTerminalForceActionFailsClosed`` in
+        ``tests.test_import_queue``).
+
+        Both sets are qualified by fault injection (a ``raise RuntimeError``
+        planted as the first statement of each file's own central,
+        every-job-type entry point -- ``process_claimed_job`` for
+        importer.py, ``process_claimed_preview_job`` for
+        import_preview_worker.py -- run against every plausible candidate;
+        see the registry's own comment for the full killed/not-killed
+        breakdown).
+        """
+        importer_selected = expand_test_selection(
+            (),
+            changed_paths=("scripts/importer.py",),
+            repo_root=REPO_ROOT,
+        )
+        self.assertTrue(
+            {
+                "tests.test_import_dispatch",
+                "tests.test_import_operation_fence",
+                "tests.test_import_queue",
+                "tests.test_integration_slices",
+                "tests.test_local_import_lane",
+                "tests.test_terminal_outcomes",
+            }.issubset(importer_selected)
+        )
+
+        preview_selected = expand_test_selection(
+            (),
+            changed_paths=("scripts/import_preview_worker.py",),
+            repo_root=REPO_ROOT,
+        )
+        self.assertTrue(
+            {
+                "tests.test_import_queue",
+                "tests.test_integration_slices",
+                "tests.test_issue_1030_postgres_slice",
+                "tests.test_terminal_outcome_callers",
+            }.issubset(preview_selected)
+        )
+
     def test_unknown_explicit_selector_fails_closed(self) -> None:
         with self.assertRaisesRegex(ValueError, "unknown test selector"):
             expand_test_selection(

--- a/tests/test_targeted_test_selection.py
+++ b/tests/test_targeted_test_selection.py
@@ -174,23 +174,29 @@ class TestTargetedTestSelection(unittest.TestCase):
     def test_importer_and_preview_worker_changes_add_their_real_consumers(
         self,
     ) -> None:
-        """Issue #1246 F3: ``scripts/importer.py`` and
-        ``scripts/import_preview_worker.py`` had no ``EXACT_PATH_NEIGHBOURS``
-        entry. Both live under ``scripts/``, not ``lib/``, so
-        ``_changed_path_neighbours``'s lib-only fail-closed check never
-        caught the resulting under-selection either -- silent, not admitted.
-        A diff touching only ``scripts/importer.py`` previously selected
-        zero of its real behavior coverage, including this issue's own item-2
-        pin (``TestCleanupTerminalForceActionFailsClosed`` in
-        ``tests.test_import_queue``).
+        """``scripts/importer.py`` and ``scripts/import_preview_worker.py``
+        had no ``EXACT_PATH_NEIGHBOURS`` entry. Both live under ``scripts/``,
+        not ``lib/``, so ``_changed_path_neighbours``'s lib-only fail-closed
+        check never caught the resulting under-selection either -- silent,
+        not admitted. A diff touching only ``scripts/importer.py``
+        previously selected zero of its real behavior coverage, including
+        ``TestCleanupTerminalForceActionFailsClosed`` in
+        ``tests.test_import_queue`` -- and, sharper still, never selected
+        ``tests.test_dispatch_outcomes_generated``, the generated property
+        specifically written to patrol the lane discriminator this file's
+        caller (``lib/dispatch/entry_points.py``) relies on -- the exact
+        module whose non-selection is the reason this registry exists.
 
         Both sets are qualified by fault injection (a ``raise RuntimeError``
         planted as the first statement of each file's own central,
         every-job-type entry point -- ``process_claimed_job`` for
-        importer.py, ``process_claimed_preview_job`` for
-        import_preview_worker.py -- run against every plausible candidate;
-        see the registry's own comment for the full killed/not-killed
-        breakdown).
+        importer.py, ``process_claimed_preview_job`` for import_preview_
+        worker.py) run against every module found by grepping for real
+        imports PLUS every module reaching the entry point indirectly
+        through ``tests/helpers.py::finalize_claimed_dispatch`` -- a
+        QUALIFIED SUBSET of confirmed killers, not a claimed-complete kill
+        set; see the registry's own comment for the full killed/not-killed/
+        excluded-for-cost breakdown.
         """
         importer_selected = expand_test_selection(
             (),
@@ -205,6 +211,12 @@ class TestTargetedTestSelection(unittest.TestCase):
                 "tests.test_integration_slices",
                 "tests.test_local_import_lane",
                 "tests.test_terminal_outcomes",
+                "tests.test_dispatch_outcomes_generated",
+                "tests.test_force_import_service_generated",
+                "tests.test_import_job_lifecycle_generated",
+                "tests.test_processing_lifecycle_generated",
+                "tests.test_spectral_attempt_audit_generated",
+                "tests.test_wrong_match_post_commit_generated",
             }.issubset(importer_selected)
         )
 
@@ -219,6 +231,10 @@ class TestTargetedTestSelection(unittest.TestCase):
                 "tests.test_integration_slices",
                 "tests.test_issue_1030_postgres_slice",
                 "tests.test_terminal_outcome_callers",
+                "tests.test_evidence_generated",
+                "tests.test_path_authority_generated",
+                "tests.test_preview_failure_evidence_generated",
+                "tests.test_spectral_attempt_audit_generated",
             }.issubset(preview_selected)
         )
 


### PR DESCRIPTION
## Summary

All four items of #1246, the post-ship reflection from the #1211 series.

**1 — A generated property was not selected when its own subject changed.** PR #1245 added `TestGeneratedLaneDistanceAudit` to patrol the lane discriminator in `lib/dispatch/entry_points.py`, but editing that file selected 37 modules and not that one. Fixed via `EXACT_PATH_NEIGHBOURS`. Review then found the same defect in the file item 2 changes: `scripts/importer.py` and `scripts/import_preview_worker.py` each resolved only the 29-module ambient-audit set, so this PR's own new pin did not run when its subject changed — and because they sit under `scripts/` rather than `lib/`, `LIB_MODULES_WITHOUT_SELECTION_COVERAGE`'s loud stderr never fired, making it silent under-selection rather than an admitted gap. Now 45 / 39 / 39 modules respectively.

**2 — A fail-open cleanup fallback (production).** `_cleanup_terminal_force_action` resolved its prefix as `ACTION_COPY_PREFIX_BY_JOB_TYPE.get(job.job_type, FORCE_ACTION_PREFIX)`, silently treating an unknown job type as force; its preview-worker sibling fails closed. Now matches the sibling. Verified dead four independent ways before changing it (below).

**3 — Briefs are an unreviewed claim surface** (`.claude/rules/code-quality.md`). Every artifact in the pipeline gets an independent read except the brief an orchestrator hands an implementer, which is then treated as settled fact. The remedy: a brief separates what its author MEASURED from what they INFERRED, and the implementer verifies load-bearing claims before building on them.

**4 — Rule D's vacuous case** (`.claude/rules/test-fidelity.md`): when the affected live population is empty, the differential is zero by construction and the honest evidence is the population query itself.

Refs #1246 (non-closing).

## Kill matrix

| Site | One-line production mutant | Test that must go RED | Result |
| --- | --- | --- | --- |
| `_cleanup_terminal_force_action` fail-closed guard | restore `.get(job.job_type, FORCE_ACTION_PREFIX)` | `TestCleanupTerminalForceActionFailsClosed` | Killed (both subTests) |
| same guard | neuter to `is not None and False` | same | Killed |
| same guard | widen to skip `local_import` | `TestLocalImportSlice` | Killed |
| same guard | widen to skip `force_import` | `TestForceImportSlice` | Killed |
| `ACTION_COPY_PREFIX_BY_JOB_TYPE[IMPORT_JOB_LOCAL]` | drop the entry | `TestCleanupTerminalForceActionFailsClosed` | Killed |
| `LOCAL_IMPORT_ACTION_PREFIX` value | drift the string | same | Killed |
| `IMPORT_JOB_TYPES` | add a fifth member | derived exhaustiveness assertion | Killed (survived before the fix) |
| `entry_points.py` discriminator | `is not None` → `is None` | `test_dispatch_outcomes_generated` | Killed; `test_local_import_lane` does NOT kill it (injects a recorder) — stated in the comment |
| each new registry entry | drop the neighbour | `TestTargetedTestSelection` | Killed |

The 14 additional modules that kill `process_claimed_job` / `process_claimed_preview_job` were each fault-injected individually; the generated-property killers were added and two confirmed-killing modules were excluded on cost with the rationale recorded.

## Reviewer

Two full independent review rounds, 11 confirmed findings, none from the suite. Round 1 verified item 2 dead four ways and found three MEDIUMs, including that this PR had staled a docstring count that an earlier commit exists solely to fix, and that item 1's defect was unclosed in the very file item 2 changes. Round 2 found that the fault-injection comment claimed a completeness it did not have — 14 further modules kill those mutants, including `tests.test_dispatch_outcomes_generated`, the exact module whose non-selection is this issue's item 1 — and that three comments cited "issue #1246 F5/F3/F4", a numbering that exists nowhere, reproducing the dangling-citation shape this series documents.

One finding was the orchestrator's own: the new rule asserted three brief-borne false claims "all caught only by an independent reviewer", which its own cited memory file refutes — the third never shipped, because the implementer verified the count. Corrected in both places; the accurate version is stronger, since that third instance is the rule working as intended.

## Risk

One runtime behaviour change (item 2), verified unreachable four ways: `ImportJob.from_row` runs `validate_job_type` so `job.job_type` is constrained to the four `IMPORT_JOB_TYPES`; `action_path` is written only inside the force/local branch of `execute_preview_job`; live doc2 shows zero non-null `action_path` values across all `automation_import` and `youtube_import` rows; and the startup replay sweep already filters to force/local. In every hypothetical the old code raised and returned `{"removed": False}` rather than removing anything, so the new early return is strictly safer.

Everything else is test selection, tests, and rules text. Both typing-ratchet baselines are byte-identical to `origin/main`; no semantic scanner was added; no Hypothesis property was attached to test-selection machinery, per "Never property-test the test machinery".
