### PR TITLE
fix(#1266): line-insensitive vulture freshness; node-replacement drift DOMs; exact 503 pins

### DIFF
--- a/docs/dead-code.md
+++ b/docs/dead-code.md
@@ -31,10 +31,15 @@ The whitelist at `tools/vulture/whitelist.py` masks the known aggregate
 false positives on main (msgspec Struct fields, beets ImportSession overrides,
 route handler dispatch, SQL DictRow attribute access). The default command
 regenerates Vulture's raw whitelist at a fixed confidence of 60 and requires
-the committed non-comment lines to match that output exactly. A deleted,
-renamed, moved, or additional candidate therefore makes the baseline stale;
-this also prevents a same-name candidate elsewhere from hiding behind an old
-name-based Vulture exception.
+the committed entries to match that output as a SORTED SET over identifier +
+kind + file — line numbers in the trailing `(path:line)` comments are NOT
+compared (#1266 item 1: an edit above a whitelisted site used to break the
+gate with a pure line-number delta; a within-file move now passes). A
+deleted, renamed, additional, or cross-FILE-moved candidate still makes the
+baseline stale; the retained file attribution is what prevents a same-name
+candidate elsewhere from hiding behind an old name-based Vulture exception.
+The committed line comments are human-facing only and refresh whenever the
+baseline is regenerated.
 `--confidence` changes only the ordinary new-candidate scan; `--baseline`
 deliberately omits both the committed whitelist and this freshness check.
 

--- a/docs/dead-code.md
+++ b/docs/dead-code.md
@@ -31,15 +31,15 @@ The whitelist at `tools/vulture/whitelist.py` masks the known aggregate
 false positives on main (msgspec Struct fields, beets ImportSession overrides,
 route handler dispatch, SQL DictRow attribute access). The default command
 regenerates Vulture's raw whitelist at a fixed confidence of 60 and requires
-the committed entries to match that output as a SORTED SET over identifier +
-kind + file — line numbers in the trailing `(path:line)` comments are NOT
+the committed entries to match that output as a sorted MULTISET over
+identifier + kind + file (duplicate occurrences are counted) — line numbers in the trailing `(path:line)` comments are NOT
 compared (#1266 item 1: an edit above a whitelisted site used to break the
 gate with a pure line-number delta; a within-file move now passes). A
 deleted, renamed, additional, or cross-FILE-moved candidate still makes the
 baseline stale; the retained file attribution is what prevents a same-name
 candidate elsewhere from hiding behind an old name-based Vulture exception.
-The committed line comments are human-facing only and refresh whenever the
-baseline is regenerated.
+The line NUMBERS in those comments are human-facing only and refresh
+whenever the baseline is regenerated.
 `--confidence` changes only the ordinary new-candidate scan; `--baseline`
 deliberately omits both the committed whitelist and this freshness check.
 
@@ -58,7 +58,9 @@ forever. Ruff deliberately has the opposite scope: tests are first-class code
 and must meet the same lint floor. A production field consumed only through
 serialization, framework reflection, or an external client therefore needs a
 narrow entry in
-`tools/vulture/whitelist.py` with its reason on the same line. Intentional
+`tools/vulture/whitelist.py` with its reason on a comment line ABOVE it —
+a same-line reason changes the entry's compared text and breaks the
+freshness comparison. Intentional
 unused imports use an explicit export (`__all__` or a redundant alias) at that
 import, never a whole-file ignore; this keeps every module ratcheted against
 new F401 debt.
@@ -91,8 +93,7 @@ The mechanic is simple but easy to miss: vulture's whitelist contains an entry p
 **Workflow per deletion PR:**
 1. Make the deletion + delete the tests that exercised it.
 2. Regenerate the whitelist with the roots from
-   `tools/production_python_sources.txt` (the command above), then prepend the
-   header from the previous version.
+   `tools/production_python_sources.txt` (the command above).
 3. Diff the whitelist (`git diff tools/vulture/whitelist.py`). New entries are cascading orphans you exposed.
 4. For each new entry, decide:
    - **Fold into this PR** if the orphan is small, contained, and the test cleanup is bounded (~50 LOC). Best when the orphan is structurally tied to the deletion (`strip_short_tokens` was the canonical example — its body matched what only the deleted callers needed).

--- a/scripts/find_dead_code.sh
+++ b/scripts/find_dead_code.sh
@@ -51,6 +51,22 @@ if [[ "$SOURCE_LIST" != /* ]]; then
 fi
 mapfile -t SOURCES < <(sed '/^[[:space:]]*#/d; /^[[:space:]]*$/d' "$SOURCE_LIST")
 
+# Normalize one whitelist stream for comparison (#1266 item 1): drop
+# full-line comments and blanks, strip the LINE NUMBER from each entry's
+# trailing "(path:line)" location comment, and sort. The identifier, its
+# kind ("unused attribute"/...), and its FILE all stay in the compared
+# text — only the line number is comparison-irrelevant, because any edit
+# above a whitelisted site shifts it without changing what is
+# whitelisted (this broke the gate four times across #1260/#1264 for one
+# entry). Sorting makes the comparison a set comparison, so two entries
+# in one file swapping relative order under line drift cannot break it
+# either. The committed file keeps its human-facing line comments; they
+# refresh whenever the whitelist is regenerated.
+normalize_vulture_whitelist() {
+  sed '/^[[:space:]]*#/d; /^[[:space:]]*$/d; s/:[0-9]\{1,\})[[:space:]]*$/)/' "$1" \
+    | LC_ALL=C sort
+}
+
 check_vulture_whitelist_freshness() {
   VULTURE_FRESHNESS_TMP=$(mktemp "${TMPDIR:-/tmp}/cratedigger-vulture-whitelist.XXXXXX")
   set +e
@@ -68,9 +84,9 @@ check_vulture_whitelist_freshness() {
   if ! diff -u \
     --label committed-vulture-whitelist \
     --label generated-vulture-whitelist \
-    <(sed '/^[[:space:]]*#/d; /^[[:space:]]*$/d' "$VULTURE_WHITELIST_FILE") \
-    "$VULTURE_FRESHNESS_TMP" >&2; then
-    echo "Vulture whitelist is not the exact confidence-60 candidate baseline" >&2
+    <(normalize_vulture_whitelist "$VULTURE_WHITELIST_FILE") \
+    <(normalize_vulture_whitelist "$VULTURE_FRESHNESS_TMP") >&2; then
+    echo "Vulture whitelist does not match the confidence-60 candidate baseline (identifier/kind/file set; line numbers are not compared)" >&2
     return 3
   fi
 }

--- a/scripts/find_dead_code.sh
+++ b/scripts/find_dead_code.sh
@@ -61,7 +61,15 @@ mapfile -t SOURCES < <(sed '/^[[:space:]]*#/d; /^[[:space:]]*$/d' "$SOURCE_LIST"
 # entry). Sorting makes the comparison a set comparison, so two entries
 # in one file swapping relative order under line drift cannot break it
 # either. The committed file keeps its human-facing line comments; they
-# refresh whenever the whitelist is regenerated.
+# refresh whenever the whitelist is regenerated. Two accepted precision
+# losses (#1266 review findings 4/5): full-line-comment stripping now
+# applies to the GENERATED stream too, so a "# unreachable code ..."
+# comment vulture emits is invisible to freshness (the main run still
+# reports it at confidence 100 and exits 3); and within one normalized
+# group (same identifier + kind + FILE, e.g. web/server.py's ten
+# _.close_connection occurrences) entries are counted, not located —
+# deleting one site and adding another in the same file is invisible,
+# while a changed COUNT still fails.
 normalize_vulture_whitelist() {
   sed '/^[[:space:]]*#/d; /^[[:space:]]*$/d; s/:[0-9]\{1,\})[[:space:]]*$/)/' "$1" \
     | LC_ALL=C sort

--- a/tests/test_js_pipeline.mjs
+++ b/tests/test_js_pipeline.mjs
@@ -60,30 +60,50 @@ async function flushMicrotasks(times = 30) {
 }
 
 /**
- * DOM stand-in for the merge-rekey drift row (#1089): `pipeline-content`
- * (read by `loadPipelineDashboard`'s loading/failure states), `toast`, and
- * one `drift-note-<id>` element — the exact three ids
- * `mergeRekeyRequest`/`loadPipelineDashboard` look up by id.
+ * Node-REPLACEMENT DOM stand-in for the merge-rekey drift row (#1089,
+ * re-modeled for #1266 item 2): the `drift-note-<id>` element LIVES
+ * inside `#pipeline-content`, and `loadPipelineDashboard()` rewrites
+ * that container's `innerHTML` — so a dashboard reload genuinely
+ * REPLACES the note node. Assigning `pipelineContent.innerHTML` here
+ * swaps which note object `getElementById` returns, exactly like
+ * `installReplacingRetagDom` below, so a handler that reloads the
+ * dashboard and THEN writes a note it captured earlier goes RED (the
+ * #1264 M26 / #1266 M4 stale-node shape). The shipped handler is
+ * correct by write ORDERING — its only reloading path returns without
+ * touching the note — and that ordering is now what these tests pin.
  */
 function installDriftDom(requestId) {
-  const pipelineContent = { innerHTML: '' };
+  const preNote = { textContent: '', className: '' };
+  const postNote = { textContent: '', className: '' };
   const toast = { textContent: '', className: '', style: { display: 'none' } };
-  const note = { textContent: '', className: '' };
-  const elements = new Map([
-    ['pipeline-content', pipelineContent],
-    ['toast', toast],
-    [`drift-note-${requestId}`, note],
-  ]);
+  let reloaded = false;
+  const pipelineContent = {
+    _html: '',
+    get innerHTML() { return this._html; },
+    set innerHTML(value) { this._html = value; reloaded = true; },
+  };
   globalThis.document = {
     getElementById(id) {
-      return elements.has(id) ? elements.get(id) : null;
+      if (id === 'pipeline-content') return pipelineContent;
+      if (id === `drift-note-${requestId}`) {
+        return reloaded ? postNote : preNote;
+      }
+      if (id === 'toast') return toast;
+      return null;
     },
   };
   globalThis.setTimeout = (fn) => {
     fn();
     return 0;
   };
-  return { pipelineContent, toast, note };
+  return {
+    pipelineContent,
+    preNote,
+    postNote,
+    toast,
+    isReloaded: () => reloaded,
+    visibleNote: () => (reloaded ? postNote : preNote),
+  };
 }
 
 console.log('renderPipelineNav() has operational views only');
@@ -395,7 +415,8 @@ console.log('mergeRekeyRequest() success path posts, toasts, and reloads the das
     'Request #8792 rekeyed to 9b59f78b-3ca6-41e1-8025-6ed4bcfad4e4',
     'toasts the exact survivor id');
   assertEqual(dom.toast.className, 'toast', 'success toast is not an error');
-  assertEqual(dom.note.textContent, '', 'success never writes the refusal note');
+  assertEqual(dom.preNote.textContent, '', 'success never writes the pre-reload note');
+  assertEqual(dom.postNote.textContent, '', 'success never writes the post-reload note');
   assertEqual(btn.textContent, 'Rekeying...',
     'success leaves the disabled mid-flight label — the dashboard reload replaces the row entirely');
 }
@@ -426,11 +447,11 @@ console.log('mergeRekeyRequest() refusal path re-arms the button and writes the 
   assert(!calls.includes('/api/pipeline/dashboard'), 'a refusal never reloads the dashboard');
   assertEqual(btn.disabled, false, 'the button re-arms for a retry');
   assertEqual(btn.textContent, 'Follow MB merge', 'the button label resets');
-  assertEqual(dom.note.textContent,
+  assertEqual(dom.visibleNote().textContent,
     'not_merged: MusicBrainz names no merge survivor for the stored id; '
     + 'this request has not been merged',
-    'the inline note names the exact outcome and message');
-  assertEqual(dom.note.className, 'drift-row-note metric-bad', 'the inline note uses the bad tone');
+    'the VISIBLE inline note names the exact outcome and message');
+  assertEqual(dom.visibleNote().className, 'drift-row-note metric-bad', 'the visible note uses the bad tone');
   assertEqual(dom.toast.className, 'toast error', 'a refusal toast is an error');
 }
 
@@ -446,9 +467,9 @@ console.log('mergeRekeyRequest() network-error path re-arms the button with a ge
 
   assertEqual(btn.disabled, false, 'the button re-arms after a network failure');
   assertEqual(btn.textContent, 'Follow MB merge', 'the button label resets');
-  assertEqual(dom.note.textContent, 'Merge-rekey request failed',
-    'the inline note falls back to a generic message with no response to read');
-  assertEqual(dom.note.className, 'drift-row-note metric-bad', 'the inline note uses the bad tone');
+  assertEqual(dom.visibleNote().textContent, 'Merge-rekey request failed',
+    'the VISIBLE inline note falls back to a generic message with no response to read');
+  assertEqual(dom.visibleNote().className, 'drift-row-note metric-bad', 'the visible note uses the bad tone');
   assertEqual(dom.toast.className, 'toast error', 'a network failure toast is an error');
 }
 
@@ -464,7 +485,7 @@ console.log('mergeRekeyRequest() refusal note falls back to the raw error field 
 
   await mergeRekeyRequest(42, btn);
 
-  assertEqual(dom.note.textContent, 'rekey_refused: route-level error text',
+  assertEqual(dom.visibleNote().textContent, 'rekey_refused: route-level error text',
     'falls back to the route-level "error" field when error_message is absent');
 }
 
@@ -625,6 +646,7 @@ console.log('recheckRetagDivergenceAlbum() not-found path re-arms the button and
   assertEqual(dom.visibleNote().textContent, 'No Beets album with id 999',
     'the VISIBLE inline note names the exact error');
   assertEqual(dom.visibleNote().className, 'drift-row-note metric-bad', 'the visible note uses the bad tone');
+  assertEqual(dom.postNote.textContent, '', 'nothing is written to the unrendered post-render note');
   assertEqual(dom.toast.className, 'toast error', 'a refusal toast is an error');
 }
 
@@ -750,8 +772,10 @@ console.log('syncRetagDivergenceAlbum() album-less refusal re-arms the still-att
   assert(!dom.isRerendered(), 'no album payload, no re-render');
   assertEqual(btn.disabled, false, 'the still-attached button re-arms');
   assertEqual(btn.textContent, 'Write tags', 'the button label resets');
-  assertContains(dom.preNote.textContent, 'identity_mismatch',
-    'the note names the refusal outcome');
+  assertContains(dom.visibleNote().textContent, 'identity_mismatch',
+    'the visible note names the refusal outcome');
+  assertEqual(dom.postNote.textContent, '',
+    'nothing is written to the unrendered post-render note');
   assertEqual(dom.toast.className, 'toast error', 'a refusal toast is an error');
 }
 

--- a/tests/test_js_pipeline.mjs
+++ b/tests/test_js_pipeline.mjs
@@ -411,6 +411,8 @@ console.log('mergeRekeyRequest() success path posts, toasts, and reloads the das
   assertEqual(calls[0].options.body, '{}', 'sends an empty JSON body — no request payload');
   assert(calls.some(c => c.url === '/api/pipeline/dashboard'),
     'success reloads the dashboard so the healed row disappears');
+  assert(dom.isReloaded(),
+    'the reload really rewrote #pipeline-content — the note nodes were replaced');
   assertEqual(dom.toast.textContent,
     'Request #8792 rekeyed to 9b59f78b-3ca6-41e1-8025-6ed4bcfad4e4',
     'toasts the exact survivor id');

--- a/tests/test_js_pipeline.mjs
+++ b/tests/test_js_pipeline.mjs
@@ -471,34 +471,57 @@ console.log('mergeRekeyRequest() refusal note falls back to the raw error field 
 // --- issue #1142: per-album retag-divergence recheck ---
 
 /**
- * DOM stand-in for one retag-divergence album row: the id'd container
- * `recheckRetagDivergenceAlbum` patches in place, its inline note slot,
- * and `toast` — mirrors `installDriftDom` above.
+ * Node-REPLACEMENT DOM stand-in for one retag-divergence album row
+ * (#1266 item 2, generalising #1264's S1 helper): assigning
+ * `container.innerHTML` swaps which note object `getElementById`
+ * returns, so a handler that captures the note BEFORE re-rendering
+ * writes to a detached node and the assertions catch it — the exact bug
+ * shape a fixed-map DOM (one note object forever) can never see.
+ * `visibleNote()` is "whatever note node the page shows NOW"; assert
+ * refusal copy through it so a future re-render-then-stale-write
+ * regression goes RED. Shared by the recheck and sync handler tests;
+ * `mergeRekeyRequest`'s inline drift DOM above stays a fixed map on
+ * purpose — that handler performs no in-place container re-render, so
+ * there is no node replacement to model.
+ * @param {number} albumId
  */
-function installRetagAlbumDom(albumId) {
-  const container = { innerHTML: '' };
+function installReplacingRetagDom(albumId) {
+  const preNote = { textContent: '', className: '' };
+  const postNote = { textContent: '', className: '' };
   const toast = { textContent: '', className: '', style: { display: 'none' } };
-  const note = { textContent: '', className: '' };
-  const elements = new Map([
-    [`retag-album-${albumId}`, container],
-    ['toast', toast],
-    [`retag-album-note-${albumId}`, note],
-  ]);
+  let rerendered = false;
+  const container = {
+    _html: '',
+    get innerHTML() { return this._html; },
+    set innerHTML(value) { this._html = value; rerendered = true; },
+  };
   globalThis.document = {
     getElementById(id) {
-      return elements.has(id) ? elements.get(id) : null;
+      if (id === `retag-album-${albumId}`) return container;
+      if (id === `retag-album-note-${albumId}`) {
+        return rerendered ? postNote : preNote;
+      }
+      if (id === 'toast') return toast;
+      return null;
     },
   };
   globalThis.setTimeout = (fn) => {
     fn();
     return 0;
   };
-  return { container, toast, note };
+  return {
+    container,
+    preNote,
+    postNote,
+    toast,
+    isRerendered: () => rerendered,
+    visibleNote: () => (rerendered ? postNote : preNote),
+  };
 }
 
 console.log('recheckRetagDivergenceAlbum() success path GETs, patches the row in place, and toasts');
 {
-  const dom = installRetagAlbumDom(6612);
+  const dom = installReplacingRetagDom(6612);
   const btn = { disabled: false, textContent: 'Recheck' };
   const calls = [];
   globalThis.fetch = async (url, options) => {
@@ -524,12 +547,13 @@ console.log('recheckRetagDivergenceAlbum() success path GETs, patches the row in
     'patched row keeps its own recheck button wired for a further recheck');
   assertEqual(dom.toast.textContent, 'Album #6612 rechecked: agrees', 'toasts the fresh result');
   assertEqual(dom.toast.className, 'toast', 'success toast is not an error');
-  assertEqual(dom.note.textContent, '', 'success never writes the refusal note');
+  assertEqual(dom.preNote.textContent, '', 'success never writes the pre-render note');
+  assertEqual(dom.postNote.textContent, '', 'success never writes the post-render note');
 }
 
 console.log('recheckRetagDivergenceAlbum() N2 (fresh review) — the patched row shows fresh non-agreeing item detail');
 {
-  const dom = installRetagAlbumDom(6612);
+  const dom = installReplacingRetagDom(6612);
   const btn = { disabled: false, textContent: 'Recheck' };
   globalThis.fetch = async () => ({
     ok: true,
@@ -564,7 +588,7 @@ console.log('recheckRetagDivergenceAlbum() N2 (fresh review) — the patched row
 
 console.log('recheckRetagDivergenceAlbum() never reloads the whole dashboard on success');
 {
-  installRetagAlbumDom(6612);
+  installReplacingRetagDom(6612);
   const btn = { disabled: false, textContent: 'Recheck' };
   const calls = [];
   globalThis.fetch = async (url) => {
@@ -586,7 +610,7 @@ console.log('recheckRetagDivergenceAlbum() never reloads the whole dashboard on 
 
 console.log('recheckRetagDivergenceAlbum() not-found path re-arms the button and writes the inline note');
 {
-  const dom = installRetagAlbumDom(999);
+  const dom = installReplacingRetagDom(999);
   const btn = { disabled: true, textContent: 'Rechecking...' };
   globalThis.fetch = async () => ({
     ok: false,
@@ -598,15 +622,15 @@ console.log('recheckRetagDivergenceAlbum() not-found path re-arms the button and
 
   assertEqual(btn.disabled, false, 'the button re-arms for a retry');
   assertEqual(btn.textContent, 'Recheck', 'the button label resets');
-  assertEqual(dom.note.textContent, 'No Beets album with id 999',
-    'the inline note names the exact error');
-  assertEqual(dom.note.className, 'drift-row-note metric-bad', 'the inline note uses the bad tone');
+  assertEqual(dom.visibleNote().textContent, 'No Beets album with id 999',
+    'the VISIBLE inline note names the exact error');
+  assertEqual(dom.visibleNote().className, 'drift-row-note metric-bad', 'the visible note uses the bad tone');
   assertEqual(dom.toast.className, 'toast error', 'a refusal toast is an error');
 }
 
 console.log('recheckRetagDivergenceAlbum() network-error path re-arms the button with a generic note');
 {
-  const dom = installRetagAlbumDom(6612);
+  const dom = installReplacingRetagDom(6612);
   const btn = { disabled: true, textContent: 'Rechecking...' };
   globalThis.fetch = async () => {
     throw new TypeError('network down');
@@ -616,52 +640,16 @@ console.log('recheckRetagDivergenceAlbum() network-error path re-arms the button
 
   assertEqual(btn.disabled, false, 'the button re-arms after a network failure');
   assertEqual(btn.textContent, 'Recheck', 'the button label resets');
-  assertEqual(dom.note.textContent, 'Recheck request failed',
-    'the inline note falls back to a generic message with no response to read');
+  assertEqual(dom.visibleNote().textContent, 'Recheck request failed',
+    'the VISIBLE inline note falls back to a generic message with no response to read');
   assertEqual(dom.toast.className, 'toast error', 'a network failure toast is an error');
-}
-
-/**
- * Sync-specific DOM: models node REPLACEMENT on re-render (#1260 review
- * S1/M26). `container.innerHTML = …` swaps which note object
- * `getElementById` returns, so a handler that captures the note BEFORE
- * re-rendering writes to a detached node and the post-render assertion
- * catches it — the exact bug shape the recheck-style fixed-map DOM
- * cannot see.
- * @param {number} albumId
- */
-function installSyncAlbumDom(albumId) {
-  const preNote = { textContent: '', className: '' };
-  const postNote = { textContent: '', className: '' };
-  const toast = { textContent: '', className: '', style: { display: 'none' } };
-  let rerendered = false;
-  const container = {
-    _html: '',
-    get innerHTML() { return this._html; },
-    set innerHTML(value) { this._html = value; rerendered = true; },
-  };
-  globalThis.document = {
-    getElementById(id) {
-      if (id === `retag-album-${albumId}`) return container;
-      if (id === `retag-album-note-${albumId}`) {
-        return rerendered ? postNote : preNote;
-      }
-      if (id === 'toast') return toast;
-      return null;
-    },
-  };
-  globalThis.setTimeout = (fn) => {
-    fn();
-    return 0;
-  };
-  return { container, preNote, postNote, toast, isRerendered: () => rerendered };
 }
 
 const SYNC_DB_ID = '26693e58-02c0-4bb1-b66f-f0f44f8a234d';
 
 console.log('syncRetagDivergenceAlbum() POSTs the compare-and-set body and patches the row on success');
 {
-  const dom = installSyncAlbumDom(16948);
+  const dom = installReplacingRetagDom(16948);
   const btn = {
     disabled: false, textContent: 'Write tags',
     dataset: { expected: SYNC_DB_ID },
@@ -701,7 +689,7 @@ console.log('syncRetagDivergenceAlbum() POSTs the compare-and-set body and patch
 
 console.log('syncRetagDivergenceAlbum() residual refusal re-renders AND writes the POST-re-render note');
 {
-  const dom = installSyncAlbumDom(16948);
+  const dom = installReplacingRetagDom(16948);
   const btn = {
     disabled: false, textContent: 'Write tags',
     dataset: { expected: SYNC_DB_ID },
@@ -741,7 +729,7 @@ console.log('syncRetagDivergenceAlbum() residual refusal re-renders AND writes t
 
 console.log('syncRetagDivergenceAlbum() album-less refusal re-arms the still-attached button');
 {
-  const dom = installSyncAlbumDom(42);
+  const dom = installReplacingRetagDom(42);
   const btn = {
     disabled: false, textContent: 'Write tags',
     dataset: { expected: SYNC_DB_ID },
@@ -769,7 +757,7 @@ console.log('syncRetagDivergenceAlbum() album-less refusal re-arms the still-att
 
 console.log('syncRetagDivergenceAlbum() network-error path re-arms the button with a generic note');
 {
-  const dom = installSyncAlbumDom(16948);
+  const dom = installReplacingRetagDom(16948);
   const btn = {
     disabled: true, textContent: 'Writing tags...',
     dataset: { expected: SYNC_DB_ID },

--- a/tests/test_unused_import_audit.py
+++ b/tests/test_unused_import_audit.py
@@ -610,11 +610,20 @@ class TestUnusedImportAudit(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertEqual(leftovers, ())
 
-    def test_deleted_or_renamed_candidate_fails_freshness(self) -> None:
+    def test_deleted_renamed_or_file_moved_candidate_fails_freshness(self) -> None:
+        """The ``cross_file_moved`` case is the one the RETURN CODE owes to
+        file attribution (#1266 review finding 3): the same identifier at
+        the same cardinality, in a different FILE, must still fail — a
+        comparison that dropped the trailing comment entirely would pass
+        it on identifier count alone."""
         baseline = {"lib/orphan.py": "def orphan():\n    return 1\n"}
         cases = {
             "deleted": {"lib/orphan.py": "VALUE = 1\nprint(VALUE)\n"},
             "renamed": {"lib/orphan.py": "def replacement():\n    return 1\n"},
+            "cross_file_moved": {
+                "lib/orphan.py": "VALUE = 1\nprint(VALUE)\n",
+                "lib/other.py": "def orphan():\n    return 1\n",
+            },
         }
 
         for label, current in cases.items():

--- a/tests/test_unused_import_audit.py
+++ b/tests/test_unused_import_audit.py
@@ -570,19 +570,44 @@ class TestUnusedImportAudit(unittest.TestCase):
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertEqual(leftovers, ())
 
-    def test_same_symbol_moved_location_names_stale_exact_entry(self) -> None:
+    def test_same_symbol_moved_location_passes_line_insensitively(self) -> None:
+        """#1266 item 1 — the founding scenario: an edit above a
+        whitelisted site shifts only its line comment. The freshness
+        comparison is a set over identifier + kind + file; pure line
+        drift must never break the gate (it broke four times for one
+        entry across #1260/#1264 under the old byte-diff)."""
         baseline = {"lib/orphan.py": "def orphan():\n    return 1\n"}
         current = {"lib/orphan.py": "\n\ndef orphan():\n    return 1\n"}
 
         result, leftovers = run_vulture_freshness_world(baseline, current)
 
-        self.assertEqual(result.returncode, 3, result.stdout + result.stderr)
-        self.assertIn(
-            "not the exact confidence-60 candidate baseline",
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+        self.assertNotIn(
+            "does not match the confidence-60 candidate baseline",
             result.stderr,
         )
-        self.assertIn("orphan", result.stderr)
-        self.assertIn("orphan.py:1", result.stderr)
+        self.assertEqual(leftovers, ())
+
+    def test_reordered_same_file_entries_under_drift_pass(self) -> None:
+        """#1266 item 1, sort clause: line drift that also swaps two
+        entries' relative order in the generated whitelist must not
+        break a set comparison."""
+        baseline = {
+            "lib/orphan.py": (
+                "def orphan_alpha():\n    return 1\n\n\n"
+                "def orphan_beta():\n    return 2\n"
+            ),
+        }
+        current = {
+            "lib/orphan.py": (
+                "def orphan_beta():\n    return 2\n\n\n"
+                "def orphan_alpha():\n    return 1\n"
+            ),
+        }
+
+        result, leftovers = run_vulture_freshness_world(baseline, current)
+
+        self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertEqual(leftovers, ())
 
     def test_deleted_or_renamed_candidate_fails_freshness(self) -> None:
@@ -598,7 +623,7 @@ class TestUnusedImportAudit(unittest.TestCase):
 
                 self.assertEqual(result.returncode, 3, result.stdout + result.stderr)
                 self.assertIn(
-                    "not the exact confidence-60 candidate baseline",
+                    "does not match the confidence-60 candidate baseline",
                     result.stderr,
                 )
                 self.assertIn("orphan", result.stderr)
@@ -614,10 +639,13 @@ class TestUnusedImportAudit(unittest.TestCase):
 
         self.assertEqual(result.returncode, 3, result.stdout + result.stderr)
         self.assertIn(
-            "not the exact confidence-60 candidate baseline",
+            "does not match the confidence-60 candidate baseline",
             result.stderr,
         )
-        self.assertIn("lib/other.py:1", result.stderr)
+        # Line numbers are no longer compared (#1266 item 1); the FILE
+        # attribution is, and it is what stops a same-name candidate in
+        # another file hiding behind the baseline entry.
+        self.assertIn("lib/other.py", result.stderr)
         self.assertEqual(leftovers, ())
 
     def test_baseline_mode_deliberately_bypasses_freshness(self) -> None:
@@ -632,7 +660,7 @@ class TestUnusedImportAudit(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
         self.assertNotIn(
-            "not the exact confidence-60 candidate baseline",
+            "does not match the confidence-60 candidate baseline",
             result.stderr,
         )
         self.assertEqual(leftovers, ())
@@ -648,7 +676,7 @@ class TestUnusedImportAudit(unittest.TestCase):
         )
 
         self.assertEqual(result.returncode, 3, result.stdout + result.stderr)
-        self.assertIn("exact confidence-60 candidate baseline", result.stderr)
+        self.assertIn("confidence-60 candidate baseline", result.stderr)
 
     def test_freshness_wiring_mutant_is_killed(self) -> None:
         runner_source = Path("scripts/find_dead_code.sh").read_text(encoding="utf-8")
@@ -679,7 +707,7 @@ class TestUnusedImportAudit(unittest.TestCase):
 
         self.assertEqual(result.returncode, 3, result.stdout + result.stderr)
         self.assertIn(
-            "not the exact confidence-60 candidate baseline",
+            "does not match the confidence-60 candidate baseline",
             result.stderr,
         )
         self.assertIn("orphan", result.stderr)

--- a/tests/web/test_routes_retag_divergence_audit.py
+++ b/tests/web/test_routes_retag_divergence_audit.py
@@ -414,6 +414,10 @@ class TestRetagDivergenceAuditAlbumRoute(_FakeDbWebServerCase):
         self.assertIn("out of range", payload.get("error", ""))
 
     def test_missing_beets_is_503(self) -> None:
+        """#1266 item 3 — the exact copy pins the INTENDED classified
+        path: a bare 503 + "error"-key assertion also passes when a
+        deleted guard routes through the generic unexpected-failure
+        except with a spurious traceback (#1264 mutant runner S2)."""
         from web import server
 
         with patch.object(server, "_beets_db", return_value=None):
@@ -422,9 +426,14 @@ class TestRetagDivergenceAuditAlbumRoute(_FakeDbWebServerCase):
             )
 
         self.assertEqual(status, 503)
-        self.assertIn("error", payload)
+        self.assertEqual(
+            payload["error"],
+            "current Beets authority unavailable (FileNotFoundError)",
+        )
 
     def test_expected_open_failure_is_503(self) -> None:
+        """#1266 item 3 — same exact-copy pin for the classified SQLite
+        lane (BUSY is primary code 5)."""
         from web import server
 
         failure = sqlite3.OperationalError("database is locked")
@@ -435,7 +444,10 @@ class TestRetagDivergenceAuditAlbumRoute(_FakeDbWebServerCase):
             )
 
         self.assertEqual(status, 503)
-        self.assertIn("error", payload)
+        self.assertEqual(
+            payload["error"],
+            "current Beets authority unavailable (sqlite_5)",
+        )
 
     def test_unexpected_failure_is_logged_and_returns_503(self) -> None:
         from web import server


### PR DESCRIPTION
## Summary

Implements the three items of reflection issue #1266 (non-closing until deploy):

1. **Vulture whitelist line-number brittleness** — `scripts/find_dead_code.sh`'s freshness gate now compares the committed whitelist against the fresh `--make-whitelist` output as a sorted MULTISET over identifier + kind + file (`normalize_vulture_whitelist`: strip the `:line` suffix, sort both sides). Pure line drift and reorder-under-drift pass; deleted, renamed, additional, and cross-FILE-moved candidates (same name, same count, different file — the case whose return code depends on the retained file attribution) still fail exit 3. Coverage lives in the pre-existing owner harness `tests/test_unused_import_audit.py` via `run_vulture_freshness_world`; the old moved-location pin now asserts the deliberately reversed contract. `docs/dead-code.md` rewritten to the new contract (including the measured fact that a whitelist entry's reason must sit on a comment line ABOVE it; a same-line reason breaks freshness).
2. **Node-replacement fake DOM for the drift-row handlers** — the fixed-map DOMs could never see a handler writing to a note node its own re-render/reload had just destroyed (#1264 M26/S1 shape). `installReplacingRetagDom` (recheck + sync) and the re-modeled `installDriftDom` (mergeRekey — its note genuinely lives inside `#pipeline-content`, which a dashboard reload rewrites; the shipped handler is correct by write ORDERING, and that ordering is now pinned) both swap the note object on `innerHTML` assignment, with failure copy asserted through `visibleNote()`.
3. **Exact 503 payload pins** — the album-route `test_missing_beets_is_503` / `test_expected_open_failure_is_503` pin the real classified producer copies (`current Beets authority unavailable (FileNotFoundError)` / `(sqlite_5)`), closing #1264 mutant-runner S2's deleted-guard blind spot. The other `return_value=None` route tests were checked and already assert rich contracts.

## Fault injection

Author-side, each planted/reverted under `PYTHONDONTWRITEBYTECODE=1` with a clean `git status` after: the old byte-diff comparison restored → both drift pins RED (2 failures); a failure-path re-render inserted before recheck's pre-captured note write → RED on the migrated pins (previously invisible by construction); the album route's `beets is None` guard deleted → RED on the exact-copy pin (previously survived, per #1264 S2); the comment-stripping normalization mutant → RED at RETURN-CODE level on the new `cross_file_moved` case (before that case, only a stderr string assertion stood in its way); mergeRekey's M4 (reload in the catch before the note write) → RED on the migrated network-error pin after the drift-DOM re-model (it survived the shipped tree at review time — that survivor is what the second commit closes).

Independent reviewer (single opus agent doing both reader and runner jobs — small, low-risk diff): 6 script mutants (V1–V6) + 6 JS mutants (M1–M6) + 3 route mutants (R1–R3) with real output evidence; the one SURVIVOR (M4) drove the correction round, then 4 verification mutants (N1–N4) + V2′ confirmed every correction claim, with byte-level restoration proofs each round. Recorded residuals: `# unreachable code` full-line comments are now invisible to freshness (the main run still reports them at confidence 100); within one identifier+kind+file group, occurrences are counted, not located.

## Reviewer

One independent opus agent (both jobs, per the small-diff carve-out in `.claude/rules/code-quality.md` § "Pre-Commit Review Gate"), three rounds: full review of `ffe7b34a` (1 survivor + 5 prose/doc findings), re-read of correction `252a6b62` (no blockers, 5 one-line findings), all applied as prescribed in `dd17a69d`.

## Risk

Test/docs/gate-script only — zero runtime production behavior changes. The one semantic change is deliberate: the dead-code gate no longer fails on pure line-number drift; every identifier/kind/file-level protection (including duplicate counts) is mutation-proven intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
