### PR TITLE
feat(nix): support private bridge web listeners

### DIFF
--- a/docs/nixos-module.md
+++ b/docs/nixos-module.md
@@ -4,8 +4,8 @@ The upstream module lives in this repo at `nix/module.nix`, exposed via
 `nixosModules.default` in `flake.nix`. It is generic and homelab-agnostic:
 every secret is a `*File` path, the DB is a `dsn` string, and there are no
 sops/nspawn or site-specific public-proxy assumptions. The module does own its
-loopback nginx authentication gateway; the consumer supplies the public HTTPS
-edge that forwards to it.
+nginx authentication gateway, which defaults to loopback listeners; the
+consumer supplies the HTTPS edge that forwards to it.
 
 The flake export pins the module's package set to **Cratedigger's own
 flake.lock**. The application environment is built from the nixpkgs revision
@@ -61,9 +61,10 @@ upstream module and adds:
 | `redis.{enable,host,port,maxmemory}` | enabled, `127.0.0.1:6379`, `2gb` | App-owned local Redis server for the pipeline peer cache and web metadata cache. Uses `allkeys-lru`. |
 | `peerCache.{ttlSeconds,speedTtlSeconds,redisConnectTimeoutMs,redisOperationTimeoutMs}` | 7d, 24h, 200ms, 100ms | Redis TTL and timeout settings rendered into `[Peer Cache]`. |
 | `beets.validation.{enable,distanceThreshold,stagingDir,trackingFile,verifiedLosslessTarget}` | sensible defaults | Beets validation config. |
-| `web.enable` | `false` | Enable the Unix-only web backend and module-owned loopback nginx gateway. Exactly one of `basicAuthFile`, `enableInsecure = true`, or `externalAuth = true` is then required. |
+| `web.enable` | `false` | Enable the Unix-only web backend and module-owned nginx gateway. The gateway defaults to host loopback only. Exactly one of `basicAuthFile`, `enableInsecure = true`, or `externalAuth = true` is then required. |
 | `web.hostName` | `null` | Lowercase canonical public DNS hostname. Required when web is enabled; it defines the fixed `https://` browser origin and exact gateway vhost. IP literals are rejected. |
-| `web.gatewayPort` | `8086` | Loopback-only nginx gateway port. The public HTTPS reverse proxy forwards here; this is not a Python application listener. |
+| `web.gatewayPort` | `8086` | Module-owned nginx gateway port. The HTTPS reverse proxy forwards here; this is not a Python application listener. |
+| `web.gatewayAddresses` | IPv4 loopback plus IPv6 loopback when enabled | Non-empty nginx listener-address set for `web.gatewayPort`. Keep the default for a same-host proxy. A deployment may explicitly add a private bridge address for a sandboxed proxy, but then owns the firewall and network-perimeter restriction for that address. |
 | `web.accessGroup` | `"cratedigger-web"` | Dedicated group authorized to connect to the web backend Unix socket. This grants complete HTTP/API authority, not Basic-password-file access or unrelated CLI authority. Known privileged or overlapping authority groups are rejected. |
 | `web.basicAuthFile` | `null` | Absolute runtime `htpasswd` file outside `/nix/store`. Basic mode requires a root-owned, non-empty `root:<nginx-group>` `0440` target readable by nginx and denied to the application/non-nginx socket users. |
 | `web.enableInsecure` | `false` | Explicitly disable browser authentication while retaining the gateway, Unix socket, canonical-origin checks, and all other request-security controls. Mutually exclusive with `basicAuthFile` and `externalAuth`. |
