### PR TITLE
fix(harness): drop Discogs heading rows so beets candidates agree with the manifests

### DIFF
--- a/.claude/memory/MEMORY.md
+++ b/.claude/memory/MEMORY.md
@@ -106,3 +106,4 @@
 - [#1229 suite residuals CLOSED](project_1229_suite_residuals.md) — `nix develop` hits Nix's eval cache where `nix-shell` cannot; LPT queue ordering; gate 109s→93s
 - [Alert blast radius](feedback_alert_blast_radius.md) — never fix a silent-alert path by paging unconditionally; enumerate cases, fix only the broken one
 - [Poll gates at short intervals](feedback_poll_gates_short_intervals.md) — doc1 gates run ~2 min now; 60-90s polls, never long sleeps
+- [Mutant restore git-checkout trap](feedback_mutant_restore_git_checkout_trap.md) — restoring a mutant via git checkout wipes uncommitted edits in the same file; restore by inverse edit

--- a/.claude/memory/feedback_mutant_restore_git_checkout_trap.md
+++ b/.claude/memory/feedback_mutant_restore_git_checkout_trap.md
@@ -1,0 +1,21 @@
+---
+name: mutant-restore-git-checkout-trap
+description: git checkout <file> after a planted mutant wipes uncommitted edits sharing that file — restore by inverse edit instead
+metadata:
+  type: feedback
+---
+
+Restoring a planted mutant with `git checkout <file>` restores from HEAD, which
+also silently discards any UNCOMMITTED work in the same file. Bit the #1258
+session (2026-08-25): the item-2 transitions inversion (unstaged) was wiped
+mid-mutant-round and had to be re-applied from context.
+
+**Why:** mutant planting and real editing often share a file within one
+convergence loop; `git checkout` cannot distinguish the mutant from the work.
+
+**How to apply:** when a file carries uncommitted edits, plant mutants with a
+scripted exact-string replace and restore with the inverse replace (assert
+`count == 1` both ways); `git checkout <file>` is safe only when the file is
+committed-clean. Commit your own work before any mutant round when possible.
+Pairs with [[mutation-testing-pycache-trap]] (always
+`PYTHONDONTWRITEBYTECODE=1`). Encoded for the repo in issue #1270 item 2.

--- a/harness/beets_compat.py
+++ b/harness/beets_compat.py
@@ -209,6 +209,50 @@ def _discogs_subtrack_methods(
     )
 
 
+def _is_discogs_heading_row(track: dict[str, object]) -> bool:
+    if track.get("type_") == "heading":
+        return True
+    return (
+        track.get("position") == ""
+        and track.get("duration") == ""
+        and not track.get("sub_tracks")
+    )
+
+
+def filter_discogs_heading_rows(
+    tracklist: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    """Drop Discogs section-label rows before candidate construction.
+
+    Two measured producer shapes (issue #1261's validation-side half,
+    request 6937 / Discogs 8439330): the real api.discogs.com marks
+    section labels ``type_ == "heading"``, but the deployment's beets
+    talks to the DISCOGS MIRROR (``nix/beets.nix`` repoints
+    ``discogs_client._base_url``), whose ``/releases/<id>`` endpoint
+    serves those same rows RETYPED ``type_ == "track"`` with a literal
+    empty position and empty duration — so Beets' own heading handling
+    never fires, on any version, and the labels become zero-length
+    candidate tracks (live: a 12-file rip faced a 14-track candidate —
+    ``extra_tracks`` reject at distance 0.5669 for a copy whose true
+    mapping is 12↔12, with each label starting its own phantom medium).
+
+    The shape branch is the same measured header rule as
+    ``lib/library_completeness.py`` and ``lib/discogs_positions.py``
+    (mirrored here because the harness cannot import ``lib/``): a
+    literal empty position AND empty duration, never a row carrying
+    nested ``sub_tracks`` (an index parent's children are real audio).
+    A tracklist that is ENTIRELY heading-shaped is returned unchanged:
+    never manufacture an empty candidate from non-empty input.
+    """
+    kept = [
+        track for track in tracklist
+        if not _is_discogs_heading_row(track)
+    ]
+    if not kept:
+        return tracklist
+    return kept
+
+
 def configure_discogs_subtracks(*, preserve_flat: bool) -> None:
     """Install Cratedigger's narrow Discogs physical-track compatibility.
 
@@ -343,6 +387,7 @@ def configure_discogs_subtracks(*, preserve_flat: bool) -> None:
         tracklist: list[dict[str, object]],
         albumartistinfo: object,
     ) -> object:
+        tracklist = filter_discogs_heading_rows(tracklist)
         programs_by_position: dict[str, DiscogsIndexedProgram] = {}
         if not preserve_flat:
             coalesce = getattr(self, "_coalesce_tracks", None)

--- a/harness/beets_compat.py
+++ b/harness/beets_compat.py
@@ -209,11 +209,14 @@ def _discogs_subtrack_methods(
     )
 
 
-def _is_discogs_heading_row(track: dict[str, object]) -> bool:
+def _is_discogs_heading_row(
+    track: dict[str, object], *, any_positioned: bool,
+) -> bool:
     if track.get("type_") == "heading":
         return True
     return (
-        track.get("position") == ""
+        any_positioned
+        and track.get("position") == ""
         and track.get("duration") == ""
         and not track.get("sub_tracks")
     )
@@ -226,8 +229,9 @@ def filter_discogs_heading_rows(
 
     Two measured producer shapes (issue #1261's validation-side half,
     request 6937 / Discogs 8439330): the real api.discogs.com marks
-    section labels ``type_ == "heading"``, but the deployment's beets
-    talks to the DISCOGS MIRROR (``nix/beets.nix`` repoints
+    section labels ``type_ == "heading"`` (dropped unconditionally —
+    Beets' own data says it is not a musical work), but the deployment's
+    beets talks to the DISCOGS MIRROR (``nix/beets.nix`` repoints
     ``discogs_client._base_url``), whose ``/releases/<id>`` endpoint
     serves those same rows RETYPED ``type_ == "track"`` with a literal
     empty position and empty duration — so Beets' own heading handling
@@ -236,17 +240,25 @@ def filter_discogs_heading_rows(
     ``extra_tracks`` reject at distance 0.5669 for a copy whose true
     mapping is 12↔12, with each label starting its own phantom medium).
 
-    The shape branch is the same measured header rule as
-    ``lib/library_completeness.py`` and ``lib/discogs_positions.py``
-    (mirrored here because the harness cannot import ``lib/``): a
-    literal empty position AND empty duration, never a row carrying
-    nested ``sub_tracks`` (an index parent's children are real audio).
-    A tracklist that is ENTIRELY heading-shaped is returned unchanged:
-    never manufacture an empty candidate from non-empty input.
+    The shape branch mirrors ``lib/discogs_positions.py``'s measured
+    header rule exactly, because the two sides must count the same
+    tracks for the same payload: a literal empty position AND empty
+    duration, never a row carrying nested ``sub_tracks`` (an index
+    parent's children are real audio), and only when the release
+    positions at least one other row — a release that positions NOTHING
+    has no heading signal and keeps every row, exactly as the
+    acquisition manifest does. (``lib/library_completeness.py`` shares
+    the empty/empty shape but scopes it differently for the census; the
+    manifest normalizer is the agreement partner here.) A tracklist that
+    is ENTIRELY heading-shaped is returned unchanged: never manufacture
+    an empty candidate from non-empty input.
     """
+    any_positioned = any(
+        str(track.get("position") or "") for track in tracklist
+    )
     kept = [
         track for track in tracklist
-        if not _is_discogs_heading_row(track)
+        if not _is_discogs_heading_row(track, any_positioned=any_positioned)
     ]
     if not kept:
         return tracklist

--- a/tests/test_discogs_subtracks.py
+++ b/tests/test_discogs_subtracks.py
@@ -255,41 +255,132 @@ class TestDiscogsHeadingRowExclusion(unittest.TestCase):
         titles = [t.title for t in track_infos]
         self.assertNotIn(
             'Selections From "Tiny Dots" Original Score', titles)
-        # The heading must not have split the medium numbering either:
         # A/B are two sides of ONE vinyl medium (sides_per_medium=2).
-        # Unfiltered, the headings measurably split this to {1, 3}.
+        # NOTE: typed headings are already excluded by the pinned Beets'
+        # own TracklistState.build, so this pin alone cannot kill a
+        # filter-removal mutant — the mirror-retyped pin below is the
+        # decisive one. This branch is fail-closed legislation for a
+        # typed heading carrying a duration (see the direct filter pin).
         self.assertEqual({t.medium for t in track_infos}, {1})
+
+    @staticmethod
+    def _mirror_heading(title: str) -> Track:
+        return {
+            "type_": "track",
+            "position": "",
+            "title": title,
+            "duration": "",
+        }
 
     def test_mirror_retyped_heading_rows_are_excluded(self) -> None:
         # The DECISIVE live shape: the mirror serves section labels as
         # type_=='track' with empty position and duration (probed on
         # /releases/8439330). Upstream Beets keeps these as zero-length
         # tracks that each start a phantom medium — only the compat
-        # filter's shape rule removes them.
+        # filter's shape rule removes them. Both subtrack modes: the
+        # preserve_flat=True observational rerun is a live path (it is
+        # triggered by exactly the unmapped-audio situation headings
+        # cause).
+        for preserve_flat in (False, True):
+            with self.subTest(preserve_flat=preserve_flat):
+                configure_discogs_subtracks(preserve_flat=preserve_flat)
+                plugin = self._configured_plugin()
+                tracklist: list[Track] = [
+                    self._mirror_heading(
+                        'Selections From "Tiny Dots" Original Score'),
+                    _audio("A1", "A", "6:44"),
+                    _audio("A2", "B", "2:32"),
+                    self._mirror_heading(
+                        "Selections From Live Seated Performance"),
+                    _audio("B1", "A Departure", "3:33"),
+                    _audio("B2", "For Mayor In Splitsville", "3:29"),
+                ]
+
+                track_infos = plugin.get_tracks(
+                    tracklist, self._artist_state(plugin))
+
+                self.assertEqual(len(track_infos), 4)
+                self.assertEqual({t.medium for t in track_infos}, {1})
+
+    def test_positionless_release_keeps_every_row(self) -> None:
+        # R1: a release that positions NOTHING has no heading signal —
+        # the acquisition manifest (lib/discogs_positions.py) keeps all
+        # rows, so the candidate must count the same tracks.
         configure_discogs_subtracks(preserve_flat=False)
         plugin = self._configured_plugin()
-
-        def mirror_heading(title: str) -> Track:
-            return {
-                "type_": "track",
-                "position": "",
-                "title": title,
-                "duration": "",
-            }
-
         tracklist: list[Track] = [
-            mirror_heading('Selections From "Tiny Dots" Original Score'),
-            _audio("A1", "A", "6:44"),
-            _audio("A2", "B", "2:32"),
-            mirror_heading("Selections From Live Seated Performance"),
-            _audio("B1", "A Departure", "3:33"),
-            _audio("B2", "For Mayor In Splitsville", "3:29"),
+            {"type_": "track", "position": "", "title": "Untitled One",
+             "duration": "3:00"},
+            {"type_": "track", "position": "", "title": "Untitled Two",
+             "duration": ""},
+            {"type_": "track", "position": "", "title": "Untitled Three",
+             "duration": "2:30"},
         ]
 
         track_infos = plugin.get_tracks(tracklist, self._artist_state(plugin))
 
-        self.assertEqual(len(track_infos), 4)
-        self.assertEqual({t.medium for t in track_infos}, {1})
+        self.assertEqual(len(track_infos), 3)
+
+    def test_shape_rule_is_a_conjunction(self) -> None:
+        # R3: each conjunct alone is catastrophic — position-only eats
+        # the ambiguous positionless-but-timed row; duration-only eats
+        # every untimed REAL track (routine on Discogs). Both survive.
+        configure_discogs_subtracks(preserve_flat=False)
+        plugin = self._configured_plugin()
+        tracklist: list[Track] = [
+            self._mirror_heading("Heading"),
+            _audio("A1", "Untimed Real Track", ""),
+            {"type_": "track", "position": "", "title": "Timed Ambiguous",
+             "duration": "2:00"},
+            _audio("A2", "Ordinary", "3:00"),
+        ]
+
+        track_infos = plugin.get_tracks(tracklist, self._artist_state(plugin))
+
+        titles = [t.title for t in track_infos]
+        self.assertEqual(len(track_infos), 3)
+        self.assertIn("Untimed Real Track", titles)
+        self.assertIn("Timed Ambiguous", titles)
+        self.assertNotIn("Heading", titles)
+
+    def test_typed_heading_with_duration_is_still_dropped(self) -> None:
+        # R5: the typed branch's own observable pin — beets' data model
+        # allows a heading to carry a duration, and the type_ marker
+        # outranks the shape. Only the direct filter call can see this
+        # (upstream drops typed headings through get_tracks regardless).
+        from harness.beets_compat import filter_discogs_heading_rows
+
+        rows: list[dict[str, object]] = [
+            {"type_": "heading", "position": "", "title": "Timed Heading",
+             "duration": "3:00"},
+            {"type_": "track", "position": "A1", "title": "Real",
+             "duration": "3:00"},
+        ]
+        kept = filter_discogs_heading_rows(rows)
+        self.assertEqual([r["title"] for r in kept], ["Real"])
+
+    def test_heading_inside_flat_subtrack_run_keeps_program_marking(
+        self,
+    ) -> None:
+        # R6: the pre-pass coalesce dry-run and the real get_tracks call
+        # must see the SAME filtered list — a mirror heading interrupting
+        # a flat A2.1/A2.2 run would otherwise split the groupby and lose
+        # the indexed-program marker on the merged composite.
+        configure_discogs_subtracks(preserve_flat=False)
+        plugin = self._configured_plugin()
+        tracklist: list[Track] = [
+            _audio("A1", "Opener", "3:00"),
+            _audio("A2.1", "Part One", "4:00"),
+            self._mirror_heading("Interrupting Heading"),
+            _audio("A2.2", "Part Two", "4:00"),
+        ]
+
+        track_infos = plugin.get_tracks(tracklist, self._artist_state(plugin))
+
+        self.assertEqual(len(track_infos), 2)
+        composite = track_infos[1]
+        self.assertEqual(discogs_indexed_component_count(composite), 2)
+        self.assertTrue(discogs_indexed_duration_complete(composite))
 
     def test_all_heading_tracklist_is_left_untouched(self) -> None:
         # Pathological upstream data: every row a heading. The filter

--- a/tests/test_discogs_subtracks.py
+++ b/tests/test_discogs_subtracks.py
@@ -184,5 +184,153 @@ class TestDiscogsSubtrackCompatibility(unittest.TestCase):
         self.assertEqual(tracks[0]["position"], "A2")
 
 
+class TestDiscogsHeadingRowExclusion(unittest.TestCase):
+    """Heading rows never become candidate tracks (the Tiny Dots shape).
+
+    Live evidence (request 6937 / Discogs 8439330, download_log 40576):
+    two section-label rows survived candidate construction as zero-length
+    tracks, inflating the candidate to 14 tracks for a 12-file rip —
+    `extra_tracks` rejection at distance 0.5669 for a copy whose true
+    mapping is 12↔12. The deployment's beets reads the DISCOGS MIRROR
+    (nix/beets.nix repoints discogs_client), which serves headings
+    RETYPED type_=='track' with empty position/duration — so upstream
+    Beets' own heading handling never fires. The pipeline's manifests
+    drop headings (`lib/discogs_positions.py`, same measured shape
+    rule); the validation-side candidate must agree.
+    """
+
+    def tearDown(self) -> None:
+        configure_discogs_subtracks(preserve_flat=False)
+
+    def _configured_plugin(self) -> DiscogsPlugin:
+        plugin = object.__new__(DiscogsPlugin)
+        plugin.config = config["discogs"]
+        plugin.config.add({
+            "index_tracks": False,
+            "strip_disambiguation": True,
+            "featured_string": "Feat.",
+            "anv": {
+                "artist_credit": True,
+                "artist": False,
+                "album_artist": False,
+            },
+        })
+        return plugin
+
+    def _artist_state(self, plugin: DiscogsPlugin) -> ArtistState:
+        artist: Artist = {
+            "id": "1",
+            "name": "La Dispute",
+            "anv": "",
+            "join": "",
+            "role": "",
+            "tracks": "",
+            "resource_url": "",
+        }
+        return ArtistState.from_config(plugin.config, [artist])
+
+    def _heading(self, title: str) -> Track:
+        return {
+            "type_": "heading",
+            "position": "",
+            "title": title,
+            "duration": "",
+        }
+
+    def test_typed_heading_rows_are_excluded_from_candidates(self) -> None:
+        configure_discogs_subtracks(preserve_flat=False)
+        plugin = self._configured_plugin()
+        tracklist: list[Track] = [
+            self._heading('Selections From "Tiny Dots" Original Score'),
+            _audio("A1", "A", "2:00"),
+            _audio("A2", "B", "2:00"),
+            self._heading("Selections From Live Seated Performance"),
+            _audio("B1", "A Departure (live)", "4:00"),
+            _audio("B2", "For Mayor in Splitsville (live)", "4:00"),
+        ]
+
+        track_infos = plugin.get_tracks(tracklist, self._artist_state(plugin))
+
+        self.assertEqual(len(track_infos), 4)
+        titles = [t.title for t in track_infos]
+        self.assertNotIn(
+            'Selections From "Tiny Dots" Original Score', titles)
+        # The heading must not have split the medium numbering either:
+        # A/B are two sides of ONE vinyl medium (sides_per_medium=2).
+        # Unfiltered, the headings measurably split this to {1, 3}.
+        self.assertEqual({t.medium for t in track_infos}, {1})
+
+    def test_mirror_retyped_heading_rows_are_excluded(self) -> None:
+        # The DECISIVE live shape: the mirror serves section labels as
+        # type_=='track' with empty position and duration (probed on
+        # /releases/8439330). Upstream Beets keeps these as zero-length
+        # tracks that each start a phantom medium — only the compat
+        # filter's shape rule removes them.
+        configure_discogs_subtracks(preserve_flat=False)
+        plugin = self._configured_plugin()
+
+        def mirror_heading(title: str) -> Track:
+            return {
+                "type_": "track",
+                "position": "",
+                "title": title,
+                "duration": "",
+            }
+
+        tracklist: list[Track] = [
+            mirror_heading('Selections From "Tiny Dots" Original Score'),
+            _audio("A1", "A", "6:44"),
+            _audio("A2", "B", "2:32"),
+            mirror_heading("Selections From Live Seated Performance"),
+            _audio("B1", "A Departure", "3:33"),
+            _audio("B2", "For Mayor In Splitsville", "3:29"),
+        ]
+
+        track_infos = plugin.get_tracks(tracklist, self._artist_state(plugin))
+
+        self.assertEqual(len(track_infos), 4)
+        self.assertEqual({t.medium for t in track_infos}, {1})
+
+    def test_all_heading_tracklist_is_left_untouched(self) -> None:
+        # Pathological upstream data: every row a heading. The filter
+        # must never manufacture an empty candidate from non-empty
+        # input — the unfiltered list passes through to Beets.
+        from harness.beets_compat import filter_discogs_heading_rows
+
+        tracklist: list[dict[str, object]] = [
+            dict(self._heading("Section One")),
+            dict(self._heading("Section Two")),
+        ]
+        self.assertEqual(
+            filter_discogs_heading_rows(list(tracklist)), tracklist)
+
+    def test_nested_index_parent_is_never_dropped(self) -> None:
+        # An index parent carries real audio in sub_tracks — kept and
+        # coalesced by Beets' own path, in both subtrack modes.
+        for preserve_flat in (False, True):
+            with self.subTest(preserve_flat=preserve_flat):
+                configure_discogs_subtracks(preserve_flat=preserve_flat)
+                plugin = self._configured_plugin()
+                nested: IndexTrack = {
+                    "type_": "index",
+                    "position": "",
+                    "title": "A Physical Suite",
+                    "duration": "",
+                    "sub_tracks": [
+                        _audio("A2.1", "Part One", "4:00"),
+                        _audio("A2.2", "Part Two", "4:00"),
+                    ],
+                }
+                tracklist: list[Track] = [
+                    _audio("A1", "Opener", "3:00"),
+                    nested,
+                ]
+
+                track_infos = plugin.get_tracks(
+                    tracklist, self._artist_state(plugin))
+
+                self.assertEqual(len(track_infos), 2)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_discogs_subtracks_generated.py
+++ b/tests/test_discogs_subtracks_generated.py
@@ -1,0 +1,155 @@
+"""Generated agreement property for Discogs candidate construction.
+
+The invariant that would have caught the whole #1261 validation-side
+class for free: **for one mirror-shaped Discogs payload, the harness's
+REAL candidate (``DiscogsPlugin.get_tracks`` through the compat layer)
+counts exactly the tracks the acquisition manifest
+(``lib.discogs_positions.normalize_release_tracks``) counts.** The two
+are independent implementations on either side of the pipeline↔beets
+boundary; a rip satisfies the matcher's count gate iff it satisfies
+beets' mapping, or every download bounces at one side or the other.
+
+Worlds are drawn structurally (mirror-retyped headings, positioned
+tracks with and without durations, positionless-but-timed ambiguous
+rows, ADJACENT flat subtrack runs, positionless-only releases). Known
+limits (deliberate): subtrack runs are always adjacent — Beets'
+``groupby`` coalescing is consecutive-only while the manifest groups by
+base string, so a non-adjacent run is a real upstream-data pathology
+with no live producer and no agreed answer yet; and the placeholder
+grammar axes are owned by the deterministic pins in
+``tests/test_discogs_subtracks.py`` and ``tests/test_discogs_api.py``.
+"""
+
+from __future__ import annotations
+
+import unittest
+from dataclasses import dataclass
+
+from beets import config
+from beetsplug.discogs import ArtistState, DiscogsPlugin
+from beetsplug.discogs.types import Track
+from hypothesis import example, given
+from hypothesis import strategies as st
+
+import tests._hypothesis_profiles  # noqa: F401
+from harness.beets_compat import configure_discogs_subtracks
+from lib.discogs_positions import normalize_release_tracks
+
+
+@dataclass(frozen=True)
+class World:
+    rows: tuple[tuple[str, str, str], ...]  # (position, title, duration)
+
+
+_titles = st.text(
+    alphabet="abcdefghij XYZ'", min_size=1, max_size=12,
+).filter(lambda t: t.strip())
+
+_durations = st.sampled_from(("", "2:30", "4:07", "0:39"))
+
+
+@st.composite
+def worlds(draw: st.DrawFn) -> World:
+    positionless_only = draw(st.booleans())
+    rows: list[tuple[str, str, str]] = []
+    if positionless_only:
+        for _ in range(draw(st.integers(min_value=1, max_value=4))):
+            rows.append(("", draw(_titles), draw(_durations)))
+        return World(rows=tuple(rows))
+    count = draw(st.integers(min_value=1, max_value=5))
+    for index in range(count):
+        number = index + 1
+        kind = draw(st.sampled_from(
+            ("track", "untimed_track", "heading", "ambiguous", "subrun"),
+        ))
+        if kind == "track":
+            rows.append((f"A{number}", draw(_titles), draw(_durations)))
+        elif kind == "untimed_track":
+            rows.append((f"A{number}", draw(_titles), ""))
+        elif kind == "heading":
+            rows.append(("", draw(_titles), ""))
+        elif kind == "ambiguous":
+            rows.append(("", draw(_titles), "2:30"))
+        else:
+            for sub in range(1, draw(st.integers(min_value=2, max_value=3)) + 1):
+                rows.append((f"A{number}.{sub}", draw(_titles), "4:00"))
+    # Guarantee the world is not accidentally positionless-only (the
+    # heading/ambiguous kinds could be the only draws): ensure at least
+    # one positioned row so both sides use their positioned semantics.
+    if not any(position for position, _, _ in rows):
+        rows.append(("A9", draw(_titles), "3:00"))
+    return World(rows=tuple(rows))
+
+
+_TINY_DOTS_PIN = World(rows=(
+    ("", 'Selections XYZ', ""),
+    ("A1", "a", "6:44"),
+    ("A2", "b", "2:32"),
+    ("", "Selections Live", ""),
+    ("B1", "departure", "3:33"),
+    ("B2", "mayor", "3:29"),
+))
+
+_POSITIONLESS_PIN = World(rows=(
+    ("", "one", "3:00"),
+    ("", "two", ""),
+    ("", "three", "2:30"),
+))
+
+
+def _plugin() -> DiscogsPlugin:
+    plugin = object.__new__(DiscogsPlugin)
+    plugin.config = config["discogs"]
+    plugin.config.add({
+        "index_tracks": False,
+        "strip_disambiguation": True,
+        "featured_string": "Feat.",
+        "anv": {
+            "artist_credit": True,
+            "artist": False,
+            "album_artist": False,
+        },
+    })
+    return plugin
+
+
+def _artist_state(plugin: DiscogsPlugin) -> ArtistState:
+    return ArtistState.from_config(plugin.config, [{
+        "id": "1", "name": "Agreement Artist", "anv": "", "join": "",
+        "role": "", "tracks": "", "resource_url": "",
+    }])
+
+
+class TestCandidateManifestAgreement(unittest.TestCase):
+    def tearDown(self) -> None:
+        configure_discogs_subtracks(preserve_flat=False)
+
+    @given(worlds())
+    @example(_TINY_DOTS_PIN)
+    @example(_POSITIONLESS_PIN)
+    def test_candidate_counts_agree_with_the_manifest(
+        self, world: World,
+    ) -> None:
+        mirror_tracklist: list[Track] = [
+            {"type_": "track", "position": position, "title": title,
+             "duration": duration}
+            for position, title, duration in world.rows
+        ]
+        manifest = normalize_release_tracks([
+            {"position": position, "title": title, "duration": duration}
+            for position, title, duration in world.rows
+        ])
+
+        configure_discogs_subtracks(preserve_flat=False)
+        plugin = _plugin()
+        candidate = plugin.get_tracks(mirror_tracklist, _artist_state(plugin))
+
+        self.assertEqual(
+            len(candidate), len(manifest),
+            "the harness candidate and the acquisition manifest must "
+            f"count the same tracks for one payload; rows={world.rows!r}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The beets-validation half of the #1261 heading pathology — the meta-fix so the pipeline's manifests and beets' candidates count the same tracks for the same Discogs release.

## The live failure

Request 6937 (La Dispute — Tiny Dots): the corrected search manifest produced its first-ever download — a 12-FLAC copy whose true mapping is 12↔12 — and beets validation rejected it twice as `extra_tracks` at distance 0.5669, because the harness's candidate carried **14 tracks**: both section-label rows survived as zero-length tracks, each starting its own phantom medium.

## Root cause (proven by instrumenting the real validation path on doc2)

The deployment's beets discogs plugin is repointed at the **Discogs mirror** (`nix/beets.nix` patches `discogs_client._base_url`), and the mirror's `/releases/<id>` endpoint serves heading rows **retyped `type_ == "track"`** with a literal empty position and empty duration. The real api.discogs.com marks the same rows `type_ == "heading"`, which the pinned beets 2.13.1 handles correctly — probed both. So upstream's heading handling never fires on live data, on any beets version, and a `type_`-keyed filter alone is measurably a no-op.

## The fix

`harness/beets_compat.py::filter_discogs_heading_rows`, applied at the one `get_tracks` choke point the compat layer already owns: drop rows that are explicitly `type_ == "heading"`, or shape-headers — literal empty position AND empty duration, never a row carrying nested `sub_tracks`, and **only when the release positions at least one other row** (the review's R1: without that guard, a positionless release lost its untimed rows while the acquisition manifest kept them — the same mismatch class in the missing-track direction). An all-heading tracklist passes through unchanged. The predicate mirrors `lib/discogs_positions.py` exactly; the harness cannot import `lib/`.

End-to-end proof on doc2 (real `beets_validate` against the preserved Wrong Matches folder): candidate 14 / `extra_tracks` / 0.5669 before → **12 tracks / one medium** after. The remaining `high_distance` 0.4396 on this specific album is the ordinary distance gate judging single-letter track titles — the per-album operator call deliberately out of scope. Heading-cohort albums with real titles (Kid A et al.) now validate against agreeing counts.

## Tests

- Pins through the REAL `DiscogsPlugin.get_tracks` on the pinned beets: the decisive mirror-retyped shape (both subtrack modes — the `preserve_flat=True` rerun is a live path), the conjunction halves (position-only eats untimed real tracks; duration-only eats the ambiguous timed row), the positionless release (every row kept, agreeing with the manifest), the pre-pass/real-call consistency (a heading interrupting a flat `A2.1/A2.2` run must not split the indexed-program marking), the nested index parent, the all-headings guard, and the typed-branch's direct-call pin (a typed heading WITH a duration — the only place that branch is observable, since upstream drops typed headings itself).
- **Pair-rule property** (`tests/test_discogs_subtracks_generated.py`): for one mirror-shaped payload, the real harness candidate counts exactly the tracks `lib.discogs_positions.normalize_release_tracks` counts — two independent implementations across the pipeline↔beets boundary; this is the invariant that would have caught the whole class for free. Limits (adjacent-only subtrack runs, placeholder grammar owned by pins) declared in the module docstring.

## Fault injection

Combined reader+runner review of the first commit: 10 mutants, 5 survivors — every one now killed by a named pin, re-verified in one sweep against the final tree: filter removal, both single-conjunct weakenings, filter-after-prepass, typed-branch deletion, and preserve_flat-skip all RED (evidence in the review round commit). The reviewer confirmed the mirror-retype claim live, the phantom-medium claim, the one-choke-point claim, and that no other harness consumer reads the raw tracklist. Reader R2's false test comment ("{1,3}") was this round's minted-false-claim and is corrected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
