### PR TITLE
fix(#1261 follow-up): drop enhanced-CD video-marker position rows from Discogs manifests

### DIFF
--- a/docs/pipeline-db-schema.md
+++ b/docs/pipeline-db-schema.md
@@ -1121,7 +1121,12 @@ the release positions its other tracks; an empty position WITH a
 duration is ambiguous and survives (the measured mirror rule in
 `lib/library_completeness.py`), an all-unpositioned tracklist keeps
 every row, and a nested `sub_tracks` index parent is never treated as a
-heading. Bare vinyl side letters (`A`/`B`) parse as track 1 of their
+heading. Video-marker positions (`Video`, `Video 1` — enhanced-CD bonus
+rows, request 5936's shape) drop as non-audio unless every non-heading
+row is video-marked: a whole-release video pressing's content is
+rip-real (the Placebo `ignore_video_tracks` precedent,
+`docs/plans/2026-05-12-001-feat-video-track-wrong-matches-plan.md`).
+Bare vinyl side letters (`A`/`B`) parse as track 1 of their
 side, consistent with the existing `A1`/`B1` side-as-disc convention;
 `1A`-style and trailing-dot (`1.`) positions parse instead of falling
 to the track-0 sentinel.

--- a/lib/discogs_positions.py
+++ b/lib/discogs_positions.py
@@ -222,11 +222,17 @@ def normalize_release_tracks(
 
     sub_bases = {base for _, base, sub, _, _, _, _ in parsed if sub is not None}
     any_positioned = any(position for position, _, _, _, _, _, _ in parsed)
-    non_header_bases = [
-        base for _, base, _, _, _, _, is_header in parsed if not is_header
+    # The all-video vote is cast by every row the heading rule does NOT
+    # drop — including a nested sub_tracks index parent (real audio) and
+    # ambiguous empty-position rows — so one surviving non-video row is
+    # enough to make video markers droppable phantoms.
+    voting_bases = [
+        base
+        for _, base, _, _, _, has_children, is_header in parsed
+        if not (is_header and any_positioned and not has_children)
     ]
-    all_video = bool(non_header_bases) and all(
-        VIDEO_POSITION_RE.match(base) for base in non_header_bases
+    all_video = bool(voting_bases) and all(
+        VIDEO_POSITION_RE.match(base) for base in voting_bases
     )
 
     ordered: list[dict[str, object] | _PositionGroup] = []

--- a/lib/discogs_positions.py
+++ b/lib/discogs_positions.py
@@ -32,6 +32,10 @@ SUB_POSITION_RE = re.compile(r"^(.+)\.(\d+)$")
 # Discogs hidden-track placeholder titles: "(silence)", "[silence]",
 # bare "silence". These never name an audio file in a rip.
 SILENCE_TITLE_RE = re.compile(r"^[\[(]?\s*silence\s*[\])]?$", re.IGNORECASE)
+# Enhanced-CD bonus-video POSITION markers ("Video", "Video 1", "Video2",
+# request 5936's live shape): non-audio rows no rip has an audio file
+# for. Positions only — titles are never consulted.
+VIDEO_POSITION_RE = re.compile(r"^video\s*\d*$", re.IGNORECASE)
 
 
 def parse_duration(duration_str: str) -> float | None:
@@ -176,12 +180,22 @@ def normalize_release_tracks(
     key values and matches the measured mirror rule in
     ``lib/library_completeness.py`` exactly: an empty position whose
     duration is present OR whose duration/position key is ABSENT is
-    ambiguous and is kept; a release that
-    positions NOTHING has no heading signal and keeps every row, and a
-    row carrying nested ``sub_tracks`` is an index parent, never a
-    heading (the deployed mirror has not been observed emitting nested
-    ``sub_tracks`` — that carve-out is fail-closed legislation, as in
-    the sibling census module). Positions whose base parses to no known
+    ambiguous and is kept; a release that positions NOTHING has no
+    heading signal and keeps every row; and a row carrying nested
+    ``sub_tracks`` is an index parent, never a heading (the deployed
+    mirror has not been observed emitting nested ``sub_tracks`` — that
+    carve-out is fail-closed legislation, as in the sibling census
+    module).
+
+    Video-marker positions (``Video``, ``Video 1``) are enhanced-CD
+    bonus rows — non-audio, dropped like headings — UNLESS every
+    non-heading row on the release is video-marked: a whole-release
+    video pressing's content IS what rips contain (the Placebo
+    ``ignore_video_tracks`` precedent,
+    ``docs/plans/2026-05-12-001-feat-video-track-wrong-matches-plan.md``),
+    so an all-video tracklist keeps every row.
+
+    Positions whose base parses to no known
     grammar share the ``(1, 0)`` sentinel; their rows survive with
     correct COUNT, but their relative order under ``album_tracks``'s
     ``(disc_number, track_number)`` read ordering is not defined. Raw
@@ -208,12 +222,20 @@ def normalize_release_tracks(
 
     sub_bases = {base for _, base, sub, _, _, _, _ in parsed if sub is not None}
     any_positioned = any(position for position, _, _, _, _, _, _ in parsed)
+    non_header_bases = [
+        base for _, base, _, _, _, _, is_header in parsed if not is_header
+    ]
+    all_video = bool(non_header_bases) and all(
+        VIDEO_POSITION_RE.match(base) for base in non_header_bases
+    )
 
     ordered: list[dict[str, object] | _PositionGroup] = []
     groups: dict[str, _PositionGroup] = {}
     for position, base, sub, title, duration, has_children, is_header in parsed:
         length = parse_duration(duration)
         if is_header and any_positioned and not has_children:
+            continue
+        if not all_video and VIDEO_POSITION_RE.match(base):
             continue
         member_base = base if sub is not None else position
         if member_base in sub_bases:

--- a/tests/test_discogs_api.py
+++ b/tests/test_discogs_api.py
@@ -528,6 +528,57 @@ class TestGetReleaseSubPositionTracks(unittest.TestCase):
         ])
         self.assertEqual(len(tracks), 2)
 
+    def test_index_parent_vote_keeps_video_rows_droppable(self):
+        # A nested sub_tracks index parent survives the heading rule as
+        # real audio, so it must VOTE in the all-video decision: this
+        # release has audio, and the phantom video row drops.
+        tracks = self._tracks(910024, [
+            {"position": "", "title": "Medley", "duration": "", "sub_tracks": [
+                {"position": "2.1", "title": "Part One", "duration": "1:00"},
+            ]},
+            {"position": "Video", "title": "Bonus Clip", "duration": "4:00"},
+        ])
+        self.assertEqual(len(tracks), 1)
+        only = tracks[0]
+        assert _is_dict(only)
+        self.assertEqual(only["title"], "Medley")
+
+    def test_heading_plus_all_video_release_keeps_video_rows(self):
+        # A dropped section heading casts no vote: the remaining rows
+        # are all video, so the whole-release guard preserves them
+        # (never an empty manifest).
+        tracks = self._tracks(910025, [
+            {"position": "", "title": "Bonus Section", "duration": ""},
+            {"position": "Video", "title": "Clip", "duration": "4:00"},
+        ])
+        self.assertEqual(len(tracks), 1)
+        only = tracks[0]
+        assert _is_dict(only)
+        self.assertEqual(only["title"], "Clip")
+
+    def test_video_like_positions_are_not_markers(self):
+        # The marker grammar is anchored: positions merely CONTAINING
+        # the word survive (they fall to the (1, 0) sentinel but are
+        # never dropped).
+        tracks = self._tracks(910026, [
+            {"position": "1", "title": "Song", "duration": "3:00"},
+            {"position": "Videos", "title": "Kept One", "duration": "2:00"},
+            {"position": "DVD Video", "title": "Kept Two", "duration": "2:00"},
+            {"position": "Video 1-2", "title": "Kept Three", "duration": "2:00"},
+        ])
+        self.assertEqual(len(tracks), 4)
+
+    def test_video_sub_positions_drop_before_grouping(self):
+        # 'Video.1'/'Video.2' bases match the marker too; on a mixed
+        # release they drop before the grouping pass, leaving no phantom
+        # group behind.
+        tracks = self._tracks(910027, [
+            {"position": "1", "title": "Song", "duration": "3:00"},
+            {"position": "Video.1", "title": "Clip A", "duration": "1:00"},
+            {"position": "Video.2", "title": "Clip B", "duration": "1:00"},
+        ])
+        self.assertEqual(len(tracks), 1)
+
     def test_video_in_title_never_drops_a_row(self):
         # Only the POSITION grammar decides; titles are never consulted.
         tracks = self._tracks(910023, [

--- a/tests/test_discogs_api.py
+++ b/tests/test_discogs_api.py
@@ -497,6 +497,45 @@ class TestGetReleaseSubPositionTracks(unittest.TestCase):
         ]
         self.assertEqual(numbers, [(1, 1), (1, 2), (2, 1), (1, 1)])
 
+    def test_video_position_row_is_dropped_from_mixed_release(self):
+        # The live 5936 shape (Discogs 4345679): an enhanced-CD bonus
+        # video carries a literal "Video" position; no audio rip has a
+        # file for it, so it must not count against the audio gate.
+        tracks = self._tracks(910020, [
+            {"position": "1", "title": "Opener", "duration": "3:00"},
+            {"position": "2", "title": "Closer", "duration": "3:00"},
+            {"position": "Video", "title": "Bonus Clip", "duration": "4:00"},
+        ])
+        self.assertEqual(len(tracks), 2)
+        titles = [t["title"] for t in tracks if _is_dict(t)]
+        self.assertEqual(titles, ["Opener", "Closer"])
+
+    def test_numbered_video_positions_drop_too(self):
+        tracks = self._tracks(910021, [
+            {"position": "1", "title": "Song", "duration": "3:00"},
+            {"position": "Video 1", "title": "Clip One", "duration": "1:00"},
+            {"position": "Video2", "title": "Clip Two", "duration": "1:00"},
+        ])
+        self.assertEqual(len(tracks), 1)
+
+    def test_whole_release_video_positions_are_preserved(self):
+        # The Placebo precedent (docs/plans/2026-05-12-001): a release
+        # whose content IS video is rip-real — its files exist in rips,
+        # so an all-video tracklist keeps every row.
+        tracks = self._tracks(910022, [
+            {"position": "Video 1", "title": "Part One", "duration": "20:00"},
+            {"position": "Video 2", "title": "Part Two", "duration": "20:00"},
+        ])
+        self.assertEqual(len(tracks), 2)
+
+    def test_video_in_title_never_drops_a_row(self):
+        # Only the POSITION grammar decides; titles are never consulted.
+        tracks = self._tracks(910023, [
+            {"position": "1", "title": "Video Killed the Radio Star", "duration": "3:00"},
+            {"position": "2", "title": "Closer", "duration": "3:00"},
+        ])
+        self.assertEqual(len(tracks), 2)
+
     def test_flat_tracklists_pass_through_unchanged(self):
         tracks = self._tracks(910005, [
             {"position": "1", "title": "Airbag", "duration": "4:44"},

--- a/tests/test_discogs_api_generated.py
+++ b/tests/test_discogs_api_generated.py
@@ -30,7 +30,9 @@ run instead of duplicating its position, with its title authoritative
 and its duration, when present, replacing the children's sum;
 empty-position-AND-empty-duration heading rows are dropped exactly when
 some other row is positioned (an all-unpositioned tracklist keeps every
-row, and an empty position with a duration survives).
+row, and an empty position with a duration survives); video-marker
+positions drop as non-audio unless every non-heading row is
+video-marked (a whole-release video pressing keeps all rows).
 
 **P2 — flat tracklists are untouched.** The no-sub-position subset of
 P1, kept as an explicitly named law: normalization must never reshape an
@@ -76,6 +78,7 @@ class _FlatSlot:
     disc: int
     track: int
     entry: Entry
+    is_video: bool = False
 
 
 @dataclass(frozen=True)
@@ -148,7 +151,17 @@ def worlds(draw: st.DrawFn) -> World:
     wire: list[tuple[str, Entry]] = []
     for index in range(count):
         number = index + 1
-        kind = draw(st.sampled_from(("flat", "flat_dup", "sub", "sub_parent")))
+        kind = draw(st.sampled_from(
+            ("flat", "flat_dup", "sub", "sub_parent", "video"),
+        ))
+        if kind == "video":
+            position = draw(st.sampled_from(
+                ("Video", f"Video {number}", f"Video{number}"),
+            ))
+            entry = draw(_entries())
+            wire.append((position, entry))
+            slots.append(_FlatSlot(position, 1, 0, entry, is_video=True))
+            continue
         if kind in ("flat", "flat_dup"):
             position, disc, track = draw(st.sampled_from((
                 (str(number), 1, number),
@@ -185,17 +198,28 @@ def worlds(draw: st.DrawFn) -> World:
             )
 
     any_positioned = any(position for position, _ in wire)
+
+    def _is_heading(slot: _FlatSlot) -> bool:
+        return not slot.position and not slot.entry.duration_text
+
+    non_heading_flats = [
+        s for s in slots if isinstance(s, _FlatSlot) and not _is_heading(s)
+    ]
+    all_video = (
+        bool(non_heading_flats)
+        and not any(isinstance(s, _MergedSlot) for s in slots)
+        and all(s.is_video for s in non_heading_flats)
+    )
+
     expected: list[tuple[int, int, str, float | None]] = []
     for slot in slots:
         if isinstance(slot, _MergedSlot):
             expected.append(slot.row)
             continue
-        if (
-            not slot.position
-            and not slot.entry.duration_text
-            and any_positioned
-        ):
+        if _is_heading(slot) and any_positioned:
             continue  # heading row — dropped
+        if slot.is_video and not all_video:
+            continue  # enhanced-CD bonus video row — dropped
         expected.append(
             (slot.disc, slot.track, slot.entry.title, slot.entry.duration_seconds),
         )
@@ -275,6 +299,25 @@ _PARENT_TOTAL_PIN = World(
     expected=((1, 10, "Suite", 480),),
 )
 
+_VIDEO_MIXED_PIN = World(
+    wire=(
+        ("1", Entry("Opener", "3:00", 180)),
+        ("Video", Entry("Bonus Clip", "4:00", 240)),
+    ),
+    expected=((1, 1, "Opener", 180),),
+)
+
+_ALL_VIDEO_PIN = World(
+    wire=(
+        ("Video 1", Entry("Part One", "20:00", 1200)),
+        ("Video 2", Entry("Part Two", "20:00", 1200)),
+    ),
+    expected=(
+        (1, 0, "Part One", 1200),
+        (1, 0, "Part Two", 1200),
+    ),
+)
+
 _HEADING_PIN = World(
     wire=(
         ("", Entry("Alpha", "", None)),
@@ -311,6 +354,8 @@ class TestNormalizeReleaseTracksProperties(unittest.TestCase):
     @example(_HEADING_PIN)
     @example(_ALL_UNPOSITIONED_PIN)
     @example(_PARENT_TOTAL_PIN)
+    @example(_VIDEO_MIXED_PIN)
+    @example(_ALL_VIDEO_PIN)
     def test_normalizer_emits_exactly_the_spec_rows(self, world: World):
         self.assertEqual(
             _to_rows(world), _spec_rows(world),

--- a/tests/test_discogs_api_generated.py
+++ b/tests/test_discogs_api_generated.py
@@ -42,9 +42,15 @@ Known limits (deliberate): the placeholder-title alphabet here is the
 exact marker list, so these worlds cannot distinguish production's
 anchored ``SILENCE_TITLE_RE`` from a substring check — the deterministic
 pin ``test_title_containing_silence_is_not_a_placeholder`` owns that
-axis; and sub-parent rows are always emitted immediately before their
+axis; sub-parent rows are always emitted immediately before their
 run, so parent-position independence is owned by the deterministic pin
-``test_parent_after_subs_still_titles_the_group``.
+``test_parent_after_subs_still_titles_the_group``; and video positions
+are drawn from the marker literals only — regex anchoring
+(``test_video_like_positions_are_not_markers``), video sub-positions
+(``test_video_sub_positions_drop_before_grouping``), and the nested
+``sub_tracks`` index-parent vote
+(``test_index_parent_vote_keeps_video_rows_droppable``) are owned by
+deterministic pins.
 """
 
 from __future__ import annotations
@@ -318,6 +324,14 @@ _ALL_VIDEO_PIN = World(
     ),
 )
 
+_HEADING_PLUS_ALL_VIDEO_PIN = World(
+    wire=(
+        ("", Entry("Bonus Section", "", None)),
+        ("Video", Entry("Clip", "4:00", 240)),
+    ),
+    expected=((1, 0, "Clip", 240),),
+)
+
 _HEADING_PIN = World(
     wire=(
         ("", Entry("Alpha", "", None)),
@@ -356,6 +370,7 @@ class TestNormalizeReleaseTracksProperties(unittest.TestCase):
     @example(_PARENT_TOTAL_PIN)
     @example(_VIDEO_MIXED_PIN)
     @example(_ALL_VIDEO_PIN)
+    @example(_HEADING_PLUS_ALL_VIDEO_PIN)
     def test_normalizer_emits_exactly_the_spec_rows(self, world: World):
         self.assertEqual(
             _to_rows(world), _spec_rows(world),


### PR DESCRIPTION
Follow-up to #1262, per operator request — closes the `"Video"`-position residual recorded on #1261.

## What

Request 5936's Discogs tracklist (release 4345679) carries a literal `Video` position row — an enhanced-CD bonus video no audio rip has a file for — leaving its manifest one phantom track over every real copy: the same count-gate class #1262 fixed, in a fourth flavor. `VIDEO_POSITION_RE` (`Video`, `Video 1`, `Video2`; matched on the split position BASE, never the title) now drops such rows as non-audio — **unless every row surviving the heading rule is video-marked**: a whole-release video pressing's content IS what rips contain, honoring the Placebo `ignore_video_tracks` precedent (`docs/plans/2026-05-12-001-feat-video-track-wrong-matches-plan.md`).

## Live population

One wanted request (5936, verified: 10 `album_tracks` rows for a 9-audio-track disc, the `Video` row landing at the `(1,0)` sentinel with a duplicated title). Backfill: the same one-shot shape as #1262 (re-fetch + `search-plan regenerate`) for this single request after deploy.

## Tests

Pins: the live 5936 mixed shape, numbered variants, the all-video guard, regex anchoring (`Videos`/`DVD Video`/`Video 1-2` survive), title-never-consulted ("Video Killed the Radio Star"), video sub-positions dropping before grouping, the index-parent vote, and the heading+all-video world (never an empty manifest). Generated worlds gain a video flat kind with a structural all-video oracle; both shapes plus the heading+all-video world pinned as P1 `@example`s. Axes the strategy cannot reach are declared in the generated module's Known limits with their deterministic owners.

## Fault injection

Combined reader+runner review (single agent, small-diff carve-out): 10 mutants — 3 survivors, every one fixed-and-killed in the review round: the all-video vote was fail-open for nested `sub_tracks` index parents (M8 — production fix: the vote now excludes exactly the rows the heading rule drops); the heading+all-video world was a gating-tier-only kill (M5 — now a deterministic pin + `@example`); regex anchoring was unpatrolled (M4a — near-miss pin). One survivor proven an equivalent mutant by 1,463-world brute force (`bool(voting_bases)` clause — defensive only, not a tested clause). The reviewer also proved the drop can never empty a manifest that had audio rows (same brute-force sweep), and that `test_video_in_title_never_drops_a_row` owns the substring-title mutant specifically (M3b sole kill).

## Known residual (stated, not fixed here)

The deployed Beets Discogs plugin has no video handling (`ignore_video_tracks` is MB-only), so beets validation still sees 10 target tracks for release 4345679 while our manifest now counts 9 — 5936 may move from "never enqueued" to "downloaded, judged at distance against a 10-track candidate". If its downloads start rejecting on distance, that's the beets-side half of this class and gets its own look.

## Rule D

Affected live population: exactly one wanted request (the vacuous-case population query is the cohort scan in #1261 — 5936 was the only `Video`-position release among 28). Browse display for such releases drops the phantom row through an unchanged renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