@@ -123,7 +124,7 @@ The production web path has three separate listeners/authorities:
 ```text
 browser
   -> https://music.example.net (operator-owned DNS, ACME, and TLS proxy)
-  -> 127.0.0.1:<web.gatewayPort> (module-owned nginx auth gateway)
+  -> <web.gatewayAddresses>:<web.gatewayPort> (module-owned nginx auth gateway)
   -> /run/cratedigger-web/web.sock (systemd-owned, root:<web.accessGroup> 0660)
   -> web/server.py (one inherited Unix listener; no production TCP listener)
 
@@ -150,10 +151,14 @@ release IDs and master IDs share the integer namespace; after the mirror
 establishes the master, the normal post-widen durable-cache read may return
 from cache.
 
-The outer HTTPS proxy and the loopback gateway may be server blocks in the
-same nginx process, but they remain distinct listeners. Configure the outer
-proxy to forward only to `127.0.0.1:<web.gatewayPort>`. Do not publish that
-port, expose the Unix socket, or recreate the retired Python port `8085`.
+The outer HTTPS proxy and the default loopback gateway may be server blocks in
+the same nginx process, but they remain distinct listeners. With the default
+`web.gatewayAddresses`, configure the outer proxy to forward only to
+`127.0.0.1:<web.gatewayPort>`. A sandboxed proxy may instead require an
+explicit private bridge address; restrict that listener to the bridge at the
+deployment firewall and do not add a routable host address. Never publish the
+gateway port, expose the Unix socket, or recreate the retired Python port
+`8085`.
 `web.hostName` is the canonical public hostname in both modes; the application
 uses exactly `https://<web.hostName>` for mutation provenance rather than
 trusting `Host` or any forwarded-host header.
@@ -194,8 +199,10 @@ instead of logging a `[CRITICAL]` warning that authentication is absent.
 
 The deployment contract you are asserting:
 
-- Your proxy runs on the same host. The module gateway listens on loopback
-  only, so nothing can reach it from another machine without host access.
+- With default `web.gatewayAddresses`, your proxy runs on the same host and
+  nothing can reach the loopback gateway from another machine. A sandboxed
+  same-host proxy may instead use an explicitly configured private bridge
+  listener; the deployment firewall must admit only that bridge.
 - Your proxy forwards the canonical `web.hostName` as the `Host` header. A
   non-canonical Host is rejected by the module's own default vhost.
 - You decide whether `/healthz` stays anonymous at your layer. The module's
@@ -345,8 +352,8 @@ and service dependencies may still prevent the web process from starting.
 
 ### Explicit insecure mode
 
-Insecure mode removes only nginx's Basic challenge. It keeps the loopback
-gateway, Unix backend, canonical Host/origin, header reconstruction,
+Insecure mode removes only nginx's Basic challenge. It keeps the module-owned
+gateway on the configured addresses, Unix backend, canonical Host/origin, header reconstruction,
 same-origin mutation checks, CORS removal, response isolation, request-channel
 classification, and destructive intent gates. Every application start logs
 `Authentication is disabled for this Cratedigger instance.` at `CRITICAL`, and
@@ -822,8 +829,8 @@ See [`examples/cratedigger.nix`](../examples/cratedigger.nix) for the full worke
 - `cratedigger-web.service` — long-running Unix-only web backend. It requires
   the socket and adopts exactly its one inherited fd; a direct start activates
   the same socket rather than creating a bypass listener.
-- `nginx.service` — when web is enabled, the module adds an exact-host
-  loopback gateway plus a default-reject vhost, joins nginx only to the
+- `nginx.service` — when web is enabled, the module adds an exact-host gateway
+  on `web.gatewayAddresses` plus a default-reject vhost, joins nginx only to the
   dedicated web access group, and validates Basic runtime material before
   start/reload. The module requires nginx reload support so policy and
   credential changes validate before HUP without stopping unrelated vhosts.

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -137,17 +137,12 @@
       webBasicAuthPathSegments
     && cfg.web.basicAuthFile != "/nix/store"
     && !lib.hasPrefix "/nix/store/" cfg.web.basicAuthFile;
-  webGatewayListen =
-    [
-      {
-        addr = "127.0.0.1";
-        port = cfg.web.gatewayPort;
-      }
-    ]
-    ++ optional config.networking.enableIPv6 {
-      addr = "[::1]";
+  webGatewayListen = map
+    (addr: {
+      inherit addr;
       port = cfg.web.gatewayPort;
-    };
+    })
+    cfg.web.gatewayAddresses;
   webProxyRequestConfig = ''
     proxy_http_version 1.1;
     proxy_pass_request_headers off;
