### PR TITLE
test(quality): scope V6 oracle to participating anchor

### DIFF
--- a/tests/test_quality_generated.py
+++ b/tests/test_quality_generated.py
@@ -3155,6 +3155,18 @@ _UNANCHORED_MEASURED_REJECT_WORLD = replace(
     target_format="opus 64",
     verified_lossless_target="opus 64",
 )
+#: Request 2066 with both #1241 conjuncts set: the operator marked the
+#: installed OPUS 110 copy incomplete AND this attempt's candidate covers
+#: the whole declared program. Production disregards the installed side
+#: entirely on this predicate — the 177/175 anchor comparison V6 polices
+#: never happens, because there is no existing side left to anchor against.
+#: V6's checker must recognise this as out of its own scope, not assert the
+#: anchor law over a world production never treats as anchored.
+_REQUEST_2066_MARKED_INCOMPLETE_WORLD = replace(
+    _REQUEST_2066_WORLD,
+    installed_marked_incomplete=True,
+    candidate_covers_declared_program=True,
+)
 # Issue #1241 pin — request 1852, Dirt Dress *Theme Songs* (Discogs
 # 4738671, download_log 40355). Installed AAC ~128 missing 700 s of declared
 # program (operator-marked incomplete); candidate MP3 ~196 that beets proved
@@ -4842,6 +4854,7 @@ class TestUltrasonicProofLegProperties(unittest.TestCase):
 
     @given(world=parity_worlds())
     @example(world=_REQUEST_2066_WORLD)
+    @example(world=_REQUEST_2066_MARKED_INCOMPLETE_WORLD)
     def test_v6_an_unproven_source_never_outranks_its_anchor(self, world):
         candidate, current, facts = _parity_evidence_inputs(world)
         self.assertTrue(
@@ -5175,6 +5188,74 @@ class TestUltrasonicProofLegCheckerSelfTests(unittest.TestCase):
                 decider=_decoy_decider_lets_an_unproven_album_skip_the_anchor,
             )
         )
+
+    def test_v6_out_of_scope_when_installed_incomplete_disregarded(self):
+        """Issue #1241's predicate is out of V6's scope, Q1 half: when both
+        conjuncts hold, production nulls the anchor probe and admits the
+        candidate fresh, so there is no anchor left for V6 to police. Drive
+        the exact denial the checker itself would construct, straight
+        through the real decider, and confirm the decided outcome is NOT
+        the anchor law's confident reject — proving the scope exit is
+        load-bearing, not vacuous — while the checker still reports True."""
+        candidate, current, facts = _parity_evidence_inputs(
+            _REQUEST_2066_MARKED_INCOMPLETE_WORLD,
+        )
+        denied_candidate = _with_adjudicable_ultrasonic(
+            candidate, _DENYING_DEFICIT_DB,
+        )
+        self.assertFalse(_leg_is_withheld_by_oracle(denied_candidate))
+        real = full_pipeline_decision_from_evidence(
+            denied_candidate, current, facts=facts,
+        )
+        self.assertTrue(real["installed_incomplete_disregarded"])
+        self.assertIsNone(real["comparison_basis"])
+        self.assertEqual(real["stage2_import"], "provisional_lossless_upgrade")
+        self.assertTrue(real["imported"])
+        self.assertTrue(
+            an_unproven_lossless_source_never_outranks_its_anchor(
+                candidate, current, facts=facts,
+            )
+        )
+
+    def test_v6_stays_in_scope_when_only_one_1241_conjunct_holds(self):
+        """Issue #1241's predicate is out of V6's scope, Q2 half: neither
+        conjunct alone disarms the anchor law (mirrors the disregard
+        property's own four-corners pin at
+        ``test_operator_incomplete_mark_disregards_the_installed_side``).
+        A marked-but-not-covered or covered-but-not-marked world must
+        still decide the ordinary anchor law and the checker must still
+        catch the shipped grade-keyed-router bug on both."""
+        for label, world in (
+            ("marked_only", replace(
+                _REQUEST_2066_WORLD, installed_marked_incomplete=True)),
+            ("covered_only", replace(
+                _REQUEST_2066_WORLD, candidate_covers_declared_program=True)),
+        ):
+            with self.subTest(world=label):
+                candidate, current, facts = _parity_evidence_inputs(world)
+                denied_candidate = _with_adjudicable_ultrasonic(
+                    candidate, _DENYING_DEFICIT_DB,
+                )
+                real = full_pipeline_decision_from_evidence(
+                    denied_candidate, current, facts=facts,
+                )
+                self.assertFalse(real["installed_incomplete_disregarded"])
+                self.assertEqual(
+                    real["stage2_import"], "suspect_lossless_downgrade",
+                )
+                self.assertTrue(
+                    an_unproven_lossless_source_never_outranks_its_anchor(
+                        candidate, current, facts=facts,
+                    )
+                )
+                self.assertFalse(
+                    an_unproven_lossless_source_never_outranks_its_anchor(
+                        candidate, current, facts=facts,
+                        decider=(
+                            _decoy_decider_lets_an_unproven_album_skip_the_anchor
+                        ),
+                    )
+                )
 
 # ===========================================================================
 # Proof gate v4 — the AAC frame-lattice leg (issue #829 AAC-lattice leg PR-B)
