### PR TITLE
fix(tests): scripts/** fails closed on zero selection neighbours, and stop the nix-eval __pycache__ race (#1248)

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -397,10 +397,11 @@ through to the SAME return every other path takes — never a silent cap, and
 a registration that later gains real coverage is selected immediately with
 no code change here (only the now-stale registry entry needs deleting,
 which the audit demands). A changed `scripts/**/*.py` file gets the SAME
-non-early-return, admitted-gap treatment (issue #1248) via `SCRIPTS_
-MODULES_WITHOUT_SELECTION_COVERAGE` and `tests/test_scripts_selection_
-coverage_audit.py` — the scripts/ mirror of the lib/ case above, including
-the same nested-subdirectory basename-only miss (`scripts/pipeline_cli/
+non-early-return, admitted-gap treatment (issue #1248) via
+`SCRIPTS_MODULES_WITHOUT_SELECTION_COVERAGE` and
+`tests/test_scripts_selection_coverage_audit.py` — the scripts/ mirror of
+the lib/ case above, including the same nested-subdirectory basename-only
+miss (`scripts/pipeline_cli/
 cli.py` probes only `tests.test_cli`, ignoring the `pipeline_cli/`
 component). This is development feedback; the full suite
 remains the exhaustive pre-review boundary.

--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -396,7 +396,13 @@ branch only prints a loud stderr line naming the admitted gap and falls
 through to the SAME return every other path takes — never a silent cap, and
 a registration that later gains real coverage is selected immediately with
 no code change here (only the now-stale registry entry needs deleting,
-which the audit demands). This is development feedback; the full suite
+which the audit demands). A changed `scripts/**/*.py` file gets the SAME
+non-early-return, admitted-gap treatment (issue #1248) via `SCRIPTS_
+MODULES_WITHOUT_SELECTION_COVERAGE` and `tests/test_scripts_selection_
+coverage_audit.py` — the scripts/ mirror of the lib/ case above, including
+the same nested-subdirectory basename-only miss (`scripts/pipeline_cli/
+cli.py` probes only `tests.test_cli`, ignoring the `pipeline_cli/`
+component). This is development feedback; the full suite
 remains the exhaustive pre-review boundary.
 
 Always use `nix-shell --run` for Python (`.claude/rules/nix-shell.md`). Direct

--- a/scripts/targeted_test_selection.py
+++ b/scripts/targeted_test_selection.py
@@ -502,6 +502,215 @@ EXACT_PATH_NEIGHBOURS: dict[str, tuple[str, ...]] = {
         "tests.test_preview_failure_evidence_generated",
         "tests.test_spectral_attempt_audit_generated",
     ),
+    # Issue #1248: 10 of the 11 scripts/*.py files that resolve zero
+    # neighbours have real coverage -- `_direct_test_candidates` only ever
+    # probes `tests.test_<basename>`, which misses coverage filed under a
+    # differently-named test module or reached only via subprocess/dynamic
+    # load. Each entry below was verified by reading the referencing test
+    # file, not just grepping the filename (a plain grep for several of
+    # these names alone would have produced false positives from comment/
+    # docstring mentions or from the string, unrelated
+    # lib.beets_config_contract.check_beets_config function that
+    # scripts/check_beets_config.py itself imports and wraps).
+    "scripts/audit_issue_references.py": (
+        # tests.test_issue_reference_contract:10 --
+        # "from scripts.audit_issue_references import find_closing_issue_references"
+        "tests.test_issue_reference_contract",
+    ),
+    "scripts/check_beets_config.py": (
+        # tests.test_beets_config_contract_integration launches this file
+        # as a real subprocess (TestStandaloneBeetsConfigChecker._run,
+        # `subprocess.run([sys.executable, "scripts/check_beets_config.py",
+        # ...])`) and separately imports its CheckerResult wire type.
+        # tests.test_beets_config_startup_generated does the same real
+        # subprocess launch to assert redacted-secret behaviour on a load
+        # failure. Neither is the unrelated lib.beets_config_contract.
+        # check_beets_config function this script imports and wraps --
+        # that shared function's own ~90 call sites across
+        # test_beets_config_contract*.py and test_harness_beets2_contract.py
+        # exercise lib/beets_config_contract.py, not this file.
+        "tests.test_beets_config_contract_integration",
+        "tests.test_beets_config_startup_generated",
+    ),
+    "scripts/cratedigger_deploy_hold.py": (
+        # tests.test_deploy_hold: "import scripts.cratedigger_deploy_hold
+        # as deploy_hold_module" + a real-module import block.
+        # tests.test_deploy_hold_generated: "from scripts.cratedigger_
+        # deploy_hold import (...)".
+        "tests.test_deploy_hold",
+        "tests.test_deploy_hold_generated",
+    ),
+    "scripts/plex_dupes_audit.py": (
+        # tests.test_plex_dupes_scripts: "from scripts import
+        # plex_dupes_audit, plex_dupes_merge" plus real calls
+        # (plex_dupes_audit.fetch_children, ._parse_children_xml,
+        # ._load_albums) -- the one test module covering BOTH plex_dupes_
+        # scripts, contrary to this issue's own opening measurement, which
+        # assumed the plex_dupes_* pair was a genuine gap without reading
+        # this file first.
+        "tests.test_plex_dupes_scripts",
+    ),
+    "scripts/plex_dupes_merge.py": (
+        # Same tests.test_plex_dupes_scripts module -- real call:
+        # plex_dupes_merge.merge("1", ["2"], "merge-token").
+        "tests.test_plex_dupes_scripts",
+    ),
+    "scripts/refresh_beets_compat_releases.py": (
+        # Both test modules load this file via
+        # importlib.util.spec_from_file_location (not a dotted import --
+        # presumably because the module needs loading under two distinct
+        # synthetic names, "beets_compat_releases" and "beets_compat_
+        # releases_generated", for the deterministic/generated split) and
+        # execute it for real.
+        "tests.test_beets_compat_releases",
+        "tests.test_beets_compat_releases_generated",
+    ),
+    "scripts/run_fuzz_tests.py": (
+        # tests.test_fuzz_burst: "from scripts.run_fuzz_tests import
+        # (...)" plus RUNNER = .../run_fuzz_tests.py driving real
+        # subprocess bursts. tests.test_parallel_test_runner: "from
+        # scripts.run_fuzz_tests import (...)". tests.test_unused_import_
+        # audit.py and tests.test_hypothesis_profile_audit.py also mention
+        # this filename but only as a string/comment (a TID251 ruff-rule
+        # entry keyed by path, and prose citing where a real bug lived) --
+        # neither imports or executes the module, so neither is listed.
+        "tests.test_fuzz_burst",
+        "tests.test_parallel_test_runner",
+    ),
+    "scripts/run_library_completeness_census.py": (
+        # tests.test_library_completeness_snapshot: "from scripts import
+        # run_library_completeness_census as census" +
+        # "from scripts.run_library_completeness_census import
+        # publish_library_completeness_census" -- fault-injection
+        # confirmed (a runtime raise planted as the first statement of
+        # publish_library_completeness_census fails this module with 2
+        # errors). tests.test_beets_config_startup_entrypoints: real
+        # subprocess exec, "subprocess.run([sys.executable,
+        # 'scripts/run_library_completeness_census.py', ...])", but
+        # against a deliberately invalid config -- it proves the module's
+        # main()/config-load path fails closed before publish_library_
+        # completeness_census ever runs, so the SAME mutant above does
+        # NOT reach it (confirmed: 6/6 pass with the mutant live). Kept
+        # as a real, independent neighbour for the startup/config-load
+        # code this module owns, not because it kills every mutant in
+        # the census body.
+        "tests.test_library_completeness_snapshot",
+        "tests.test_beets_config_startup_entrypoints",
+    ),
+    "scripts/run_world_model_burst.py": (
+        # tests.test_world_model_coordinator: "from scripts.run_world_
+        # model_burst import (...)" including build_targets, called
+        # directly at 5 sites -- fault-injection confirmed (a runtime
+        # raise planted as the first statement of build_targets fails
+        # this module with 3 failures/5 errors). tests.test_ephemeral_pg
+        # only imports the IN_PROCESS_JOB_CAP constant, never a function
+        # -- confirmed it does NOT kill the same mutant (14/14 pass with
+        # the mutant live). Kept anyway: it is real, independent module-
+        # level-import coverage (an import-time break in this file would
+        # still fail it), just not of build_targets specifically.
+        # tests.test_world_model_burst.py, tests.test_negative_coverage_
+        # audit.py, and tests.test_fuzz_burst.py also mention this
+        # filename but only in a string literal/comment/docstring, never
+        # a real import, so none of the three is listed.
+        "tests.test_world_model_coordinator",
+        "tests.test_ephemeral_pg",
+    ),
+    "scripts/world_audit_debt_gate.py": (
+        # tests.test_world_audit_debt: "from scripts.world_audit_debt_
+        # gate import run".
+        "tests.test_world_audit_debt",
+    ),
+    # scripts/pipeline_cli/*.py: 19 of the 20 files in this package
+    # (everything except beets_distance.py, whose basename-derived
+    # candidate tests.test_beets_distance already exists) resolve zero
+    # neighbours -- _direct_test_candidates derives tests.test_<basename>
+    # from ONLY the basename, ignoring the pipeline_cli/ subdirectory
+    # component entirely, the same nested-lib/ shape lib/dispatch/core.py
+    # had under #1199. Of those 19, __main__.py is the one genuine gap
+    # (its own SCRIPTS_MODULES_WITHOUT_SELECTION_COVERAGE entry, defined
+    # further down this file, has the rationale); the other 18 get real
+    # EXACT_PATH_NEIGHBOURS entries below.
+    # tests.test_pipeline_cli.py (8k+ lines) is this
+    # package's real, dedicated coverage: scripts/pipeline_cli/__init__.py
+    # re-exports every cmd_* handler, and tests.test_pipeline_cli.py does
+    # "from scripts import pipeline_cli" then calls
+    # pipeline_cli.cmd_<name>(db, args) directly -- the SAME function
+    # object the owning family module defines (Python re-export is a name
+    # binding, not a copy), so the call is real execution of that module's
+    # code. Verified by grep for a direct call to at least one cmd_*
+    # (or, for cli.py, pipeline_cli.main(...); for routes_meta.py,
+    # _build_parser()) owned by each module below, confirmed present in
+    # tests.test_pipeline_cli.py. _format.py has no direct call of its own
+    # -- its own docstring names it as shared helpers used by query, show,
+    # quality, search_plan, triage, replace, beets_distance, and long_tail,
+    # every one of which IS called directly above, so _format.py's code
+    # runs for real whenever any of those command tests run.
+    "scripts/pipeline_cli/__init__.py": (
+        "tests.test_pipeline_cli",
+    ),
+    "scripts/pipeline_cli/_format.py": (
+        "tests.test_pipeline_cli",
+    ),
+    "scripts/pipeline_cli/album_requests.py": (
+        "tests.test_pipeline_cli",
+    ),
+    "scripts/pipeline_cli/api_mutations.py": (
+        # api_mutations.py additionally has its own dedicated test
+        # modules: tests.test_pipeline_cli_api_mutations ("from
+        # scripts.pipeline_cli import api_mutations" + real
+        # cmd_merge_rekey/cmd_wrong_match_delete_group/... calls) and its
+        # generated sibling.
+        "tests.test_pipeline_cli",
+        "tests.test_pipeline_cli_api_mutations",
+        "tests.test_pipeline_cli_api_mutations_generated",
+    ),
+    "scripts/pipeline_cli/audit.py": (
+        "tests.test_pipeline_cli",
+    ),
+    "scripts/pipeline_cli/cli.py": (
+        "tests.test_pipeline_cli",
+        "tests.test_pipeline_cli_api_mutations",
+    ),
+    "scripts/pipeline_cli/destructive.py": (
+        "tests.test_pipeline_cli",
+    ),
+    "scripts/pipeline_cli/imports.py": (
+        "tests.test_pipeline_cli",
+        "tests.test_pipeline_cli_api_mutations",
+    ),
+    "scripts/pipeline_cli/long_tail.py": (
+        "tests.test_pipeline_cli",
+    ),
+    "scripts/pipeline_cli/quality.py": (
+        "tests.test_pipeline_cli",
+    ),
+    "scripts/pipeline_cli/query.py": (
+        "tests.test_pipeline_cli",
+    ),
+    "scripts/pipeline_cli/replace.py": (
+        "tests.test_pipeline_cli",
+    ),
+    "scripts/pipeline_cli/routes_meta.py": (
+        "tests.test_pipeline_cli",
+        "tests.test_pipeline_cli_api_mutations",
+    ),
+    "scripts/pipeline_cli/search_plan.py": (
+        "tests.test_pipeline_cli",
+    ),
+    "scripts/pipeline_cli/show.py": (
+        "tests.test_pipeline_cli",
+    ),
+    "scripts/pipeline_cli/triage.py": (
+        "tests.test_pipeline_cli",
+    ),
+    "scripts/pipeline_cli/wrong_match.py": (
+        "tests.test_pipeline_cli",
+        "tests.test_pipeline_cli_api_mutations",
+    ),
+    "scripts/pipeline_cli/youtube.py": (
+        "tests.test_pipeline_cli",
+        "tests.test_pipeline_cli_api_mutations",
+    ),
 }
 
 #: Shared tests/ modules with NO real consuming test today — an admitted,
@@ -743,6 +952,66 @@ LIB_MODULES_WITHOUT_SELECTION_COVERAGE: dict[str, str] = {
 }
 
 
+#: Changed `scripts/**/*.py` files whose full neighbour resolution
+#: (EXACT_PATH_NEIGHBOURS + prefix rules + direct candidates that actually
+#: exist) yields ZERO test modules -- the scripts/ twin of
+#: LIB_MODULES_WITHOUT_SELECTION_COVERAGE (issue #1248). `_direct_test_
+#: candidates` probes only `tests.test_<basename>` for a scripts/ path (no
+#: `_generated` sibling probe, unlike lib/), so a script whose real coverage
+#: lives under a differently-named test module, or whose basename collides
+#: with a sibling file in a subdirectory `_direct_test_candidates` cannot
+#: see (it ignores every path component except the basename), resolves zero
+#: neighbours from that mechanism alone. Mirrors the lib/ registry's
+#: non-early-return shape: `_changed_path_neighbours` does NOT return early
+#: for a path listed here -- the full resolution already ran, so a script
+#: that later gains a real EXACT_PATH_NEIGHBOURS entry, prefix rule, or
+#: `tests.test_<stem>` module selects it immediately with no code change
+#: here, and the stale registration is what `tests/test_scripts_selection_
+#: coverage_audit.py` then demands be deleted.
+#:
+#: Population is a fresh measurement (driving the real resolution function
+#: plus a grep-and-read pass over every candidate test file to confirm REAL
+#: import/exec, not a docstring or comment mention -- see that same file's
+#: audit test for the mechanical proof), never hand-curated. Of the 11
+#: top-level `scripts/*.py` files issue #1248 found resolving zero
+#: neighbours, measurement showed 10 have real test coverage reachable only
+#: through a missing EXACT_PATH_NEIGHBOURS entry (added below) -- only
+#: `bench_parallel_search.py` is a genuine gap. The same sweep found a
+#: second, undercounted cohort: 19 of 20 `scripts/pipeline_cli/*.py` files
+#: also resolve zero neighbours (`_direct_test_candidates` derives
+#: `tests.test_<basename>` from ONLY the basename, ignoring the
+#: `pipeline_cli/` subdirectory, exactly the nested-lib/ shape
+#: `lib/dispatch/core.py` had under #1199) despite the package having
+#: extensive real coverage in `tests/test_pipeline_cli.py` -- every command-
+#: family module is re-exported by `scripts/pipeline_cli/__init__.py` and
+#: called there as `pipeline_cli.cmd_<name>(...)`, the SAME function object
+#: the family module defines, so the call is real execution of that
+#: module's code, not a lookalike. `scripts/pipeline_cli/beets_distance.py`
+#: is the one file in that package whose basename-derived candidate
+#: (`tests.test_beets_distance`) already exists, so it needs no entry.
+#: `scripts/pipeline_cli/__main__.py` is a genuine gap: its own docstring
+#: states nothing does `import scripts.pipeline_cli.__main__` (running it
+#: as a script sets `sys.path[0]` to its own directory, the #445 hazard its
+#: bootstrap works around), so no dotted-import test module can drive it.
+SCRIPTS_MODULES_WITHOUT_SELECTION_COVERAGE: dict[str, str] = {
+    "scripts/bench_parallel_search.py": (
+        "measured 2026-08-22: zero neighbours -- tests.test_bench_parallel_"
+        "search does not exist; the only reference anywhere under tests/ is "
+        "a comment in tests/conftest.py naming it as the dev benchmarking "
+        "script an optional fallback exists for, not an import or exec "
+        "(issue #1248)"
+    ),
+    "scripts/pipeline_cli/__main__.py": (
+        "measured 2026-08-22: zero neighbours -- tests.test___main__ does "
+        "not exist and no EXACT_PATH_NEIGHBOURS/prefix rule covers it; the "
+        "module's own docstring states nothing imports it under a dotted "
+        "name (script-mode-only entry shim, the #445 sys.path[0] hazard), "
+        "so no dotted-import test module can drive its bootstrap or its "
+        "delegation into scripts.pipeline_cli.cli.main (issue #1248)"
+    ),
+}
+
+
 def _assert_no_double_registration(
     exact_path_neighbours: Mapping[str, tuple[str, ...]],
     admitted_gap_registry: Mapping[str, str],
@@ -780,6 +1049,11 @@ _assert_no_double_registration(
     EXACT_PATH_NEIGHBOURS,
     LIB_MODULES_WITHOUT_SELECTION_COVERAGE,
     gap_registry_name="LIB_MODULES_WITHOUT_SELECTION_COVERAGE",
+)
+_assert_no_double_registration(
+    EXACT_PATH_NEIGHBOURS,
+    SCRIPTS_MODULES_WITHOUT_SELECTION_COVERAGE,
+    gap_registry_name="SCRIPTS_MODULES_WITHOUT_SELECTION_COVERAGE",
 )
 
 
@@ -970,6 +1244,26 @@ def _changed_path_neighbours(
             raise ValueError(
                 f"unmapped lib module: {relative_path} resolves zero test "
                 "neighbours — add an EXACT_PATH_NEIGHBOURS entry or a "
+                "prefix rule for it in scripts/targeted_test_selection.py"
+            )
+    if path.suffix == ".py" and path.parts[:1] == ("scripts",) and not neighbours:
+        # The scripts/ twin of the lib/ check above (issue #1248): a changed
+        # scripts/**/*.py file that resolves zero test neighbours
+        # under-selects silently unless it is an admitted, reviewed gap.
+        # Same non-early-return shape as the lib/ branch: selection proceeds
+        # (ambient gates still run) either way, only the stderr/raise
+        # differs.
+        if relative_path in SCRIPTS_MODULES_WITHOUT_SELECTION_COVERAGE:
+            print(
+                "admitted selection gap: "
+                f"{relative_path} resolves zero test neighbours "
+                f"({SCRIPTS_MODULES_WITHOUT_SELECTION_COVERAGE[relative_path]})",
+                file=sys.stderr,
+            )
+        else:
+            raise ValueError(
+                f"unmapped scripts module: {relative_path} resolves zero "
+                "test neighbours — add an EXACT_PATH_NEIGHBOURS entry or a "
                 "prefix rule for it in scripts/targeted_test_selection.py"
             )
     return tuple(neighbours)

--- a/scripts/targeted_test_selection.py
+++ b/scripts/targeted_test_selection.py
@@ -524,19 +524,20 @@ EXACT_PATH_NEIGHBOURS: dict[str, tuple[str, ...]] = {
         # ...])`) and separately imports its CheckerResult wire type.
         # tests.test_beets_config_startup_generated does the same real
         # subprocess launch to assert redacted-secret behaviour on a load
-        # failure. Neither is the unrelated lib.beets_config_contract.
-        # check_beets_config function this script imports and wraps --
-        # that shared function's own ~90 call sites across
-        # test_beets_config_contract*.py and test_harness_beets2_contract.py
-        # exercise lib/beets_config_contract.py, not this file.
+        # failure. Neither is the unrelated
+        # lib.beets_config_contract.check_beets_config function this
+        # script imports and wraps -- that shared function's own ~90 call
+        # sites across test_beets_config_contract*.py and
+        # test_harness_beets2_contract.py exercise
+        # lib/beets_config_contract.py, not this file.
         "tests.test_beets_config_contract_integration",
         "tests.test_beets_config_startup_generated",
     ),
     "scripts/cratedigger_deploy_hold.py": (
         # tests.test_deploy_hold: "import scripts.cratedigger_deploy_hold
         # as deploy_hold_module" + a real-module import block.
-        # tests.test_deploy_hold_generated: "from scripts.cratedigger_
-        # deploy_hold import (...)".
+        # tests.test_deploy_hold_generated:
+        # "from scripts.cratedigger_deploy_hold import (...)".
         "tests.test_deploy_hold",
         "tests.test_deploy_hold_generated",
     ),
@@ -544,7 +545,7 @@ EXACT_PATH_NEIGHBOURS: dict[str, tuple[str, ...]] = {
         # tests.test_plex_dupes_scripts: "from scripts import
         # plex_dupes_audit, plex_dupes_merge" plus real calls
         # (plex_dupes_audit.fetch_children, ._parse_children_xml,
-        # ._load_albums) -- the one test module covering BOTH plex_dupes_
+        # ._load_albums) -- the one test module covering both plex_dupes
         # scripts, contrary to this issue's own opening measurement, which
         # assumed the plex_dupes_* pair was a genuine gap without reading
         # this file first.
@@ -559,9 +560,9 @@ EXACT_PATH_NEIGHBOURS: dict[str, tuple[str, ...]] = {
         # Both test modules load this file via
         # importlib.util.spec_from_file_location (not a dotted import --
         # presumably because the module needs loading under two distinct
-        # synthetic names, "beets_compat_releases" and "beets_compat_
-        # releases_generated", for the deterministic/generated split) and
-        # execute it for real.
+        # synthetic names, "beets_compat_releases" and
+        # "beets_compat_releases_generated", for the deterministic/
+        # generated split) and execute it for real.
         "tests.test_beets_compat_releases",
         "tests.test_beets_compat_releases_generated",
     ),
@@ -569,10 +570,11 @@ EXACT_PATH_NEIGHBOURS: dict[str, tuple[str, ...]] = {
         # tests.test_fuzz_burst: "from scripts.run_fuzz_tests import
         # (...)" plus RUNNER = .../run_fuzz_tests.py driving real
         # subprocess bursts. tests.test_parallel_test_runner: "from
-        # scripts.run_fuzz_tests import (...)". tests.test_unused_import_
-        # audit.py and tests.test_hypothesis_profile_audit.py also mention
-        # this filename but only as a string/comment (a TID251 ruff-rule
-        # entry keyed by path, and prose citing where a real bug lived) --
+        # scripts.run_fuzz_tests import (...)".
+        # tests.test_unused_import_audit.py and
+        # tests.test_hypothesis_profile_audit.py also mention this
+        # filename but only as a string/comment (a TID251 ruff-rule entry
+        # keyed by path, and prose citing where a real bug lived) --
         # neither imports or executes the module, so neither is listed.
         "tests.test_fuzz_burst",
         "tests.test_parallel_test_runner",
@@ -588,36 +590,37 @@ EXACT_PATH_NEIGHBOURS: dict[str, tuple[str, ...]] = {
         # subprocess exec, "subprocess.run([sys.executable,
         # 'scripts/run_library_completeness_census.py', ...])", but
         # against a deliberately invalid config -- it proves the module's
-        # main()/config-load path fails closed before publish_library_
-        # completeness_census ever runs, so the SAME mutant above does
-        # NOT reach it (confirmed: 6/6 pass with the mutant live). Kept
-        # as a real, independent neighbour for the startup/config-load
-        # code this module owns, not because it kills every mutant in
-        # the census body.
+        # main()/config-load path fails closed before
+        # publish_library_completeness_census ever runs, so the SAME
+        # mutant above does NOT reach it (confirmed: 6/6 pass with the
+        # mutant live). Kept as a real, independent neighbour for the
+        # startup/config-load code this module owns, not because it
+        # kills every mutant in the census body.
         "tests.test_library_completeness_snapshot",
         "tests.test_beets_config_startup_entrypoints",
     ),
     "scripts/run_world_model_burst.py": (
-        # tests.test_world_model_coordinator: "from scripts.run_world_
-        # model_burst import (...)" including build_targets, called
-        # directly at 5 sites -- fault-injection confirmed (a runtime
-        # raise planted as the first statement of build_targets fails
-        # this module with 3 failures/5 errors). tests.test_ephemeral_pg
-        # only imports the IN_PROCESS_JOB_CAP constant, never a function
-        # -- confirmed it does NOT kill the same mutant (14/14 pass with
-        # the mutant live). Kept anyway: it is real, independent module-
-        # level-import coverage (an import-time break in this file would
-        # still fail it), just not of build_targets specifically.
-        # tests.test_world_model_burst.py, tests.test_negative_coverage_
-        # audit.py, and tests.test_fuzz_burst.py also mention this
-        # filename but only in a string literal/comment/docstring, never
-        # a real import, so none of the three is listed.
+        # tests.test_world_model_coordinator:
+        # "from scripts.run_world_model_burst import (...)" including
+        # build_targets, called directly at 5 sites -- fault-injection
+        # confirmed (a runtime raise planted as the first statement of
+        # build_targets fails this module with 3 failures/5 errors).
+        # tests.test_ephemeral_pg only imports the IN_PROCESS_JOB_CAP
+        # constant, never a function -- confirmed it does NOT kill the
+        # same mutant (14/14 pass with the mutant live). Kept anyway: it
+        # is real, independent module-level-import coverage (an
+        # import-time break in this file would still fail it), just not
+        # of build_targets specifically. tests.test_world_model_burst.py,
+        # tests.test_negative_coverage_audit.py, and
+        # tests.test_fuzz_burst.py also mention this filename but only in
+        # a string literal/comment/docstring, never a real import, so
+        # none of the three is listed.
         "tests.test_world_model_coordinator",
         "tests.test_ephemeral_pg",
     ),
     "scripts/world_audit_debt_gate.py": (
-        # tests.test_world_audit_debt: "from scripts.world_audit_debt_
-        # gate import run".
+        # tests.test_world_audit_debt:
+        # "from scripts.world_audit_debt_gate import run".
         "tests.test_world_audit_debt",
     ),
     # scripts/pipeline_cli/*.py: 19 of the 20 files in this package
@@ -645,6 +648,20 @@ EXACT_PATH_NEIGHBOURS: dict[str, tuple[str, ...]] = {
     # quality, search_plan, triage, replace, beets_distance, and long_tail,
     # every one of which IS called directly above, so _format.py's code
     # runs for real whenever any of those command tests run.
+    #
+    # TWO CARVE-OUTS from the "direct cmd_* call" claim above, both owning
+    # no cmd_* of the shape just described:
+    # - api_mutations.py: its own six cmd_* handlers are NEVER called by
+    #   tests.test_pipeline_cli (fault-injection confirmed: a mutant in
+    #   all six survives at exit 0). What IS real there is
+    #   api_mutations._post, a shared helper OTHER modules' handlers call
+    #   through -- see its own entry below for the exact evidence and
+    #   where the six handlers themselves ARE covered.
+    # - __init__.py: it owns no cmd_* of its own at all (only re-exports).
+    #   Its coverage is import-level -- "from scripts import pipeline_cli"
+    #   runs this file's top-level code (the imports + __all__ list)
+    #   merely by being imported, which every test in
+    #   tests.test_pipeline_cli.py does at module load.
     "scripts/pipeline_cli/__init__.py": (
         "tests.test_pipeline_cli",
     ),
@@ -655,11 +672,28 @@ EXACT_PATH_NEIGHBOURS: dict[str, tuple[str, ...]] = {
         "tests.test_pipeline_cli",
     ),
     "scripts/pipeline_cli/api_mutations.py": (
-        # api_mutations.py additionally has its own dedicated test
-        # modules: tests.test_pipeline_cli_api_mutations ("from
-        # scripts.pipeline_cli import api_mutations" + real
-        # cmd_merge_rekey/cmd_wrong_match_delete_group/... calls) and its
-        # generated sibling.
+        # NOT covered by tests.test_pipeline_cli the way the general block
+        # comment above describes for its siblings: this module's own six
+        # cmd_* handlers (cmd_merge_rekey, cmd_pipeline_delete,
+        # cmd_resolve_rg, cmd_set_quality, cmd_upgrade,
+        # cmd_wrong_match_converge) are NEVER called there -- confirmed by
+        # fault injection, a mutant raising in all six survives
+        # tests.test_pipeline_cli at exit 0. What tests.test_pipeline_cli
+        # DOES exercise for real is api_mutations._post, the shared HTTP
+        # POST helper OTHER family modules' handlers call through -- e.g.
+        # wrong_match.py's cmd_wrong_match_triage /
+        # cmd_wrong_match_triage_cancel, tested at
+        # tests/test_pipeline_cli.py:1409-1454 and :1741-1757 via
+        # "real_post = api_mutations._post" then
+        # patch.object(api_mutations, "_post", <wrapper calling real_post>)
+        # -- fault-injection confirmed (a mutant in _post fails
+        # tests.test_pipeline_cli). The six handlers themselves are
+        # covered by tests.test_pipeline_cli_api_mutations: its _run()
+        # helper dict-dispatches all six by name (TestApiMutationCli._run,
+        # exercised by
+        # test_each_command_preserves_canonical_method_path_and_body's
+        # six-case loop plus several other tests) and its generated
+        # sibling.
         "tests.test_pipeline_cli",
         "tests.test_pipeline_cli_api_mutations",
         "tests.test_pipeline_cli_api_mutations_generated",
@@ -955,9 +989,10 @@ LIB_MODULES_WITHOUT_SELECTION_COVERAGE: dict[str, str] = {
 #: Changed `scripts/**/*.py` files whose full neighbour resolution
 #: (EXACT_PATH_NEIGHBOURS + prefix rules + direct candidates that actually
 #: exist) yields ZERO test modules -- the scripts/ twin of
-#: LIB_MODULES_WITHOUT_SELECTION_COVERAGE (issue #1248). `_direct_test_
-#: candidates` probes only `tests.test_<basename>` for a scripts/ path (no
-#: `_generated` sibling probe, unlike lib/), so a script whose real coverage
+#: LIB_MODULES_WITHOUT_SELECTION_COVERAGE (issue #1248).
+#: `_direct_test_candidates` probes only `tests.test_<basename>` for a
+#: scripts/ path (no `_generated` sibling probe, unlike lib/), so a
+#: script whose real coverage
 #: lives under a differently-named test module, or whose basename collides
 #: with a sibling file in a subdirectory `_direct_test_candidates` cannot
 #: see (it ignores every path component except the basename), resolves zero
@@ -966,8 +1001,8 @@ LIB_MODULES_WITHOUT_SELECTION_COVERAGE: dict[str, str] = {
 #: for a path listed here -- the full resolution already ran, so a script
 #: that later gains a real EXACT_PATH_NEIGHBOURS entry, prefix rule, or
 #: `tests.test_<stem>` module selects it immediately with no code change
-#: here, and the stale registration is what `tests/test_scripts_selection_
-#: coverage_audit.py` then demands be deleted.
+#: here, and the stale registration is what
+#: `tests/test_scripts_selection_coverage_audit.py` then demands be deleted.
 #:
 #: Population is a fresh measurement (driving the real resolution function
 #: plus a grep-and-read pass over every candidate test file to confirm REAL
@@ -995,8 +1030,9 @@ LIB_MODULES_WITHOUT_SELECTION_COVERAGE: dict[str, str] = {
 #: bootstrap works around), so no dotted-import test module can drive it.
 SCRIPTS_MODULES_WITHOUT_SELECTION_COVERAGE: dict[str, str] = {
     "scripts/bench_parallel_search.py": (
-        "measured 2026-08-22: zero neighbours -- tests.test_bench_parallel_"
-        "search does not exist; the only reference anywhere under tests/ is "
+        "measured 2026-08-22: zero neighbours -- "
+        "tests.test_bench_parallel_search does not exist; the only "
+        "reference anywhere under tests/ is "
         "a comment in tests/conftest.py naming it as the dev benchmarking "
         "script an optional fallback exists for, not an import or exec "
         "(issue #1248)"

--- a/tests/test_lib_selection_coverage_audit.py
+++ b/tests/test_lib_selection_coverage_audit.py
@@ -125,9 +125,22 @@ class TestLibSelectionCoverageRegistryIsExact(unittest.TestCase):
 
 
 class TestLibSelectionCoverageCheckerTripsOnViolations(unittest.TestCase):
-    """Known-bad self-tests, driven through synthetic registries/paths —
-    never the real registry — so the checker's own correctness is proven
-    independently of today's registrations happening to be clean."""
+    """Known-bad self-tests proving the checker's own correctness, split
+    two ways (issue #1248 review correction — a prior version of this
+    docstring claimed ALL six tests below use only synthetic registries/
+    paths; three do not). The two "fails closed" tests (unmapped
+    top-level / nested lib/ paths) and the stale-registration trip test
+    drive entirely synthetic paths/registries never present in the real
+    module-level data. The remaining three ("admitted gap log names
+    itself", "registered zero-neighbour gap does not raise", "stale
+    checker is quiet on a genuine gap") deliberately drive the REAL
+    registry's first entry via
+    `next(iter(LIB_MODULES_WITHOUT_SELECTION_COVERAGE))` — they are
+    must-still-work controls proving a real admitted gap behaves
+    correctly, not proof the checker fires on a violation; they depend on
+    today's registry actually holding a genuine, non-stale gap, which
+    `TestLibSelectionCoverageRegistryIsExact` above independently
+    proves."""
 
     def test_unmapped_zero_neighbour_lib_file_fails_closed_with_its_name(
         self,

--- a/tests/test_scripts_selection_coverage_audit.py
+++ b/tests/test_scripts_selection_coverage_audit.py
@@ -1,0 +1,235 @@
+"""Audit: `SCRIPTS_MODULES_WITHOUT_SELECTION_COVERAGE` stays exact (issue #1248).
+
+`scripts/targeted_test_selection.py::SCRIPTS_MODULES_WITHOUT_SELECTION_
+COVERAGE` is the scripts/ twin of `LIB_MODULES_WITHOUT_SELECTION_COVERAGE` —
+a changed `scripts/**/*.py` file whose full neighbour resolution
+(`EXACT_PATH_NEIGHBOURS` + prefix rules + direct candidates that actually
+exist) yields zero test modules now fails closed in `_changed_path_
+neighbours` (an exit-code-2 refusal through `scripts/test.sh`, the same
+shape the lib/-side unmapped-module check already had) unless the path is
+admitted here.
+
+Same non-early-return shape as the lib/ registry: `_changed_path_neighbours`
+does NOT return early for a path registered here — the full resolution still
+runs, so a registration can go stale the moment someone adds a real
+`EXACT_PATH_NEIGHBOURS` entry, a new prefix rule, or a `tests.test_<stem>`
+module for it. This audit proves the registry exact by construction in BOTH
+directions, driving the REAL resolution function (not a reimplementation):
+
+1. every registered path still resolves zero neighbours (else it is a
+   STALE admission and must be removed); and
+2. every real `scripts/**/*.py` file NOT registered here still resolves at
+   least one neighbour (else it is an UNLISTED gap and must be registered,
+   or given real coverage).
+
+This is deliberately test infrastructure (selection machinery), so — per
+`.claude/rules/code-quality.md` § "Never property-test the test machinery"
+— it is a deterministic audit, no generated property. Direction 2 is proven
+for free by `_changed_path_neighbours` itself: an unregistered zero-
+neighbour scripts/ path raises `ValueError` naming the path, so simply
+calling it for every real `scripts/**/*.py` file (inside a `subTest` so
+unittest reports every offender, not just the first) is the check.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import unittest
+from collections.abc import Mapping
+from pathlib import Path
+
+from scripts.targeted_test_selection import (
+    SCRIPTS_MODULES_WITHOUT_SELECTION_COVERAGE,
+    _changed_path_neighbours,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _stale_scripts_selection_gaps(
+    registry: Mapping[str, str],
+    repo_root: Path,
+) -> list[str]:
+    """Return one message per STALE registry entry — a path registered as
+    "resolves zero neighbours" that now resolves real ones. Drives the
+    REAL `_changed_path_neighbours`, never a reimplementation of its logic.
+    """
+    violations: list[str] = []
+    for path in sorted(registry):
+        neighbours = _changed_path_neighbours(path, repo_root)
+        if neighbours:
+            violations.append(
+                f"{path} is registered in "
+                "SCRIPTS_MODULES_WITHOUT_SELECTION_COVERAGE as resolving "
+                f"zero test neighbours, but now resolves: "
+                f"{', '.join(neighbours)}"
+            )
+    return violations
+
+
+class TestScriptsSelectionCoverageRegistryIsExact(unittest.TestCase):
+    """The real registry, verified against the real resolution function."""
+
+    def test_no_registered_gap_is_stale(self) -> None:
+        violations = _stale_scripts_selection_gaps(
+            SCRIPTS_MODULES_WITHOUT_SELECTION_COVERAGE, REPO_ROOT
+        )
+        self.assertEqual(
+            violations,
+            [],
+            "A path registered in SCRIPTS_MODULES_WITHOUT_SELECTION_"
+            "COVERAGE as a zero-neighbour gap now resolves real "
+            "coverage — remove the stale registration:\n  "
+            + "\n  ".join(violations),
+        )
+
+    def test_registry_is_non_empty(self) -> None:
+        """Pin: this audit has something real to check today."""
+        self.assertTrue(SCRIPTS_MODULES_WITHOUT_SELECTION_COVERAGE)
+
+    def test_registered_paths_carry_a_non_empty_rationale(self) -> None:
+        for path, rationale in SCRIPTS_MODULES_WITHOUT_SELECTION_COVERAGE.items():
+            with self.subTest(path=path):
+                self.assertTrue(
+                    rationale.strip(),
+                    f"{path} is registered with an empty rationale",
+                )
+
+    def test_registered_paths_still_exist_on_disk(self) -> None:
+        for path in SCRIPTS_MODULES_WITHOUT_SELECTION_COVERAGE:
+            with self.subTest(path=path):
+                self.assertTrue(
+                    (REPO_ROOT / path).is_file(),
+                    f"registered scripts/ gap does not exist on disk: {path}",
+                )
+
+    def test_every_scripts_module_resolves_or_is_registered(self) -> None:
+        """Tree-walking pin: every real `scripts/**/*.py` file either
+        resolves at least one neighbour, or is admitted in
+        SCRIPTS_MODULES_WITHOUT_SELECTION_COVERAGE. Calls the REAL
+        `_changed_path_neighbours` for every file — an unregistered
+        zero-neighbour file raises `ValueError` naming itself, which
+        `subTest` reports as that file's own failure without stopping the
+        walk (so every offender is named in one run, not just the first).
+        """
+        scripts_files = sorted(
+            path for path in (REPO_ROOT / "scripts").rglob("*.py")
+            if "__pycache__" not in path.parts
+        )
+        self.assertTrue(scripts_files, "expected scripts/**/*.py files to exist")
+
+        for path in scripts_files:
+            relative = path.relative_to(REPO_ROOT).as_posix()
+            with self.subTest(path=relative):
+                _changed_path_neighbours(relative, REPO_ROOT)
+
+
+class TestScriptsSelectionCoverageCheckerTripsOnViolations(unittest.TestCase):
+    """Known-bad self-tests, driven through synthetic registries/paths —
+    never the real registry — so the checker's own correctness is proven
+    independently of today's registrations happening to be clean."""
+
+    def test_unmapped_zero_neighbour_scripts_file_fails_closed_with_its_name(
+        self,
+    ) -> None:
+        """Direction 2 (unlisted gap): a scripts/ path with zero
+        neighbours that is NOT registered must raise, naming itself. The
+        path need not exist on disk — `_changed_path_neighbours` never
+        stats its own target, only candidate test modules (mirrors the
+        lib/-side known-bad self-test's same non-existent-path shape,
+        `test_unmapped_zero_neighbour_lib_file_fails_closed_with_its_name`
+        in tests/test_lib_selection_coverage_audit.py)."""
+        with self.assertRaisesRegex(
+            ValueError,
+            r"scripts/_totally_unmapped_selection_probe\.py",
+        ):
+            _changed_path_neighbours(
+                "scripts/_totally_unmapped_selection_probe.py", REPO_ROOT
+            )
+
+    def test_unmapped_nested_scripts_file_fails_closed_with_its_name(
+        self,
+    ) -> None:
+        """Direction 2, NESTED shape: the top-level probe above
+        (`scripts/_totally_unmapped_selection_probe.py`,
+        `len(path.parts) == 2`) cannot by itself distinguish the real
+        `path.parts[:1] == ("scripts",)` guard from a narrower
+        `len(path.parts) == 2` mutant — every nested scripts/ file in the
+        real tree today (scripts/pipeline_cli/*.py) happens to be either
+        registered or resolved. This probe is nested inside
+        scripts/pipeline_cli/ and unregistered, so only the real
+        first-component guard, not a top-level-only narrowing, can make
+        this raise."""
+        with self.assertRaisesRegex(
+            ValueError,
+            r"scripts/pipeline_cli/_totally_unmapped_nested_probe\.py",
+        ):
+            _changed_path_neighbours(
+                "scripts/pipeline_cli/_totally_unmapped_nested_probe.py",
+                REPO_ROOT,
+            )
+
+    def test_admitted_gap_log_names_the_path_and_its_rationale(
+        self,
+    ) -> None:
+        """The loud admitted-gap stderr line must name BOTH the registered
+        path AND its registered rationale — not merely print SOME line.
+        Captures the real stderr `_changed_path_neighbours` writes for a
+        real registered path, driven through the public entry point."""
+        registered = next(iter(SCRIPTS_MODULES_WITHOUT_SELECTION_COVERAGE))
+        rationale = SCRIPTS_MODULES_WITHOUT_SELECTION_COVERAGE[registered]
+        buffer = io.StringIO()
+
+        with contextlib.redirect_stderr(buffer):
+            result = _changed_path_neighbours(registered, REPO_ROOT)
+
+        self.assertEqual(result, ())
+        emitted = buffer.getvalue()
+        self.assertIn(registered, emitted)
+        self.assertIn(rationale, emitted)
+
+    def test_registered_gap_with_zero_neighbours_does_not_raise(self) -> None:
+        """Must-still-work: a genuinely zero-neighbour path that IS
+        registered proceeds (ambient-only selection), never raises."""
+        registered = next(iter(SCRIPTS_MODULES_WITHOUT_SELECTION_COVERAGE))
+        self.assertEqual(
+            _changed_path_neighbours(registered, REPO_ROOT), ()
+        )
+
+    def test_stale_registration_checker_trips_on_a_planted_stale_entry(
+        self,
+    ) -> None:
+        """Direction 1 (stale admission): a fabricated registry entry
+        naming a scripts/ path with a real EXACT_PATH_NEIGHBOURS mapping
+        (here, scripts/targeted_test_selection.py itself) must be reported
+        as stale, naming the path and what it now resolves to. The real
+        module-level registry is never touched."""
+        fabricated = {
+            "scripts/targeted_test_selection.py": (
+                "synthetic stale entry for self-test"
+            ),
+        }
+
+        violations = _stale_scripts_selection_gaps(fabricated, REPO_ROOT)
+
+        self.assertEqual(len(violations), 1)
+        self.assertIn("scripts/targeted_test_selection.py", violations[0])
+        self.assertIn("tests.test_targeted_test_selection", violations[0])
+
+    def test_stale_registration_checker_is_quiet_on_a_genuine_gap(
+        self,
+    ) -> None:
+        """Must-still-work: a fabricated registry entry that genuinely
+        resolves zero neighbours (an existing real gap) produces no
+        violation."""
+        registered = next(iter(SCRIPTS_MODULES_WITHOUT_SELECTION_COVERAGE))
+        fabricated = {registered: "synthetic rationale for self-test"}
+
+        violations = _stale_scripts_selection_gaps(fabricated, REPO_ROOT)
+
+        self.assertEqual(violations, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_scripts_selection_coverage_audit.py
+++ b/tests/test_scripts_selection_coverage_audit.py
@@ -1,13 +1,13 @@
 """Audit: `SCRIPTS_MODULES_WITHOUT_SELECTION_COVERAGE` stays exact (issue #1248).
 
-`scripts/targeted_test_selection.py::SCRIPTS_MODULES_WITHOUT_SELECTION_
-COVERAGE` is the scripts/ twin of `LIB_MODULES_WITHOUT_SELECTION_COVERAGE` —
-a changed `scripts/**/*.py` file whose full neighbour resolution
+`scripts/targeted_test_selection.py::SCRIPTS_MODULES_WITHOUT_SELECTION_COVERAGE`
+is the scripts/ twin of `LIB_MODULES_WITHOUT_SELECTION_COVERAGE` — a changed
+`scripts/**/*.py` file whose full neighbour resolution
 (`EXACT_PATH_NEIGHBOURS` + prefix rules + direct candidates that actually
-exist) yields zero test modules now fails closed in `_changed_path_
-neighbours` (an exit-code-2 refusal through `scripts/test.sh`, the same
-shape the lib/-side unmapped-module check already had) unless the path is
-admitted here.
+exist) yields zero test modules now fails closed in
+`_changed_path_neighbours` (an exit-code-2 refusal through
+`scripts/test.sh`, the same shape the lib/-side unmapped-module check
+already had) unless the path is admitted here.
 
 Same non-early-return shape as the lib/ registry: `_changed_path_neighbours`
 does NOT return early for a path registered here — the full resolution still
@@ -78,8 +78,8 @@ class TestScriptsSelectionCoverageRegistryIsExact(unittest.TestCase):
         self.assertEqual(
             violations,
             [],
-            "A path registered in SCRIPTS_MODULES_WITHOUT_SELECTION_"
-            "COVERAGE as a zero-neighbour gap now resolves real "
+            "A path registered in SCRIPTS_MODULES_WITHOUT_SELECTION_COVERAGE "
+            "as a zero-neighbour gap now resolves real "
             "coverage — remove the stale registration:\n  "
             + "\n  ".join(violations),
         )
@@ -126,9 +126,19 @@ class TestScriptsSelectionCoverageRegistryIsExact(unittest.TestCase):
 
 
 class TestScriptsSelectionCoverageCheckerTripsOnViolations(unittest.TestCase):
-    """Known-bad self-tests, driven through synthetic registries/paths —
-    never the real registry — so the checker's own correctness is proven
-    independently of today's registrations happening to be clean."""
+    """Known-bad self-tests proving the checker's own correctness, split
+    two ways. The two "fails closed" tests (unmapped top-level / nested
+    scripts/ paths) and the stale-registration trip test drive entirely
+    synthetic paths/registries never present in the real module-level
+    data. The remaining three ("admitted gap log names itself",
+    "registered zero-neighbour gap does not raise", "stale checker is
+    quiet on a genuine gap") deliberately drive the REAL registry's first
+    entry via `next(iter(SCRIPTS_MODULES_WITHOUT_SELECTION_COVERAGE))` —
+    they are must-still-work controls proving a real admitted gap behaves
+    correctly, not proof the checker fires on a violation; they depend on
+    today's registry actually holding a genuine, non-stale gap, which
+    `TestScriptsSelectionCoverageRegistryIsExact` above independently
+    proves."""
 
     def test_unmapped_zero_neighbour_scripts_file_fails_closed_with_its_name(
         self,

--- a/tests/test_web_auth_mode_generated.py
+++ b/tests/test_web_auth_mode_generated.py
@@ -129,15 +129,43 @@ def _evaluate_mode_worlds() -> dict[str, dict[str, object]]:
     on the very flake it is about to fetch. Filtering a DIRECTORY out of a
     ``builtins.path``/``filterSource`` walk means Nix never recurses into
     it at all, so this is not "less likely to race", it is structurally
-    unable to: the walk never calls ``readdir``/``stat`` on anything under
-    ``__pycache__/`` in the first place. Both raw-path references below
-    (the old ``getFlake (toString ./.)`` and the module config's own
-    ``src = ./.;``, which named the same live directory independently) now
-    read the SAME filtered copy, so no live-tree read in this expression
-    is left unfiltered. Nothing about which worlds are evaluated, what the
-    module asserts, or the module's own source (every non-``__pycache__``
-    file is still present, unchanged) is affected -- this only removes a
-    subtree the module never references anyway.
+    unable to race ``__pycache__/`` specifically: the walk never calls
+    ``readdir``/``stat`` on anything under it in the first place (verified
+    empirically, not just argued -- see below). This claim is deliberately
+    narrow: ``builtins.path``'s filter here only excludes ``__pycache__``,
+    so ``.git``, untracked files, and other gitignored-but-locally-churned
+    paths (``.hypothesis/``, ``.nixpkgs-src``, ``result*``) are still
+    copied by the walk and remain a theoretical, unmeasured race surface of
+    the same shape -- not fixed by this change, and not claimed to be. The
+    two raw-path references that named the live directory for the
+    getFlake-triggered directory WALK (the old ``getFlake (toString ./.)``
+    and the module config's own ``src = ./.;``) both now read the filtered
+    ``repoSource`` copy instead. A third raw-path reference remains
+    unfiltered on purpose: ``import ./nix/beets.nix`` below still reads the
+    live tree directly, but it is a single-FILE import, not a directory
+    walk, so it cannot reproduce this race (nothing under it can vanish
+    mid-``readdir`` the way a churning directory's children can) and
+    filtering it would add nothing. Nothing about which worlds are
+    evaluated, what the module asserts, or the module's own source (every
+    non-``__pycache__`` file is still present, unchanged) is affected by
+    the filter itself; realizing the filtered copy as its own store path
+    does mean this eval now does two whole-tree store copies instead of
+    one, not zero extra cost. Measured directly: the unfiltered getFlake's
+    own realized copy is ~80 MB on disk (``du -sh`` on its ``outPath``);
+    forcing just that ``.outPath`` (no module evaluation) ran ~0.2-0.3s
+    when the store already held a matching copy and ~0.3-0.4s when a
+    fresh store name forced a genuine re-walk, so the added copy is on the
+    order of a few tenths of a second and tens of MB on DISK (the Nix
+    store, not the tmpfs test RAM root) -- negligible next to this
+    module's ~20s real wall time with all sixteen worlds, but real, not
+    "nothing else is affected".
+
+    Residual, out of scope here: ``tests/test_nix_module.py`` has FOUR more
+    call sites using the identical ``getFlake (toString ./.)`` shape
+    (lines 410, 631, 1071, and 1774, as of this writing), unfixed by this
+    change -- and that file is ~97% of the nix phase's wall time (issue
+    #1226), so the false-red generator this fix closes here remains live
+    on the heaviest consumer.
     """
     worlds = "\n            ".join(
         f"{world.key} = evaluate {{ {_nix_web_attrs(world)} }};"

--- a/tests/test_web_auth_mode_generated.py
+++ b/tests/test_web_auth_mode_generated.py
@@ -114,6 +114,30 @@ def _evaluate_mode_worlds() -> dict[str, dict[str, object]]:
     in a real phase run. See
     ``tests/test_nix_module.py::_shared_module_worlds_web_auth_matrix_part1``
     for the mechanism and the byte-identical-output evidence.
+
+    Issue #1248: ``builtins.getFlake`` unconditionally walks and NAR-hashes
+    its ENTIRE source directory the moment it is called -- before any
+    output is even referenced -- so pointing it at a bare ``./.`` names
+    this live, possibly-dirty worktree and races any concurrent test
+    worker's Python bytecode cache writes/removals under ``**/__pycache__``
+    (gitignored, never part of the module's real input; a suite run
+    observed this as ``path '.../tests/__pycache__/test_quality_generated.
+    cpython-314.pyc.<n>' does not exist``, a directory-walk read of a file
+    a sibling worker had already renamed away). ``repoSource`` filters that
+    subtree out with a plain ``builtins.path`` -- a Nix builtin, not a
+    nixpkgs helper, so it needs no ``lib`` and has no circular dependency
+    on the very flake it is about to fetch. Filtering a DIRECTORY out of a
+    ``builtins.path``/``filterSource`` walk means Nix never recurses into
+    it at all, so this is not "less likely to race", it is structurally
+    unable to: the walk never calls ``readdir``/``stat`` on anything under
+    ``__pycache__/`` in the first place. Both raw-path references below
+    (the old ``getFlake (toString ./.)`` and the module config's own
+    ``src = ./.;``, which named the same live directory independently) now
+    read the SAME filtered copy, so no live-tree read in this expression
+    is left unfiltered. Nothing about which worlds are evaluated, what the
+    module asserts, or the module's own source (every non-``__pycache__``
+    file is still present, unchanged) is affected -- this only removes a
+    subtree the module never references anyway.
     """
     worlds = "\n            ".join(
         f"{world.key} = evaluate {{ {_nix_web_attrs(world)} }};"
@@ -121,7 +145,18 @@ def _evaluate_mode_worlds() -> dict[str, dict[str, object]]:
     )
     expression = f'''
       let
-        f = builtins.getFlake (toString ./.);
+        repoSource = builtins.path {{
+          path = toString ./.;
+          filter = path: type: baseNameOf path != "__pycache__";
+          name = "cratedigger-nix-eval-source";
+        }};
+        # builtins.path's result carries a store-path context (it tracks
+        # that the string provenance is a store path), and getFlake
+        # refuses a context-carrying argument ("... is not allowed to
+        # refer to a store path"). The directory is already realized on
+        # disk synchronously by builtins.path above, so there is no build
+        # step being skipped -- discarding the context is safe here.
+        f = builtins.getFlake (builtins.unsafeDiscardStringContext (toString repoSource));
         lib = f.inputs.nixpkgs.lib;
         modulePkgs = import f.inputs.nixpkgs {{
           system = builtins.currentSystem;
@@ -137,7 +172,7 @@ def _evaluate_mode_worlds() -> dict[str, dict[str, object]]:
                 ({{ ... }}: {{
                   services.cratedigger = {{
                     enable = true;
-                    src = ./.;
+                    src = repoSource;
                     user = "cratedigger";
                     group = "cratedigger";
                     slskd.apiKeyFile = "/run/secrets/slskd-key";


### PR DESCRIPTION
## Summary

Both items of #1248.

**1 — `scripts/**` under-selected silently.** `_changed_path_neighbours`'s fail-closed check fired only for `path.parts[:1] == ("lib",)`, so a `scripts/` file resolving zero test neighbours returned the ambient-audit-only set with no stderr line and no registry entry demanded — silent under-selection rather than an admitted gap. That is exactly how #1246 item 1's defect survived in `scripts/importer.py` while the PR fixing it was under review.

Measured with the real resolver over every `scripts/**/*.py`: **30 files resolved zero neighbours before, 2 after** — and both survivors are registered admitted gaps. The gap was much wider than the issue stated: `scripts/pipeline_cli/` alone had **19 of 20** files invisible, despite extensive real coverage reached through the package's `__init__.py` re-export surface (the same basename-only miss `lib/dispatch/core.py` had under #1199).

Now `scripts/**` fails closed exactly as `lib/**` does, via a `SCRIPTS_MODULES_WITHOUT_SELECTION_COVERAGE` registry wired through the existing `_assert_no_double_registration`, plus `tests/test_scripts_selection_coverage_audit.py` proving the registry exact in both directions.

**2 — a nix-eval test raced sibling workers' bytecode.** `tests/test_web_auth_mode_generated.py::_evaluate_mode_worlds` called `builtins.getFlake (toString ./.)`, which unconditionally walks and NAR-hashes the entire live worktree — racing a concurrent test worker writing and removing `tests/__pycache__/*.pyc` temp files. It surfaced as an ordinary assertion failure in an unrelated auth-mode property, so it read as a real defect in whatever the PR touched. It cost a gate cycle and a wrong diagnosis during #1246.

Fixed by filtering `__pycache__` out through `builtins.path` before `getFlake` (plus `unsafeDiscardStringContext`, which `getFlake` requires). Not fixed with `PYTHONDONTWRITEBYTECODE=1`: that breaks `test_daily_flake_update.py`'s deliberate bytecode-caching assertion, which is documented in the docstring so the next person doesn't try it.

Refs #1248 (non-closing).

## Kill matrix

Every registry entry was qualified by fault injection — `raise RuntimeError` planted in the module, the claimed neighbour confirmed RED, then reverted.

| Site | Mutant | Test that must go RED | Result |
| --- | --- | --- | --- |
| 10 top-level `scripts/*.py` entries | raise in the covered function | each entry's claimed neighbour | Killed (all 10) |
| `run_library_completeness_census.py` | raise in `publish_...` | `test_library_completeness_snapshot` | Killed; `test_beets_config_startup_entrypoints` confirmed NOT to kill — documented |
| `run_world_model_burst.py` | raise in `build_targets` | `test_world_model_coordinator` | Killed; `test_ephemeral_pg` confirmed NOT to kill — documented |
| 18 `scripts/pipeline_cli/*` entries | raise in each module's `cmd_*` | `tests.test_pipeline_cli` (+ second neighbour where listed) | Killed; `api_mutations.py` is the documented exception, covered via `_post` not its handlers |
| new unregistered `scripts/` file | create one | `test_scripts_selection_coverage_audit` | RED, `ValueError: unmapped scripts module` |
| stale registry entry | plant one | same | RED, both directions |
| nix filter | old vs new expression under a `__pycache__` hammer | — | old 10/20 failures, new 0/20 |

## Reviewer

One independent round, **36 planted mutants**, no functional defects. It re-derived the 30→2 zero-neighbour counts, constructed the fail-closed worlds rather than reading the shipped self-tests, rendered both nix expressions and diffed the JSON (**byte-identical**, 16 worlds), and reproduced the race independently (old 10/20, new 0/20).

Six claim-accuracy findings, all fixed. The significant one repeated the defect the immediately-preceding PR was corrected for: a blanket "verified by grep for a direct `cmd_*` call" comment that was false for `api_mutations.py`, whose six handlers are never called by `tests.test_pipeline_cli` — a mutant in all six survives at exit 0. The entry is still valid (that module's `_post` genuinely is exercised, proven by mutant), but the comment overclaimed where two sibling entries documented the identical shape honestly. Also corrected: a residual undercount (four `getFlake` sites in `tests/test_nix_module.py`, not three), an over-broad "nothing is left unfiltered" claim, a docstring in **both** selection-coverage audits claiming an independence three of six tests do not have, and — pleasingly — identifiers wrapped mid-token inside backticks so `grep SCRIPTS_MODULES_WITHOUT_SELECTION_COVERAGE` returned zero hits in the very rules file that legislates searching prose by the artifact. That last one was then swept systematically, finding 11 further instances in the same author's new content.

## Risk

No production runtime code changes — this is test selection, test infrastructure, and rules. The behavioural change is that `scripts/test.sh` now exits 2 for a `scripts/` path with zero neighbours that is not registered, identical to the `lib/` precedent; deletions never reach the check (`--diff-filter=ACMR`), and `run_tests.sh` / `run_final_gate.sh` / the daily-gate runners do not use targeted selection.

Known and stated: the nix fix realizes two whole-tree store copies per eval instead of one (~80 MB, ~0.2-0.4s, on disk rather than the tmpfs RAM root); `.git`, untracked files and other churned gitignored paths remain inside the walk, so the guarantee is specifically "cannot race `__pycache__`", not "cannot race anything"; and four identical `getFlake` call sites remain in `tests/test_nix_module.py`, unfixed and recorded in the docstring. Both typing-ratchet baselines are byte-identical to `origin/main`.
