### PR TITLE
feat: dashboard button + CLI to force the library-completeness census

### DIFF
--- a/docs/debugging-cli.md
+++ b/docs/debugging-cli.md
@@ -23,8 +23,8 @@ ssh doc2 'pipeline-cli routes --json'
 The installed wrapper has two independent authority shapes:
 
 - `pipeline-delete`, `set-quality`, `upgrade`, `wrong-match-converge`,
-  `merge-rekey`, `sync-file-tags`, `resolve-rg`, `wrong-match-delete`,
-  `wrong-match-delete-group`,
+  `merge-rekey`, `sync-file-tags`, `library-census-refresh`, `resolve-rg`,
+  `wrong-match-delete`, `wrong-match-delete-group`,
   `wrong-match-triage`, `wrong-match-triage-cancel`, `replace`,
   `force-import`, `import-local`, `beets-distance`,
   `import-preview --download-log-id`, and `triage quarantine` connect to
@@ -139,8 +139,8 @@ remains after a purge failure.
 ## API-backed mutation commands
 
 `pipeline-delete`, `set-quality`, `upgrade`, `wrong-match-converge`,
-`merge-rekey`, `sync-file-tags`, `resolve-rg`, `wrong-match-delete`,
-`wrong-match-delete-group`,
+`merge-rekey`, `sync-file-tags`, `library-census-refresh`, `resolve-rg`,
+`wrong-match-delete`, `wrong-match-delete-group`,
 `wrong-match-triage`, `wrong-match-triage-cancel`, `replace`,
 `force-import`, `import-local`, `beets-distance`, and
 `import-preview --download-log-id` call the canonical web route over the
@@ -367,6 +367,12 @@ inside socket authorization, never credentials.
   the installed copy for any candidate beets proves whole, so a complete
   candidate is admitted as into an empty slot; a covered terminal acceptance
   clears the mark automatically (issue #1241).
+- `pipeline-cli library-census-refresh` — Request an out-of-schedule
+  library-completeness census run through its canonical web route: writes
+  the trigger file the module's census path unit watches (the daily
+  oneshot stays the single execution path). The dashboard card's
+  "Run census now" button is the same route. 200/0 requested; 503/5
+  unconfigured or state dir unwritable.
 - `pipeline-cli set-quality` — Set request quality through its canonical web route.
 - `pipeline-cli show` — Show a request, attempts, and quality state.
 - `pipeline-cli sync-file-tags` — Write one

--- a/docs/nixos-module.md
+++ b/docs/nixos-module.md
@@ -823,6 +823,13 @@ See [`examples/cratedigger.nix`](../examples/cratedigger.nix) for the full worke
 - `cratedigger-library-completeness-census.timer` — `OnCalendar=daily`,
   `Persistent=true`, `RandomizedDelaySec=30min`, independent of the five-minute
   pipeline and the retag census.