@@ -5612,8 +5693,23 @@ def an_unproven_lossless_source_never_outranks_its_anchor(
     Accused grades are out of scope on purpose: their lane/override laws
     belong to V5/L5, and the V0-avg trust override may legitimately import
     over a within-tolerance anchor (PR3's core).
+
+    Issue #1241's disregard predicate is out of scope too, for the same
+    reason: when the operator marked the installed copy incomplete AND this
+    attempt's candidate covers the whole declared program, production nulls
+    every existing-side input — including the anchor probe this checker
+    reads — before Stage 2 ever runs, so there is no anchor left to compare
+    against. The decided outcome in that world is the ordinary fresh-import
+    admission (``installed_incomplete_disregarded=True``,
+    ``comparison_basis=None``), never this lane's confident reject.
     """
     if candidate.measurement.spectral_grade not in ("genuine", "marginal"):
+        return True
+    if (
+        facts is not None
+        and facts.installed_marked_incomplete
+        and facts.candidate_covers_declared_program
+    ):
         return True
     if current is None or current.verified_lossless_proof is not None:
         return True


### PR DESCRIPTION
## Summary

- Scope V6’s installed-anchor oracle to worlds where the installed side still participates.
- Add a readable request-2066 example for the exact `installed_marked_incomplete && candidate_covers_declared_program` world introduced by #1241.
- Preserve V6 for both one-sided controls and assert production’s disregarded-anchor outcome directly.
- Production quality code is unchanged; this corrects stale generated-test policy only.

## Fault injection

- V6 property/example: deleting the new scope guard (M1), widening production’s predicate (M2), and breaking the anchor tolerance law (M3) were all KILLED; deleting both the guard and named example made the suite-tier property survive, proving the new `@example` is load-bearing.
- Disregarded-anchor self-test: guard removal (M1), retaining installed V0 inputs (M4), suppressing `installed_incomplete_disregarded` (M5), and turning the unanchored upgrade into a confident reject (M10) were all KILLED.
- One-sided-control self-test: production `and → or` (M2), broken anchor tolerance (M3), and checker-guard `and → or` (M6) were all KILLED for marked-only and covered-only worlds.
- Changed checker clause: removal (M1) and widening (M6) both die at the deterministic suite tier. Existing `test_operator_incomplete_mark_disregards_the_installed_side` separately killed production-disregard mutants M4/M5/M8/M12, preserving the division between V6 scope and #1241 behavior.

All mutants were real temporary source edits in a detached worktree with `PYTHONDONTWRITEBYTECODE=1`; the worktree was restored byte-identical and clean.

## Reviewer

- READER: uncapped Opus independently re-derived the #1241 predicate, measured old/new oracle divergence, inspected guard placement and sibling invariants, requested two test-strengthening changes, then re-reviewed exact signed commit `4185f597c7a1e2cd71d50ef43613ed848bc9aaf1`: **PASS, no blockers or regressions**.
- MUTANT RUNNER: separate uncapped Opus run in a detached worktree executed 12 real mutants. Per changed test: V6 property 3 kills; disregarded-anchor self-test 4 kills; one-sided-control self-test 3 kills. Guard removal and widening both killed. Survivors were covered by the existing #1241 sibling property, unreachable defensive syntax, or an empirically byte-identical/equivalent route.

## Verification

- Exact retained Hypothesis replay: old failure **did not reproduce** after correction.
- Focused V6 + checker tests: 20/20.
- `tests.test_quality_generated`: 126/126.
- `bash scripts/test.sh tests.test_quality_generated`: all 6 phases passed.
- Canonical receipt-backed full suite: PASS (`/run/user/1000/cratedigger-final-gate.Tl5dvpwm`).
- Full fuzz profile: **ALL GREEN** — 148 modules, 1,920 tests, 1,286 scheduled targets, 140.7s.
- Signed commit verification: good ED25519 signature, `%G? = G`.

## Risk

Test-only, one file. The carve-out is exactly the conjunction already used by production #1241. Marked-only and covered-only worlds remain governed by V6. No production behavior, database schema, deployment module, or runtime configuration changes.