@@ -1705,8 +1700,21 @@ in {
         type = types.port;
         default = 8086;
         description = ''
-          Loopback-only port for the module-owned nginx authentication
-          gateway. The public TLS reverse proxy should forward to this port.
+          Port for the module-owned nginx authentication gateway. Listener
+          addresses are controlled by gatewayAddresses; the public TLS reverse
+          proxy should forward to this port.
+        '';
+      };
+      gatewayAddresses = mkOption {
+        type = types.nonEmptyListOf types.nonEmptyStr;
+        default = ["127.0.0.1"] ++ optional config.networking.enableIPv6 "[::1]";
+        defaultText = lib.literalExpression ''["127.0.0.1"] ++ lib.optional config.networking.enableIPv6 "[::1]"'';
+        description = ''
+          Addresses for the module-owned nginx authentication gateway. The
+          default is loopback-only. A deployment may add an address belonging
+          to a private container bridge when a separately isolated ingress
+          sidecar must reach the gateway; perimeter firewall policy remains
+          deployment-owned.
         '';
       };
       accessGroup = mkOption {

--- a/nix/tests/module-vm.nix
+++ b/nix/tests/module-vm.nix
@@ -748,6 +748,7 @@ pkgs.testers.nixosTest {
         enable = true;
         hostName = "music.vm.test";
         gatewayPort = 18086;
+        gatewayAddresses = ["127.0.0.1" "127.0.0.2" "[::1]"];
         basicAuthFile = "/run/cratedigger-test-auth/basic.htpasswd";
       };
       # Enable the YouTube-rescue ingest worker so its unit is rendered.
@@ -2381,7 +2382,8 @@ pkgs.testers.nixosTest {
     )
     machine.succeed(
         "actual=$(ss -H -ltn 'sport = :18086' | awk '{print $4}' | sort); "
-        "expected=$(printf '%s\\n' '127.0.0.1:18086' '[::1]:18086' | sort); "
+        "expected=$(printf '%s\\n' '127.0.0.1:18086' '127.0.0.2:18086' "
+        "'[::1]:18086' | sort); "
         "test \"$actual\" = \"$expected\""
     )
     machine.fail("ss -H -ltn 'sport = :8085' | grep -q .")
@@ -4003,7 +4005,8 @@ pkgs.testers.nixosTest {
             "actual=$(ss -H -ltn 'sport = :18086' "
             "| awk '{print $4}' | sort); "
             "expected=$(printf '%s\\n' "
-            "'127.0.0.1:18086' '[::1]:18086' | sort); "
+            "'127.0.0.1:18086' '127.0.0.2:18086' "
+            "'[::1]:18086' | sort); "
             "test \"$actual\" = \"$expected\""
         )
         machine.fail("ss -H -ltn 'sport = :8085' | grep -q .")

--- a/tests/test_nix_module.py
+++ b/tests/test_nix_module.py
@@ -2030,12 +2030,17 @@ class TestWebAuthenticationModuleContract(unittest.TestCase):
             text,
         )
 
-    def test_gateway_is_exact_host_loopback_and_default_reject(self) -> None:
+    def test_gateway_uses_configured_addresses_and_default_reject(self) -> None:
         text = _nix_source(MODULE_NIX)
         self.assertNotIn("cfg.web.port", text)
         self.assertIn("services.nginx.virtualHosts", text)
-        self.assertIn('addr = "127.0.0.1";', text)
-        self.assertIn('addr = "[::1]";', text)
+        self.assertIn("webGatewayListen = map", text)
+        self.assertIn("inherit addr;", text)
+        self.assertIn("cfg.web.gatewayAddresses;", text)
+        self.assertIn(
+            'default = ["127.0.0.1"] ++ optional config.networking.enableIPv6 "[::1]";',
+            text,
+        )
         self.assertIn("port = cfg.web.gatewayPort;", text)
         self.assertIn("serverName = webHostName;", text)
         self.assertIn("default = true;", text)


### PR DESCRIPTION
## Summary

- allow deployments to select a non-empty set of nginx gateway listener addresses
- preserve loopback-only defaults while supporting a private container bridge ingress
- extend the module VM to prove the exact configured listener set

## Fault injection

- Removing the option reproduces the RED unknown-option evaluation failure; retaining the old hard-coded loopback listener is killed by the module VM exact socket-set assertion.

## Reviewer

- Review should mutate the address mapper to drop the second IPv4 listener and to widen one listener to 0.0.0.0; the exact socket-set assertion must kill both.

## Risk

- Defaults are unchanged. Only deployments explicitly setting gatewayAddresses gain a non-loopback listener, and perimeter firewall policy remains deployment-owned.
