### PR TITLE
Post-#1258 reflection: production-anchored stage-2 vocabulary + mutant-restore discipline (#1270)

### DIFF
--- a/.claude/rules/code-quality.md
+++ b/.claude/rules/code-quality.md
@@ -1105,7 +1105,10 @@ rationale; never allowlist a pure decision.
     discipline, not judgment: `PYTHONDONTWRITEBYTECODE=1`, its OWN
     isolated worktree (mutant planting mutates production files — a
     shared tree makes the reader read lies), every edit restored exactly
-    and proven restored (`git status --porcelain` empty), and a final
+    and proven restored (`git status --porcelain` empty; when the file
+    carries uncommitted work, restore by INVERSE EDIT — `git checkout
+    <file>` restores from HEAD and silently wipes that work, #1270),
+    and a final
     table where every row carries the actual command evidence for
     KILLED/SURVIVED — a prose claim of RED without output is the #1209
     confabulation shape and counts as no evidence. A SURVIVOR is a

--- a/tests/test_quality_decisions.py
+++ b/tests/test_quality_decisions.py
@@ -20,6 +20,8 @@ from lib.quality import (
     DECISION_PROVISIONAL_LOSSLESS_UPGRADE,
     DECISION_SUSPECT_LOSSLESS_DOWNGRADE,
     DECISION_SUSPECT_LOSSLESS_PROBE_MISSING,
+    QUALITY_DECISION_IMPORT_STAGE_DECISIONS,
+    QUALITY_DECISION_REJECT_STAGE_DECISIONS,
     AlbumQualityEvidence,
     AlbumQualityEvidenceDecisionFacts,
     AlbumQualityEvidenceFile,
@@ -1039,13 +1041,16 @@ VALID_PREIMPORT_NESTED = {None, "pass", "reject_nested", "skipped_auto"}
 VALID_STAGE0 = {None, "would_run", "skipped_flac",
                 "skipped_uncalibrated_codec"}
 VALID_STAGE1 = {None, "import", "import_upgrade", "import_no_exist", "reject"}
-VALID_STAGE2 = {None, "import", "downgrade", "transcode_upgrade",
-                "transcode_downgrade", "transcode_first",
-                "preflight_existing",
-                DECISION_PROVISIONAL_LOSSLESS_UPGRADE,
-                DECISION_SUSPECT_LOSSLESS_DOWNGRADE,
-                DECISION_SUSPECT_LOSSLESS_PROBE_MISSING,
-                DECISION_LOSSLESS_SOURCE_LOCKED}
+# Stage-2 vocabulary derives from the production-owned stage sets (issue
+# #1270 item 1: the previous hand-maintained literal had silently gone
+# stale — it was missing verified_lossless_locked, which the pipeline
+# emits as stage2_import). Membership of the source sets is pinned in
+# TestDispatchActionContract so a set change is a deliberate act.
+VALID_STAGE2_DECISIONS: frozenset[str] = (
+    QUALITY_DECISION_IMPORT_STAGE_DECISIONS
+    | QUALITY_DECISION_REJECT_STAGE_DECISIONS
+)
+VALID_STAGE2 = {None} | VALID_STAGE2_DECISIONS
 VALID_STAGE3 = {None, "accept", "requeue_upgrade", "requeue_lossless"}
 VALID_FINAL_STATUS = {None, "imported", "wanted"}
 
@@ -2635,13 +2640,47 @@ class TestExtractUsernames(unittest.TestCase):
 class TestDispatchActionContract(unittest.TestCase):
     """Verify dispatch_action covers all import_decision outcomes."""
 
-    def test_covers_import_decision_outcomes(self):
+    def test_production_stage_set_membership_is_pinned(self):
+        """VALID_STAGE2 derives from these sets, so their membership IS the
+        contract — changing either is a deliberate act that must touch this
+        pin (issue #1270 item 1; PR #1269's A2 lesson: a derived domain
+        silently shrinks with its source)."""
+        self.assertEqual(
+            QUALITY_DECISION_IMPORT_STAGE_DECISIONS,
+            {
+                "import",
+                "preflight_existing",
+                "transcode_upgrade",
+                "transcode_first",
+                "provisional_lossless_upgrade",
+            },
+        )
+        self.assertEqual(
+            QUALITY_DECISION_REJECT_STAGE_DECISIONS,
+            {
+                "downgrade",
+                "transcode_downgrade",
+                "suspect_lossless_downgrade",
+                "suspect_lossless_probe_missing",
+                "lossless_source_locked",
+                "verified_lossless_locked",
+            },
+        )
+
+    def test_production_stage_sets_agree_with_dispatch_action(self):
+        """Import-stage decisions mark done and never reject; reject-stage
+        decisions reject and never mark done."""
         from lib.quality import dispatch_action
-        for outcome in VALID_STAGE2 - {None}:
-            a = dispatch_action(outcome)
-            self.assertTrue(a.mark_done or a.record_rejection,
-                            f"dispatch_action('{outcome}') must set mark_done or "
-                            "record_rejection")
+        for decision in sorted(QUALITY_DECISION_IMPORT_STAGE_DECISIONS):
+            with self.subTest(stage="import", decision=decision):
+                action = dispatch_action(decision)
+                self.assertTrue(action.mark_done)
+                self.assertFalse(action.record_rejection)
+        for decision in sorted(QUALITY_DECISION_REJECT_STAGE_DECISIONS):
+            with self.subTest(stage="reject", decision=decision):
+                action = dispatch_action(decision)
+                self.assertFalse(action.mark_done)
+                self.assertTrue(action.record_rejection)
 
 
 class TestAcceptanceInstallsNewFiles(unittest.TestCase):
@@ -2686,7 +2725,7 @@ class TestAcceptanceInstallsNewFiles(unittest.TestCase):
                 "mark_done in dispatch_action",
             )
         self.assertEqual(
-            {d for d in VALID_STAGE2 - {None} if dispatch_action(d).mark_done},
+            {d for d in VALID_STAGE2_DECISIONS if dispatch_action(d).mark_done},
             accepted,
             "dispatch_action's mark_done subset of the known stage-2 "
             "vocabulary drifted from the production import-stage set",


### PR DESCRIPTION
## Summary

Implements issue #1270 items 1+2 (post-#1258 reflection); item 3 stays deferred per the issue's own recommendation (fold into whatever next touches the audit registries).

1. **Stage-2 vocabulary derives from production** (`tests/test_quality_decisions.py`): the hand-maintained `VALID_STAGE2` literal had silently gone stale — it was missing `verified_lossless_locked`, which the pipeline emits as `stage2_import` (`lib/quality/pipeline.py:334`) and which sits in the production reject-stage set. `VALID_STAGE2` is now `{None}` ∪ `QUALITY_DECISION_IMPORT_STAGE_DECISIONS` ∪ `QUALITY_DECISION_REJECT_STAGE_DECISIONS` (measured: the old literal was a strict subset of that union — nothing extra, one member missing). Per the #1258 A2 lesson (a derived domain silently shrinks with its source), the source sets' membership is pinned literally in `TestDispatchActionContract`, and a new bidirectional agreement test requires every import-stage decision to be `mark_done` ∧ ¬`record_rejection` and every reject-stage decision the inverse.
2. **Mutant-restore discipline** (`.claude/rules/code-quality.md` § Pre-Commit Review Gate): the runner's restoration clause now says HOW when the file carries uncommitted work — restore by inverse edit; `git checkout <file>` restores from HEAD and silently wipes that work (bit the #1258 series live).

For issue #1270 (non-closing per template); closed manually after merge (test+rules only — deploy is pin hygiene, not activation).

## Fault injection

Three mutants, all killed: removing `verified_lossless_locked` from the production reject set fails the membership pin; a phantom decision added to the import set (no dispatch arm, no CASES stance) fails both the agreement test and the #1269 stance test (2 RED); making `verified_lossless_locked` `mark_done=True` fails the agreement test. The independent reviewer's own disjoint mutant sweep is reported in the review round below.

## Reviewer

Small, low-risk test+rules diff → the single-combined-reviewer carve-out applies: one opus agent doing both the reader and mutant-runner jobs in its own isolated worktree, `PYTHONDONTWRITEBYTECODE=1`, evidence-backed verdicts, restoration proven. Results appended.

## Risk

- No production code changes. Item 1 widens a test vocabulary to match what production already emits and adds pins/agreement checks that hold on the current tree; item 2 is one rules clause.
- Stated residual (unchanged from #1269): a new `dispatch_action` `mark_done` arm added WITHOUT updating the production import-stage set still escapes these tests; the production set is the anchor the stage classification already derives from, and enumerating `dispatch_action`'s arms statically is the prohibited semantic-scanner shape.
- No Rule D surface, no schema, no wire formats.

## Review round

The combined reviewer (opus, own isolated worktree) planted 8 mutants disjoint from the author's 3 — no survivors — and independently re-derived the staleness claim, the exact widening (+1 member, −0), all consumers, and docs freshness. Notable measured positive: `verified_lossless_locked`'s dispatch stance had ZERO module coverage before this PR (dropping its `record_rejection` left all 232 tests green on base); the agreement test closes that. Findings, all resolved in the final stack: F1 the ruff `I001` import-order failure (also caught by the first gate run; fixed); F2 `test_covers_import_decision_outcomes` fully shadowed by the agreement test over the identical domain — removed with the equivalence proof in the commit message; F4 a long rules line re-wrapped; F5 the "#1258 A2" citation corrected to PR #1269's mutant ID. F3 (the rules clause's placement in the runner bullet vs the author-side fault-injection section) is retained as filed — issue #1270 explicitly targeted that section, and the commit message now states which case the clause bites.

Receipts: gate run 1 failed on exactly the ruff finding; gate run 2 `pass` on the intermediate stack (`/run/user/1000/cratedigger-final-gate.dreE9pas`); gate run 3 `pass` on the final review-fixed stack `9c46f231` + `84877105` (`/run/user/1000/cratedigger-final-gate.38W4mfEM`). The review ran against pre-rebuild `f73f1ce2`; the final stack differs only by the reviewer's own prescriptions above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