+- `cratedigger-library-completeness-census.path` — on-demand trigger: starts
+  the same-named oneshot when `library-completeness-census.trigger` exists in
+  `cfg.stateDir`. The web service (same user) writes that file for the
+  dashboard's "Run census now" button and `pipeline-cli
+  library-census-refresh`; the service's `ExecStartPre` removes it, so a
+  request landing mid-run re-triggers one follow-up run. No sudo/polkit
+  surface — stateDir ownership is the authority.
 - `cratedigger-web.socket` — systemd-owned AF_UNIX listener at
   `/run/cratedigger-web/web.sock`, node `root:<web.accessGroup> 0660` beneath a
   separately managed `root:<web.accessGroup> 0750` directory.

--- a/docs/web-dev-server.md
+++ b/docs/web-dev-server.md
@@ -77,9 +77,12 @@ waiting for (or triggering) the real ~200s whole-library scan.
 `library-completeness.json` snapshot for the Library Completeness card. It
 never starts a source, Beets, or filesystem census from the dev server. The
 card's census listing stays read-only; its per-album "Mark incomplete"
-button (issue #1241) POSTs `/api/pipeline/mark-incomplete`, which the
-GET-only live-db dev server does not dispatch — the button renders for
-screenshot verification but the action needs the real deployment.
+button (issue #1241) POSTs `/api/pipeline/mark-incomplete`, and its
+"Run census now" button POSTs
+`/api/pipeline/dashboard/library-census/refresh` — the GET-only live-db
+dev server dispatches neither (both 405, observed in the census button's
+own screenshot round): the buttons render for screenshot verification
+but the actions need the real deployment.
 
 ## Screenshot verification loop
 

--- a/lib/library_completeness_snapshot.py
+++ b/lib/library_completeness_snapshot.py
@@ -11,6 +11,15 @@ from lib.sidecar_service import _atomic_write_bytes
 
 LIBRARY_COMPLETENESS_SNAPSHOT_FILENAME = "library-completeness.json"
 
+#: Trigger file watched by the module's
+#: ``cratedigger-library-completeness-census.path`` unit: its existence
+#: starts the same-named census oneshot, whose ``ExecStartPre`` removes
+#: it. Written by the operator-facing refresh action (web route +
+#: ``pipeline-cli library-census-refresh`` relay) so a census can be
+#: forced without waiting for the daily timer — the unit's ``ExecStart``
+#: stays the ONE census execution path.
+LIBRARY_COMPLETENESS_TRIGGER_FILENAME = "library-completeness-census.trigger"
+
 
 class LibraryCompletenessSnapshot(msgspec.Struct, frozen=True):
     generated_at: str
@@ -38,3 +47,29 @@ def read_library_completeness_snapshot(
     except FileNotFoundError:
         return None
     return msgspec.convert(json.loads(data.decode("ascii")), type=LibraryCompletenessSnapshot)
+
+
+def library_completeness_trigger_path(var_dir: str) -> str:
+    return os.path.join(var_dir, LIBRARY_COMPLETENESS_TRIGGER_FILENAME)
+
+
+class CensusTriggerResult(msgspec.Struct, frozen=True):
+    """Wire-facing outcome of a census refresh request."""
+
+    outcome: str
+
+
+def request_library_completeness_census(var_dir: str) -> CensusTriggerResult:
+    """Request an out-of-schedule census run by writing the trigger file.
+
+    Idempotent: a second request while one is pending rewrites the same
+    file. systemd's ``PathExists=`` semantics give the useful behavior
+    for a request made DURING a run: the path unit re-triggers after the
+    active run deactivates, so the next snapshot reflects post-request
+    state. Raises ``OSError`` when the state dir is unwritable — the
+    callers map that to 503/exit 5.
+    """
+    path = library_completeness_trigger_path(var_dir)
+    with open(path, "w", encoding="ascii") as fh:
+        fh.write("requested\n")
+    return CensusTriggerResult(outcome="requested")

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -2746,6 +2746,13 @@ in {
         User = cfg.user;
         Group = cfg.group;
         BindReadOnlyPaths = beetsObserverReadOnlyPaths;
+        # The trigger file is the operator "run census now" request (web
+        # button / `pipeline-cli library-census-refresh`), watched by the
+        # same-named path unit below. Removing it FIRST means a request
+        # arriving DURING a run re-triggers after deactivation, so the
+        # next snapshot reflects post-request state; a completed run
+        # leaves no file and no re-trigger.
+        ExecStartPre = "${pkgs.coreutils}/bin/rm -f ${cfg.stateDir}/library-completeness-census.trigger";
         ExecStart = "${libraryCompletenessCensusPkg}/bin/cratedigger-library-completeness-census";
         WorkingDirectory = cfg.stateDir;
         # Public MusicBrainz remains a supported (1 request/sec) posture:
@@ -2764,6 +2771,18 @@ in {
         OnCalendar = "daily";
         Persistent = true;
         RandomizedDelaySec = "30min";
+      };
+    };
+
+    # Operator-forced census runs: the web service (same user) writes the
+    # trigger file into stateDir; this path unit starts the same-named
+    # oneshot. No sudo/polkit surface — file ownership IS the authority,
+    # and the census service's ExecStart stays the single execution path.
+    systemd.paths.cratedigger-library-completeness-census = {
+      description = "Cratedigger library completeness census on-demand trigger";
+      wantedBy = ["multi-user.target"];
+      pathConfig = {
+        PathExists = "${cfg.stateDir}/library-completeness-census.trigger";
       };
     };
 

--- a/scripts/pipeline_cli/api_mutations.py
+++ b/scripts/pipeline_cli/api_mutations.py
@@ -542,8 +542,10 @@ def cmd_library_census_refresh(_db: object, args: argparse.Namespace) -> int:
     file the module's ``cratedigger-library-completeness-census.path``
     unit watches, and the daily census oneshot itself remains the single
     census execution path. Relayed rather than written directly because
-    the trigger lives in the web service's state dir, which the invoking
-    operator cannot write (same #1122 F1 shape as ``triage quarantine``).
+    the trigger lives in the web service's state dir
+    (``0755 cratedigger``), which the invoking operator cannot write —
+    the write-side analogue of the CLI-over-HTTP permission relays like
+    ``triage quarantine``.
 
     Exit codes: 0 — 200 requested; 5 — 503 unconfigured/unwritable, or
     the API unreachable.

--- a/scripts/pipeline_cli/api_mutations.py
+++ b/scripts/pipeline_cli/api_mutations.py
@@ -534,6 +534,26 @@ def cmd_sync_file_tags(_db: object, args: argparse.Namespace) -> int:
     ), timeout_seconds=TIMEOUT_TAG_SYNC_SECONDS)
 
 
+def cmd_library_census_refresh(_db: object, args: argparse.Namespace) -> int:
+    """Thin HTTP adapter for
+    ``POST /api/pipeline/dashboard/library-census/refresh``.
+
+    The route is the one canonical execution path: it writes the trigger
+    file the module's ``cratedigger-library-completeness-census.path``
+    unit watches, and the daily census oneshot itself remains the single
+    census execution path. Relayed rather than written directly because
+    the trigger lives in the web service's state dir, which the invoking
+    operator cannot write (same #1122 F1 shape as ``triage quarantine``).
+
+    Exit codes: 0 — 200 requested; 5 — 503 unconfigured/unwritable, or
+    the API unreachable.
+    """
+    return _relay(args.api_endpoint, _ApiMutation(
+        path="/api/pipeline/dashboard/library-census/refresh",
+        body={},
+    ))
+
+
 def add_api_mutation_subparsers(
     sub: argparse._SubParsersAction[argparse.ArgumentParser],
 ) -> None:
@@ -541,6 +561,12 @@ def add_api_mutation_subparsers(
     delete = sub.add_parser("pipeline-delete", help="Delete a pipeline request via the web API")
     delete.add_argument("request_id", type=int)
     delete.add_argument("--confirm", default=None)
+
+    sub.add_parser(
+        "library-census-refresh",
+        help="Request an out-of-schedule library-completeness census run "
+             "via the web API (the daily oneshot stays the execution path)",
+    )
 
     quality = sub.add_parser("set-quality", help="Set request quality via the web API")
     quality.add_argument("release_id")

--- a/scripts/pipeline_cli/cli.py
+++ b/scripts/pipeline_cli/cli.py
@@ -22,6 +22,7 @@ from scripts.pipeline_cli.album_requests import (
     cmd_status,
 )
 from scripts.pipeline_cli.api_mutations import (
+    cmd_library_census_refresh,
     cmd_merge_rekey,
     cmd_pipeline_delete,
     cmd_resolve_rg,
@@ -122,6 +123,7 @@ def main(*, api_socket: str | None = None):
         "wrong-match-converge": cmd_wrong_match_converge,
         "resolve-rg": cmd_resolve_rg,
         "merge-rekey": cmd_merge_rekey,
+        "library-census-refresh": cmd_library_census_refresh,
         "sync-file-tags": cmd_sync_file_tags,
         "wrong-match-delete": cmd_wrong_match_delete,
         "wrong-match-delete-group": cmd_wrong_match_delete_group,

--- a/tests/test_js_pipeline_dashboard.mjs
+++ b/tests/test_js_pipeline_dashboard.mjs
@@ -887,7 +887,13 @@ console.log('main.js binds window.refreshLibraryCensus (the onclick dead-end gua
       return { forEach(/** @type {(t: any) => void} */ fn) { fn(fakeEl); } };
     },
     querySelector() { return fakeEl; },
-    getElementById() { return fakeEl; },
+    getElementById(/** @type {string} */ id) {
+      // main.js wires a listener on #q only when present; the stub has
+      // no addEventListener, so 'q' must be absent (same shape as the
+      // search-plan F12 stub).
+      if (id === 'q') return null;
+      return fakeEl;
+    },
   };
   try {
     await import('../web/js/main.js');

--- a/tests/test_js_pipeline_dashboard.mjs
+++ b/tests/test_js_pipeline_dashboard.mjs
@@ -844,5 +844,66 @@ console.log('renderLibraryCompletenessCard() wires the mark buttons per row (#12
     'card never wires an action to an unresolvable album');
 }
 
+console.log('renderLibraryCompletenessCard() offers Run census now in every branch');
+{
+  const missing = __test__.renderLibraryCompletenessCard({state: 'missing'});
+  assertContains(missing, 'window.refreshLibraryCensus(this)',
+    'missing branch offers the census run action');
+  const unreadable = __test__.renderLibraryCompletenessCard({
+    state: 'unreadable', error: 'boom',
+  });
+  assertContains(unreadable, 'window.refreshLibraryCensus(this)',
+    'unreadable branch offers the repair action');
+  const populated = __test__.renderLibraryCompletenessCard({
+    state: 'ok', error: null, albums_shown: 0, albums_listed_total: 0,
+    snapshot: {
+      generated_at: new Date().toISOString(),
+      duration_seconds: 90.0,
+      report: {
+        status: 'complete',
+        counts: {albums_scanned: 1, audio_complete: 1,
+                 missing_source_audio: 0, catalog_drift: 0, unknown: 0},
+        albums: [],
+      },
+    },
+  });
+  assertContains(populated, 'window.refreshLibraryCensus(this)',
+    'populated branch offers the census run action');
+  assertContains(populated, 'metric-value-push',
+    'Last run value clusters with the button in the value column');
+}
+
+console.log('main.js binds window.refreshLibraryCensus (the onclick dead-end guard, #1110 shape)');
+{
+  const prevWindow = globalThis.window;
+  const prevDocument = globalThis.document;
+  /** @type {any} */
+  globalThis.window = { setTimeout: () => 0 };
+  /** @type {any} */
+  const fakeEl = { classList: { add() {}, remove() {} } };
+  /** @type {any} */
+  globalThis.document = {
+    querySelectorAll() {
+      return { forEach(/** @type {(t: any) => void} */ fn) { fn(fakeEl); } };
+    },
+    querySelector() { return fakeEl; },
+    getElementById() { return fakeEl; },
+  };
+  try {
+    await import('../web/js/main.js');
+    /** @type {any} */
+    const bound = globalThis.window.refreshLibraryCensus;
+    assert(typeof bound === 'function',
+      'main.js wires window.refreshLibraryCensus');
+    /** @type {any} */
+    const mark = globalThis.window.toggleMarkIncomplete;
+    assert(typeof mark === 'function',
+      'main.js wires window.toggleMarkIncomplete (#1241)');
+  } finally {
+    globalThis.window = prevWindow;
+    globalThis.document = prevDocument;
+  }
+}
+
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/tests/test_pipeline_cli_api_mutations.py
+++ b/tests/test_pipeline_cli_api_mutations.py
@@ -805,6 +805,43 @@ class TestApiMutationRealRouteRoundTrips(_FakeDbWebServerCase):
             body["db_mb_albumid"], "26693e58-02c0-4bb1-b66f-f0f44f8a234d",
         )
 
+    def test_library_census_refresh_writes_trigger_and_maps_exit_codes(
+        self,
+    ) -> None:
+        """The census force button's relay: 200→0 with the trigger file
+        really written; unconfigured snapshot path relays 503→5."""
+        import tempfile
+
+        import web.server as srv
+        from lib.library_completeness_snapshot import (
+            library_completeness_snapshot_path,
+            library_completeness_trigger_path,
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            snapshot_path = library_completeness_snapshot_path(tmpdir)
+            previous = srv.library_completeness_snapshot_path
+            srv.library_completeness_snapshot_path = snapshot_path
+            try:
+                code, body = self._call(api_mutations.cmd_library_census_refresh)
+                trigger_exists = os.path.exists(
+                    library_completeness_trigger_path(tmpdir),
+                )
+            finally:
+                srv.library_completeness_snapshot_path = previous
+        self.assertEqual(code, 0)
+        self.assertEqual(body["outcome"], "requested")
+        self.assertTrue(trigger_exists)
+
+        previous = srv.library_completeness_snapshot_path
+        srv.library_completeness_snapshot_path = None
+        try:
+            code, body = self._call(api_mutations.cmd_library_census_refresh)
+        finally:
+            srv.library_completeness_snapshot_path = previous
+        self.assertEqual(code, 5)
+        self.assertEqual(body["outcome"], "unconfigured")
+
     def test_pipeline_delete_round_trip_preserves_processing_owner(self) -> None:
         self._seed(106, "a0000000-0000-0000-0000-000000000006")
         owner = handoff_automation_owner(self.db, 106)

--- a/tests/web/test_routes_pipeline_dashboard.py
+++ b/tests/web/test_routes_pipeline_dashboard.py
@@ -852,8 +852,6 @@ class TestPipelineDashboardLibraryCompletenessContract(_FakeDbWebServerCase):
         self.assertIsNotNone(census["error"])
 
 
-if __name__ == "__main__":
-    unittest.main()
 
 
 LIBRARY_CENSUS_REFRESH_FIELDS = {"outcome", "error"}
@@ -919,3 +917,7 @@ class TestLibraryCensusRefreshContract(_FakeDbWebServerCase):
         self.assertEqual(status, 503)
         self.assertEqual(data["outcome"], "unavailable")
         self.assertTrue(data["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/web/test_routes_pipeline_dashboard.py
+++ b/tests/web/test_routes_pipeline_dashboard.py
@@ -25,6 +25,7 @@ from lib.library_completeness import (
 from lib.library_completeness_snapshot import (
     LibraryCompletenessSnapshot,
     library_completeness_snapshot_path,
+    library_completeness_trigger_path,
     read_library_completeness_snapshot,
     write_library_completeness_snapshot,
 )
@@ -853,3 +854,68 @@ class TestPipelineDashboardLibraryCompletenessContract(_FakeDbWebServerCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+LIBRARY_CENSUS_REFRESH_FIELDS = {"outcome", "error"}
+
+
+class TestLibraryCensusRefreshContract(_FakeDbWebServerCase):
+    """POST /api/pipeline/dashboard/library-census/refresh — the census
+    force button. Writes the trigger file the module's path unit
+    watches; the daily oneshot stays the single execution path."""
+
+    def test_refresh_writes_trigger_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = library_completeness_snapshot_path(tmpdir)
+            with _library_completeness_snapshot_path_set(path):
+                status, data = self._post(
+                    "/api/pipeline/dashboard/library-census/refresh", {},
+                )
+            trigger = library_completeness_trigger_path(tmpdir)
+            trigger_exists = os.path.exists(trigger)
+        self.assertEqual(status, 200)
+        _assert_required_fields(
+            self, data, LIBRARY_CENSUS_REFRESH_FIELDS, "census refresh",
+        )
+        self.assertEqual(data["outcome"], "requested")
+        self.assertIsNone(data["error"])
+        self.assertTrue(trigger_exists)
+
+    def test_refresh_is_idempotent_while_pending(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = library_completeness_snapshot_path(tmpdir)
+            with _library_completeness_snapshot_path_set(path):
+                first = self._post(
+                    "/api/pipeline/dashboard/library-census/refresh", {},
+                )
+                second = self._post(
+                    "/api/pipeline/dashboard/library-census/refresh", {},
+                )
+        self.assertEqual(first[0], 200)
+        self.assertEqual(second[0], 200)
+        self.assertEqual(second[1]["outcome"], "requested")
+
+    def test_unconfigured_snapshot_path_returns_503(self) -> None:
+        with _library_completeness_snapshot_path_set(None):
+            status, data = self._post(
+                "/api/pipeline/dashboard/library-census/refresh", {},
+            )
+        self.assertEqual(status, 503)
+        self.assertEqual(data["outcome"], "unconfigured")
+
+    def test_unwritable_state_dir_returns_503(self) -> None:
+        # The real adapter raises OSError on an unwritable dir (Rule B:
+        # the failure-case shape is the real exception, not a stand-in).
+        with tempfile.TemporaryDirectory() as tmpdir:
+            os.chmod(tmpdir, 0o500)
+            try:
+                path = library_completeness_snapshot_path(tmpdir)
+                with _library_completeness_snapshot_path_set(path):
+                    status, data = self._post(
+                        "/api/pipeline/dashboard/library-census/refresh", {},
+                    )
+            finally:
+                os.chmod(tmpdir, 0o700)
+        self.assertEqual(status, 503)
+        self.assertEqual(data["outcome"], "unavailable")
+        self.assertTrue(data["error"])

--- a/web/index.html
+++ b/web/index.html
@@ -477,6 +477,10 @@
   .metric-list { display: flex; flex-direction: column; gap: 4px; }
   .metric-row { display: flex; justify-content: space-between; gap: 12px; color: #888; font-size: 0.82em; }
   .metric-row strong { color: #ddd; font-weight: 600; text-align: right; }
+  /* 3-child rows (label / value / action button): space-between would
+     park the value mid-row — push it right so value + button share the
+     card's value column. */
+  .metric-row .metric-value-push { margin-left: auto; }
   .metric-row.metric-clickable { cursor: pointer; border-radius: 3px; padding: 2px 4px; margin: -2px -4px; }
   .metric-row.metric-clickable:hover, .metric-row.metric-open { background: #202820; color: #aaa; }
   .completeness-category { border-top: 1px solid #242424; padding-top: 4px; }

--- a/web/js/main.js
+++ b/web/js/main.js
@@ -9,7 +9,7 @@ import { state } from './state.js';
 import { searchArtists, cancelBrowseSearch, setSearchType, setBrowseSource, openBrowseArtist, closeBrowseArtist, reloadBrowseArtist, invalidateBrowseArtist, closeVaFallback } from './browse.js';
 import { loadReleaseGroup, addRelease, toggleReleaseDetail } from './discography.js';
 import { loadRecents, setRecentsFilter, setRecentsSub, renderRecentsItems } from './recents.js';
-import { loadPipeline, loadPipelineDashboard, mergeRekeyRequest, recheckRetagDivergenceAlbum, setPipelineView, renderPipeline, syncRetagDivergenceAlbum, toggleCoverageMatchGraph, toggleDetail, toggleMarkIncomplete, deleteRequest, updateStatus } from './pipeline.js';
+import { loadPipeline, loadPipelineDashboard, mergeRekeyRequest, recheckRetagDivergenceAlbum, refreshLibraryCensus, setPipelineView, renderPipeline, syncRetagDivergenceAlbum, toggleCoverageMatchGraph, toggleDetail, toggleMarkIncomplete, deleteRequest, updateStatus } from './pipeline.js';
 import { loadLongTail, setLongTailBand, onLongTailSearchInput } from './long_tail.js';
 import { toggleLongTailDetail, toggleLongTailPeers, checkYoutube, pickYoutubeRescue, longTailAcceptSibling, longTailSetIntent, longTailSetImported, longTailDeleteRequest } from './long_tail_console.js';
 import { checkYoutubeRescue } from './youtube_rescue_control.js';
@@ -189,6 +189,7 @@ Object.assign(window, {
   renderPipeline,
   toggleCoverageMatchGraph,
   toggleDetail,
+  refreshLibraryCensus,
   toggleMarkIncomplete,
   deleteRequest,
   updateStatus,

--- a/web/js/pipeline.js
+++ b/web/js/pipeline.js
@@ -246,6 +246,38 @@ export async function toggleMarkIncomplete(requestId, marked, btn) {
 }
 
 /**
+ * Operator action: request an out-of-schedule library-completeness
+ * census run. The server writes the trigger file the census path unit
+ * watches; the daily oneshot stays the single execution path, so the
+ * snapshot (and this card) refreshes when that run completes.
+ * @param {HTMLButtonElement} btn
+ */
+export async function refreshLibraryCensus(btn) {
+  btn.disabled = true;
+  btn.textContent = 'Requesting...';
+  try {
+    const r = await fetch(`${API}/api/pipeline/dashboard/library-census/refresh`, {
+      method: 'POST',
+      headers: {'Content-Type': 'application/json'},
+      body: JSON.stringify({}),
+    });
+    const data = await r.json();
+    if (r.ok) {
+      btn.textContent = 'Census requested';
+      toast('Census run requested — the card refreshes when it completes (minutes on local mirrors)');
+      return;
+    }
+    btn.disabled = false;
+    btn.textContent = 'Run census now';
+    toast(`census refresh refused: ${data.error || r.status}`, true);
+  } catch (_e) {
+    btn.disabled = false;
+    btn.textContent = 'Run census now';
+    toast('census refresh request failed', true);
+  }
+}
+
+/**
  * Operator action (#1142): a cheap, explicit per-album retag-divergence
  * recheck. Called from the "Beets DB ↔ File Tags Drift" card's
  * "Recheck" button (`pipeline_dashboard.js::renderRetagDivergenceAlbumRowInner`).

--- a/web/js/pipeline_dashboard.js
+++ b/web/js/pipeline_dashboard.js
@@ -236,7 +236,9 @@ function renderLibraryCompletenessCard(census) {
     return `<div class="dashboard-card dashboard-wide"><div class="dashboard-card-title">Library Completeness</div><div class="metric-list"><div class="metric-row"><span>Status</span><strong class="metric-muted">no census published yet</strong></div><div class="metric-row"><span>Actions</span>${runButton}</div></div></div>`;
   }
   if (c.state === 'unreadable') {
-    return `<div class="dashboard-card dashboard-wide"><div class="dashboard-card-title">Library Completeness</div><div class="metric-list"><div class="metric-row"><span>Status</span><strong class="metric-bad">snapshot unreadable</strong></div><div class="metric-row"><span>Error</span><strong>${esc(c.error || '')}</strong></div></div></div>`;
+    // A forced run is exactly the repair for an unreadable snapshot —
+    // the census rewrites it atomically.
+    return `<div class="dashboard-card dashboard-wide"><div class="dashboard-card-title">Library Completeness</div><div class="metric-list"><div class="metric-row"><span>Status</span><strong class="metric-bad">snapshot unreadable</strong></div><div class="metric-row"><span>Error</span><strong>${esc(c.error || '')}</strong></div><div class="metric-row"><span>Actions</span>${runButton}</div></div></div>`;
   }
   const snapshot = c.snapshot || {};
   const report = snapshot.report || {};

--- a/web/js/pipeline_dashboard.js
+++ b/web/js/pipeline_dashboard.js
@@ -231,8 +231,9 @@ function renderMarkIncompleteButton(row) {
 /** Render the persisted read-only source/catalog/files census. */
 function renderLibraryCompletenessCard(census) {
   const c = census || {};
+  const runButton = `<button class="p-btn" onclick="window.refreshLibraryCensus(this)">Run census now</button>`;
   if (c.state === 'missing') {
-    return `<div class="dashboard-card dashboard-wide"><div class="dashboard-card-title">Library Completeness</div><div class="metric-list"><div class="metric-row"><span>Status</span><strong class="metric-muted">no census published yet</strong></div></div></div>`;
+    return `<div class="dashboard-card dashboard-wide"><div class="dashboard-card-title">Library Completeness</div><div class="metric-list"><div class="metric-row"><span>Status</span><strong class="metric-muted">no census published yet</strong></div><div class="metric-row"><span>Actions</span>${runButton}</div></div></div>`;
   }
   if (c.state === 'unreadable') {
     return `<div class="dashboard-card dashboard-wide"><div class="dashboard-card-title">Library Completeness</div><div class="metric-list"><div class="metric-row"><span>Status</span><strong class="metric-bad">snapshot unreadable</strong></div><div class="metric-row"><span>Error</span><strong>${esc(c.error || '')}</strong></div></div></div>`;
@@ -271,7 +272,7 @@ function renderLibraryCompletenessCard(census) {
       <div class="dashboard-card-title">Library Completeness</div>
       <div class="metric-list">
         <div class="metric-row"><span>Status</span><strong class="${statusClass}">${esc(stale ? `${report.status || 'unknown'} (stale)` : report.status || 'unknown')}</strong></div>
-        <div class="metric-row"><span>Last run</span><strong>${snapshot.generated_at ? awstDateTime(snapshot.generated_at) : 'n/a'} (${formatDuration(snapshot.duration_seconds)})</strong></div>
+        <div class="metric-row"><span>Last run</span><strong class="metric-value-push">${snapshot.generated_at ? awstDateTime(snapshot.generated_at) : 'n/a'} (${formatDuration(snapshot.duration_seconds)})</strong>${runButton}</div>
         <div class="metric-row"><span>Audio complete</span><strong>${formatCount(counts.audio_complete)} / ${formatCount(counts.albums_scanned)}</strong></div>
         ${categories.map(renderCategory).join('')}
       </div>

--- a/web/routes/pipeline_dashboard.py
+++ b/web/routes/pipeline_dashboard.py
@@ -6,11 +6,15 @@ Split from web/routes/pipeline.py (#522) — mirrors
 
 import json
 import logging
+import os
 
 import msgspec
 
 from lib.disk_coverage_service import disk_coverage
-from lib.library_completeness_snapshot import read_library_completeness_snapshot
+from lib.library_completeness_snapshot import (
+    read_library_completeness_snapshot,
+    request_library_completeness_census,
+)
 from lib.retag_divergence_census_snapshot import (
     read_retag_divergence_census_snapshot,
 )
@@ -199,11 +203,48 @@ def _empty_library_completeness(state: str) -> dict[str, object]:
             "albums_shown": 0, "albums_listed_total": 0}
 
 
+def post_library_census_refresh(
+    h: RouteHandler, _body: dict[str, object],
+) -> None:
+    """Request an out-of-schedule library-completeness census run.
+
+    Writes the trigger file the module's path unit watches; the census
+    oneshot itself remains the single execution path. The state dir is
+    derived from the configured snapshot path — both live in the
+    module's ``stateDir``.
+    """
+    s = _server()
+    snapshot_path = s.library_completeness_snapshot_path
+    if snapshot_path is None:
+        h._json({
+            "outcome": "unconfigured",
+            "error": "library completeness snapshot path is not configured",
+        }, status=503)
+        return
+    try:
+        result = request_library_completeness_census(
+            os.path.dirname(snapshot_path),
+        )
+    except OSError as exc:
+        log.exception("census trigger write failed")
+        h._json({"outcome": "unavailable", "error": str(exc)}, status=503)
+        return
+    h._json({"outcome": result.outcome, "error": None})
+
+
 ROUTES: list[RouteRegistration] = [
     route(
         "GET", "/api/pipeline/dashboard", get_pipeline_dashboard,
         "Operational metrics for the dashboard subtab (searches, cycles, "
         "redis, read-only library census snapshots).",
+        classified=True,
+    ),
+    route(
+        "POST", "/api/pipeline/dashboard/library-census/refresh",
+        post_library_census_refresh,
+        "Request an out-of-schedule library-completeness census run "
+        "(writes the trigger file the census path unit watches; the "
+        "daily oneshot stays the single execution path).",
         classified=True,
     ),
 ]


### PR DESCRIPTION
Adds the operator "force the census" action requested after the #1261 close-out (a just-fixed finding stared back from a stale once-daily snapshot for up to a day).

## What

One canonical execution path, per the CLI ⇄ API symmetry rule:

- `lib/library_completeness_snapshot.py::request_library_completeness_census` writes `library-completeness-census.trigger` into the state dir (idempotent; `OSError` → 503/5).
- **Web**: `POST /api/pipeline/dashboard/library-census/refresh` (classified). **CLI**: `pipeline-cli library-census-refresh`, an HTTP relay — the trigger lives in the web service's state dir (`0755 cratedigger`), which the invoking operator cannot write.
- **Module**: `cratedigger-library-completeness-census.path` (`PathExists=` on the trigger) starts the existing census oneshot; its new `ExecStartPre` removes the trigger first. The census `ExecStart` stays the *only* census execution path; no sudo/polkit surface — stateDir ownership is the authority. `moduleVm` check green.
- **Dashboard**: "Run census now" button on the Library Completeness card, in all three branches (populated, missing, and unreadable — a forced run is exactly the repair for an unreadable snapshot). A one-rule CSS fix (`.metric-value-push`) keeps the card's value column unbroken in the 3-child row.

## systemd semantics — empirically verified, not reasoned

The reviewer replicated the exact unit shape and measured: one trigger → exactly one run with no spurious re-trigger from `ExecStartPre`'s own rm; a request landing mid-run (either a triggered or a timer-style run) → exactly one follow-up run on deactivation; a boot-leftover trigger self-heals into one run. `restartIfChanged = false` predates the change, so the new `ExecStartPre` causes no switch-time restart.

## UI verification (live-db screenshot loop, four rounds)

Round 1: button placement + the 405-refusal click path (dev server is GET-only) on the missing branch. Round 2: populated branch — caught the 3-child flex row parking the timestamp mid-card. Round 3: the `.metric-value-push` fix verified before/after (value column right edges 921 px down the whole card; gap timestamp→button = the flex gap exactly; responsive sweep 1100→380 px unchanged). `/tmp/census-btn-{1..4}.png`.

## Fault injection

Combined reader+runner review: 13 mutants, 11 killed on the Python surface (trigger identity, OSError honesty, unconfigured 503, dirname derivation, relay path/exit codes, idempotency both sides, payload contracts, outcome strings). The two survivors were both on the untested JS surface — the #1110 onclick-dead-end shape: deleting the button and unbinding `window.refreshLibraryCensus` each passed the whole JS suite. Fixed in the review round: render pins for all three branches + a stubbed `main.js` import asserting the binding (plus #1241's binding, free hardening); both mutants re-planted and killed. One test-infra correction from that round: the binding block's earlier green was a node module-cache artifact — the suite's per-file isolation exposed the stub gap (`#q` must be absent), now mirrored from the search-plan F12 stub.

Reviewer's remaining notes carried honestly: the `missing` card branch also renders when the snapshot path is *unconfigured*, so the button can appear where it can only 503 (it fails honestly with the reason in the toast); dev-server docs updated for both blocked buttons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
